### PR TITLE
Bugfix/2.8 adaptive params

### DIFF
--- a/lib/Value/Formula.pm
+++ b/lib/Value/Formula.pm
@@ -200,7 +200,7 @@ sub compare {
       my ($lv,$rv,$av) = ($lvalues->[$i]->value,$rvalues->[$i]->value,$avalues->[$i]->value);
       if ($isRelative) {
 	if (CORE::abs($lv) <= $zeroLevel) {$tol = $zeroLevelTol}
-	                       else {$tol *= CORE::abs($lv)}
+                                     else {$tol *= CORE::abs($av)}
       }
       return $rv <=> $av unless CORE::abs($rv - $av) < $tol;
     }


### PR DESCRIPTION
This fixes the relative error test for adaptive parameters which currently compares the difference of the student and adapted values to the _unadapted_ correct answer.  That only works if the adapted and unadapted values are close to each other in magnitude, but fails if, for example, the unadapted value is large in comparison to the adapted one.  See [bug 2784](http://bugs.webwork.maa.org/show_bug.cgi?id=2784) for details.
