### PR TITLE
Adjust assignments so that they are not treated as lists

### DIFF
--- a/macros/parserAssignment.pl
+++ b/macros/parserAssignment.pl
@@ -260,6 +260,20 @@ sub new {
   }
 }
 
+#
+#  Mark assignments so that they are not treated as lists by classMatch()
+#
+sub make {
+  my $self = shift;
+  $self = $self->SUPER::make(@_);
+  $self->{isList} = 0;
+  return $self;
+}
+sub class {"Assignment"}
+
+#
+#  Produce proper output
+#
 sub string {
   my $self = shift; my ($x,$v) = $self->value;
   $x->string . ' = ' . $v->string;
@@ -296,6 +310,7 @@ sub typeRef {
   my $self = shift;
   Value::Type('Assignment',2,$self->{data}[1]->typeRef,list=>1);
 }
+
 
 ######################################################################
 


### PR DESCRIPTION
This fixes a problem where an assignment can be incorrectly treated as a list during answer checking.  You can test the patch using

```
loadMacros("parserAssignment.pl");

Context("Numeric")->variables->add(y=>'Real');
parser::Assignment->Allow;

$f = List("3x+1");

TEXT(ans_rule(20));
ANS($f->cmp);
```
and entering the answer `y=1` in the answer blank.

Before the patch, you will get no warning message about the incorrect type of answer, and after, you will get a message indicating that the answer isn't a formula returning a number.