### PR TITLE
UTF8 Encoding

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -566,7 +566,7 @@ sub encode_base64 ($;$) {
 sub encode_pg_and_html {
     my $input = shift;
     $input = HTML::Entities::encode_entities($input,
-		   '<>"&\'\$\@\\\\`\\[*_\x00-\x1F\x7F-\xFF');
+		   '<>"&\'\$\@\\\\`\\[*_\x00-\x1F\x7F');
     return $input;
 }
 


### PR DESCRIPTION
Don't encode utf characters in encode_pg_and_html because it breaks rendering.

Test this bug by entering something like ñeumé into an answer blank and check.  The preloaded answer should look the same as you entered it.  Pre patch behavior is to mangle the accented characters.  

