### PR TITLE
Patch answer hash

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -245,6 +245,22 @@ sub score {
 	$self->{score}
 }
 
+=head4  stringify_hash
+
+        Usage:      $rh_ans->stringify_hash;
+
+        Turns all values in the hash into strings (so they won't cause trouble outside
+        the safe compartment).
+
+=cut
+
+sub stringify_hash {
+  my $self = shift;
+  foreach my $key (keys %$self) {
+    $self->{$key} = "$self->{$key}" if ref($self->{$key});
+  }
+}
+
 # error methods
 
 =head4 throw_error

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1255,6 +1255,14 @@ sub process_answers{
 }
 
 
+sub stringify_answers {
+  my $self = shift;
+  no strict;
+  local $rh_answers = $self->{rh_evaluated_answers};
+  $self->{safe}->share('$rh_answers');
+  $self->{safe}->reval('(sub {foreach my $label (keys %$rh_answers) {$rh_answers->{$label}->stringify_hash}})->();');
+  die $@ if $@;
+}
 
 =head3 grade_problem
 
@@ -1284,6 +1292,7 @@ sub grade_problem {
 		$self->{safe}->reval('&{$rf_grader}($rh_answers,$rh_state,%rf_options)');
 	use strict;
 	die $@ if $@;
+	$self->stringify_answers;
 	($self->{rh_problem_result}, $self->{rh_problem_state});
 }
 

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1260,7 +1260,13 @@ sub stringify_answers {
   no strict;
   local $rh_answers = $self->{rh_evaluated_answers};
   $self->{safe}->share('$rh_answers');
-  $self->{safe}->reval('(sub {foreach my $label (keys %$rh_answers) {$rh_answers->{$label}->stringify_hash}})->();');
+  $self->{safe}->reval(<<'  END_EVAL;');
+    (sub {
+      foreach my $label (keys %$rh_answers) {
+        $rh_answers->{$label}->stringify_hash if ref($rh_answers->{$label}) =~ m/AnswerHash/;
+      }
+    })->();
+  END_EVAL;
   die $@ if $@;
 }
 


### PR DESCRIPTION
This implements two features:
1.  CODE answer checkers are converted to AnswerEvaluator objects by LABELED_ANS so that the rest of PG doesn't have to have to handle two different kinds of answer checkers.

2.  AnswerHashes have all their objects stringified after the problem is graded.  This is so that there will be no problems when the AnswerHash is used outside the safe compartment (in particular, MathObjects created using macro files loaded by the PG file could cause errors).  This is accomplished in the new `stringify_hash()` method of the AnswerHash, which is called by the new `stringify_answers()` method in `PG::Translate`, which is called by the existing `grade_problem()` method.

---

To test (1), you can use

    TEXT(ans_rule(10));
    $checker = sub {new AnswerHash(correct_ans=>"pi",score=>1)};
    ANS($checker);
    TEXT(ref($PG->{PG_ANSWERS_HASH}{AnSwEr0001}{ans_eval}));

in a problem.  This should display an answer rule followed by "AnswerEvaluator" in the patched code, and "CODE(...)" in the unpatched code.

For (2), you can't really test this from inside the problem, since the change isn't made until after the grading is over.  But you can test the `stringify_hash()` method using

    $ans = Formula("1-x")->cmp->evaluate("x^2+2");
    $ans->stringify_hash;
    TEXT('<table cellpadding="3" border="1">');
    foreach my $key (keys %$ans) {
      TEXT("<tr><td>$key</td><td>$ans->{$key}</td><td>",ref($ans->{$key}) || "scalar","</td></tr>");
    }
    TEXT('</table>');

This should show "scalar" in all entries of the right-hand column.  Commenting out the `$ans->stringify_hash;` call should include several Value::Formula entries in the right-hand column.

If you want to test this more completely, you would need to print something from within the code that called `PG::Translator->grade_problem` to check that the answer hashes are now stringified.