### PR TITLE
Make inline matrices use the CSS style for making inline tables

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1,4 +1,3 @@
-
 =head1 DESCRIPTION
 
  #############################################################
@@ -479,7 +478,7 @@ sub format_matrix_HTML {
           . '</TR>'."\n";
   }
   return '<TABLE BORDER="0" CELLSPACING="0" CELLPADDING="0" CLASS="ArrayLayout"'
-          . ' STYLE="display:inline;margin:0;vertical-align:-'.(1.1*$rows-.6).'em">'
+          . ' STYLE="display:inline-table;margin:0;vertical-align:-'.(1.1*$rows-.6).'em">'
           . $HTML
           . '</TABLE>';
 }


### PR DESCRIPTION
Matrices were not inline before in some browsers.  This uses the proper css for inline tables (defined in CSS 2.1).
