### PR TITLE
made it so that -1/b x is bizarro equivalent to -x/b

### DIFF
--- a/macros/bizarroArithmetic.pl
+++ b/macros/bizarroArithmetic.pl
@@ -176,7 +176,7 @@ sub _eval {
   my $context = $self->context;
   my ($a,$b) = @_;
   if ($context->flag("bizarroDiv")) {
-    if ($a == 1) {return bizarro::f(1 * bizarro::g(1/$b));}
+    if (($a == 1) or ($a == -1)) {return $a/$b;}
     else {return bizarro::f(bizarro::g($a) * bizarro::g(1/$b));}
   } else {
     return $a / $b;


### PR DESCRIPTION
Bizarro temporarily changes how arithmetic operators behave, in order to compare the form of a student answer to the form of the instructor's answer in a decent way. We generally want things like "1/2 x" to be counted as equivalent to "x/2". But the way bizarro works, this won't happen unless special treatment is given to the number 1 when it is the first operand of a bizarro division.

That detail about 1 was already in place, but the corresponding special treatment for -1 was not. This commit makes it so that "-1/2 x" is equivalent to "-x/2", which was already equivalent to "-(1/2 x)" and "x/-2". Out of these four versions, note that two only involve division, while the other two involve multiplication as well, and that the one that has been working so far is the one where 1 is the first operand of the division.

It is theoretically possible that by addressing this issue, a different issue with bizarro will pop up somewhere else. However, the special treatment of 1 has been in place for a long time causing no trouble, so it's reasonable to believe that this special treatment of -1 will cause no trouble either.

This issue was noticed in the PG problem below. To test, you could run this problem with seed 2204. Before the commit, "-1/64 x^54" will give a "please simplify further" message. After the commit, this answer is accepted.

```
DOCUMENT();      

loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",     
   "niceTables.pl",
);

################################# WeBWorK problem written by Chris Hughes
# Portland Community College
#
# Template:
#
#  Rewrite the following expression using only positive exponents.
#
#    ( a x^-m ) ^-n
#
# a is an integer on [-5,-2], m is integer on [2,20], n is integer on [2,3].
# 
# Last updated: Hughes 9/4/13, Carl Yao, 7/03/13
# ENDDESCRIPTION

## DBsubject('Algebra')
## DBchapter('Basic Algebra')
## DBsection('Exponents and Radicals')
## KEYWORDS('exponent','negative','fraction','simplify')
## DBCCSS('8.EE.1')
## TitleText1('')
## EditionText1('')
## AuthorText1('')
## Section1('')
## Problem1('')
## Author('Alex Jordan, Carl Yao, Chris Hughes')
## Institution('PCC')

##############################################

DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "PGML.pl",
  "PCCmacros.pl",
  "contextLimitedPolynomial.pl",
  "bizarroArithmetic.pl",
  "PGcourse.pl",
);

##############################################

Context("LimitedPolynomial-Strict");
$var = RandomVariableName(type=>'variable');
Context()->variables->are($var=>'Real');

Context()->operators->set(
   '/' => {class => 'bizarro::BOP::divide', isCommand => 1},
   '/ ' => {class => 'bizarro::BOP::divide', isCommand => 1},
   ' /' => {class => 'bizarro::BOP::divide', isCommand => 1},
   '//' => {class => 'bizarro::BOP::divide', isCommand => 1},
   '*' => {class => 'bizarro::BOP::multiply', isCommand => 1},
   '* ' => {class => 'bizarro::BOP::multiply', isCommand => 1},
   ' *' => {class => 'bizarro::BOP::multiply', isCommand => 1});




#    ( a x^-m ) ^-n
#
# a is an integer on [2,5], m is integer on [2,20], n is integer on [2,3].

# exponents
$m = random(3,20,1);
$n = random(2,3,1);
$a = random(-5,-2,1);

# total
$total = ($m*$n);
$totalCoeff = $a**$n;
$ans = Formula("$var^($total)/$totalCoeff")->reduce;

##############################################
TEXT(beginproblem());

BEGIN_PGML
Simplify the following expression, and write your answer using only _positive_ exponents.

    [`
          \left([$a][$var]^{[$m*(-1)]}\right)^{[$n*(-1)]}
     `][____________]

END_PGML

ANS($ans -> cmp(
   checker=>sub{
      my ( $correct, $student, $ansHash ) = @_;
      Context()->flags->set(limits=>[0.95,1.05]);
      return 0 if $ansHash->{isPreview} || $correct != $student;
      $student = $ansHash->{student_formula};
      $correct = $correct->{original_formula} if defined $correct->{original_formula};
      $student = Formula("$student"); $correct = Formula("$correct");
      return 0 unless ($correct == $student);
      Context()->flags->set(bizarroDiv=>1,bizarroMul=>1);
      delete $correct->{test_values}, $student->{test_values};
      Context()->flags->set(limits=>[0.28,0.36]);
      Value->Error("Your answer is correct, but please simplify it further") unless (($correct == $student) or ($student == $correct));
      Context()->flags->set(bizarroDiv=>0,bizarroMul=>0);
      return 1;
}
)); 


BEGIN_PGML_SOLUTION

We use the properties of exponents to help us here, remembering that [`\left(a^m\right)^n = a^{mn}`]

    [`
           \begin{aligned}
                           \left([$a][$var]^{[$m*(-1)]}\right)^{[$n*(-1)]} &= ([$a])^{[$n*(-1)]}[$var]^{([$m*(-1)])\cdot([$n*(-1)])}\\
& = \frac{1}{([$a])^{[$n]}}[$var]^{[$m*$n]}\\
& = \frac{1}{[$totalCoeff]}[$var]^{[$m*$n]}\\
                                    & = [$ans]
           \end{aligned}
    `]

END_PGML_SOLUTION
##############################################


ENDDOCUMENT();
```
