### PR TITLE
Fix MultiAnswer to set the correct_ans_latex_string

### DIFF
--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -246,11 +246,16 @@ sub cmp {
 #  as a single result.
 #
 sub single_cmp {
-  my $self = shift; my @correct;
-  foreach my $cmp (@{$self->{cmp}}) {push(@correct,$cmp->{rh_ans}{correct_ans})}
+  my $self = shift; my @correct; my @correct_tex;
+  foreach my $cmp (@{$self->{cmp}}) {
+    push(@correct,$cmp->{rh_ans}{correct_ans});
+    push(@correct_tex,$cmp->{rh_ans}{correct_ans_latex_string}||$cmp->{rh_ans}{correct_value}->TeX);
+  }
   my $ans = new AnswerEvaluator;
   $ans->ans_hash(
-    correct_ans => join($self->{separator},@correct),
+    correct_ans => (defined($self->{format}) ? sprintf($self->{format},@correct) : join($self->{separator},@correct)),
+    correct_ans_latex_string => (defined($self->{tex_format}) ?
+        sprintf($self->{tex_format},@correct_tex) : join($self->{tex_separator},@correct_tex)),
     type        => "MultiAnswer",
     @_,
   );


### PR DESCRIPTION
Fix MultiAnswer to set the corect_ans_latex_string, and also make it use the format and tex_format strings for the correct answer when singleResult is used.

This can be tested using

```
loadMacros("parserMultiAnswer.pl");
Context("Matrix");
$M = Compute("[[1/2,1],[2,3]]");
$r = Real(1);
$ma = MultiAnswer($M,1)->with(
  singleResult => 1,
  format => "%s and %s",
  tex_format => "%s \hbox{ and } %s",
  checker => sub {1},     # we don't care about the checking, only the correct answer display
);
BEGIN_TEXT
Matrix and number: \{$ma->ans_rule\} and \{$ma->ans_rule\}
END_TEXT
ANS($ma->cmp);
```

Check the `Show Correct Answers` and hit the `Check Answers` button.  Without the fix the correct answer will be `[[1/2,1],[2,3]]; 1`, with the fix, is should be a properly formatted matrix with the word " and " between the matrix and the number.
