### PR TITLE
Add macro files for new contexts

### DIFF
--- a/macros/contextAlternateDecimal.pl
+++ b/macros/contextAlternateDecimal.pl
@@ -1,0 +1,319 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader:$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+C<Context("AlternateDecimal")> - Provides a context that allows the
+entry of decimal numbers using a comma for the decimal indicator
+rather than a dot (e.g., C<3,14159> rather than C<3.14159>).
+
+
+=head1 DESCRIPTION
+
+This macro file defines contexts in which decimal numbers can be
+entered using a comma rather than a period as the decimal separator.
+Both forms are always recognized, but you can determine whether one or
+the other form produces an error message when used.  You can also
+force the display of numbers to use one or the other form.
+
+
+=head1 USAGE
+
+To use this file, first load it into your problem, then select the
+context that you wish to use.  There are three pre-defined contexts,
+C<AlternateDecimal>, C<AlternateDecimal-Only>, and
+C<AlternateDecimal-Warning>.  The first allows both the standard and
+alternate forms to be used, the second allows only the alternate form,
+and the third allows only the standard form, but recognizes the
+alternate form and gives an error message when it is used.
+
+	loadMacros("contextAlternateDecimal.pl");
+	
+	Context("AlternateDecimal");
+	
+	$r1 = Compute("3.14159");
+        $r2 = Compute("3,14159");    # equivalent to $r1;
+	
+	Context("AlternateDecimal-Only");
+	
+	$r1 = Compute("3.14159");
+        $r2 = Compute("3,14159");    # causes an error message
+	
+	Context("AlternateDecimal-Warning");
+	
+	$I1 = Compute("3.14159");    # causes an error message
+        $I2 = Compute("3,14159");
+
+There are two context flags that control the input and output of
+decimals.
+
+=over
+
+=item C<S<< enterDecimals => "either" (or "," or ".") >>>
+
+This specifies what formats the student is allowed to use to enter a
+decimal.  A value of C<"either"> allows either of the formats to be
+accepted, while the other two options produce error messages if the
+wrong form is used.
+
+=item C<S<< displayDecimals => "either" (or "," or ".") >>>
+
+This controls how decimals are displayed.  When set to C<"either">,
+the decimal is displayed in whatever format was used to create it.
+When set to C<"."> or C<",">, the display is forced to be in the given
+format regardless of how it was entered.
+
+=back
+
+The C<AlternateDecimal> context has both flags set to C<"either">, so
+the decimals remain in the format the student entered them, and either
+form can be used.  The C<AlternateDecimal-Only> context has both set
+to C<",">, so only the alternate format can be used, and any number
+will be displayed in the alternate format.  The
+C<AlternateDecimal-Warning> context has both set to C<".">, so only
+standard format can be used, and all numbers will be displayed in
+standard format.
+
+It is possible to set C<enterDecimals> and C<displayDecimals> to
+different values.  For example.
+
+	Context()->flags->set(
+	  enterDecimals => "either",
+	  displayDecimals => ".",
+	);
+
+would allow students to enter decimals in either format, but all
+numebrs would be displayed in standard form.
+
+=head1 LISTS IN ALTERNATE FORMAT
+
+Because the alternate format allows numbers to be entered using commas
+rather than periods, this makes the formation of lists harder.  For
+example, C<3,5> is the number 3-and-5-tenths, not the list consisting
+of 3 followed by 5. Because of this ambiguity, the C<AlternateDecimal>
+contexts also include the semi-colon as a replacement for the comma as
+a separator.  So C<3;5> is the list consisting of 3 followed by 5, and
+C<3,1;5.2> is the list consisting of 3.1 and 5.2.
+
+Note that the comma is still available for use as a separator, but
+this makes things like C<3,2,1> tricky, because it is not clear if
+this is 3.2 followed by 1, or 3.2 times .1, or the list of 3, 2, and
+1.  To help make this unambiguous, numbers that use a comma as decimal
+inidcator must have a digit on both sides of the comma.  So one tenth
+would have to be entered as C<0,1> not just C<,1> (but you can still
+enter C<.1>.  Similarly, You must enter C<3,0> or just C<3> rather
+than C<3,>, even though C<3.> is acceptable.
+
+With this notation C<3,2,1> means the list consisting of 3.2 followed
+by 1.  If you want the list consisting of 3 followed by 2.1, you could
+use C<3, 2,1> since the comma in C<3,> is not part of the number, so
+must be a list separator.
+
+
+=head1 SETTING THE ALTERNATE FORM AS THE DEFAULT
+
+If you want to force existing problems to allow (or force, or warn about)
+the alternate format instead, then create a file named
+C<parserCustomization.pl> in your course's C<templates/macros>
+directory, and enter the following in it:
+
+	loadMacros("contextAlternateDecimal.pl");
+        context::AlternateDecimal->Default("either","either");
+        Context("Numeric");
+
+This will alter all the standard contexts to allow students to enter
+numbers in either format, and will display them using the form that
+was used to enter them.
+
+You could also do
+
+	loadMacros("contextAlternateDecimal.pl");
+        context::AlternateDecimal->Default(".",".");
+        Context("Numeric");
+
+to cause a warning message to appear when students enter the alternate
+format.
+
+If you want to force students to enter the alternate format, use
+
+	loadMacros("contextAlternateDecimal.pl");
+        context::AlternateDecimal->Default(",",",");
+        Context("Numeric");
+
+This will force the display of all numbers into the alternate form (so
+even the ones created in the problem using standard form will show
+using commas), and will force students to enter their results using
+commas, though professors answers will still be allowed to be entered
+in either format (the C<Default()> function converts the first C<",">
+to C<"either">, but arranges that the default flags for the answer
+checker are set to only allow students to enter decimals with commas).
+This allows you to force comma notation in problems without having to
+rewrite them.
+
+=cut
+
+
+###########################################################
+
+loadMacros("MathObjects.pl");
+
+sub _contextAlternateDecimal_init {
+  my $context = $main::context{AlternateDecimal} = Parser::Context->getCopy("Numeric");
+  $context->{name} = "AlternateDecimal";
+  context::AlternateDecimal->Enable($context);
+
+  $context = $main::context{"AlternateDecimal-Warning"} = $context->copy;
+  $context->{name} = "AlternateDecimal-Warning";
+  $context->flags->set(
+    enterDecimals => ".",
+    displayDecimals => ".",
+  );
+
+  $context = $main::context{"AlternateDecimal-Only"} = $context->copy;
+  $context->{name} = "AlternateDecimal-Only";
+  $context->flags->set(
+    enterDecimals => ",",
+    displayDecimals => ",",
+  );
+  foreach my $list ($context->lists->names) {
+    my $sep = $context->lists->get($list)->{separator};
+    $context->lists->set($list,{separator => ";"}) if $sep eq ",";
+    $context->lists->set($list,{separator => "; "}) if $sep eq ", ";
+  }
+}
+
+###########################################################
+
+package context::AlternateDecimal;
+
+#
+#  Enables alternate decimals in the given context
+#
+sub Enable {
+  my $self = shift; my $context = shift || main::Context();
+  $context->flags->set(
+    enterDecimals => "either",        # or "." or ","
+    displayDecimals => "either",      # or "." or ","
+  );
+  $context->{pattern}{number} = '(?:\d+(?:\.\d*|,\d+)?|\.\d+)(?:E[-+]?\d+)?';
+  $context->{pattern}{signedNumber} = '[-+]?(?:\d+(?:\.\d*|,\d+)?|\.\d+)(?:E[-+]?\d+)?';
+  $context->operators->add(';' => {%{$context->operators->get(',')}, string => ";"})
+    if $context->{operators}{','};
+  $context->update;
+  $context->{parser}{Number} = "context::AlternateDecimal::Number";
+  $context->{value}{Real} = "context::AlternateDecimal::Real";
+}
+
+#
+#  Sets all the default contexts to use alternate decimals.
+#  The two arguments determine the values for the
+#  enterDecimals and displayDecimals flags.  If enterDecimals
+#  is ",", then student answers must use commas for decimals
+#  (though professors can use either).  If the display is not
+#  ".", then separators for lists, points, vectors, etc, are
+#  displayed as ";".
+#
+sub Default {
+  my $self = shift; my $enter = shift || "either";  my $display = shift || "either";
+  my $cmp = ($enter eq ","); $enter = "either" if $cmp;
+  foreach my $name (keys %Parser::Context::Default::context) {
+    my $context = $main::context{$name} = Parser::Context->getCopy($name);
+    $self->Enable($context);
+    $context->flags->set(enterDecimals => $enter, displayDecimals => $display);
+    if ($display ne ".") {
+      foreach my $list ($context->lists->names) {
+	my $sep = $context->lists->get($list)->{separator};
+	$context->lists->set($list,{separator => ";"}) if $sep eq ",";
+	$context->lists->set($list,{separator => "; "}) if $sep eq ", ";
+      }
+    }
+    if ($cmp) {
+      foreach my $class (grep {/::/} (keys %Value::)) {
+        $context->{cmpDefaults}{substr($class,0,-2)}{enterDecimals} = ",";
+      }
+    }
+  }
+  main::Context(main::Context()->{name});
+}
+
+###########################################################
+
+package context::AlternateDecimal::Number;
+our @ISA = ('Parser::Number');
+
+#
+#  Handle numbers with commas as decimal indicators, and produce
+#  an error if the format is not what is allowed.  Mark the
+#  number if it in the alternate form, so we can display it
+#  correctly later, if needed.
+#
+sub new {
+  my $self = shift; my $class = ref($self) || $self;
+  my $equation = shift; my $format = $equation->{context}->flag("enterDecimals");
+  my $value = shift;
+  my $alternate = (Value::isHash($value) ? $value->{alternateForm} : ref($value) ? 0 : ($value =~ s/,/./));
+  my $num = $self->SUPER::new($equation,$value,@_);
+  $num->Error("Decimal numbers should be entered using a comma not a period")
+    if !$alternate && $format eq ",";
+  $num->Error("Decimal numbers should be entered using a period not a comma")
+    if $alternate && $format eq ".";
+  if ($alternate) {
+    $num->{alternateForm} = 1;
+    $num->{value_original_string} = $num->{value_string};
+    $num->{value_string} = $num->{value};
+  }
+  return $num;
+}
+
+#
+#  If we have an alternate form, make a Real out of it so that
+#  we can retain the alternateForm flag.  (I'm not sure if there
+#  will be any problems from that, since it usually only returns
+#  a Perl real).
+#
+sub eval {
+  my $self = shift;
+  my $n = $self->{value};
+  $n = $self->Package("Real")->new($n)->with(alternateForm => 1) if $self->{alternateForm};
+  return $n;
+}
+
+sub class {
+  my $self = shift;
+  ($self->isComplex ? "Complex" : "Number");
+}
+
+###########################################################
+
+package context::AlternateDecimal::Real;
+our @ISA = ('Value::Real');
+
+sub string {
+  my $self = shift; my $n = $self->SUPER::string(@_);
+  my $format = $self->getFlag("displayDecimals");
+  $n =~ s/\./,/ if ($self->{alternateForm} || $format eq ",") && $format ne ".";
+  return $n;
+}
+
+sub TeX {
+  my $self = shift; my $n = $self->SUPER::TeX(@_);
+  $n =~ s/,/{,}/;  # original TeX calls string(), which already has put in the comma
+  return $n;
+}
+
+###########################################################
+
+1;

--- a/macros/contextAlternateIntervals.pl
+++ b/macros/contextAlternateIntervals.pl
@@ -1,0 +1,306 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader:$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+C<Context("AlternateIntervals")> - Provides a context that allows the
+entry of intervals using reversed bracket notation for open endpoints
+(e.g., C<]a,b[> rather than C<(a,b)> for an open interval).
+
+
+=head1 DESCRIPTION
+
+This macro file defines contexts in which open intervals can be
+specified using reversed brackets rather than parentheses.  Both forms
+are always recognized, but you can determine whether one or the other
+form produces an error message when used.  You can also force the
+display of intervals to use one or the other form.
+
+
+=head1 USAGE
+
+To use this file, first load it into your problem, then select the
+context that you wish to use.  There are three pre-defined contexts,
+C<AlternateIntervals>, C<AlternateIntervals-Only>, and
+C<AlternateIntervals-Warning>.  The first allows both the standard and
+alternate forms to be used, the second allows only the alternate form,
+and the third allows only the standard form, but recognizes the
+alternate form and gives an error message when it is used.
+
+	loadMacros("contextAlternateIntervals.pl");
+	
+	Context("AlternateIntervals");
+	
+	$I1 = Compute("]2,5[");
+        $I2 = Compute("(2,5)");    # equivalent to $I1;
+	
+	Context("AlternateIntervals-Only");
+	
+	$I1 = Compute("]2,5[");
+        $I2 = Compute("(2,5)");    # causes an error message
+	
+	Context("AlternateIntervals-Warning");
+	
+	$I1 = Compute("]2,5[");    # causes an error message
+        $I2 = Compute("(2,5)");
+
+There are two context flags that control the input and output of
+intervals.
+
+=over
+
+=item C<S<< enterIntervals => "either" (or "alternate" or "stanard") >>>
+
+This specifies what formats the student is allowed to use to enter an
+interval.  A value of C<"either"> allows either of the formats to be
+accepted, while the other two options produce error messages if the
+wrong form is used.
+
+=item C<S<< displayIntervals => "either" (or "alternate" or "standard") >>>
+
+This controls how intervals are displayed.  When set to C<"either">, the
+interval is displayed in whatever format was used to create it.  When
+set to C<"standard"> or C<"alternate">, the display is forced to be in the
+given format regardless of how it was entered.
+
+=back
+
+The C<AlternateIntervals> context has both flags set to C<"either">, so the
+intervals remain in the format the student entered them, and either
+form can be used.  The C<AlternateIntervals-Only> context has both set to
+C<"alternate">, so only the alternate format can be used, and any
+Interval will be displayed in alternate format.  The
+C<AlternateIntervals-Warning> context has both set to C<"standard">, so only
+standard format can be used, and all intervals will be displayed in
+standard format.
+
+It is possible to set C<enterIntervals> and C<displayIntervals> to
+different values.  For example.
+
+	Context()->flags->set(
+	  enterIntervals => "either",
+	  displayIntervals => "standard",
+	);
+
+would allow students to enter intervals in either format, but all
+intervals would be displayed in standard form.
+
+=head1 SETTING THE ALTERNATE FORM AS THE DEFAULT
+
+If you want to force existing problems that use the Interval context
+to use one of the alternate contexts instead, then create a file named
+C<parserCustomization.pl> in your course's C<templates/macros>
+directory, and enter the following in it:
+
+	loadMacros("contextAlternateIntervals.pl");
+	$context{Interval} = $context{"AlternateIntervals"};
+
+This will replace the C<Interval> context with the
+C<AlternateIntervals> context so that any problem that sets
+C<Context("Interval")> will get the C<AlternateInervals> context
+instead, so students can enter intervals in either format.
+
+You could also do
+
+	loadMacros("contextAlternateIntervals.pl");
+	$context{Interval} = $context{"AlternateIntervals-Warning"};
+
+to cause a warning message to appear when students enter the alternate
+format.
+
+If you want to force students to enter the alternate format, you can't
+use C<AlternateIntervals-Only> because the original problem code
+probably involves the creation of intervals using the standard
+notation.  Instead, use
+
+	loadMacros("contextAlternateIntervals.pl");
+	$context{Interval} = $context{"AlternateIntervals"};
+	$context{Interval}->flags->set(displayIntervals => "alternate");
+	$context{Interval}->{cmpDefaults}{Interval}{enterIntervals} = "alternate";
+
+This will force the display of all intervals into the alternate form
+(so even the ones created in the problem using standard form will show
+using reverse brackets), and will force students to enter their
+results using the alternate format. So this makes the problem work as
+though it were written using C<AlternateIntervals->Only>.
+
+=cut
+
+##########################################################################
+
+loadMacros("MathObjects.pl");
+
+sub _contextAlternateIntervals_init {
+  my $context = $main::context{AlternateIntervals} = Parser::Context->getCopy("Interval");
+  $context->{name} = "AlternateIntervals";
+  $context->flags->set(
+    enterIntervals   => "either",    # or "standard" or "alternate"
+    displayIntervals => "either",    # or "standard" or "alternate"
+  );
+  $context->parens->set(
+    "[" => {close => "[", type => "Interval", formInterval => ["]",")"], removable => 0},
+    "]" => {close => "]", type => "Interval", formInterval => "["},
+  );
+  $context->update;
+  $context->{value}{Interval} = "context::AlternateIntervals::Interval";
+  $context->{value}{Formula}  = "context::AlternateIntervals::Formula";
+  $context->{parser}{Formula} = "context::AlternateIntervals::Formula";
+
+  $context = $main::context{"AlternateIntervals-Only"} = $context->copy;
+  $context->{name} = "AlternativeIntervals-Only";
+  $context->flags->set(
+    enterIntervals   => "alternate",
+    displayIntervals => "alternate",
+  );
+
+  $context = $main::context{"AlternateIntervals-Warning"} = $context->copy;
+  $context->{name} = "AlternativeIntervals-Warning";
+  $context->flags->set(
+    enterIntervals   => "standard",
+    displayIntervals => "standard",
+  );
+}
+
+##########################################################################
+
+package context::AlternateIntervals::Formula;
+our @ISA = ('Value::Formula');
+
+#
+#  Replace the standard Open with one that handles formInterval better.
+#  We need to handle several possible close delimiters.
+#
+sub Open {
+  my $self = shift; my $type = shift;
+  my $paren = $self->{context}{parens}{$type};
+  if ($self->state eq 'operand') {
+    if ($type eq $paren->{close}) {
+      my $stack = $self->{stack}; my $i = scalar(@{$stack})-1;
+      while ($i >= 0 && $stack->[$i]{type} ne "open") {$i--}
+      if ($i >= 0 && $stack->[$i]{close}{$type}) {
+	$self->Close($type,$self->{ref});
+	return;
+      }
+    }
+    $self->ImplicitMult();
+  }
+  my $item = {type => 'open', value => $type, ref => $self->{ref}, close => {}};
+  if ($paren->{formInterval}) {
+    my $close = $paren->{formInterval}; $close = [$close] unless ref($close) eq 'ARRAY';
+    $item->{close} = {map {$_ => 1} @$close};
+  }
+  $item->{close}{$type} = 1;
+  $self->push($item);
+}
+
+#
+#  We need to modify the test for formInterval to NOT check the number
+#  of entries so that better error messages are produced, and to handle
+#  multiple close delimiters.  These are both in teh "operand" branch,
+#  so do the original for all the choices, and copy that branch here,
+#  with our modifications.
+#
+sub Close {
+  my $self = shift; my $type = shift;
+  my $ref = $self->{ref} = shift;
+  my $parens = $self->{context}{parens};
+
+  return $self->SUPER::Close($type,$ref,@_) if $self->state ne "operand";
+
+  $self->Precedence(-1); return if ($self->{error});
+  if ($self->state ne 'operand') {$self->Close($type,$ref); return}
+  my $paren = $parens->{$self->prev->{value}};
+  if ($paren->{close} eq $type) {
+    my $top = $self->pop;
+    if (!$paren->{removable} || ($top->{value}->type eq "Comma")) {
+      $top = $top->{value};
+      $top = {type => 'operand', value =>
+	      $self->Item("List")->new($self,[$top->makeList],$top->{isConstant},$paren,
+				       ($top->type eq 'Comma') ? $top->entryType : $top->typeRef,
+				       ($type ne 'start') ? ($self->top->{value},$type) : () )};
+    } else {$top->{value}{hadParens} = 1}
+    $self->pop; $self->push($top);
+    $self->CloseFn() if ($paren->{function} && $self->prev->{type} eq 'fn');
+  } else {
+    my $close = $paren->{formInterval}||[]; $close = [$close] unless ref($close) eq 'ARRAY';
+    $close = {map {$_ => 1} @$close};
+    if ($close->{$type}) {
+      my $top = $self->pop->{value}; my $open = $self->pop->{value};
+      $self->pushOperand(
+         $self->Item("List")->new($self,[$top->makeList],$top->{isConstant},
+				  $paren,$top->entryType,$open,$type));
+    } else {
+      my $prev = $self->prev;
+      if ($type eq "start") {$self->Error(["Missing close parenthesis for '%s'",$prev->{value}],$prev->{ref})}
+      elsif ($prev->{value} eq "start") {$self->Error(["Extra close parenthesis '%s'",$type],$ref)}
+      else {$self->Error(["Mismatched parentheses: '%s' and '%s'",$prev->{value},$type],$ref)}
+    }
+  }
+}
+
+sub class {'Formula'}
+
+##########################################################################
+
+package context::AlternateIntervals::Interval;
+our @ISA = ('Value::Interval');
+
+#
+#  Convert alternative form to regular form, but mark it as alternative.
+#  Give error messages about forms that aren't allowed by the context flags.
+#
+sub new {
+  my $self = shift;
+  return $self->SUPER::new(@_) unless scalar(@_) == 5;
+  my @args = @_; my $alternate; my $format = $self->getFlag("enterIntervals");
+  if ($args[1] eq "]") {$alternate = 1; $args[1] = "("}
+  if ($args[4] eq "[") {$alternate = 1; $args[4] = ")"}
+  Value->Error("You must use parentheses to form open intervals")
+    if $alternate && $format eq "standard";
+  Value->Error("You must use reversed brackets to form open intervals")
+    if ($_[1] eq "(" || $_[4] eq ")") && $format eq "alternate";
+  $self->SUPER::new(@args)->with(alternateForm => $alternate);
+}
+
+#
+#  For alternative form, switch back to the alternative brackets for printing,
+#  or force standard or alternative form based on the context flags.
+#
+sub string {
+  my $self = shift; my @args = @_;
+  my $format = $self->getFlag("displayIntervals");
+  my $alternate = ($self->{alternateForm} || $format eq "alternate") && $format ne "standard";
+  $args[1] = "]" if $alternate && ($args[1]||$self->{open}) eq "(";
+  $args[2] = "[" if $alternate && ($args[2]||$self->{close}) eq ")";
+  $self->SUPER::string(@args);
+}
+
+#
+#  For alternative form, switch back to the alternative brackets for printing,
+#  or force standard or alternative form based on the context flags.
+#
+sub TeX {
+  my $self = shift; my @args = @_;
+  my $format = $self->getFlag("displayIntervals");
+  my $alternate = ($self->{alternateForm} || $format eq "alternate") && $format ne "standard";
+  $args[1] = "]" if $alternate && ($args[1]||$self->{open}) eq "(";
+  $args[2] = "[" if $alternate && ($args[2]||$self->{close}) eq ")";
+  $self->SUPER::TeX(@args);
+}
+
+##########################################################################
+
+1;

--- a/macros/contextInequalitySetBuilder.pl
+++ b/macros/contextInequalitySetBuilder.pl
@@ -1,0 +1,384 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader:$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+
+=head1 NAME
+
+C<Context("InequalitySetBuilder")>, C<Context("InequalitySetBuilder-Only")> - Provides
+contexts that allow sets to be specified using set-builder notation and inequalities.
+
+=head1 DESCRIPTION
+
+Implements contexts that provides for sets described using set-builder
+notation with inequalities.  (This actually is a special way of
+creating Intervals, Sets, and Unions, and they can be used together
+with standard interval notation.)  There are two such contexts:
+C<Context("InequalitySetBuilder")>, in which both intervals and sets
+formed by inequalities are defined, and
+C<Context("InequalitySetBuilder-Only")>, which allows only set-builder
+notation (not intervals or point sets).
+
+=head1 USAGE
+
+	loadMacros("contextInequalitySetBuilder.pl");
+	
+	Context("InequalitySetBuilder");
+	$S1 = Compute("{ x : 1 < x <= 4 }");
+	$S2 = SetBuilder("(1,4]");     # force interval to be set in set-builder notation
+	
+	Context("InequalitySetBuilder-Only");
+	$S1 = Compute("{ x : 1 < x <= 4 }");
+	$S2 = SetBuilder("(1,4]");     # generates an error
+	
+	$S3 = Compute("{ x : x < -2 or x > 2 }");  # forms the Union (-inf,-2) U (2,inf)
+	$S4 = Compute("{ x : x > 2 and x <= 4 }"); # forms the Interval (2,4]
+	$S5 = Compute("{ x : x = 1 }");            # forms the Set {1}
+	$S6 = Compute("{ x : x != 1 }");           # forms the Union (-inf,1) U (1,inf)
+
+The C<InequalitySetBuilder> contexts accept the flags for the
+Inequalities contexts from the C<contextInequalities.pl> file (see its
+documentation for details).
+
+Set-builder and interval notation both can coexist side by side, but
+you may wish to convert from one to the other.  Use C<SetBuilder()> to
+convert from an Interval, Set or Union to an Inequality, and use
+C<Interval()> to convert from an Inequality object to one in interval
+notation.  For example:
+
+	$I0 = Compute("(1,2]");               # the interval (1,2]
+	$I1 = SetBuilder($I1);                # the set { x : 1 < x <= 2 }
+	
+	$I0 = Compute("{ x : 1 < x <= 2 }");  # the set { x : 1 < x <= 2 }
+	$I1 = Interval($I0);                  # the interval (1,2]
+
+Note that sets and intervals can be compared and combined
+regardless of the format, so C<$I0 == $I1> is true in either example
+above.
+
+Since SetBuilder objects are actually Interval objects in disguise,
+the variable used to create them doesn't matter.  That is,
+
+	$I0 = Compute("{ x : 1 < x <= 2 }");
+	$I1 = Compute("{ y : 1 < y <= 2 }");
+
+would both produce the same interval, so C<$I0 == $I1> would be true in
+this case.  If you need to distinguish between these two, use
+
+	$I0 == $I1 && $I0->{varName} eq $I1->{varName}
+
+instead.
+
+Note that the "such that" symbol is "C<:>" since the vertical line is
+already in use for absolute values.  If you wish to use "C<|>" rather
+than "C<:>", you can do that, but must then use C<abs()> to obtain
+absolute values.  To enable the vertical line as "such that", use
+
+        InequalititySetBuilder::UseVerticalSuchThat();
+
+prior to setting the context to one of the set-builder contexts.  This
+will disable "C<:>" and enable "C<|>" as such-that rather than absolute-value.
+
+=cut
+
+loadMacros("contextInequalities.pl");
+
+sub _contextInequalitySetBuilder_init {InequalitySetBuilder::Init()}
+
+package InequalitySetBuilder;
+
+sub Init {
+  #
+  #  Make a new context from an old one and add SetBuilder notation
+  #
+  my $addSetBuilder = sub {
+    my ($new,$old) = @_;
+    my $context = $main::context{$new} = Parser::Context->getCopy($old);
+    $context->{name} = $new;
+    $context->operators->add(
+      ":" => {precedence => .25, associativity => "left", type => "bin", string => " : ",
+              class => "InequalitySetBuilder::BOP::suchthat"},
+      "_suchthat" => {alias => ":", hidden => 1},
+    );
+    $context->operators->set(
+      "+" => {class => "InequalitySetBuilder::BOP::add"},
+      "-" => {class => "InequalitySetBuilder::BOP::subtract"},
+      "U" => {class => "InequalitySetBuilder::BOP::union"},
+    );
+    $context->lists->set(Set => {class => "InequalitySetBuilder::List::Set"});
+    $context->{precedence}{InequalitySetBuilder} = $context->{precedence}{Inequality} + .5;
+    $context->{value}{SetBuilder} = "InequalitySetBuilder::SetBuilder";
+    $context->{value}{InequalitySetBuilder} = "InequalitySetBuilder::SetBuilder";
+    $context->{value}{InequalitySetBuilderInterval} = "InequalitySetBuilder::Interval";
+    $context->{value}{InequalitySetBuilderUnion} = "InequalitySetBuilder::Union";
+    $context->{value}{InequalitySetBuilderSet} = "InequalitySetBuilder::Set";
+    $context->{error}{msg}{"You are not allowed to use intervals or sets in this context"} =
+      "You are not allowed to use intervals in this context";
+    return $context;
+  };
+
+  #
+  #  Make the two new contexts
+  #
+  &{$addSetBuilder}("InequalitySetBuilder","Inequalities");
+  &{$addSetBuilder}("InequalitySetBuilder-Only","Inequalities-Only")->flags->set(noSets => 1);
+
+  #
+  #  Define the SetBuilder() constructor
+  #
+  main::PG_restricted_eval('sub SetBuilder {Value->Package("SetBuilder")->new(@_)}');
+}
+
+sub UseVerticalSuchThat {
+  my $adjust = sub {
+    my $context = $main::context{$_[0]};
+    $context->operators->remove(":");
+    $context->operators->set(
+      "|" => {precedence => .25, associativity => "left", type => "bin", string => " | ", TeX => ' \mid ',
+              class => "InequalitySetBuilder::BOP::suchthat"},
+      "_suchthat" => {alias => "|", hidden => 1},
+    );
+    $context->parens->remove("|");
+  };
+  &{$adjust}("InequalitySetBuilder");
+  &{$adjust}("InequalitySetBuilder-Only");
+}
+
+##################################################
+#
+#  A class for making set-builder sets by hand
+#
+package InequalitySetBuilder::SetBuilder;
+our @ISA = ('Value');
+
+sub new {
+  my $self = shift; my $class = ref($self) || $self;
+  my $context = (Value::isContext($_[0]) ? shift : $self->context);
+  my $S = shift; my $x = shift;
+  $S = Value::makeValue($S,context=>$context);
+  if (Value::classMatch($S,"InequalitySetBuilder")) {
+    if (defined($x)) {$S->{varName} = $x; $S->updateParts}
+    return $S;
+  }
+  $x = ($context->variables->names)[0] unless $x;
+  $S = bless $S->inContext($context), $context->Package("InequalitySetBuilder".$S->type);
+  $S->{varName} = $x; $S->{reduceSets} = $S->{"is".$S->Type} = 1;
+  $S->updateParts;
+  return $S;
+}
+
+##################################################
+##################################################
+#
+#  The Parser object that holds the set-builder notation
+#  (and also allows point-set notation)
+#
+package InequalitySetBuilder::List::Set;
+our @ISA = ('Parser::List::Set');
+
+sub _check {
+  my $self = shift; my $arg = $self->{coords}[0];
+  if ($self->{type}{length} == 1 && $arg->{isSuchThat}) {
+    $self->{type}{list} = 0;
+    $self->{type} = $arg->{type};
+    $self->{isSetBuilder} = 1;
+  } else {
+    $self->SUPER::_check(@_);
+    $self->Error("You are not allowed to use point sets in this context")
+     if $self->context->flag("noSets");
+  }
+}
+
+sub eval {
+  my $self = shift;
+  if ($self->{isSetBuilder}) {
+    my $set = $self->{coords}[0]->{rop}->eval;
+    return $set->demote if $set->string eq $self->context->flag("noneWord");
+    $set->{isSetBuilder} = $set->{isInequality} = 1;
+    bless $set, $self->Package("InequalitySetBuilder".$set->type);
+    return $set;
+  } else {
+    return $self->SUPER::eval(@_);
+  }
+}
+
+sub canBeInUnion {1}
+
+##################################################
+##################################################
+#
+#  The such-that operator
+#
+package InequalitySetBuilder::BOP::suchthat;
+our @ISA = ('Parser::BOP');
+
+sub _check {
+  my $self = shift;
+  $self->Error("%s should follow a variable name",$self->{bop})
+    unless $self->{lop}->class eq 'Variable';
+  $self->Error("The condition for the set should be an inequality")
+    unless $self->{rop}{isInequality};
+  $self->Error("The variable of the condition to the right of %s should match the variable on the left",$self->{bop})
+    unless $self->{lop}{name} eq $self->{rop}{varName};
+  $self->{type} = $self->{rop}->typeRef;
+  $self->{isSuchThat} = 1;
+  delete $self->{equation}{variables}{$self->{lop}{name}};
+  $self->{lop} = Inequalities::DummyVariable->new($self->{equation},$self->{lop}{name},$self->{lop}{ref});
+}
+
+#
+#  Make sure it is only used in set braces
+#
+sub eval {
+  my $self = shift;
+  $self->Error("'%s' can only appear within set-builder notation (did you forget braces?)",$self->{bop});
+}
+
+##################################################
+#
+#  Give a warning about adding sets
+#
+package InequalitySetBuilder::BOP::add;
+our @ISA = ('Inequalities::BOP::add');
+
+sub _check {
+  my $self = shift;
+  $self->SUPER::_check(@_);
+  $self->Error("Can't add sets (do you mean to use a union?)")
+    if $self->{lop}{isSetBuilder} || $self->{rop}{isSetBuilder};
+}
+
+##################################################
+#
+#  Handle subtraction of sets
+#
+package InequalitySetBuilder::BOP::subtract;
+our @ISA = ("Inequalities::BOP::subtract");
+
+sub _check {
+  my $self = shift;
+  if ($self->{lop}{isSetBuilder} && $self->{rop}{isSetBuilder})
+    {$self->{isSetBuilder} = 1} else {$self->SUPER::_check(@_)}
+}
+
+##################################################
+#
+#  Handle unions of sets
+#
+package InequalitySetBuilder::BOP::union;
+our @ISA = ("Parser::BOP::union");
+
+sub _check {
+  my $self = shift;
+  if ($self->{lop}{isSetBuilder} && $self->{rop}{isSetBuilder})
+    {$self->{isSetBuilder} = 1} else {$self->SUPER::_check(@_)}
+}
+
+##################################################
+##################################################
+#
+#  Common function for the classes below
+#
+
+package InequalitySetBuilder::common;
+our @ISA = ();
+
+sub _updateParts {
+  my $self = shift;
+  $self->{isSetBuilder} = 1;
+}
+
+sub _apply {
+  my $self = shift; my $I = shift;
+  $I->{isSetBuilder} = 1;
+  bless $I, $self->Package("InequalitySetBuilder".$I->type);
+  return $I;
+}
+
+sub _string {
+  my $self = shift; my $string = shift;
+  my $bop = $self->context->operators->get("_suchthat") || {};
+  while ($bop->{alias}) {$bop = $self->context->operators->get($bop->{alias})}
+  return '{ '.$self->{varName}.($bop->{string}||' : ').$string.' }';
+}
+
+sub _TeX {
+  my $self = shift; my $string = shift;
+  my $bop = $self->context->operators->get("_suchthat") || {};
+  while ($bop->{alias}) {$bop = $self->context->operators->get($bop->{alias})}
+  return '\{ '.$self->{varName}.($bop->{TeX}||$bop->{string}||' : ').$string.' \}';
+}
+
+sub _typeMatch {
+  my ($self,$other,$result) = @_;
+  return 0 if ($result && $other->class eq 'Inequality');
+  return $result;
+}
+
+sub class {"InequalitySetBuilder"}
+sub cmp_class {"a Set in Set-Builder Notation"}
+sub showClass {"a Set in Set-Builder Notation"}
+
+
+##################################################
+#
+#  Special Inequalities::Interval subclass that
+#  prints using set-builder notation.
+#
+package InequalitySetBuilder::Interval;
+our @ISA = ('InequalitySetBuilder::common', 'Inequalities::Interval');
+
+sub updateParts {my $self = shift; $self->_updateParts($self->SUPER::updateParts)}
+sub apply       {my $self = shift; $self->_apply($self->SUPER::apply(@_))}
+sub string      {my $self = shift; $self->_string($self->SUPER::string)}
+sub TeX         {my $self = shift; $self->_TeX($self->SUPER::TeX)}
+sub typeMatch   {my $self = shift; my $other = Value::makeValue(shift);
+                 $self->_typeMatch($other,$self->SUPER::typeMatch($other))}
+
+##################################################
+#
+#  Special Inequalities::Union subclass that
+#  prints using set-builder notation.
+#
+
+package InequalitySetBuilder::Union;
+our @ISA = ('InequalitySetBuilder::common', 'Inequalities::Union');
+
+sub updateParts {my $self = shift; $self->_updateParts($self->SUPER::updateParts)}
+sub apply       {my $self = shift; $self->_apply($self->SUPER::apply(@_))}
+sub string      {my $self = shift; $self->_string($self->SUPER::string)}
+sub TeX         {my $self = shift; $self->_TeX($self->SUPER::TeX)}
+sub typeMatch   {my $self = shift; my $other = Value::makeValue(shift);
+                 $self->_typeMatch($other,$self->SUPER::typeMatch($other))}
+
+##################################################
+#
+#  Special Inequalities::Set subclass that
+#  prints using set-builder notation.
+#
+
+package InequalitySetBuilder::Set;
+our @ISA = ('InequalitySetBuilder::common', 'Inequalities::Set');
+
+sub updateParts {my $self = shift; $self->_updateParts($self->SUPER::updateParts)}
+sub apply       {my $self = shift; $self->_apply($self->SUPER::apply(@_))}
+sub string      {my $self = shift; $self->_string($self->SUPER::string)}
+sub TeX         {my $self = shift; $self->_TeX($self->SUPER::TeX)}
+sub typeMatch   {my $self = shift; my $other = Value::makeValue(shift);
+                 $self->_typeMatch($other,$self->SUPER::typeMatch($other))}
+
+##################################################
+
+1;

--- a/macros/contextPartition.pl
+++ b/macros/contextPartition.pl
@@ -1,0 +1,223 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader:$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+
+=head1 NAME
+
+C<Context("Partition")> - Provides a context that allows the
+entry of a partition of an integer as a sum of positive integers.
+
+
+=head1 DESCRIPTION
+
+A partition is a sum of positive integers (usually that add up to a
+given number).  Different partitions are ones that are made up of
+different integers in the sum.  This context allows students to enter
+partitions, and provides the answer checker to determine if partitions
+are equal.
+
+
+=head1 USAGE
+
+	loadMacros("contextPartition.pl");
+	
+	Context("Partition");
+	
+	$P1 = Compute("3 + 2 + 5");
+	$P2 = Partition(3,2,5);          # same as $P1
+	
+	$P1->canonical;                  # produces "2 + 3 + 5"
+	
+	$P3 = Compute("5 + 3 + 2");
+        $P4 = Compute("5 + 3 + 1 + 1");
+        $P3 == $P1;                      # true
+        $P3 == $P4;                      # false
+	
+	$P3->sum;                        # returns 10
+
+=cut
+
+###########################################################
+#
+#  Create the contexts and add the constructor functions
+#
+
+sub _contextPartition_init {
+  my $context = $main::context{Partition} = Parser::Context->getCopy("Numeric");
+  $context->{name} = "Partition";
+
+  $context->{pattern}{number} = '-?'.$context->{pattern}{number};
+  Parser::Number::NoDecimals($context);
+
+  $context->variables->clear();
+  $context->constants->clear();
+  $context->strings->clear();
+  $context->functions->disable("All");
+  $context->operators->undefine($context->operators->names);
+  $context->operators->redefine(["fn",",","+"]);
+  $context->operators->remove(" ");
+
+  $context->operators->set(
+    '+' => {class => 'context::Partition::BOP::add', type => "bin"},
+  );
+
+  $context->{value}{Partition} = "context::Partition";
+  $context->{precedence}{Partition} = $context->{precedence}{special};
+
+  PG_restricted_eval("sub Partition {context::Partition->new(\@_)}");
+}
+
+###########################################################
+#
+#  The Partition object
+#
+package context::Partition;
+our @ISA = ("Value");
+
+#
+#  Check the data and create the object
+#
+sub new {
+  my $self = shift; my $class = ref($self) || $self;
+  my $context = (Value::isContext($_[0]) ? shift : $self->context);
+  my $p = [@_]; $p = $p->[0] if scalar(@$p) == 1 && ref($p->[0]) eq "ARRAY";
+  $p = [$p->{data}] if scalar(@$p) == 1 && Value::classMatch($p->[0],$class);
+  foreach my $x (@{$p}) {
+    $x = Value::makeValue($x,context => $context);
+    Value->Error("An element of a Partition can't be %s",$x->showType)
+       unless $x->isNumber && !$x->isFormula;
+    my $i = $x->value;
+    Value->Error("Elements of Partitions must be positive") unless $i > 0;
+    Value->Error("Elements of Partitions must be integers") unless $i == int($i);
+  }
+  return bless {data => $p, context => $context}, $class;
+}
+
+#
+#  Add a number to a partition, or add two partitions
+#
+sub add {
+  my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
+  $self->make(@{$self->{data}},@{$other->{data}});
+}
+
+#
+#  Produce the sum for a partition
+#
+sub sum {
+  my $self = shift;
+  my $n = 0; map {$n += $_} @{$self->{data}};
+  return $n;
+}
+
+#
+#  Compare two partitions (numbers are promoted)
+#
+sub compare {
+  my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
+  return $l->canonical cmp $r->canonical;
+}
+
+#
+#  Produce a canonical representation (numbers sorted)
+#
+sub canonical {
+  my $self = shift;
+  $self->make(main::num_sort(@{$self->{data}}));
+}
+
+#
+#  Promote a number to a Real (since we can add a number to a
+#  partition), and promote others to partitions, if possible.
+#
+sub promote {
+  my $self = shift; my $other = shift;
+  Value->Error("Can't promote %s to %s",Value::makeValue($other)->showType,$self->showType)
+    unless $self->typeMatch($other);
+  $self->SUPER::promote($other);
+}
+
+#
+#  Check if types are compatible
+#
+sub typeMatch {
+  my ($self,$other) = @_;
+  return Value::classMatch($other,$self->class) ||
+         Value::matchNumber($other) ||
+         ref($other) eq 'ARRAY';
+}
+
+#
+#  Produce a string version
+#
+sub string {
+  my $self = shift;
+  join(" + ",@{$self->{data}});
+}
+
+#
+#  Produce a TeX version
+#
+sub string {
+  my $self = shift;
+  join(" + ",@{$self->{data}});
+}
+
+
+###########################################################
+#
+#  Implement special + operator that produces
+#  partitions rather than sums
+#
+package context::Partition::BOP::add;
+our @ISA = ("Parser::BOP");
+
+#
+#  Check that the operands are appropriate, and return
+#  the proper type reference, or give an error.
+#
+sub _check {
+  my $self = shift;
+  my ($ltype,$rtype) = ($self->{lop}->typeRef,$self->{rop}->typeRef);
+  $self->{equation}->Error(["Entries in a Partition must be positive integers"])
+    unless $self->checkOp($ltype) && $self->checkOp($rtype);
+  $self->{type} = Value::Type("Partition",$ltype->{length}+$rtype->{length},$Value::Type{number});
+}
+
+#
+#  Check that the type of an operand is OK
+#  (It must be a partiation or a number)
+#
+sub checkOp {
+  my $self = shift; my $op = shift;
+  return $op->{name} eq "Partition" || ($op->{name} eq "Number" && $op->{length} == 1);
+}
+
+#
+#  Evaluate two numbers by forming a partition,
+#   otherwise use addition (Value object will take over)
+#
+sub _eval {
+  my $self = shift;
+  my ($a,$b) = @_;
+  return Value->Package($self->type)->new($a,$b) if !ref($a) && !ref($b);
+  return $a + $b;
+}
+
+###########################################################
+
+1;
+

--- a/macros/contextPermutation.pl
+++ b/macros/contextPermutation.pl
@@ -1,0 +1,593 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader:$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+
+=head1 NAME
+
+C<Context("Permutation")> - Provides contexts that allow the
+entry of cycles and permutations.
+
+
+=head1 DESCRIPTION
+
+These contexts allow you to enter permutations using cycle notation.
+The entries in a cycle are separated by spaces and enclosed in
+parentheses.  Cycles are multiplied by juxtaposition.  A permutation
+can be multiplied on the left by a number in order to obtain the
+result of that number under the action of the permutation.
+Exponentiation is alos allowed (as described below).
+
+There are three contexts included here: C<Context("Permutation")>, which
+allows permutations in any form, C<Context("Permutation-Strict")>, which
+only allows permutations that use disjoint cycles, and
+C<Context("Permutation-Canonical")>, which only allows permutations that
+are written in canonical form (as described below).
+
+
+=head1 USAGE
+
+	loadMacros("contextPermutation.pl");
+	
+	Context("Permutation");
+	
+	$P1 = Compute("(1 4 2)(3 5)");
+	$P2 = Permutation([1,4,2],[3,5]);  # same as $P1
+        $C1 = Cycle(1,4,2);
+        $P3 = Cycle(1,4,2)*Cycle(3,5);     # same as $P1
+        
+        $n = 3 * $P1;                      # sets $n to 5
+        $m = Compute("3 (2 4 3 1)");       # sets $m to 1
+	
+	$P4 = Compute("(1 2 3)^2");        # square a cycle
+        $P5 = Compute("((1 2)(3 4))^2");   # square a permutation
+        $I = Comptue("(1 2 3)^-1");        # inverse
+	
+	$L = Compute("(1 2),(1 3 2)");     # list of permutations
+	
+	$P = $P1->inverse;                 # inverse
+	$P = $P1->canonical;               # canonical representation
+	
+	$P1 = Compute("(1 2 3)(4 5)");
+	$P2 = Compute("(5 4)(3 1 2)");
+	$P1 == $P2;                        # is true
+
+Cycles and permutations can be multiplied to obtain the permutation
+that consists of one followed by the other, or multiplied on the left
+by a number to obtain the image of the number under the permutation.
+A permutation raised to a positive integer is the permutation
+multiplied by itself that many times.  A power of -1 is the inverse of
+the permutation, while a larger negative number is the inverse
+multiplied by itself that many times (the absolute value of the
+power).
+
+There are times when you might not want to allow inverses to be
+computed automatically.  In this case, set
+
+	Context()->flags->set(noInverses => 1);
+
+This will cause an error message if a student enters a negative power
+for a cycle or permutation.
+
+If you don't want to allow any powers at all, then set
+
+	Context()->flags->set(noPowers => 1);
+
+Similarly, if you don't want to allow grouping of cycles via
+parentheses (e.g., "((1 2)(3 4))^2 (5 6)"), then use
+
+	Context()->flags->set(noGroups => 1);
+
+The comparison between permutations is done by comparing the
+canonical forms, so even if they are entered in different orders or
+with the cycles rotated, two equivalent permutations will be counted
+as equal.  If you want to perform more sophisticated checks, then a
+custom error checker could be used.
+
+You can require that permutations be entered using disjoint cycles by
+setting
+
+	Context()->flags->set(requireDisjoint => 1);
+
+When this is set, Compute("(1 2) (1 3)") will produce an error
+indicating that the permutation doesn't have disjoint cycles.
+
+You can also require that students enter permutations in a canonical
+form.  The canonical form has each cycle listed with its lowest entry
+first, and with the cycles ordered by their initial entries.  So the
+canonical form for
+
+	(5 4 6) (3 1 2)
+
+is
+
+	(1 2 3) (4 6 5)
+
+To require that permutations be entered in canonical form, use
+
+	Context()->flags->set(requireCanonical => 1);
+
+The C<Permutation-Strict> context has C<noInverses>, C<noPowers>, C<noGroups>, and
+C<requireDisjoint> all set to 1, while the C<Permutation-Canonical> has
+C<noInverses>, C<noPowers>, C<noGroups>, and C<requireCanonical> all set to 1.
+The C<Permutation> context has all the flags set to 0, so any permutation
+is allowed.  All three contexts allow lists of permutations to be
+entered.
+
+=cut
+
+###########################################################
+#
+#  Create the contexts and add the constructor functions
+#
+
+sub _contextPermutation_init {
+  my $context = $main::context{Permutation} = Parser::Context->getCopy("Numeric");
+  $context->{name} = "Permutation";
+  Parser::Number::NoDecimals($context);
+  $context->variables->clear();
+  $context->operators->clear();
+  $context->constants->clear();
+  $context->strings->clear();
+  $context->functions->disable("All");
+
+  $context->{pattern}{number} = $context->{pattern}{signedNumber};
+
+  $context->operators->add(
+    ',' => {precedence => 0, associativity => 'left', type => 'bin', string => ',',
+            class => 'Parser::BOP::comma', isComma => 1},
+
+    'fn'=> {precedence => 7.5, associativity => 'left', type => 'unary', string => '',
+            parenPrecedence => 5, hidden => 1},
+
+    ' ' => {precedence => 3, associativity => 'right', type => 'bin', string => ' ',
+            class => 'context::Permutation::BOP::space', hidden => 1, isComma => 1},
+
+    '^' => {precedence => 7, associativity => 'right', type => 'bin', string => '^', perl => '**',
+            class => 'context::Permutation::BOP::power'},
+
+    '**'=> {precedence => 7, associativity => 'right', type => 'bin', string => '^', perl => '**',
+            class => 'context::Permutation::BOP::power'},
+  );
+
+  $context->{value}{Cycle} = "context::Permutation::Cycle";
+  $context->{value}{Permutation} = "context::Permutation::Permutation";
+  $context->{precedence}{Cycle} = $context->{precedence}{special};
+  $context->{precedence}{Permutation} = $context->{precedence}{special}+1;
+  $context->lists->add(
+    "Cycle" => {class => "context::Permutation::List::Cycle", open => "(", close => ")", separator => " "},
+    "Permutation" => {open => "", close => "", separator => " "},  # used for output only
+  );
+  $context->parens->set(
+    '(' => {close => ')', type => 'Cycle', formList => 0, removable => 0, emptyOK => 0, function => 1},
+  );
+
+  $context->flags->set(
+    requireDisjoint => 0,    # require disjoint cycles as answers?
+    requireCanonical => 0,  # require canonical form?
+    noPowers => 0,           # allow powers of cycles and permutations?
+    noInverses => 0,         # allow negative powers to mean inverse?
+    noGroups => 0,           # allow parens for grouping (for powers)?
+  );
+
+  $context->{error}{msg}{"Entries in a Cycle must be of the same type"} =
+     "Entries in a Cycle must be positive integers";
+
+  #
+  #  A context in which permutations must be entered as
+  #  products of disjoint cycles.
+  #
+  $context = $main::context{"Permutation-Strict"} = $context->copy;
+  $context->{name} = "Permutation-Strict";
+  $context->flags->set(
+    requireDisjoint => 1,
+    noPowers => 1,
+    noInverses => 1,
+    noGroups => 1,
+  );
+
+  #
+  #  A context in which permutation must be entered
+  #  in canonical form.
+  #
+  $context = $main::context{"Permutation-Canonical"} = $context->copy;
+  $context->{name} = "Permutation-Canonical";
+  $context->flags->set(
+    requireCanonical => 1,
+    requireDisjoint => 0,     # requireCanonical already covers that
+  );
+
+
+  PG_restricted_eval("sub Cycle {context::Permutation::Cycle->new(\@_)}");
+  PG_restricted_eval("sub Permutation {context::Permutation::Permutation->new(\@_)}");
+
+}
+
+###########################################################
+#
+#  Methods common to cycles and permutations
+#
+
+package context::Permutation;
+our @ISA = ("Value");
+
+#
+#  Use the usual make(), and then add the permutation data
+#
+sub make {
+  my $self = shift;
+  $self = $self->SUPER::make(@_);
+  $self->makeP;
+  return $self;
+}
+
+#
+#  Permform multiplication of a number by a cycle or permutation,
+#  or a product of two cycles or permutations.
+#
+sub mult {
+  my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
+  if ($l->isReal) {
+    $l = $l->value;
+    Value->Error("Can't multiply %s by a non-integer value",$self->showType) unless $l == int($l);
+    Value->Error("Can't multiply %s by a negative value",$self->showType) if $l < 0;
+    my $n = $self->{P}{$l}; $n = $l unless defined $n;
+    return $self->Package("Real")->make($n);
+  } else {
+    Value->Error("Can't multiply %s by %s",$l->showType,$r->showType)
+      unless $r->classMatch("Cycle","Permutation");
+    return $self->Package("Permutation")->new($l,$r);
+  }
+}
+
+#
+#  Perform powers by repeated multiplication;
+#  Negative powers are inverses.
+#
+sub power {
+  my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
+  Value->Error("Can't raise %s to %s",$l->showType,$r->showType) unless $r->isNumber;
+  Value->Error("Powers are not allowed") if $self->getFlag("noPowers");
+  if ($r < 0) {
+    Value->Error("Inverses are not allowed",$l->showType) if $self->getFlag("noInverses");
+    $r = -$r; $l = $l->inverse;
+  }
+  $self->Package("Permutation")->make(map {$l} (1..$r))->canonical;
+}
+
+#
+#  Compare canonical representations
+#
+sub compare {
+  my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
+  Value->Error("Can't compare %s and %s",$self->showType,$other->showType)
+    unless $other->classMatch("Cycle","Permutation");
+  return $l->canonical cmp $r->canonical;
+}
+
+#
+#  True if the permutation is in canonical form
+#
+sub isCanonical {
+  my $self = shift;
+  return $self eq $self->canonical;
+}
+
+#
+#  Promote a number to a Real (since we can take a number times a
+#  permutation, or a permutation to a power), and anything else to a
+#  Cycle or Permutation.
+#
+sub promote {
+  my $self = shift; my $other = shift;
+  return Value::makeValue($other,context => $self->{context}) if Value::matchNumber($other);
+  return $self->SUPER::promote($other);
+}
+
+#
+#  Produce a canonical representation as a collection of
+#  cycles that have their lowest entry first, sorted
+#  by initial entry.
+#
+sub canonical {
+  my $self = shift;
+  my @P = (); my @C;
+  my %N = (map {$_ => 1} (keys %{$self->{P}}));
+  while (scalar(keys %N)) {
+    $i = (main::num_sort(keys %N))[0]; @C = ();
+    do {
+      push(@C,$self->Package("Real")->new($i)); delete $N{$i};
+      $i = $self->{P}{$i} if defined $self->{P}{$i};
+    } while ($i != $C[0]);
+    push(@P,$self->Package("Cycle")->make($self->{context},@C));
+  }
+  return $P[0] if scalar(@P) == 1;
+  return $self->Package("Permutation")->make($self->{context},@P);
+}
+
+#
+#  Produce the inverse of a permutation or cycle.
+#
+sub inverse {
+  my $self = shift;
+  my $P = {map {$self->{P}{$_} => $_} (keys %{$self->{P}})};
+  return $self->with(P => $P)->canonical;
+}
+
+#
+#  Produce a string version (use "(1)" as the identity).
+#
+sub string {
+  my $self = shift;
+  my $string = $self->SUPER::string(@_);
+  $string = "(1)" unless length($string);
+  return $string;
+}
+
+#
+#  Produce a TeX version (uses \; for spaces)
+#
+sub TeX {
+  my $self = shift;
+  my $tex = $self->string;
+  $tex =~ s/\) \(/)\\,(/g; $tex =~ s/ /\\;/g;
+  return $tex;
+}
+
+###########################################################
+#
+#  A single cycle
+#
+
+package context::Permutation::Cycle;
+our @ISA = ("context::Permutation");
+
+sub new {
+  my $self = shift; my $class = ref($self) || $self;
+  my $context = (Value::isContext($_[0]) ? shift : $self->context);
+  my $p = [@_]; $p = $p->[0] if scalar(@$p) == 1 && ref($p->[0]) eq "ARRAY";
+  return $p->[0] if scalar(@$p) == 1 && Value::classMatch($p->[0],"Cycle","Permutation");
+  my %N;
+  foreach my $x (@{$p}) {
+    $x = Value::makeValue($x,context => $context);
+    Value->Error("An entry of a Cycle can't be %s",$x->showType)
+       unless $x->isNumber && !$x->isFormula;
+    my $i = $x->value;
+    Value->Error("An entry of a Cycle can't be negative") if $i < 0;
+    Value->Error("Cycles can't contain repeated values") if $N{$i}; $N{$i} = 1;
+  }
+  my $cycle = bless {data => $p, context => $context}, $class;
+  $cycle->makeP;
+  return $cycle;
+}
+
+#
+#  Find the internal representation of the permutation
+#  (a hash representing where each element goes)
+#
+sub makeP {
+  my $self = shift;
+  my $p = $self->{data}; my $P = {};
+  if (@$p) {
+    my $i = $p->[scalar(@$p)-1]->value;
+    foreach my $x (@{$p}) {
+      my $j = $x->value;
+      $P->{$i} = $j unless $i == $j;  # don't record identity
+      $i = $j;
+    }
+  }
+  $self->{P} = $P;
+}
+
+###########################################################
+#
+#  A combination of cycles
+#
+
+package context::Permutation::Permutation;
+our @ISA = ("context::Permutation");
+
+sub new {
+  my $self = shift; my $class = ref($self) || $self;
+  my $context = (Value::isContext($_[0]) ? shift : $self->context);
+  my $disjoint = $self->getFlag("requireDisjoint");
+  my $p = [@_]; my %N;
+  foreach my $x (@$p) {
+    $x = Value::makeValue($x,context=>$context) unless ref($x);
+    $x = Value->Package("Cycle")->new($context,$x) if ref($x) eq "ARRAY";
+    Value->Error("An entry of a Permutation can't be %s",Value::showClass($x))
+      unless Value::classMatch($x,"Cycle","Permutation");
+    if ($disjoint) {
+      foreach my $i (keys %{$x->{P}}) {
+	Value->Error("Your Permutation does not have disjoint Cycles") if $N{$i};
+	$N{$i} = 1;
+      }
+    }
+  }
+  my $perm = bless {data => $p, context => $context}, $class;
+  $perm->makeP;
+  Value->Error("Your Permutation is not in canonical form")
+    if $perm->getFlag("requireCanonical") && $perm ne $perm->canonical;
+  return $perm;
+}
+
+#
+#  Find the internal representation of the permutation
+#  (a hash representing where each element goes)
+#
+sub makeP {
+  my $self = shift; my $p = $self->{data};
+  my $P = {}; my %N;
+  foreach my $x (@$p) {map {$N{$_} = 1} (keys %{$x->{P}})}  # get all elements used
+  foreach my $i (keys %N) {
+    my $j = $i;
+    map {$j = $_->{P}{$j} if defined $_->{P}{$j}} @$p;   # apply all cycles/permutations
+    $P->{$i} = $j unless $i == $j;                       # don't record identity
+  }
+  $self->{P} = $P;
+}
+
+
+###########################################################
+#
+#  Space between numbers forms a cycle.
+#  Space between cycles forms a permutation.
+#  Space between a number and a cycle or
+#    permutation evaluates the permutation
+#    on the number.
+#
+package context::Permutation::BOP::space;
+our @ISA = ("Parser::BOP");
+
+#
+#  Check that the operands are appropriate, and return
+#  the proper type reference, or give an error.
+#
+sub _check {
+  my $self = shift; my $type;
+  my ($ltype,$rtype) = ($self->{lop}->typeRef,$self->{rop}->typeRef);
+  if ($ltype->{name} eq "Number") {
+    if ($rtype->{name} eq "Number") {
+      $type = Value::Type("Comma",2,$Value::Type{number});
+    } elsif ($rtype->{name} eq "Comma") {
+      $type = Value::Type("Comma",$rtype->{length}+1,$Value::Type{number});
+    } elsif ($rtype->{name} eq "Cycle" || $rtype->{name} eq "Permutation") {
+      $type = $Value::Type{number};
+    }
+  } elsif ($ltype->{name} eq "Cycle") {
+    if ($rtype->{name} eq "Cycle") {
+      $type = Value::Type("Permutation",2,$ltype);
+    } elsif ($rtype->{name} eq "Permutation") {
+      $type = Value::Type("Permutation",$rtype->{length}+1,$ltype);
+    }
+  }
+  if (!$type) {
+    $ltype = $ltype->{name}; $rtype = $rtype->{name};
+    $ltype = (($ltype =~ m/^[aeiou]/i)? "An ": "A ") . $ltype;
+    $rtype = (($rtype =~ m/^[aeiou]/i)? "an ": "a ") . $rtype;
+    $self->{equation}->Error(["%s can not be multiplied by %s",$ltype,$rtype]);
+  }
+  $self->{type} = $type;
+}
+
+#
+#  Evaluate by forming a list if this is acting as a comma,
+#  othewise take a product (Value object will take care of things).
+#
+sub _eval {
+  my $self = shift;
+  my ($a,$b) = @_;
+  return ($a,$b) if $self->type eq "Comma";
+  return $a * $b;
+}
+
+#
+#  If the operator is not a comma, return the item itself.
+#  Otherwise, make a list out of the lists that are the left
+#    and right operands.
+#
+sub makeList {
+  my $self = shift; my $prec = shift;
+  return $self unless $self->{def}{isComma} && $self->type eq 'Comma';
+  return ($self->{lop}->makeList,$self->{rop}->makeList);
+}
+
+#
+#  Produce the TeX form
+#
+sub TeX {
+  my $self = shift;
+  return $self->{lop}->TeX."\\,".$self->{rop}->TeX;
+}
+
+
+###########################################################
+#
+#  Powers of cycles form permutations
+#
+package context::Permutation::BOP::power;
+our @ISA = ("Parser::BOP::power");
+
+#
+#  Check that the operands are appropriate,
+#    and return the proper type reference
+#
+sub _check {
+  my $self = shift; my $equation = $self->{equation};
+  $equation->Error(["Powers of are not allowed"]) if $equation->{context}->flag("noPowers");
+  $equation->Error(["You can only take powers of Cycles or Permutations"])
+    unless $self->{lop}->type eq "Cycle";
+  $equation->Error(["Powers of Cycles and Permutations must be Numbers"])
+    unless $self->{rop}->type eq "Number";
+  $self->{type} = Value::Type("Permutation",1,$self->{lop}->typeRef);
+}
+
+
+###########################################################
+#
+#  The List subclass for cycles in the parse tree
+#
+
+package context::Permutation::List::Cycle;
+our @ISA = ("Parser::List");
+
+#
+#  Check that the coordinates are numbers.
+#  If there is one parameter and it is a cycle or permutation
+#   treat this as plain parentheses, not cycle parentheses
+#   (so you can take groups of cycles to a power).
+#
+sub _check {
+  my $self = shift;
+  if ($self->length == 1 && !$self->{equation}{context}->flag("noGroups")) {
+    my $value = $self->{coords}[0];
+    return if ($value->type eq "Cycle" || $value->typeRef->{name} eq "Permutation" ||
+              ($value->class eq "Value" && $value->{value}->classMatch("Cycle","Permutation")));
+  }
+  foreach my $x (@{$self->{coords}}) {
+    unless ($x->isNumber) {
+      my $type = $x->type;
+      $type = (($type =~ m/^[aeiou]/i)? "an ": "a ") . $type;
+      $self->{equation}->Error(["An entry in a Cycle must be a Number not %s",$type]);
+    }
+  }
+}
+
+#
+#  Produce a string version.  (Shouldn't be needed, but there is
+#  a bug in the Value.pm version that neglects the separator value.)
+#
+sub string {
+  my $self = shift; my $precedence = shift; my @coords = ();
+  foreach my $x (@{$self->{coords}}) {push(@coords,$x->string)}
+  my $comma = $self->{equation}{context}{lists}{$self->{type}{name}}{separator};
+  return $self->{open}.join($comma,@coords).$self->{close};
+}
+
+#
+#  Produce a TeX version.
+#
+sub TeX {
+  my $self = shift; my $precedence = shift; my @coords = ();
+  foreach my $x (@{$self->{coords}}) {push(@coords,$x->TeX)}
+  my $comma = $self->{equation}{context}{lists}{$self->{type}{name}}{separator};
+  $comma =~ s/ /\\;/g;
+  return $self->{open}.join($comma,@coords).$self->{close};
+}
+
+###########################################################
+
+1;
+

--- a/macros/parserRoot.pl
+++ b/macros/parserRoot.pl
@@ -1,0 +1,78 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader$
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+parserRoot.pl - defines a root(n,x) function for n-th root of x.
+
+=head1 DESCRIPTION
+
+This file defines the code necessary to add to any context a
+root(n,x) function that performs the n-th root of x.  For example,
+Compute("root(3,27)") would return the equivalent of Real(3).
+
+To accomplish this, put the line
+
+	loadMacros("parserRoot.pl");
+
+at the beginning of your problem file, then set the Context to the one
+you wish to use in the problem.  Then use the command:
+
+	parser::Root->Enable;
+
+(You can also pass the Enable command a pointer to a context if you
+wish to alter a context other than the current one.)
+
+Once that is done, you (and students) can enter roots by using the
+root() function.  You can use root() both within Formula() and
+Compute() calls, and in Perl expressions, such as
+
+        $n = root(3,27);
+
+to obtain n-th roots.
+
+=cut
+
+sub _parserRoot_init {
+  main::PG_restricted_eval('sub root {Parser::Function->call("root",@_)}');
+}
+
+package parser::Root;
+
+sub Enable {
+  my $self = shift;
+  my $context = shift;
+  $context = main::Context() unless Value::isContext($context);
+  $context->functions->add(
+    root => {class => 'parser::Root::Function::numeric2'},
+  );
+}
+
+package parser::Root::Function::numeric2;
+our @ISA = ('Parser::Function::numeric2');
+
+sub root {
+  shift; my $n = shift; my $x = shift;
+  return $x**(1/$n);
+}
+
+sub TeX {
+  my $self = shift;
+  my ($n,$x) = ($self->{params}[0],$self->{params}[1]);
+  return '\sqrt['.$n->TeX."]{".$x->TeX."}";
+}
+
+1;


### PR DESCRIPTION
This request adds several new macro files that implement some specialized contexts:
- `contextAlternateDecimal.pl`, for allowing commas rather than decimal points (can be used to set course-by-course preferences without requiring problems to be re-written).
- `contextAlternateIntervals.pl`, for allowing reversed brackets to be used for open intervals (can be used to set course-by-course preferences without requiring problems to be re-written).
- `contextInequalitySetBuilder.pl`, for specifying intervals using set-builder notation.
- `contextPartition.pl`, which implements partitions of integers as sums of integers.
- `contextPermutation.pl`, which implements cycles and permutations.
- `parserRoot`, for adding `root(n,x)` to any context to provide nth-roots.
