### PR TITLE
Fix contextComplexJ so that it can be loaded in parserCustomization.pl, ...

### DIFF
--- a/macros/contextComplexJ.pl
+++ b/macros/contextComplexJ.pl
@@ -157,6 +157,7 @@ sub Enable {
     j => {value => $context->Package("Complex")->new($context,0,1)->with(isJ=>1), isConstant => 1, perl => "j"},
     i => {value => $context->Package("Complex")->new($context,0,1), isConstant => 1, perl => "i"},
   );
+  $context->update;
 }
 
 #


### PR DESCRIPTION
Fix `contextComplexJ.pl` so that it can be loaded in `parserCustomization.pl`, allowing it to be used as a course-by-course customization file.  This makes it possible for each course to determine how complex numbers can be entered and displayed (without having to modify any of the problem files).  It allows both notations (i and j) to be recognized, and produces warning messages if desired to force students to use one or the other format, or can allow either one. It can also force the output to be ether style.
