### PR TITLE
Modified check for the 200 OK so that it doesn't have to begin the st…

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -909,7 +909,7 @@ sub check_url {
 #	 	unless (-x $check_url_command );
 	 my $response = `$check_url_command $url`; 
 	 # $self->debug_message("check_url: response for url $url is  $response");
-	 return ($response =~ /^$OK_CONSTANT/) ? 1 : 0; 
+	 return ($response =~ /$OK_CONSTANT/) ? 1 : 0; 
 }
 
 # ^variable our %appletCodebaseLocations


### PR DESCRIPTION
…ring.

My local site returns "HTTP/1.1 200 OK " when using /usr/local/bin/curl -I to ping applets so /^200 OK/ doesn't match. :-(