### PR TITLE
 Fix AskSage to work with the accepted_tos option, and to print any error

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -224,12 +224,18 @@ sub AskSage {
   my ($args) = @_;
   my $url = $args->{url} || 'https://sagecell.sagemath.org/service';
   my $seed = $args->{seed};
+  my $accepted_tos = $args->{accepted_tos} || 'false';
   my $setSeed = $seed?"set_random_seed($seed)\n":'';
-  my $output = `curl -k -f -sS -L --data-urlencode "code=${setSeed}$python" $url`;
-  my $decoded = decode_json($output);
-  chomp(my $value = $decoded->{stdout});
-  return $value;
+  my $output = `curl -k -sS -L --data-urlencode "accepted_tos=${accepted_tos}" --data-urlencode "code=${setSeed}$python" $url`;
+  eval {
+    my $decoded = decode_json($output);
+    chomp(my $value = $decoded->{stdout});
+    return $value;
+  } or do {
+    warn "Error in asking Sage to do something: $output";
+  }
 }
+
 
 =back
 


### PR DESCRIPTION
With sagecell.sagemath.org, the user will now have to specify `accepted_tos=>true`, which indicates their agreement to the server's terms of service.

So a valid call now is: `$sageReply1 = AskSage($SageCode1,{seed=>$problemSeed, accepted_tos=>true});`
