### PR TITLE
Allow Set() to coerce a union of sets to a single set

### DIFF
--- a/lib/Value/Set.pm
+++ b/lib/Value/Set.pm
@@ -19,6 +19,7 @@ sub new {
   $p = Value::makeValue($p,context=>$context) if defined($p) && !ref($p);
   return $p if Value::isFormula($p) && Value::classMatch($self,$p->type);
   my $isFormula = 0; my @d; @d = $p->dimensions if Value::classMatch($p,'Matrix');
+  $p = $p->reduce if Value::classMatch($p,'Union');
   if (Value::classMatch($p,'List') && $p->typeRef->{entryType}{name} eq 'Number') {$p = $p->data}
   elsif (Value::classMatch($p,'Point','Vector','Set')) {$p = $p->data}
   elsif (scalar(@d) == 1) {$p = [$p->value]}


### PR DESCRIPTION
This fixes the issue Alex Jordan pointed out in [pull 161](https://github.com/openwebwork/pg/pull/161#issuecomment-55204574), and allows you to use `Set()` to coerce a Union to be a single set if it is a union of sets.

You can test with 

```
Set("{1} U {2}")
```

or

```
Set(Union(Set(1),Set(2)))
```

or other similar constructs.  These should produce the set `{1,2}` in the patched version, and produce an error in the unlatched version.
