### PR TITLE
Radio buttons

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -780,8 +780,8 @@ sub cmp {
   my $self = shift;
   my $correct = ($self->{correct_ans}||$self->string);
   my $cmp = $self->SUPER::cmp(
-    correct_ans => quoteHTML($correct),
-    correct_ans_latex_string => quoteTeX($correct),
+    correct_ans => $self->quoteHTML($correct),
+    correct_ans_latex_string => $self->quoteTeX($correct),
     @_
   );
   if ($self->value =~ m/^\s*$/) {
@@ -803,7 +803,7 @@ sub cmp_preprocess {
   my $self = shift; my $ans = shift;
   if (defined $ans->{student_value}) {
     $ans->{preview_latex_string} = $ans->{student_value}->TeX;
-    $ans->{student_ans} = quoteHTML($ans->{student_value}->string);
+    $ans->{student_ans} = $self->quoteHTML($ans->{student_value}->string);
   }
 }
 

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -774,7 +774,7 @@ sub typeMatch {
 #
 #  Remove the blank-check prefilter when the string is empty,
 #  and add a filter that removes leading and trailing whitespace.
-#  Also, properly quote the correct answer string
+#  Also, properly quote the correct answer string.
 #
 sub cmp {
   my $self = shift;

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -774,10 +774,16 @@ sub typeMatch {
 #
 #  Remove the blank-check prefilter when the string is empty,
 #  and add a filter that removes leading and trailing whitespace.
+#  Also, properly quote the correct answer string
 #
 sub cmp {
   my $self = shift;
-  my $cmp = $self->SUPER::cmp(@_);
+  my $correct = ($self->{correct_ans}||$self->string);
+  my $cmp = $self->SUPER::cmp(
+    correct_ans => quoteHTML($correct),
+    correct_ans_latex_string => quoteTeX($correct),
+    @_
+  );
   if ($self->value =~ m/^\s*$/) {
     $cmp->install_pre_filter('erase');
     $cmp->install_pre_filter(sub {
@@ -788,6 +794,17 @@ sub cmp {
     });
   }
   return $cmp;
+}
+
+#
+#  Adjust student preview and anser strings so they display properly
+#
+sub cmp_preprocess {
+  my $self = shift; my $ans = shift;
+  if (defined $ans->{student_value}) {
+    $ans->{preview_latex_string} = $ans->{student_value}->TeX;
+    $ans->{student_ans} = quoteHTML($ans->{student_value}->string);
+  }
 }
 
 #############################################################

--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -89,11 +89,13 @@ sub quoteTeX {
 #
 sub quoteHTML {
   shift; my $s = shift; my $nospan = shift;
+  return unless defined $s;
+  return $s if eval ('$main::displayMode') eq 'TeX';
   $s =~ s/&/\&amp;/g;
   $s =~ s/</\&lt;/g;
   $s =~ s/>/\&gt;/g;
   $s =~ s/"/\&quot;/g;
-  return $s if $nospan;
+  return $s if $nospan || $s !~ m/(\$|\\\(|\\\[)/;
   return '<span class="tex2jax_ignore">'.$s.'</span>';
 }
 

--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -72,14 +72,14 @@ sub compare {
 #
 #  Mark a string to be display verbatim
 #
-sub verb {return "\\verb".chr(0x85).(shift).chr(0x85)}
+sub verb {shift; return "\\verb".chr(0x85).(shift).chr(0x85)}
 
 #
 #  Put normal strings into \text{} and others into \verb
 #
 sub quoteTeX {
-  my $s = shift;
-  return verb($s) unless $s =~ m/^[-a-z0-9 ,.;:+=?()\[\]]*$/i;
+  my $self = shift; my $s = shift;
+  return $self->verb($s) unless $s =~ m/^[-a-z0-9 ,.;:+=?()\[\]]*$/i;
   "\\text{$s}";
 }
 
@@ -87,10 +87,11 @@ sub quoteTeX {
 #  Quote HTML special characters
 #
 sub quoteHTML {
-  my $s = shift;
+  shift; my $s = shift;
   $s =~ s/&/\&amp;/g;
   $s =~ s/</\&lt;/g;
   $s =~ s/>/\&gt;/g;
+  $s =~ s/"/\&quot;/g;
   return $s;
 }
 
@@ -99,7 +100,7 @@ sub quoteHTML {
 #
 sub TeX {
   my $self = shift;
-  quoteTeX($self->value);
+  $self->quoteTeX($self->value);
 }
 
 sub perl {

--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -83,15 +83,17 @@ sub quoteTeX {
   "\\text{$s}";
 }
 
+
 #
 #  Quote HTML special characters
 #
 sub quoteHTML {
-  shift; my $s = shift;
+  shift; my $s = shift; my $nospan = shift;
   $s =~ s/&/\&amp;/g;
   $s =~ s/</\&lt;/g;
   $s =~ s/>/\&gt;/g;
   $s =~ s/"/\&quot;/g;
+  return $s if $nospan;
   return '<span class="tex2jax_ignore">'.$s.'</span>';
 }
 

--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -69,8 +69,44 @@ sub compare {
 #  Generate the various output formats
 #
 
-sub TeX {'{\rm '.shift->value.'}'}
-sub perl {"'".shift->value."'"}
+#
+#  Mark a string to be display verbatim
+#
+sub verb {return "\\verb".chr(0x85).(shift).chr(0x85)}
+
+#
+#  Put normal strings into \text{} and others into \verb
+#
+sub quoteTeX {
+  my $s = shift;
+  return verb($s) unless $s =~ m/^[-a-z0-9 ,.;:+=?()\[\]]*$/i;
+  "\\text{$s}";
+}
+
+#
+#  Quote HTML special characters
+#
+sub quoteHTML {
+  my $s = shift;
+  $s =~ s/&/\&amp;/g;
+  $s =~ s/</\&lt;/g;
+  $s =~ s/>/\&gt;/g;
+  return $s;
+}
+
+#
+#  Render the value verbatim
+#
+sub TeX {
+  my $self = shift;
+  quoteTeX($self->value);
+}
+
+sub perl {
+ my $s = shift->value;
+ $s =~ s/'/\\'/g;
+ "'$s'";
+}
 
 ###########################################################################
 

--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -92,7 +92,7 @@ sub quoteHTML {
   $s =~ s/</\&lt;/g;
   $s =~ s/>/\&gt;/g;
   $s =~ s/"/\&quot;/g;
-  return $s;
+  return '<span class="tex2jax_ignore">'.$s.'</span>';
 }
 
 #

--- a/macros/contextArbitraryString.pl
+++ b/macros/contextArbitraryString.pl
@@ -95,18 +95,13 @@ package context::ArbitraryString::Value::String;
 our @ISA = ("Value::String");
 
 #
-#  Mark a string to be display verbatim
-#
-sub verb {return "\\verb".chr(0x85).(shift).chr(0x85)}
-
-#
 #  Mark a multi-line string to be displayed verbatim in TeX
 #
 sub quoteTeX {
-  my $s = shift;
-  return verb($s) unless $s =~ m/\n/;
+  my $self = shift; my $s = shift;
+  return $self->verb($s) unless $s =~ m/\n/;
   my @tex = split(/\n/,$s);
-  foreach (@tex) {$_ = verb($_) if $_ =~ m/\S/}
+  foreach (@tex) {$_ = $self->verb($_) if $_ =~ m/\S/}
   "\\begin{array}{l}".join("\\\\ ",@tex)."\\end{array}";
 }
 
@@ -114,35 +109,11 @@ sub quoteTeX {
 #  Quote HTML special characters
 #
 sub quoteHTML {
-  my $s = shift;
-  $s =~ s/&/\&amp;/g;
-  $s =~ s/</\&lt;/g;
-  $s =~ s/>/\&gt;/g;
+  my $self = shift;
+  my $s = $self->SUPER::quoteHTML(shift);
   $s = "<pre style=\"text-align:left; padding-left:.2em\">$s</pre>"
     unless $main::displayMode eq "TeX";
   return $s;
-}
-
-#
-#  Render the value verbatim
-#
-sub TeX {
-  my $self = shift;
-  quoteTeX($self->value);
-}
-
-#
-#  Include the correct_ans_latex_string as the properly-displayed
-#  verbatim correct answer (or string value)
-#
-sub cmp {
-  my $self = shift;
-  my $correct = ($self->{correct_ans}||$self->string);
-  $self->SUPER::cmp(
-    correct_ans => quoteHTML($correct),
-    correct_ans_latex_string => quoteTeX($correct),
-    @_
-  );
 }
 
 #
@@ -158,7 +129,7 @@ sub cmp_preprocess {
     $ans->{preview_latex_string} = $ans->{student_value}->TeX
       if defined $ans->{student_value};
   }
-  $ans->{student_ans} = quoteHTML($ans->{student_value}->string)
+  $ans->{student_ans} = $self->quoteHTML($ans->{student_value}->string)
     if defined $ans->{student_value};
 }
 

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -178,7 +178,7 @@ sub findChoice {
     $label = $choice unless defined $label;
     return $label if $label eq $value || $index == $i || $choice eq $value;
   }
- return undef;
+  return undef;
 }
 
 #
@@ -329,7 +329,7 @@ sub orderedChoices {
     @orderLabels = @labels;
   }
 
-  my $label = $self->findChoice($self->{checked});
+  my $label = ($self->{checked} ? $self->findChoice($self->{checked}) : "");
   return map { ($_ eq $label ? "%$_" : $_) => $choiceHash{$_} } @orderLabels;
 }
 

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -16,13 +16,14 @@
 
 =head1 NAME
 
-parserRadioButtons.pl - Radio buttons compatible with MathObject,
+parserRadioButtons.pl - Radio buttons compatible with MathObjects,
                         specifically MultiAnswer objects.
 
 =head1 DESCRIPTION
 
 This file implements a radio button group object that is compatible
-with Value objects, and in particular, with the MultiAnswer object.
+with MathObjects, and in particular, with the MultiAnswer object, and
+with PGML.
 
 To create a RadioButtons object, use
 
@@ -281,7 +282,7 @@ sub getCorrectChoice {
   $value = ($self->flattenChoices)[$value] if $value =~ m/^\d+$/;
   my @choices = @{$self->{orderedChoices}};
   foreach my $i (0..$#choices) {
-    if ($value eq $choices[$i] || $value eq $self->{labels}[$i]) {
+    if ($value eq $choices[$i] || $value eq ($self->{labels}[$i]||"")) {
       $self->{data} = ["B$i"];
       return;
     }
@@ -481,6 +482,7 @@ sub BUTTONS {
   foreach my $i (0..$#choices) {
     my $value = "B$i"; my $tag = $choices[$i];
     $tag = $self->labelFormat($self->{labels}[$i]).$tag if $self->{displayLabels};
+    $tag = $self->protect($tag);
     if ($extend) {
       push(@radio,main::NAMED_ANS_RADIO_EXTENSION($name,$value,$tag,
 	   aria_label=>$label."option $i "));
@@ -500,6 +502,11 @@ sub BUTTONS {
   }
   @radio = $self->makeUncheckable(@radio) if $self->{uncheckable};
   (wantarray) ? @radio : join($self->{separator}, @radio);
+}
+
+sub protect {
+  my $self = shift; my $s = shift;
+  main::MODES(TeX => $self->quoteTeX($s), HTML => $self->quoteHTML($s));
 }
 
 sub buttons {shift->BUTTONS(0,'',@_)}

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -16,7 +16,8 @@
 
 =head1 NAME
 
-parserRadioButtons.pl - Radio buttons compatible with Value objects, specifically MultiAnswer objects.
+parserRadioButtons.pl - Radio buttons compatible with MathObject,
+                        specifically MultiAnswer objects.
 
 =head1 DESCRIPTION
 
@@ -28,67 +29,133 @@ To create a RadioButtons object, use
 	$radio = RadioButtons([choices,...],correct,options);
 
 where "choices" are the strings for the items in the radio buttons,
-"correct" is the choice that is the correct answer for the group,
-and options are chosen from among:
+"correct" is the choice that is the correct answer for the group (or
+its index, with 0 being the first one), and options are chosen from
+among those listed below.
+
+The entries in the choices array can either be strings that are the
+text to use for the choice buttons, or C<{label=>text}> where C<label>
+is a label to use for the choice when showing the student or correct
+answers, and C<text> is the text to use for the choice.  See below for
+options controlling how the labels will be used.
+
+By default, the choices are left in the order that you provide them,
+but you can cause some or all of them to be ordered randomly by
+enclosing those that should be randomized within a second set of
+brackets.  For example
+
+        $radio = RadioButtons(
+                   [
+                     "First Item",
+                     ["Random 1","Random 2","Random 3"],
+                     "Last Item"
+                   ],
+                   "Random 3"
+                 );
+
+will make a list of radio buttons that has the first item always on
+top, the next three ordered randomly, and the last item always on the
+bottom.  In this example
+
+        $radio = RadioButtons([["Random 1","Random 2","Random 3"]],2);
+
+all the entries are randomized, and the correct answer is "Random 3"
+(the one with index 2 in the original, unrandomized list).  You can
+have as many randomized groups, with as many static items in between,
+as you want.
+
+The C<options> are taken from the following list:
 
 =over
 
-=item C<S<< order => [choice,...] >>>
+=item C<S<< labels => "123" or "ABC" or [label1,...] >>>
 
-Specifies the order in which choices should be presented. All choices must be
-listed. If this option is specified, the C<first> and C<last> options are
-ignored.
+Labels are used to replace the text of the choice in the student and
+correct answers, and can also be shown just before the choice text (if
+C<displayLabels> is set).  If the value is C<"123"> then the choices
+will be labeled with numbers (the choices will be numbered
+sequentially after they have been randomized).  If the value is
+C<"ABC"> then the choices will be labeled with capital letters after
+they have been randomized.  If any choiced have explicit labels (via
+C<{label=>text}>), those labels will be used instead of the automatic
+numberof letter (and the number of letter will be skipped).  The third
+form allows you to specify labels for each of the choices in their
+original order (though the C<{label=>text}> form is preferred).
 
-=item C<S<< first => [choice,...] >>>
+=item C<S<< displayLabels => 0 or 1 >>>
 
-Specifies choices which should appear first, in the order specified, in the list
-of choices. Ignored if the C<order> option is specified.
+Specifies whether labels should be displayed after the radio butten
+and before its text.  This makes the association between the choices
+and the label used as an answer more explicit.
 
-=item C<S<< last => [choice,...] >>>
+=item C<S<< labelFormat => string >>>
 
-Specifies choices which should appear last, in the order specified, in the list
-of choices. Ignored if the C<order> option is specified.
+Specifies a format string to use when displaying labels before the
+choice text.  It is an C<sprintf()> string that contains C<%s> where
+the label should go.  By default, it is C<${BBOLD}%s. ${EBOLD}>, which
+produces the label in bold foloowed by a period and a space.
 
-=item C<S<< labels => [label1,...] >>>
+=item C<S<< forceLabel => 0 or 1 >>>
 
-Specifies the text to be used
-as the student answer for each
-entry in the radio group.
-This can also be set to the string
-"ABC" to get lettered labels or
-"123" to get numbered labels.
-The default is to use a few words
-from the text string for each button.
+This causes the labelFormat to be used even if there is no label text
+(in which case, an empty string is used).  Default: 0.
 
 =item C<S<< separator => string >>>
 
-text to put between the radio
-buttons.
-Default: $BR
+Specifies the text to put between the radio buttons.  Default: $BR
 
 =item C<S<< checked => choice >>>
 
-the text or index (starting at zero)
-of the button to be checked
-Default: none checked
+The text or index (starting at zero) of the button to be checked
+initially.  Default: none checked
 
 =item C<S<< maxLabelSize => n >>>
 
-the approximate largest size that should
-be used for the answer strings to be
-generated by the radio buttons (if
-the choice strings are too long, they
-will be trimmed and "..." inserted)
-Default: 25
+The approximate largest size that should be used for the answer
+strings to be generated by the radio buttons (if the choice strings
+are too long, they will be trimmed and "..." inserted) Default: 25
 
 =item C<S<< uncheckable => 0 or 1 or "shift" >>>
 
-determines whether the radio buttons can
-be unchecked (requires JavaScript).
-To uncheck, click a second time; when
-set to "shift", unchecking requires the
-shift key to be pressed.
-Default: 0
+Determines whether the radio buttons can be unchecked (requires
+JavaScript).  To uncheck, click a second time; when set to "shift",
+unchecking requires the shift key to be pressed.  Default: 0
+
+=back
+
+The following options are deprecated, but are available for backward
+compatibility.  This functionality can now be accomplished though
+grouping the items in the choice list.
+
+=over
+
+=item C<S<< randomize => 0 or 1 >>>
+
+Specifies whether the order of the choices should be randomized or
+not.  By default, the order is exactly as they appear in the choices
+array.  If you select random order, you can use the C<first> and
+C<last> arrays to help organize the choices.
+
+=item C<S<< order => [choice,...] >>>
+
+Specifies the order in which choices should be presented. All choices
+must be listed. If this option is specified, the C<first> and C<last>
+options are ignored.  The order can be given in terms of the indices
+of the choices (0 is the first one), or as the strings themselves.
+
+=item C<S<< first => [choice,...] >>>
+
+Specifies choices which should appear first, in the order specified,
+in the list of choices. Ignored if the C<order> option is specified.
+The entries in this list are either indices of the choices (0 is the
+first one), or the strings themselves.
+
+=item C<S<< last => [choice,...] >>>
+
+Specifies choices which should appear last, in the order specified, in
+the list of choices. Ignored if the C<order> option is specified.  The
+entries in this list are either the indices of the choices (0 is the
+first one), or the strings themselves.
 
 =back
 
@@ -104,9 +171,9 @@ and then
 
 to get the answer checker for the radion buttons.
 
-You can use the RadioButtons object in MultiPart objects.  This is
-the reason for the RadioButton's ans_rule method (since that is what
-MultiPart calls to get answer rules).
+You can use the RadioButtons object in MultiAnswer objects.  This is
+the reason for the RadioButton's C<ans_rule()> method (since that is
+what MultiAnswer calls to get answer rules).
 
 =cut
 
@@ -114,7 +181,7 @@ loadMacros('MathObjects.pl','contextString.pl');
 
 sub _parserRadioButtons_init {parserRadioButtons::Init()}; # don't reload this file
 
-##################################################
+##################################################################
 #
 #  The package that implements RadioButtons
 #
@@ -141,85 +208,216 @@ sub new {
   my %options;
   main::set_default_options(\%options,
     labels => [],
+    displayLabels => 0,
+    labelFormat => "${main::BBOLD}%s${main::EBOLD}. ",
+    forceLabels => 0,
     separator => $main::BR,
     checked => undef,
     maxLabelSize => 25,
     uncheckable => 0,
+    randomize => 0,
     first => undef,
     last => undef,
     order => undef,
     @_,
   );
-  $options{labels} = [1..scalar(@$choices)] if $options{labels} eq "123";
-  $options{labels} = [@main::ALPHABET[0..scalar(@$choices)-1]] if $options{labels} eq "ABC";
-  my $self = bless {%options, choices=>$choices}, $class; # temporary to so we can call our methods
-  Value::Error("A RadioButton's first argument should be a list of button labels")
+  Value::Error("A RadioButton's first argument should be a list of button values")
     unless ref($choices) eq 'ARRAY';
   Value::Error("A RadioButton's second argument should be the correct button choice")
     unless defined($value) && $value ne "";
   my $context = Parser::Context->getCopy("String");
-  my %choiceHash = $self->choiceHash;
-  $context->strings->add(map {$_=>{}} (keys %choiceHash));
-  $value = $self->correctChoice($value);
-  $self = bless $context->Package("String")->new($context,$value)->with(choices => $choices, %options), $class;
+  my $self = bless {%options, choices => $choices, context => $context}, $class;
+  $self->compatibility if $self->{order} || $self->{last} || $self->{first} || $self->{randomize};
+  $self->getChoiceOrder;
+  $self->addLabels;
+  $self->getCorrectChoice($value);
   $self->JavaScript if $self->{uncheckable};
+  $context->strings->are(map {"B".$_ => {}} (0..($self->{n}-1)));
   return $self;
 }
 
 #
+#  Get the choices into the correct order (randomizing where requested)
+#
+sub getChoiceOrder {
+  my $self = shift;
+  my @choices = ();
+  foreach my $choice (@{$self->{choices}}) {
+    if (ref($choice) eq "ARRAY") {push(@choices,$self->randomOrder($choice))}
+      else {push(@choices,$choice)}
+  }
+  $self->{orderedChoices} = \@choices;
+  $self->{n} = scalar(@choices);
+}
+sub randomOrder {
+  my $self = shift; my $choices = shift;
+  my %index = (map {$main::PG_random_generator->rand => $_} (0..scalar(@$choices)-1));
+  return (map {$choices->[$index{$_}]} main::PGsort(sub {$_[0] lt $_[1]},keys %index));
+}
+
+#
+#  Collect the labels from those that have them, and add ones
+#  to those that don't (if requested)
+#
+sub addLabels {
+  my $self = shift; my $choices = $self->{orderedChoices};
+  my $labels; my $n = $self->{n};
+  $labels = [1..$n] if $self->{labels} eq "123";
+  $labels = [@main::ALPHABET[0..$n-1]] if $self->{labels} eq "ABC";
+  foreach my $i (0..$n-1) {
+    if (ref($choices->[$i]) eq "HASH") {
+      my $key = (keys %{$choices->[$i]})[0];
+      $labels->[$i] = $key; $choices->[$i] = $choices->[$i]{$key};
+    }
+  }
+  $self->{labels} = $labels;
+}
+
+#
+#  Find the correct choice in the ordered array
+#
+sub getCorrectChoice {
+  my $self = shift; my $value = shift;
+  $value = ($self->flattenChoices)[$value] if $value =~ m/^\d+$/;
+  my @choices = @{$self->{orderedChoices}};
+  foreach my $i (0..$#choices) {
+    if ($value eq $choices[$i] || $value eq $self->{labels}[$i]) {
+      $self->{data} = ["B$i"];
+      return;
+    }
+  }
+  Value::Error("The correct choice must be one of the button values");
+}
+sub flattenChoices {
+  my $self = shift;
+  my @choices = map {ref($_) eq "ARRAY" ? @$_ : $_} @{$self->{choices}};
+  foreach my $choice (@choices) {
+    if (ref($choice) eq "HASH") {
+      my $key = (keys %{$choice})[0];
+      $choice = $choice->{$key};
+    }
+  }
+  return @choices;
+}
+
+#
+#  Format a label using the user-provided format string
+#
+sub labelFormat {
+  my $self = shift; my $label = shift;
+  return "" unless $label || $self->{forceLabels};
+  $label = "" unless defined $label;
+  sprintf($self->{labelFormat},$label);
+}
+
+#
+#  Trim the selected choice or label so that it is not too long
+#  to be displayed in the results table.
+#
+sub labelText {
+  my $self = shift; my $index = substr(shift,1);
+  my $choice = $self->{labels}[$index];
+  $choice = $self->{orderedChoices}[$index] unless defined $choice;
+  return $choice if length($choice) < $self->{maxLabelSize};
+  my @words = split(/\b/,$choice); my ($s,$e) = ('','');
+  do {$s .= shift(@words); $e = pop(@words) . $e}
+    while length($s) + length($e) + 10 < $self->{maxLabelSize} && scalar(@words);
+  return $s . " ... " . $e;
+}
+
+#
+#  Use the actual choice string rather than the "Bn" string as the output
+#
+sub string {
+  my $self = shift;
+  $self->labelText($self->value);
+}
+
+#
+#  Adjust student preview and answer strings to be the actual
+#  choice string rather than the "Bn" string.
+#
+sub cmp_preprocess {
+  my $self = shift; my $ans = shift;
+  if (defined $ans->{student_value}) {
+    my $label = $self->labelText($ans->{student_value}->value);
+    $ans->{preview_latex_string} = $self->quoteTeX($label);
+    $ans->{student_ans} = $self->quoteHTML($label);
+  }
+}
+
+##################################################################
+#
+#  Handle old-style options (order, first, last, randomize)
+#
+
+sub compatibility {
+  my $self = shift;
+  foreach my $choice (@{$self->{choices}}) {
+    Value::Error("Old-style options (order, first, last, randomize) can't be used with new-style choice array")
+      if ref($choice) eq "ARRAY" || ref($choice) eq "HASH";
+  }
+  $self->{n} = scalar(@{$self->{choices}});
+  my @choices; my %remaining = map {$_ => 1} @{$self->{choices}};
+
+  if ($self->{order}) {
+
+    Value::Error("You can't use 'first' or 'last' with 'order'") if $self->{first} || $self->{last};
+    my @order = @{$self->{order}};
+    foreach my $i (0..$#order) {
+      my $choice = $self->findChoice($order[$i]);
+      Value::Error("Item $i of the 'order' option is not a choice.") if !defined($choice);
+      Value::Error("Item $i of the 'order' option was already specified.") if !$remaining{$choice};
+      push(@choices,$choice); delete $remaining{$choice};
+    }
+    Value::Error("You must specify all choices in the 'order' option") if scalar(keys %remaining);
+    $self->{choices} = \@choices;
+
+  } elsif ($self->{first} || $self->{last}) {
+    my @first = @{$self->{first}||[]}; my @last = @{$self->{last}||[]};
+
+    foreach my $i (0..$#first) {
+      my $choice = $self->findChoice($first[$i]);
+      Value::Error("Item $i of the 'first' option is not a choice.") if !defined($choice);
+      Value::Error("Item $i of the 'first' option was already specified.") if !$remaining{$choice};
+      push(@choices,$choice); delete $remaining{$choice};
+    }
+
+    foreach my $i (0..$#last) {
+      my $choice = $self->findChoice($last[$i]);
+      Value::Error("Item $i of the 'last' option is not a choice.") if !defined($choice);
+      Value::Error("Item $i of the 'last' option was already specified.") if !$remaining{$choice};
+      $last[$i] = $choice; delete $remaining{$choice};
+    }
+
+    my @remaining;
+    foreach my $choice (@{$self->{choices}}) {push(@remaining,$choice) if $remaining{$choice}}
+    if (@remaining) {
+      @remaining = ([@remaining]) if $self->{randomize};
+      push(@choices,@remaining);
+    }
+
+    push(@choices,@last) if @last;
+
+    $self->{choices} = \@choices;
+
+  } elsif ($self->{randomize}) {$self->{choices} = [$self->{choices}]}
+}
+
+#
 #  Given a choice, a label, or an index into the choices array,
-#    return the label.
+#  return the choice.
 #
 sub findChoice {
   my $self = shift; my $value = shift;
   my $index = $self->Index($value);
-  foreach my $i (0..scalar(@{$self->{choices}})-1) {
+  return $self->{choices}[$index] unless $index == -1;
+  foreach my $i (0..($self->{n}-1)) {
     my $label = $self->{labels}[$i]; my $choice = $self->{choices}[$i];
-    $label = $choice unless defined $label;
-    return $label if $label eq $value || $index == $i || $choice eq $value;
+    $label = "" unless defined $label;
+    return $choice if $label eq $value || $choice eq $value;
   }
   return undef;
-}
-
-#
-#  Locate the label of the correct answer
-#  The answer can be given as an index, as the full answer
-#    or as the label itself.
-#
-sub correctChoice {
-  my $self = shift; my $value = shift;
-  my $choice = $self->findChoice($value);
-  return $choice if defined $choice;
-  Value::Error("The correct answer should be one of the button choices");
-}
-
-#
-#  Create the hash of label => answer pairs to be used for the
-#  ans_radio_buttons() routine
-#
-sub choiceHash {
-  my $self = shift; my @radio = (); my %labels;
-  foreach my $i (0..scalar(@{$self->{choices}})-1) {
-    my $label = $self->{labels}[$i]; my $choice = $self->{choices}[$i];
-    $label = $choice unless defined $label;
-    push(@radio, $label,$choice);
-  }
-  return @radio;
-}
-
-#
-#  Create a label for the answer, either using the labels
-#  provided by the author, or by creating one from the answer
-#  string (restrict its length so that the results table
-#  will not be overflowed).
-#
-sub labelText {
-  my $self = shift; my $choice = shift;
-  return $choice if length($choice) < $self->{maxLabelSize};
-  my @words = split(/\b/,$choice); my ($s,$e) = ('','');
-  do {$s .= shift(@words); $e = pop(@words) . $e}
-    while length($s) + length($e) + 15 < $self->{maxLabelSize} && scalar(@words);
-  return $s . " ... " . $e;
 }
 
 #
@@ -230,6 +428,8 @@ sub Index {
   return -1 unless defined $index && $index =~ m/^\d$/;
   return $index;
 }
+
+##################################################################
 
 #
 #  Print the JavaScript needed for uncheckable radio buttons
@@ -270,90 +470,24 @@ sub makeUncheckable {
 }
 
 #
-#  Determine the order the choices should be in.
-#
-sub orderedChoices {
-  my $self = shift;
-  my %choiceHash = $self->choiceHash;
-  my @labels = keys %choiceHash;
-
-  my @order = @{$self->{order} || []};
-  my @first = @{$self->{first} || []};
-  my @last  = @{$self->{last}  || []};
-
-  my @orderLabels;
-
-  if (@order) {
-    my %remainingChoices = %choiceHash;
-    Value::Error("When using the 'order' option, you must list all possible choices.")
-      unless @order == @labels;
-    foreach my $i (0..$#order) {
-      my $label = $self->findChoice($order[$i]);
-      Value::Error("Item $i of the 'order' option is not a choice.")
-      	if not defined $label;
-      Value::Error("Item $i of the 'order' option was already specified.")
-      	if not exists $remainingChoices{$label};
-      push @orderLabels, $label;
-      delete $remainingChoices{$label};
-    }
-  } elsif (@first or @last) {
-    my @firstLabels;
-    my @lastLabels;
-    my %remainingChoices = %choiceHash;
-
-    foreach my $i (0..$#first) {
-      my $label = $self->findChoice($first[$i]);
-      Value::Error("Item $i of the 'first' option is not a choice.")
-	if not defined $label;
-      Value::Error("Item $i of the 'first' option was already specified.")
-	if not exists $remainingChoices{$label};
-      push @firstLabels, $label;
-      delete $remainingChoices{$label};
-    }
-
-    foreach my $i (0..$#last) {
-      my $label = $self->findChoice($last[$i]);
-      Value::Error("Item $i of the 'last' option is not a choice.")
-	if not defined $label;
-      Value::Error("Item $i of the 'last' option was already specified.")
-	if not exists $remainingChoices{$label};
-      push @lastLabels, $label;
-      delete $remainingChoices{$label};
-    }
-
-    @orderLabels = (@firstLabels, keys %remainingChoices, @lastLabels);
-  } else {
-    # use the order of elements in the hash
-    # this is the current behavior
-    # might we want to explicitly randomize these?
-    @orderLabels = @labels;
-  }
-
-  my $label = ($self->{checked} ? $self->findChoice($self->{checked}) : "");
-  return map { ($_ eq $label ? "%$_" : $_) => $choiceHash{$_} } @orderLabels;
-}
-
-#
 #  Create the radio-buttons text
 #
 sub BUTTONS {
-  my $self = shift;
-  my $extend = shift; my $name = shift;
-  my @choices = $self->orderedChoices;
+  my $self = shift; my $extend = shift; my $name = shift;
+  my @choices = @{$self->{orderedChoices}};
   my @radio = ();
   $name = main::NEW_ANS_NAME() unless $name;
   my $label = main::generate_aria_label($name);
-  my $count = 1;
-  while (@choices) {
-    my $value = shift(@choices); my $tag = shift(@choices);
+  foreach my $i (0..$#choices) {
+    my $value = "B$i"; my $tag = $choices[$i];
+    $tag = $self->labelFormat($self->{labels}[$i]).$tag if $self->{displayLabels};
     if ($extend) {
       push(@radio,main::NAMED_ANS_RADIO_EXTENSION($name,$value,$tag,
-	   aria_label=>$label."option $count "));
+	   aria_label=>$label."option $i "));
     } else {
       push(@radio,main::NAMED_ANS_RADIO($name,$value,$tag));
       $extend = true;
     }
-    $count++;
   }
   #
   #  Taken from PGbasicmacros.pl
@@ -375,11 +509,5 @@ sub ans_rule {shift->BUTTONS(0,'',@_)}
 sub named_ans_rule {shift->BUTTONS(0,@_)}
 sub named_ans_rule_extension {shift->BUTTONS(1,@_)}
 
-sub cmp_postprocess {
-  my $self = shift; my $ans = shift;
-  my $text = $self->labelText($ans->{student_value}->value);
-  $ans->{preview_text_string} = $ans->{student_ans} = $text;
-  $ans->{preview_latex_string} = "\\hbox{$text}";
-}
-
+##################################################################
 1;

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -510,4 +510,5 @@ sub named_ans_rule {shift->BUTTONS(0,@_)}
 sub named_ans_rule_extension {shift->BUTTONS(1,@_)}
 
 ##################################################################
+
 1;


### PR DESCRIPTION
This pull request enhances the MathObject `RadioButtons()` macro in several ways.

* Button text can now contain arbitrary text, including mathematics.  <s>HTML and TeX special characters are handled properly.</s> HTML and TeX special characters must be properly escaped by the problem author.
* Choices can be randomized automatically.
* Labels (e.g., A,B,C... or 1,2,3...) are now added based on the final ordering, not the initial ordering, and can be displayed as part of the button text automatically.

The ability to handle any text is implemented by updating the underlying bring MathObject class to handle arbitrary text properly (it was originally designed only to handle a single word, so didn't handle spaces or special characters properly).

See the updated documentation at the top of the file for how to handle randomization and labels.  The changes should be backward compatible (all the original options are still processed, though some are no longer needed in light of the new randomization options).

Some PG code that can be used to test some of the new features include:

```
Context()->strings->add('">$%{}_^~<'=>{});
$s = String('">$%{}_^~<');

TEXT($s->ans_rule);
ANS($s->cmp);
```

for testing that the String object can handle the HTML and TeX special characters, in both screen and hardcopy.

```
loadMacros("parserRadioButtons.pl");

$radio = RadioButtons(['Item 1','math: \(x+1\)','Button3'],1);

BEGIN_TEXT
\{$radio->buttons\}
END_TEXT
ANS($radio->cmp);
```

to test mathematics in button text (in both screen and hardcopy),

```
loadMacros("parserRadioButtons.pl");

$radio = RadioButtons([["Button1","Button2","Button3"]],0);

BEGIN_TEXT
\{$radio->buttons\}
END_TEXT
ANS($radio->cmp);
```
and
```
loadMacros("parserRadioButtons.pl");

$radio = RadioButtons([
  "Button0",
  ["Button1","Button2","Button3"],
  "Button4",
  ["Button5","Button6","Button7"]
],0);

BEGIN_TEXT
\{$radio->buttons\}
END_TEXT
ANS($radio->cmp);
```
to test randomization,

```
loadMacros("parserRadioButtons.pl");

$radio = RadioButtons([["Button1","Button2","Button3"]],0,labels=>"ABC");

BEGIN_TEXT
\{$radio->buttons\}
END_TEXT
ANS($radio->cmp);
```

to test automatic labels, and

```
loadMacros("parserRadioButtons.pl");

$radio = RadioButtons([[
    "Button1",
    {"Math: (x+1)/(x-1)" => "Math: \(x+1\over x-1\)"},
    "Button3"
]],1,displayLabels=>0);

BEGIN_TEXT
\{$radio->buttons\}
END_TEXT
ANS($radio->cmp);
```

to test explicit labels (in this case, to make math format more reasonably in the results table).