### PR TITLE
Fix problem where Currency($r) changes the class of $r.

### DIFF
--- a/macros/contextCurrency.pl
+++ b/macros/contextCurrency.pl
@@ -482,6 +482,7 @@ sub new {
   my $x = shift;
   Value::Error("Can't convert %s to a monetary value",lc(Value::showClass($x)))
       if !$self->getFlag("promoteReals",1) && Value::isRealNumber($x) && !Value::classMatch($x,"Currency");
+  $x = $x->value if Value::isReal($x);
   $self = bless $self->SUPER::new($context,$x,@_), $class;
   $self->{isReal} = $self->{isValue} = $self->{isCurrency} = 1;
   return $self;


### PR DESCRIPTION
This patch fixes the problem reported in issue #171, where passing a MathObject real to `Currency()` would change the class of the real itself.  This is a test case:

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "contextCurrency.pl",
);

Context("Currency");
$r = Real(1);
$c = Currency($r);

TEXT($r," ",$r->class)

ENDDOCUMENT();
```

Without the patch, it should produce `$1.00 Currency`, and with the patch it should produce `1 Real`.
