### PR TITLE
Fix 'fileFromPath not defined or not exported'  error

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -4,11 +4,10 @@
 ################################################################################
 
 package WeBWorK::PG::IO;
-use base qw(Exporter);
+use parent qw(Exporter);
 use WeBWorK::PG::Translator;
 use JSON qw(decode_json);
 use PGcore qw(not_null);
-our @ISA = qw(PGcore);
 
 
 =head1 NAME

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -10,7 +10,7 @@ use warnings;
 use Opcode;
 use WWSafe;
 use Net::SMTP;
-use WeBWorK::PG::IO;
+use WeBWorK::PG::IO; # qw(fileFromPath) -- inconsistent exporting from IO.pm with perl 5.18???? FIXME
 
 #use PadWalker;     # used for processing error messages
 #use Data::Dumper;
@@ -540,7 +540,8 @@ sub unrestricted_load {
 	$safe_cmpt->mask(Opcode::empty_opset());
 	my $safe_cmpt_package_name = $safe_cmpt->root();
 	
-	my $macro_file_name = fileFromPath($filePath);
+	my $macro_file_name = WeBWorK::PG::IO::fileFromPath($filePath);
+	     #FIXME -- above is a work around if fileFromPath is not properly imported (seen with perl 5.18.0)
 	$macro_file_name =~s/\.pl//;  # trim off the extenstion
 	my $export_subroutine_name = "_${macro_file_name}_export";
 	my $init_subroutine_name = "${safe_cmpt_package_name}::_${macro_file_name}_init";


### PR DESCRIPTION
which occurs with perl 5.18.   the @ISA=qw(PGcore) statement should never have been there, but it does not seem to be causing the problem.  The workaround/fix for the moment is to fully qualify the function name as WeBWorK::PG::IO::fileFromPath.
