### PR TITLE
Have set addition produce an actual union, so it is controlled by the reduceUnions flag.

### DIFF
--- a/lib/Parser/BOP/union.pm
+++ b/lib/Parser/BOP/union.pm
@@ -38,7 +38,7 @@ sub canBeInUnion {(shift)->type eq 'Union'}
 #
 #  Make a union of the two operands.
 #
-sub _eval {$_[1] + $_[2]}
+sub _eval {shift->Package("Union")->new(@_)}
 
 #
 #  Make a union of intervals or sets.

--- a/lib/Value/Set.pm
+++ b/lib/Value/Set.pm
@@ -90,14 +90,11 @@ sub promote {
 #
 
 #
-#  Addition forms unions (or combines sets)
+#  Addition forms unions
 #
 sub add {
   my ($self,$l,$r) = Value::checkOpOrderWithPromote(@_);
-  return Value::Union::form($self->context,$l,$r) unless $l->type eq 'Set' && $r->type eq 'Set';
-  my $sum = $self->make($l->value,$r->value);
-  $sum = $sum->reduce if $self->getFlag("reduceSets");
-  return $sum;
+  $self->Package("Union")->new($l,$r);
 }
 sub dot {my $self = shift; $self->add(@_)}
 


### PR DESCRIPTION
This fixes the issue we discussed in the openwebwork/pg#159 where `reduceUnions` didn't control all the different ways of making unions.  Now `reduceSets` only controls the removal of repeated items from a set, and `reduceUnions` controls addition of sets, and creation of unions of sets via `Compute()` or `Union()`.

Test cases:

```
Context("Interval")->flags->set(reduceSets=>0,reduceUnions=>0);
TEXT(Set(1,1,2) + Set(2,3));
TEXT(Compute("{1,1,2} U {2,3}"));
TEXT(Union("{1,1,2}","{2,3}"));
```

should all produce `"{1,1,2} U {2,3}"`.  Changing to `reduceSets=>1` should produce `{1,2} U {2,3}`.  Changing to `reduceUnions=>1` (with either value of `reduceSets`) should produce `{1,2,3}`.
