### PR TITLE
Bizarro arithmetic

### DIFF
--- a/macros/contextLimitedFactor.pl
+++ b/macros/contextLimitedFactor.pl
@@ -28,6 +28,9 @@ sub _contextLimitedFactor_init {
      '+'  => {class => 'bizarro::BOP::add', isCommand => 1},
      '-'  => {class => 'bizarro::BOP::subtract', isCommand => 1},
      '/'  => {class => 'bizarro::BOP::divide', isCommand => 1},
+     ' /'  => {class => 'bizarro::BOP::divide', isCommand => 1},
+     '/ '  => {class => 'bizarro::BOP::divide', isCommand => 1},
+     '//'  => {class => 'bizarro::BOP::divide', isCommand => 1},
   );
 
   $context->flags->set(factorableObject => 'polynomial');


### PR DESCRIPTION
The presence of operators with spaces like '+ ' was leading to display bugs with the preview of students' answers. Removing them seems to have caused no harm and makes the display bug go away.
