### PR TITLE
Create unique UUID for graphs created on the fly

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -158,7 +158,19 @@ sub check_parameters {
 	warn "htmlURL is not defined." unless $self->{htmlURL};
 	warn "tempURL is not defined." unless $self->{tempURL};
 }
-
+sub make_resource_object {
+	my $self = shift;
+	my $aux_file_id =shift;
+	my $ext = shift;
+	my $resource = PGresource->new(
+		$self,                    #parent alias of resource
+		$aux_file_id,             # resource file name
+		$ext,                     # resource type
+		WARNING_messages => $self->{WARNING_messages},  #connect warning message channels
+		DEBUG_messages   => $self->{DEBUG_messages},
+	);	
+	return $resource;
+}
 sub make_alias {
    	my $self = shift;   	
    	my $aux_file_id = shift;
@@ -226,13 +238,12 @@ sub make_alias {
 	###################################################################
 	unless ( defined $self->get_resource($aux_file_id.".$ext") ) {
     	$self->add_resource($aux_file_id.".$ext", 
-    	                    PGresource->new(
-    	                            $self,                    #parent alias of resource
-    	                            $aux_file_id,             # resource file name
-    	                            $ext,                     # resource type
-    	                            WARNING_messages => $self->{WARNING_messages},  #connect warning message channels
-                                    DEBUG_messages   => $self->{DEBUG_messages},
-    	));
+    						$self->make_resource_object(
+    							$aux_file_id,  # resource file name
+    							$ext           # resource type
+    						)
+    	                   
+    	);
 
     } else {
     	#$self->debug_message( "found existing resource_object $aux_file_id");

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -692,13 +692,13 @@ sub insertGraph {
 	my $extension = ($WWPlot::use_png) ? '.png' : '.gif';
 	my $fileName = $graph->imageName  . $extension;
 	my $filePath = $self->convertPath("gif/$fileName");
-	my $templateDirectory = $self->{envir}->{templateDirectory};
+	my $templateDirectory = $self->{envir}{templateDirectory};
 	$filePath = $self->surePathToTmpFile( $filePath );
 	my $refreshCachedImages = $self->PG_restricted_eval(q!$refreshCachedImages!);
 	# Check to see if we already have this graph, or if we have to make it
 	if( not -e $filePath # does it exist?
-	  or ((stat "$templateDirectory"."$main::envir{probFileName}")[9] > (stat $filePath)[9]) # source has changed
-	  or $graph->imageName =~ /Undefined_Set/ # problems from SetMaker and its ilk should always be redone
+	  or ((stat "$templateDirectory".$self->{envir}{probFileName})[9] > (stat $filePath)[9]) # source has changed
+	  or $self->{envir}{setNumber} =~ /Undefined_Set/ # problems from SetMaker and its ilk should always be redone
 	  or $refreshCachedImages
 	) {
  		#createFile($filePath, $main::tmp_file_permission, $main::numericalGroupID);

--- a/lib/PGresource.pm
+++ b/lib/PGresource.pm
@@ -91,7 +91,7 @@ sub create_unique_id {
 	$self->warning_message( "missing pg file name"  ) unless $self->{parent_file_id};
 	$self->warning_message( "missing problem psvn"  ) unless $self->{parent_alias}->{psvn}; 
 	$self->warning_message( "missing unique_id_stub") unless $self->{parent_alias}->{unique_id_stub};
-	my $unique_id_seed = $self->path() . $self->{parent_file_id}.$self->{parent_alias}->{psvn}; 
+	my $unique_id_seed = $self->path() . $self->{parent_file_id}.$self->{id}; 
 	$self->{unique_id} = $self->{parent_alias}->{unique_id_stub} .
 	      '___'. create_uuid_as_string( UUID_V3, UUID_NS_URL, $unique_id_seed );
 	$self->{unique_id};

--- a/macros/PGgraphmacros.pl
+++ b/macros/PGgraphmacros.pl
@@ -51,7 +51,7 @@ See F<PGbasicmacros> for definitions of C<image> and C<caption>
                                  # of MathObjects since that can mess up 
                                  # problems that don't use MathObjects but use Matrices.
 
-my %images_created = ();  # this keeps track of the base names of the images created during this session.
+our %images_created = ();  # this keeps track of the base names of the images created during this session.
                      #  We tack on
                      # $imageNum  = ++$images_created{$imageName} to keep from overwriting files
                      # when we don't want to.
@@ -128,7 +128,7 @@ sub init_graph {
 	$studentLogin =~ s/\@/-Q-/g;
 	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
 	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
-	my $imageNum  = ++$main::images_created{$imageName};
+	my $imageNum  = ++$images_created{$imageName};
 	# this provides a unique name for the graph -- it does not include an extension.
 	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
 	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
@@ -243,7 +243,7 @@ sub init_graph_no_labels {
 	# select a  name for this graph based on the user, the psvn and the problem
 	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
 	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
-	my $imageNum  = ++$main::images_created{$imageName};
+	my $imageNum  = ++$images_created{$imageName};
 	# this provides a unique name for the graph -- it does not include an extension.
 	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
 	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");

--- a/macros/PGgraphmacros.pl
+++ b/macros/PGgraphmacros.pl
@@ -126,12 +126,14 @@ sub init_graph {
 	$studentLogin =~ s/\./-Q-/g;
 	$studentLogin =~ s/\,/-Q-/g;
 	$studentLogin =~ s/\@/-Q-/g;
-	my $imageName = "$studentLogin-$main::problemSeed-set${setName}prob${main::probNum}";
+	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
 	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
 	my $imageNum  = ++$main::images_created{$imageName};
 	# this provides a unique name for the graph -- it does not include an extension.
+	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
 	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
-	$resource->path("__");
+	$resource->path("__");  # some kind of path is required in order for create_unique_id to work
+	# the only role of the resource object is to create the UUID -- the object is then discarded.
 	$graphRef->imageName($resource->create_unique_id);
 
 	# Set the initial/default bounds for the graph.
@@ -239,11 +241,15 @@ sub init_graph_no_labels {
 	}
     my $graphRef = new WWPlot(@size);
 	# select a  name for this graph based on the user, the psvn and the problem
-	my $imageName = "$main::studentLogin-$main::psvn-set${main::setNumber}prob${main::probNum}";
+	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
 	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
 	my $imageNum  = ++$main::images_created{$imageName};
 	# this provides a unique name for the graph -- it does not include an extension.
-	$graphRef->imageName("${imageName}image${imageNum}");
+	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
+	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
+	$resource->path("__");  # some kind of path is required in order for create_unique_id to work
+	# the only role of the resource object is to create the UUID -- the object is then discarded.
+	$graphRef->imageName($resource->create_unique_id);
 
 	$graphRef->xmin($xmin) if defined($xmin);
 	$graphRef->xmax($xmax) if defined($xmax);

--- a/macros/PGgraphmacros.pl
+++ b/macros/PGgraphmacros.pl
@@ -130,7 +130,9 @@ sub init_graph {
 	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
 	my $imageNum  = ++$main::images_created{$imageName};
 	# this provides a unique name for the graph -- it does not include an extension.
-	$graphRef->imageName("${imageName}image${imageNum}");
+	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
+	$resource->path("__");
+	$graphRef->imageName($resource->create_unique_id);
 
 	# Set the initial/default bounds for the graph.
 	$graphRef->xmin($xmin) if defined($xmin);


### PR DESCRIPTION
This abstracts one subroutine in PGalias.pm so that PGresources can be created independently of being placed in the PGalias resource lists.

This is used in three lines in PGgraphmacros.pl to take an onTheFlyImage with a label like image1
and create a unique_id which contains no obvious information.  These methods from PGresources
are already used to create unique ids for .html auxiliary files and for static .png and .gif files so this is seems a good way to resolve the image conflict problem.  

It also gives the names for on the fly graphic files the same anonymity that other auxiliary files have had.  You cannot deduce the student login, set or problem number from these names although they are involved in creating it.

(PGalias could be extended to handle other files in the same way -- .js files, .css files, etc. ) 