### PR TITLE
Make Fraction MathObjects work better with Infinity

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -256,6 +256,7 @@ sub Init {
   $context->{value}{Real} = "context::Fraction::Real";
   $context->{parser}{Value} = "context::Fraction::Value";
   $context->{parser}{Number} = "Parser::Legacy::LimitedNumeric::Number";
+  $context->{precedence}{Fraction} = $context->{precedence}{Infinity} + .5;  # Fractions are above Infinity
 
   $context = $main::context{'Fraction-NoDecimals'} = $context->copy;
   $context->{name} = "Fraction-NoDecimals";


### PR DESCRIPTION
This makes the contextFraction.pl contexts interact better with Infinity objects (no warning messages when they are compared, for example).  This is needed when Fractions are used in Intervals, for example.
