### PR TITLE
removed style specification from \frac in contextFraction.pl

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -871,7 +871,7 @@ sub TeX {
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
     {$n = int($a/$b); $a = CORE::abs($a) % $b; $n .= " " unless $a == 0}
   my $s = ""; ($a,$s) = (-$a,"-") if $a < 0;
-  $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{\\textstyle\\frac{$a}{$b}}")
+  $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{\\frac{$a}{$b}}")
     unless $a == 0 && $n ne '';
   $n = "\\left($n\\right)" if defined $prec && $prec >= 1;
   return $n;


### PR DESCRIPTION
There may be a good reason that this `\textstyle` is in here. But I've removed it from our distribution because it causes `\textstyle` fraction printing even when the ambient math mode is display. I'd rather let the ambient math mode determine if the fraction should be in `\textstyle` or `\displaystyle`. It's ugly when `$r` is a rational function, `$f` is a fraction, and this happens:

```
[``$f + $r``]
```

This gives `$f$` in `textstyle` and `$r` in `\displaystyle`.

If there is a reason that `\textstyle` is in here, please let me know and disregard this pull request.
