### PR TITLE
Fix problem with alternate decimals

### DIFF
--- a/macros/contextAlternateDecimal.pl
+++ b/macros/contextAlternateDecimal.pl
@@ -285,7 +285,7 @@ sub new {
   if ($alternate) {
     $num->{alternateForm} = 1;
     $num->{value_original_string} = $value;
-    $value =~ s/,/./;
+    $value =~ s/\{?,\}?/./;
     $num->{value_string} = $value;
     $num->{value} = $value + 0;
   }
@@ -322,7 +322,7 @@ sub string {
 sub TeX {
   my $self = shift;
   my $n = $self->swapDecimal($self->SUPER::TeX(@_));
-  $n =~ s/,/{,}/;
+  $n =~ s/\{?,\}?/{,}/;
   return $n;
 }
 


### PR DESCRIPTION
There is a bad interaction with Matrices and AlternateDecimal when the matrix has a constant row and another non-constant one.  The TeX output could get truncated when `Context()->texStrings` is in play.  This patch fixes the output.  It can be tested with the following code

```
DOCUMENT();
loadMacros(
   "PGstandard.pl",     # Standard macros for PG language
   "MathObjects.pl",
   "contextAlternateDecimal.pl"
);

Context("Matrix");
context::AlternateDecimal->Default(",",",");

TEXT(beginproblem());
$pi = Compute("[[3,14; 2,18]; [3,22; 3,14*x^(2,12)]]");
Context()->texStrings;
BEGIN_TEXT
\($pi\) and \{$pi->ans_rule\} $BR
END_TEXT
Context()->normalStrings;
ANS($pi->cmp);
ENDDOCUMENT();
```