### PR TITLE
added pccTables.pl

### DIFF
--- a/macros/pccTables.pl
+++ b/macros/pccTables.pl
@@ -98,7 +98,7 @@ sub DataTable {
   my ($tablecss, $captioncss, $datacss, $headercss, $allcellcss, $texalignment) = 
     ($options{tablecss},$options{captioncss},$options{datacss},$options{headercss},$options{allcellcss},$options{texalignment},);
   my $center = $options{center};
-    if ($center !=0) {$tablecss .= 'textalign:center;margin:0 auto;'};
+    if ($center !=0) {$tablecss .= 'text-align:center;margin:0 auto;'};
 
   # for each row, store rowcss
   my @rowcss = ();
@@ -190,7 +190,7 @@ sub LayoutTable {
   my ($tablecss, $texalignment, $allcellcss) = 
     ($options{tablecss},$options{texalignment},$options{allcellcss},);
   my $center = $options{center};
-    if ($center !=0) {$tablecss .= 'textalign:center;margin:0 auto;'};
+    if ($center !=0) {$tablecss .= 'text-align:center;margin:0 auto;'};
 
   # for each row, store rowcss
   my @rowcss = ();


### PR DESCRIPTION
pccTables.pl contains two separate table-making commands that can be used to create tables with accessibility in mind. Both types allow for css styling at many levels.

DataTable() is for data tables (tables that are truly meant to be read with rows and columns). Column and row header tags can be used for greater screen-reader usability. Captioning can be used which is also encouraged for accessibility.

LayoutTable() uses div boxes with the css display key set to various table types, instead of using HTML table tags. This way, if your 'table' is really just meant to be used for laying out an array (usually of images) and the xy-position of the cells is not actually important, then the screen readers won't confuse users by mentioning rows and columns.
