### PR TITLE
Fix use of $flags in Compute()

### DIFF
--- a/macros/Parser.pl
+++ b/macros/Parser.pl
@@ -108,7 +108,7 @@ sub Compute {
   }
   my $F = $formula;
   $F = Formula($string)
-    if $formula->{original_formula} || $flags{reduceConstants} ||  $flags{reduceConstantFunctions};
+    if $formula->{original_formula} || $flags->{reduceConstants} ||  $flags->{reduceConstantFunctions};
   $formula->{correct_ans} = $F->string;
   $formula->{correct_ans_latex_string} = $F->TeX;
   Value::contextSet($context,%{$flags});


### PR DESCRIPTION
The `$flags` variable is a hash reference, and there is no `%flags` variable, so `$flags{...}` should be `$flags->{...}`.
