### PR TITLE
Reduce sets when they are added.  Fixes a problem reported on the forum.

### DIFF
--- a/lib/Value/Set.pm
+++ b/lib/Value/Set.pm
@@ -44,7 +44,7 @@ sub new {
 }
 
 #
-#  Set the canBeInterval flag
+#  Make a set (might not be reduced)
 #
 sub make {
   my $self = shift;
@@ -52,7 +52,13 @@ sub make {
   my $def = $context->lists->get('Set');
   $self = $self->SUPER::make($context,@_);
   $self->{open} = $def->{open}; $self->{close} = $def->{close};
+  delete $self->{isReduced};
   return $self;
+}
+
+sub noinherit {
+  my $self = shift;
+  ($self->SUPER::noinherit,"isReduced");
 }
 
 sub isOne {0}
@@ -88,8 +94,10 @@ sub promote {
 #
 sub add {
   my ($self,$l,$r) = Value::checkOpOrderWithPromote(@_);
-  return $self->make($l->value,$r->value) if $l->type eq 'Set' && $r->type eq 'Set';
-  Value::Union::form($self->context,$l,$r);
+  return Value::Union::form($self->context,$l,$r) unless $l->type eq 'Set' && $r->type eq 'Set';
+  my $sum = $self->make($l->value,$r->value);
+  $sum = $sum->reduce if $self->getFlag("reduceSets");
+  return $sum;
 }
 sub dot {my $self = shift; $self->add(@_)}
 

--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -52,6 +52,24 @@ sub new {
 }
 
 #
+#  Make a set (it might not be reduced)
+#
+sub make {
+  my $self = shift;
+  my $union = $self->SUPER::make(@_);
+  delete $union->{isReduced};
+  return $union;
+}
+
+#
+#  Don't inherit the reduced flags
+#
+sub noinherit {
+  my $self = shift;
+  ($self->SUPER::noinherit,"isReduced");
+}
+
+#
 #  Make a union or interval or set, depending on how
 #  many there are in the union.
 #
@@ -233,7 +251,7 @@ sub reduce {
 #  True if a union is reduced.
 #
 #  (In array context, is a pair whose first entry is true or
-#   false, and when true the second value is the reason the
+#   false, and when false the second value is the reason the
 #   set is not reduced.)
 #
 sub isReduced {


### PR DESCRIPTION
There were two problems:
1.  Unions of sets were not being reduced automatically, as they should have been.
2.  Unions were being marked as reduced despite (1).

This fixes both problems, plus similar issues in the Union object.

A test would be

```
TEXT(Set(1,2,3)+Set(2,3,4));
```

You should get `{1,2,3,4}` not `{1,2,3,2,3,4}`.

Note that student answers are NOT reduced by default, since they are supposed to do the reductions themselves, so entering `{1,2,3} U {2,3,4}` as a student should produce a warning that you can't use repeated elements.
