### PR TITLE
Fix List answer checker to set correct_ans_latex_string when parens have been removed.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1305,7 +1305,7 @@ sub cmp {
   my $self = shift;
   my %params = @_;
   my $cmp = $self->SUPER::cmp(@_);
-  if ($cmp->{rh_ans}{removeParens}) {
+  if ($cmp->{rh_ans}{removeParens} && ($self->{open} || $self->{close})) {
     $self->{open} = $self->{close} = '';
     $cmp->ans_hash(correct_ans => $self->stringify)
       unless defined($self->{correct_ans}) || defined($params{correct_ans});
@@ -1643,11 +1643,14 @@ sub getTypicalValue {
 #
 sub cmp {
   my $self = shift;
+  my %params = @_;
   my $cmp = $self->SUPER::cmp(@_);
-  if ($cmp->{rh_ans}{removeParens} && $self->type eq 'List') {
+  if ($cmp->{rh_ans}{removeParens} && $self->type eq 'List' && ($self->{tree}{open} || $self->{tree}{close})) {
     $self->{tree}{open} = $self->{tree}{close} = '';
     $cmp->ans_hash(correct_ans => $self->stringify)
-      unless defined($self->{correct_ans});
+      unless defined($self->{correct_ans}) || defined($params{correct_ans});
+    $cmp->ans_hash(correct_ans_latex_string => $self->stringify)
+      unless defined($self->{correct_ans_latex_string}) || defined($params{correct_ans_latex_string});
   }
   if ($cmp->{rh_ans}{eval} && $self->isConstant) {
     $cmp->ans_hash(correct_value => $self->eval);


### PR DESCRIPTION
When a List() has `removeParens` set, the `correct_ans` gets reset to remove the parens.  This patch causes `correct_ans_latex_string` to be updated as well.
