### PR TITLE
Fixes "undefined $ld" error message with ImplicitPlane objects  

### DIFF
--- a/macros/parserImplicitPlane.pl
+++ b/macros/parserImplicitPlane.pl
@@ -160,8 +160,8 @@ sub new {
 #  if the equations are multiples of each other.
 #
 sub compare {
-  my ($self,$l,$r) = Value::checkOpOrder(@_);
-  $r = new ImplicitPlane($r);# if ref($r) ne ref($self);
+  return 1 if Value::classMatch($_[1],"String");
+  my ($self,$l,$r) = Value::checkOpOrderWithPromote(@_);
   my ($lN,$ld) = ($l->{N},$l->{d});
   my ($rN,$rd) = ($r->{N},$r->{d});
   if ($rd == 0 || $ld == 0) {


### PR DESCRIPTION
This avoids error messages from comparisons used in testing for when the formula agrees with the previous one typed by the student when the correct answer is a list of implicit planes.  It also avoids error messages when a string answer is entered when a list of implicit planes is expected.

This can be tested using any problem that uses ImplicitPlane in a List by submitting two different answers.  The second one should produce the error message in an unpatched PG, and no error with this patch.  Entering a string like `NONE` should produce a warning about not being an implicit plane in an unpatched version and no error message with this patch.

Here is a sample problem

```
DOCUMENT();
loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "parserImplicitPlane.pl",
);

$P = ImplicitPlane("x+y=1");

Context()->texStrings;
BEGIN_TEXT
\($P\) is \{$P->ans_rule\}
END_TEXT
Context()->normalStrings;

ANS(List($P)->cmp);

ENDDOCUMENT();
```
