### PR TITLE
Fix undef msgs

### DIFF
--- a/lib/Chromatic.pm
+++ b/lib/Chromatic.pm
@@ -5,9 +5,16 @@ BEGIN {
 package Chromatic;
 
 our $webwork_directory = $WeBWorK::Constants::WEBWORK_DIRECTORY; #'/opt/webwork/webwork2';
-our $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_directory });
+# fake course name 'foobar' prevents undefined courseName warnings
+# FIXME is there a more efficient way to find the location of the PG directory?  Perhaps an ENV variable?
+# or a WEBWORK_PG_DIRECTORY variable?  -- perhaps not since all of those are in the defaults.config file
+# we would have to read that at compile time.
+
+our $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_directory, courseName =>'foobar'});
 die "Can't create seed course environment for webwork in $webwork_directory" unless ref($seed_ce);
 our $PGdirectory = $seed_ce->{pg_dir};
+
+# now that we have the PGdirectory we can get to work compiling color
 our $command = "$PGdirectory/lib/chromatic/color";
 our $compileCommand = "/usr/bin/gcc -O3 -o $PGdirectory/lib/chromatic/color $PGdirectory/lib/chromatic/color.c";
 unless (-x $command) {

--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -168,7 +168,6 @@ sub make_alias {
 	my $envir               = $self->{envir}; 
 	my $displayMode         = $self->{displayMode}; 
 	my $pgFileName          = $self->{pgFileName};    # name of .pg file
-	my $envir               = $self->{envir};
 	my $htmlDirectory       = $self->{htmlDirectory};
 	my $htmlURL             = $self->{htmlURL};
 	my $tempDirectory       = $self->{tempDirectory};

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -25,8 +25,8 @@ use PGalias;
 use PGloadfiles;
 use WeBWorK::PG::IO(); # don't important any command directly
 use Tie::IxHash;
-use MIME::Base64 qw( encode_base64 decode_base64);
-use PGUtil;
+use MIME::Base64();
+use PGUtil();
 
 ##################################
 # PGcore object

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -269,7 +269,7 @@ sub inContext {my $self = shift; $self->context(@_); $self}
 #
 sub address {oct(sprintf("0x%p",shift))}
 
-sub isBlessed {Scalar::Util::blessed(shift) ne ""}
+sub isBlessed {(Scalar::Util::blessed(shift)//'') ne ""}
 sub blessedClass {Scalar::Util::blessed(shift)}
 sub blessedType {Scalar::Util::reftype(shift)}
 

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -278,7 +278,7 @@ sub can {UNIVERSAL::can(@_)}
 
 sub isHash {
   my $self = shift;
-  return defined($self) && (  ref($self) eq 'HASH' || blessedType($self) eq 'HASH' );
+  return defined($self) && (ref($self) || blessedType($self) ) && (  ref($self) eq 'HASH' || blessedType($self) eq 'HASH' );
   #added by MEG  (at suggestion DPVC)
   # prevents warning messages when $self is undefined
 

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -662,6 +662,7 @@ sub protectHTML {
 #
 sub preformat {
   my $string = protectHTML(shift);
+  $string = $string//'';
   $string =~ s!\n!<br />!g unless eval('$main::displayMode') eq 'TeX';
   $string;
 }

--- a/lib/Value/Complex.pm
+++ b/lib/Value/Complex.pm
@@ -347,7 +347,7 @@ sub format {
 sub perl {
   my $self = shift; my $parens = shift;
   my $s = Value::Complex::format($self->{format},$self->value,"string",$self->{equation});
-  $s =~ s/(\d)i$/\1*i/; $s =~ s/-i/ - i/; $s = "(".$s.")" if $parens;
+  $s =~ s/(\d)i$/$1*i/; $s =~ s/-i/ - i/; $s = "(".$s.")" if $parens;
   return $s;
 }
 

--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -339,7 +339,7 @@ sub string {
 }
 
 sub TeX {
-  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift//0; #FIXME find out about precedece
   my $op = ($equation->{context} || $self->context)->{operators}{'U'};
   my @intervals = ();
   foreach my $x (@{$self->data}) {push(@intervals,$x->TeX($equation))}

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -27,7 +27,6 @@ BEGIN {
 		directoryFromPath
 		createFile
 		createDirectory
-		AskSage
 	);
 
 	our %SHARE = map { $_ => __PACKAGE__ } @EXPORT;


### PR DESCRIPTION
This pull request makes minor changes in constructions which sometimes generate "undefined" errors.

It also makes one more replacement of \1 by $1 in a grep substitution 

Because it uses the // operator these files will not be compatible with perl 5.8 and earlier.  Do we need to continue to support these earlier installations?