### PR TITLE
Fix correct_ans for Compute() when the result is a constant

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -81,10 +81,13 @@ sub cmp {
   my $ans = new AnswerEvaluator;
   my $correct = preformat($self->{correct_ans});
   $correct = $self->correct_ans unless defined($correct);
+  my $correct_latex = $self->{correct_ans_latex_string};
+  $correct_latex = $self->correct_ans_latex unless defined($correct_latex);
   $self->{context} = Value->context unless defined($self->{context});
   $ans->ans_hash(
     type => "Value (".$self->class.")",
     correct_ans => $correct,
+    correct_ans_latex_string => $correct_latex,
     correct_value => $self,
     $self->cmp_defaults(@_),
     %{$self->{context}{cmpDefaults}{$self->class} || {}},  # context-specified defaults
@@ -102,6 +105,7 @@ sub cmp {
 }
 
 sub correct_ans {preformat(shift->string)}
+sub correct_ans_latex {shift->TeX}
 sub cmp_diagnostics {}
 
 #
@@ -144,31 +148,6 @@ sub cmp_parse {
     $ans->{student_value}{isStudent} = 1;
     $ans->{preview_latex_string} = $ans->{student_formula}->TeX;
     $ans->{preview_text_string}  = preformat($ans->{student_formula}->string);
-    #FIXME
-    # Kludge to calculate a latex representation of the correct answer string
-    # It would be better to calculate this when the MathObject is created.
-    # the attempt to calculate the latex version may fail because the 
-    # context has changed since the creation of the original MathObject.
-    # In that case the {correct_ans_latex_string} will be blank.
-    # We could try to reset that context temporarily, but a better fix would
-    # be to consistently create latex_string versions of the correct answer
-    # when the math object is created.
-#     if ($ans->{correct_value} ) {
-#     	$ans->{correct_ans_latex_string} = $ans->{correct_value}->TeX; # answer is a MathObject
-#     } else {  # case where there is no math object
-#     	my $mathobject = Parser::Formula($ans->{correct_ans});
-#     	$ans->{correct_ans_latex_string} = ($mathobject)? $mathobject->TeX : '';
-#     }
-	unless (PGcore::not_null($ans->{correct_ans_latex_string}) ) { # don't alter the latex string if it's defined
-		my $mathobject = Parser::Formula($ans->{correct_ans});
-		if ($mathobject) {
-			$ans->{correct_ans_latex_string} = $mathobject->TeX;
-		} elsif( $ans->{correct_value} ) {
-			$ans->{correct_ans_latex_string} = $ans->{correct_value}->TeX; # answer is a MathObject
-		} else {
-			$ans->{correct_ans_latex_string}=''; 
-		}
-	}
     #
     #  Get the string for the student answer
     #


### PR DESCRIPTION
Fix `correct_ans` generated by `Compute()` when the computed value is a constant (the correct_ans was incorrectly being set to the constant, not the original string that generated it, so `Compute("sqrt(2)")` would show `1.4142...` rather than `sqrt(2)` as the correct answer.

Also, moved creation of `correct_ans_latex_string` to `Compute()` so it properly corresponds to the correct answer string, and is available immediately.  For answers not created through `Compute()`, move creation of `correct_ans_latex_string` to `cmp()` rather than `cmp_parse()`, since the latter may not be called (e.g., with blank answers), leaving no latex string.  That meant that the correct answer would be displayed as un-formatted text for blank answers, but typeset math when an answer was entered.  Moving the creation of `correction_ans_latex_string` to `cmp()` resolves that problem.
