### PR TITLE
change regexes to silence perl warnings

### DIFF
--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -40,7 +40,7 @@ sub ijk {
   foreach $n (0..scalar(@coords)-1) {
     $term = $coords[$n]->$method($prec);
     if ($term ne '0') {
-      $term =~ s/\((-(\d+(\.\d*)?|\.\d+))\)/\1/;
+      $term =~ s/\((-(\d+(\.\d*)?|\.\d+))\)/$1/;
       $term = '' if $term eq '1'; $term = '-' if $term eq '-1';
       $term = '+' . $term unless $string eq '' or $term =~ m/^-/;
       $string .= $term . $ijk[$n];

--- a/macros/parserOneOf.pl
+++ b/macros/parserOneOf.pl
@@ -195,7 +195,7 @@ sub format {
   return $c[0] unless scalar(@c) > 1;
   return join($or,@c) if scalar(@c) == 2;
   my $last = pop(@c); $or = "$sep$or";
-  $or =~ s/(\\hbox\{.+?)\}\\hbox\{/\1/; $or =~ s/  +/ /g; # clear up some extra spacing
+  $or =~ s/(\\hbox\{.+?)\}\\hbox\{/$1/; $or =~ s/  +/ /g; # clear up some extra spacing
   return join($sep,@c).$or.$last;
 }
 


### PR DESCRIPTION
Perl whines that \1 could be better written as $1 in these regexes, so this
changes them.