### PR TITLE
Fix problem with perl method for complex numbers of the form a-i.

### DIFF
--- a/lib/Value/Complex.pm
+++ b/lib/Value/Complex.pm
@@ -347,7 +347,7 @@ sub format {
 sub perl {
   my $self = shift; my $parens = shift;
   my $s = Value::Complex::format($self->{format},$self->value,"string",$self->{equation});
-  $s =~ s/(\d)i$/\1*i/; $s = "(".$s.")" if $parens;
+  $s =~ s/(\d)i$/\1*i/; $s =~ s/-i/ - i/; $s = "(".$s.")" if $parens;
   return $s;
 }
 


### PR DESCRIPTION
This resolves a warning message that appears when a complex number of the form `a-i` is used in a formula that is evaluated for comparison to another formula.
