### PR TITLE
Modification to AskSage() to allows passing $problemSeed to SAGE's set_random_seed()

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -220,11 +220,15 @@ sub createDirectory {
 }
 
 sub AskSage {
-  my ($python,$url) = @_;
-  $url = $url || 'https://sagecell.sagemath.org/service';
-  my $output = `curl -k -f -sS -L --data-urlencode "code=print $python" $url`;
+  chomp(my $python = shift);
+  my ($args) = @_;
+  my $url = $args->{url} || 'https://sagecell.sagemath.org/service';
+  my $seed = $args->{seed};
+  my $setSeed = $seed?"set_random_seed($seed)\n":'';
+  my $output = `curl -k -f -sS -L --data-urlencode "code=${setSeed}$python" $url`;
   my $decoded = decode_json($output);
-  return $decoded->{stdout};
+  chomp(my $value = $decoded->{stdout});
+  return $value;
 }
 
 =back


### PR DESCRIPTION
Also, sage blocks should `print`the result of their computation. So, e.g.

```
Context("Matrix");
$python=<<END;
print random_matrix(QQ,4,5,algorithm='echelonizable',rank=3).rows()
END
$sage = AskSage($python,{seed=>$problemSeed});
$M = Matrix($sage);

$python2 =<<END;
print matrix(QQ,$sage).rref().rows()
END
$sage2 = AskSage($python2,{seed=>$problmeSeed});
$ans = Matrix($sage2);
Context()->texStrings;
BEGIN_TEXT

Row reduce \( $M \) $BR
\{ $ans->ans_array\}
END_TEXT
Context()->normalStrings;
ANS($ans->cmp());
```
