### PR TITLE
Fixes problem with pi (and i,j,k) not being retained as a named constant

### DIFF
--- a/lib/Parser/Context/Constants.pm
+++ b/lib/Parser/Context/Constants.pm
@@ -20,8 +20,9 @@ sub init {
 #
 sub create {
   my $self = shift; my $value = shift;
-  return $value if ref($value) eq 'HASH';
-  return {value => $value, keepName => 1};
+  return {value => $value, keepName => 1} unless ref($value) eq 'HASH';
+  $value->{keepName} = 1 unless defined($value->{keepName});
+  return $value;
 }
 sub uncreate {shift; (shift)->{value}}
 


### PR DESCRIPTION
Fixes problem with `pi` (and `i`, `j`, `k`) not being retained as a named constant, but being replaced by their values.  This was introduced accidentally by commit b261ba03f0e87c867efdbf32b8e2692e1485cdd1
