### PR TITLE
Add context for percentage values.

### DIFF
--- a/macros/contextPercent.pl
+++ b/macros/contextPercent.pl
@@ -469,11 +469,6 @@ our @ISA = qw(LimitedPercent::BOP Parser::BOP::divide);
 
 ##############################################
 
-package LimitedPercent::BOP::divide;
-our @ISA = qw(LimitedPercent::BOP Parser::BOP::divide);
-
-##############################################
-
 package LimitedPercent::BOP::power;
 our @ISA = qw(LimitedPercent::BOP Parser::BOP::power);
 


### PR DESCRIPTION
This is the percentage context that @alex-jordan was asking for.  He has been using it for a while, so I think it is OK.  I don't have a test case, but I would guess that

```
loadMacros("contextPercent.pl");

Context("Percent");

$P = Compute("100%");

Context()->texStrings;
BEGIN_TEXT
\($P\) = \{$P->ans_rule\}
END_TEXT
Context()->normalStrings;

ANS($P->cmp);
```

would be a good start.  There are several other stricter versions of the context, plus some flags that can be set (these are used in the stricter contexts, so may not need to be tested by hand).
