### PR TITLE
Add missing super class to ImplicitPlane::formula.  Bugzilla 3125.

### DIFF
--- a/macros/parserImplicitPlane.pl
+++ b/macros/parserImplicitPlane.pl
@@ -204,6 +204,7 @@ sub _check {
 }
 
 package ImplicitPlane::formula;
+our @ISA = ('Value::Formula');
 
 sub new {
   my $self = shift;


### PR DESCRIPTION
This fixes the bug reported at [bugzilla 3125](http://bugs.webwork.maa.org/show_bug.cgi?id=3125), which caused ImplicitPlane problems to throw an error.
