### PR TITLE
Change \1 to  in right hand side of grep substitution expressions.

### DIFF
--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -40,7 +40,7 @@ sub ijk {
   foreach $n (0..scalar(@coords)-1) {
     $term = $coords[$n]->$method($prec);
     if ($term ne '0') {
-      $term =~ s/\((-(\d+(\.\d*)?|\.\d+))\)/\1/;
+      $term =~ s/\((-(\d+(\.\d*)?|\.\d+))\)/$1/;
       $term = '' if $term eq '1'; $term = '-' if $term eq '-1';
       $term = '+' . $term unless $string eq '' or $term =~ m/^-/;
       $string .= $term . $ijk[$n];

--- a/macros/parserOneOf.pl
+++ b/macros/parserOneOf.pl
@@ -195,7 +195,7 @@ sub format {
   return $c[0] unless scalar(@c) > 1;
   return join($or,@c) if scalar(@c) == 2;
   my $last = pop(@c); $or = "$sep$or";
-  $or =~ s/(\\hbox\{.+?)\}\\hbox\{/\1/; $or =~ s/  +/ /g; # clear up some extra spacing
+  $or =~ s/(\\hbox\{.+?)\}\\hbox\{/$1/; $or =~ s/  +/ /g; # clear up some extra spacing
   return join($sep,@c).$or.$last;
 }
 


### PR DESCRIPTION
This will suppress warning messages emitted by newer versions of perl.
This replaces an earlier modification which overzealously replaced
\1 by  on the left side of substitution grep expressions. This does
not work -- \1 must be used as a back reference on the left side
of substitution expressions.