### PR TITLE
Change hardcoded path for sketchgraphhtml5.

### DIFF
--- a/lib/Applet.pm
+++ b/lib/Applet.pm
@@ -988,7 +988,7 @@ http://www.teratechnologies.net/stevekamerman/index.php?m=01&y=07&entry=entry070
 use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
   <form></form>
 	<script> var width = 200; var height = 200;</script>
-	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
+	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
 END_OBJECT_TEXT
 
 
@@ -1055,7 +1055,7 @@ END_HEADER_SCRIPT
 use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
     <script language="javascript">ww_applet_list["$appletName"].visible = 1; // don't submit things if not visible
     </script>
-	<canvas name="cv" id="cv" data-src="/webwork2_files/js/sketchgraphhtml5b/SketchGraph.pjs" width="$width" height="$height"></canvas>  
+	<canvas name="cv" id="cv" data-src="/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="$width" height="$height"></canvas>  
 END_OBJECT_TEXT
 
 sub new {
@@ -1086,7 +1086,7 @@ package GeogebraWebApplet;
 use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
   <form></form>
 	<script> var width = 200; var height = 200;</script>
-	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
+	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
 END_OBJECT_TEXT
 
 

--- a/macros/CanvasObject.pl
+++ b/macros/CanvasObject.pl
@@ -5,8 +5,8 @@ $canvasName = "cv";
 
 HEADER_TEXT(<<END_HEADER_TEXT);
 <script language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-<script language="javascript" src="${webworkHtmlURL}js/sketchgraphhtml5b/SketchGraph.pjs"></script>
-<script language="javascript" src="${webworkHtmlURL}js/sketchgraphhtml5b/processing-dgfix.js"></script>
+<script language="javascript" src="${webworkHtmlURL}js/legacy/sketchgraphhtml5b/SketchGraph.pjs"></script>
+<script language="javascript" src="${webworkHtmlURL}js/legacy/sketchgraphhtml5b/processing-dgfix.js"></script>
 
 
 <script>


### PR DESCRIPTION
This makes the sketchgraphhtml5 applet work again.  It broke when it's code was moved to js/legacy.  

 A more permanent fix needs to be crafted.
