### PR TITLE
Radio Button Hardcopy Bug

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -356,7 +356,7 @@ sub BUTTONS {
   #  It is wrong to have \item in the radio buttons and to add itemize here,
   #    but that is the way PGbasicmacros.pl does it.
   #
-  if ($displayMode eq 'TeX') {
+  if ($main::displayMode eq 'TeX') {
     $radio[0] = "\n\\begin{itemize}\n" . $radio[0];
     $radio[$#radio_buttons] .= "\n\\end{itemize}\n";
   }


### PR DESCRIPTION
Fixed bug where parserRadioButtons wasn't printing itemize enviornment in hardcopy, in refrence to Alex's comments on bb2a5da. 

I'm not sure what actually caused this.  I changed `$displayMode` to `$main::displayMode` and the more specific variable name seemed to fix it, but I'm still not sure what went wrong.  
