### PR TITLE
Fix off by one bug in number of attempts

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1113,7 +1113,7 @@ sub hint {
 	PG_restricted_eval(q!$main::hintExists =1!);
     PG_restricted_eval(q!$main::numOfAttempts = 0 unless defined($main::numOfAttempts);!);
     my $attempts = PG_restricted_eval(q!$main::numOfAttempts!);
-    $attempts++ if PG_restricted_eval(q!$main::inputs_ref->{submitAnswers}!); # numbOfAttempts is off by one when resubmitting
+    #$attempts++ if PG_restricted_eval(q!$main::inputs_ref->{submitAnswers}!); # numbOfAttempts is off by one when resubmitting
     #FIXME -- in the current version where PGbasicmacros is reloaded do all of these values need to be recomputed?
 
 	if ($displayMode eq 'TeX')   {


### PR DESCRIPTION
Fixes bug #2376 with respect to hints.  An earlier bug #641 with regard to 
counting attempts properly for limiting the number of attempts was 
fixed in a similar way.  

The key is that the total number of attempts consists of   incorrect attempts   + correct attempts +  ungraded attempts 

The ungraded attempt (or thisAttempt) is 1 or 0 depending on whether the problem was entered via a submitAnswers request or not.
