### PR TITLE
Fix error of CORE::CORE::exp

### DIFF
--- a/macros/PGcommonFunctions.pl
+++ b/macros/PGcommonFunctions.pl
@@ -57,7 +57,7 @@ sub asec {acos($_[0],1.0/$_[1])}
 sub acsc {asin($_[0],1.0/$_[1])}
 
 sub sinh {(CORE::exp($_[1])-CORE::exp(-$_[1]))/2}
-sub cosh {(CORE::CORE::exp($_[1])+CORE::CORE::exp(-$_[1]))/2}
+sub cosh {(CORE::exp($_[1])+CORE::exp(-$_[1]))/2}
 sub tanh {(CORE::exp($_[1])-CORE::exp(-$_[1]))/(CORE::exp($_[1])+CORE::exp(-$_[1]))}
 sub sech {2/(CORE::exp($_[1])+CORE::exp(-$_[1]))}
 sub csch {2.0/(CORE::exp($_[1])-CORE::exp(-$_[1]))}


### PR DESCRIPTION
Before, cosh was failing in pg problems, and this fixes it by making calls to CORE::exp like all of the other functions.
