### PR TITLE
Make sure equivalent answer check is in the right context

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1707,8 +1707,9 @@ sub cmp_postfilter {
   $ans->{_filter_name} = "produce_equivalence_message";
   return $ans if $ans->{ans_message}; # don't overwrite other messages
   return $ans unless defined($ans->{prev_ans}); # if prefilters are erased, don't do this check
-  my $context = $self->context;
-  $ans->{prev_formula} = Parser::Formula($context,$ans->{prev_ans});
+  my $current = Parser::Context->current(); my $context = $self->context;
+  Parser::Context->current(undef,$context);
+  $ans->{prev_formula} = Parser::Formula($ans->{prev_ans});
   if (defined($ans->{prev_formula}) && defined($ans->{student_formula})) {
     my $prev = eval {$self->promote($ans->{prev_formula})->inherit($self)}; # inherit limits, etc.
     next unless defined($prev);
@@ -1720,6 +1721,7 @@ sub cmp_postfilter {
 	and $ans->{prev_ans} ne $ans->{original_student_ans}) # but not identical
       {$ans->{ans_message} = "This answer is equivalent to the one you just submitted."}
   }
+  Parser::Context->current($current);
   return $ans;
 }
 


### PR DESCRIPTION
Fix problem where formulas are checked for being equal to previous answer in the wrong context, which can cause problems with custom checkers.

To test, use

```
Context('Numeric'); 

$f = Compute("x+1");

BEGIN_TEXT
\{$f->ans_rule\}
END_TEXT

ANS($f->cmp(checker => sub {
  my ($correct,$student,$ans) = @_;
  WARN_MESSAGE(
    $correct->context->{name},
    Context()->{name}
  );
  return 1;
}));

Context("Vector");
```

and enter an answer of `x`, submit it, and submit it again.  You should get two warning messages at the bottom.  In the unpatched version, the first will say "Numeric" twice and the second will say "Numeric" followed by "Vector".  In the patch version, both will say "Numeric" twice.