### PR TITLE
Bug Fixes

### DIFF
--- a/lib/Applet.pm
+++ b/lib/Applet.pm
@@ -693,7 +693,9 @@ use constant DEFAULT_HEADER_TEXT =><<'END_HEADER_SCRIPT';
 	 	  if (obj ) {   //RECENT FIX to ==
 	 		  return( obj );
 	 	  } else {
-	 		  alert ("can't find applet " + appletName);		  
+		      // Commented out because if the applet is in a hint
+		      // this might be run with no applet
+		      // alert ("can't find applet " + appletName);		  
 	 	  }
 	  }	
 		

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -133,7 +133,7 @@ sub MENU {
 	  foreach my $option (@$list) {
 	      $menu .= "\\item{$option}\n";
 	  }
-	  $menu .= "}\n";
+	  $menu .= '\vskip3pt}'."\n";
       }
   }
   main::RECORD_ANS_NAME($name,$answer_value) unless $extend;   # record answer name

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -128,11 +128,12 @@ sub MENU {
 	  $menu = '['.join('/',@$list).']';
       } else {
 	  #otherwise we print a bulleted list
-	  $menu = "\n\\begin{itemize}\n";
+	  $menu = '\par\vtop{\def\item#1{\hbox{\indent\strut\textbullet\ #1}}';
+	  $menu = "\n".$menu."\n";
 	  foreach my $option (@$list) {
 	      $menu .= "\\item{$option}\n";
 	  }
-	  $menu .= "\\end{itemize}\n";
+	  $menu .= "}\n";
       }
   }
   main::RECORD_ANS_NAME($name,$answer_value) unless $extend;   # record answer name


### PR DESCRIPTION
This fixes two bugs
-  This is the corresponding PG pull request which removes error messages from Applet.pm that were preventing problems from running if the applet was part of a hint.  Test by going to a problem like: `Library/CSUOhio/calculus/trigonometric_substitution/trigSub12.pg` and trying the problem as a student.  You should get lots of error messages and none after the pull. 

-  This fixes bug 3337 where PopUps that use itemized lists and are included in a unionTable fail hardcopy generation.  The issue was the itemize environment inside a halign environment. The itemize environment was replaced with a custom compatible solution.  Test by trying to generate a hardcopy for a problem like `Library/LoyolaChicago/Precalc/Chap5Sec1/graph-shifting-01.pg`.  Before the patch the hardcopy should fail and after the patch it should succeeed.  
