### PR TITLE
PGML patch

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1352,7 +1352,8 @@ END_PREAMBLE
 package main;
 
 sub _PGML_init {
-  my $context = Context; # prevent Typeset context from becoming active
+  loadMacros("MathObjects.pl");
+  my $context = Context(); # prevent Typeset context from becoming active
   loadMacros("contextTypeset.pl");
   Context($context);
   $problemPreamble->{TeX} .= $PGML::preamble unless $problemPreamble->{TeX} =~ m/definitions for PGML/;


### PR DESCRIPTION
Fix problem with `Context` not being called as a function (worked in earlier versions of Perl), and make sure MathObjects are loaded.  Fixes bugzilla 3060, and Geoff's issue from pull #101.
