### PR TITLE
Fix wrong name in documentation for compoundProblem5.pl

### DIFF
--- a/macros/compoundProblem5.pl
+++ b/macros/compoundProblem5.pl
@@ -16,9 +16,9 @@
 
 =head1 NAME
 
-scaffold.pl - Provides support for multi-part problems where
-              later parts are not visible until earlier parts
-              are completed correctly.
+compoundProblem5.pl - Provides support for multi-part problems where
+                      later parts are not visible until earlier parts
+                      are completed correctly.
 
 =head1 DESCRIPTION
 
@@ -36,7 +36,7 @@ C<PROCESS_SECTIONS()> to finalize all the sections.
 
 Here is a sample:
 
-	loadMacros("scaffold.pl");
+	loadMacros("compoundProblem5.pl");
 	
 	$scaffold = Scaffold();   # create the scaffold
 	Context("Numeric");


### PR DESCRIPTION
This only affects the documentation.  No code has changed.

I had planned originally to rename `compoundProblem5.pl` as `scaffold.pl`, but then I wrote a new `scaffold.pl` from scratch, so left `compoundProblem5.pl` as is, but forgot to change the name back in the documentation.
