### PR TITLE
Fix regression affecting Linear Programming problems from ASU

### DIFF
--- a/macros/LinearProgramming.pl
+++ b/macros/LinearProgramming.pl
@@ -286,7 +286,16 @@ sub lp_current_value {
     }
   }
   if($cnt != 1) {
-    return ($fractionmode ?  Fraction(0) : 0);
+  	if ($fractionmode ) {
+  		if (defined &Fraction) {
+  			return Fraction(0);   # MathObjects version
+  		} else {
+  			return new Fraction(0);	# old style Function module version
+  		}
+  	} else {
+  		return 0;
+  	}
+ 
   }
   $cnt = scalar(@{$save});
   return $save->[$cnt-1];


### PR DESCRIPTION
Check to see what kind of Fraction to create in LinearProgramming.pl -- MathObjects Fraction or regular Fraction

```
This fixes a regression reported for the old style linear programming problems written at ASU as reported by John Jones
```

   A decision needs
    to be made as to whether to continue to support old style Fractions in this file.
    By adding a few commands to the MathObjects Fractions we could have it imitate the behavior of the old style fraction.
    This might be a better permanent fix.
