### PR TITLE
Fix TeX output so that it matches HTML output (apply math_ev3 to it).

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1225,7 +1225,7 @@ sub Verbatim {
 
 sub Math {
   my $self = shift;
-  return "\$".$self->SUPER::Math(@_)."\$";
+  return main::math_ev3($self->SUPER::Math(@_));
 }
 
 ######################################################################


### PR DESCRIPTION
This fixes the problem reported in [Bugzilla 2840](http://bugs.webwork.maa.org/show_bug.cgi?id=2840) where the math displayed in HTML might not the same as that in TeX.  The problem was that HTML mode went through `math_ev3` which does some pre-processing (like changing `+-` to `-`), but TeX didn't.  This patch makes both go through `math_ev3`.
