### PR TITLE
Popup menus

### DIFF
--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -165,7 +165,7 @@ sub MENU {
   my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
   my $label = main::generate_aria_label($name);
   if ($main::displayMode =~ m/^HTML/) {
-    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1">\n!;
+    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1" style="max-width:100%">\n!;
     foreach my $item (@list) {
       my $selected = ($item eq $answer_value) ? " selected" : "";
       my $option = $self->quoteHTML($item,true);

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -20,8 +20,9 @@ parserPopUp.pl - Pop-up menus compatible with Value objects.
 
 =head1 DESCRIPTION
 
-This file implements a pop-up menu object that is compatible
-with Value objects, and in particular, with the MultiAnswer object.
+This file implements a pop-up menu object that is compatible with
+MathObjects, and in particular, with the MultiAnswer object, and with
+PGML.
 
 To create a PopUp object, use
 
@@ -29,9 +30,39 @@ To create a PopUp object, use
 
 where "choices" are the strings for the items in the popup menu,
 and "correct" is the choice that is the correct answer for the
-popup.
+popup (or its index, with 0 being the first one).
 
-To insert the popup menu into the problem text, use
+By default, the choices are left in the order that you provide them,
+but you can cause some or all of them to be ordered randomly by
+enclosing those that should be randomized within a second set of
+brackets.  For example
+
+        $radio = PopUp(
+                   [
+                     "First Item",
+                     ["Random 1","Random 2","Random 3"],
+                     "Last Item"
+                   ],
+                   "Random 3"
+                 );
+
+will make a pop-up menu that has the first item always on top, the
+next three ordered randomly, and the last item always on the bottom.
+In this example
+
+        $radio = PopUp([["Random 1","Random 2","Random 3"]],2);
+
+all the entries are randomized, and the correct answer is "Random 3"
+(the one with index 2 in the original, unrandomized list).  You can
+have as many randomized groups, with as many static items in between,
+as you want.
+
+Note that pop-up menus can not contain mathematical notation, only
+plain text.  This is because the PopUp object uses the browser's
+native menus, and these can contain only text, not mathematics or
+graphics.
+
+To insert the pop-up menu into the problem text, use
 
 	BEGIN_TEXT
 	\{$popup->menu\}
@@ -57,7 +88,7 @@ sub _parserPopUp_init {parser::PopUp::Init()}; # don't reload this file
 #  The package that implements pop-up menus
 #
 package parser::PopUp;
-our @ISA = qw(Value::String);
+our @ISA = ('Value::String');
 my $context;
 
 #
@@ -90,15 +121,38 @@ sub new {
   my $self = shift; my $class = ref($self) || $self;
   shift if Value::isContext($_[0]); # remove context, if given (it is not used)
   my $choices = shift; my $value = shift;
-  Value::Error("A PopUp's first argument should be a list of menu items")
+  Value->Error("A PopUp's first argument should be a list of menu items")
     unless ref($choices) eq 'ARRAY';
-  Value::Error("A PopUp's second argument should be the correct menu choice")
+  Value->Error("A PopUp's second argument should be the correct menu choice")
     unless defined($value) && $value ne "";
-  my %choice; map {$choice{$_} = 1} @$choices;
-  Value::Error("The correct choice must be one of the PopUp menu items")
-    unless $choice{$value};
+  if ($value =~ m/^\d+$/) {
+    my @order = map {ref($_) eq "ARRAY" ? @$_ : $_} @$choices;
+    $value = $order[$value];
+  }
   $self = bless {data => [$value], context => $context, choices => $choices}, $class;
+  $self->getChoiceOrder;
+  my %choice; map {$choice{$_} = 1} @{$self->{choices}};
+  Value::Error("The correct choice must be one of the PopUp menu items")
+    unless defined($value) && $choice{$value};
   return $self;
+}
+
+#
+#  Get the choices into the correct order (randomizing where requested)
+#
+sub getChoiceOrder {
+  my $self = shift;
+  my @choices = ();
+  foreach my $choice (@{$self->{choices}}) {
+    if (ref($choice) eq "ARRAY") {push(@choices,$self->randomOrder($choice))}
+      else {push(@choices,$choice)}
+  }
+  $self->{choices} = \@choices;
+}
+sub randomOrder {
+  my $self = shift; my $choices = shift;
+  my %index = (map {$main::PG_random_generator->rand => $_} (0..scalar(@$choices)-1));
+  return (map {$choices->[$index{$_}]} main::PGsort(sub {$_[0] lt $_[1]},keys %index));
 }
 
 #
@@ -107,34 +161,34 @@ sub new {
 sub menu {shift->MENU(0,@_)}
 sub MENU {
   my $self = shift; my $extend = shift; my $name = shift;
-  my $list = $self->{choices}; my $menu = "";
+  my @list = @{$self->{choices}}; my $menu = "";
   $name = main::NEW_ANS_NAME() unless $name;
   my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
   my $label = main::generate_aria_label($name);
   if ($main::displayMode =~ m/^HTML/) {
-    $menu = qq!<SELECT class="pg-select" NAME="$name" id="$name" aria-label="$label" SIZE=1>\n!;
-    foreach my $option (@$list) {
-      my $selected = ($option eq $answer_value) ? " SELECTED" : "";
-      $menu .= qq!<OPTION$selected VALUE="$option">$option</OPTION>\n!;
+    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1">\n!;
+    foreach my $item (@list) {
+      my $selected = ($item eq $answer_value) ? " selected" : "";
+      my $option = $self->quoteHTML($item,true);
+      $menu .= qq!<option$selected value="$option" class="tex2jax_ignore">$option</option>\n!;
     };
-    $menu .= "</SELECT>";
+    $menu .= "</select>";
   } elsif ($main::displayMode eq "TeX") {
-      # if the total number of characters is not more than 
-      # 30 and not containing / or ] then we print out
-      # the select as a string: [A/B/C]
-      if (length(join('',@$list)) < 25 &&
-	  !grep(/(\/|\[|\])/,@$list)) {
-	  
-	  $menu = '['.join('/',@$list).']';
-      } else {
-	  #otherwise we print a bulleted list
-	  $menu = '\par\vtop{\def\item#1{\hbox{\indent\strut\textbullet\ #1}}';
-	  $menu = "\n".$menu."\n";
-	  foreach my $option (@$list) {
-	      $menu .= "\\item{$option}\n";
-	  }
-	  $menu .= '\vskip3pt}'."\n";
+    # if the total number of characters is not more than
+    # 30 and not containing / or ] then we print out
+    # the select as a string: [A/B/C]
+    if (length(join('',@list)) < 25 &&
+	!grep(/(\/|\[|\])/,@list)) {
+      $menu = '['.join('/',map {$self->quoteTeX($_)} @list).']';
+    } else {
+      #otherwise we print a bulleted list
+      $menu = '\par\vtop{\def\bitem{\hbox\bgroup\indent\strut\textbullet\ \ignorespaces}\let\eitem=\egroup';
+      $menu = "\n".$menu."\n";
+      foreach my $option (@list) {
+	$menu .= '\bitem '.$self->quoteTeX($option)."\\eitem\n";
       }
+      $menu .= '\vskip3pt}'."\n";
+    }
   }
   main::RECORD_ANS_NAME($name,$answer_value) unless $extend;   # record answer name
   $menu;

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -165,7 +165,7 @@ sub MENU {
   my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
   my $label = main::generate_aria_label($name);
   if ($main::displayMode =~ m/^HTML/) {
-    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1" style="max-width:100%">\n!;
+    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1">\n!;
     foreach my $item (@list) {
       my $selected = ($item eq $answer_value) ? " selected" : "";
       my $option = $self->quoteHTML($item,true);

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -125,15 +125,14 @@ sub new {
     unless ref($choices) eq 'ARRAY';
   Value->Error("A PopUp's second argument should be the correct menu choice")
     unless defined($value) && $value ne "";
-  if ($value =~ m/^\d+$/) {
-    my @order = map {ref($_) eq "ARRAY" ? @$_ : $_} @$choices;
-    $value = $order[$value];
-  }
   $self = bless {data => [$value], context => $context, choices => $choices}, $class;
   $self->getChoiceOrder;
   my %choice; map {$choice{$_} = 1} @{$self->{choices}};
-  Value::Error("The correct choice must be one of the PopUp menu items")
-    unless defined($value) && $choice{$value};
+  if (!$choice{$value}) {
+    my @order = map {ref($_) eq "ARRAY" ? @$_ : $_} @$choices;
+    if ($value =~ m/^\d+$/ && $order[$value]) {$self->{data}[0] = $order[$value]}
+      else {Value->Error("The correct choice must be one of the PopUp menu items")}
+  }
   return $self;
 }
 


### PR DESCRIPTION
This pull request updates the MathObject popup menu object to allow randomization of the choices (similar to the new RadioButton mechanism), and also allows arbitrary strings for the menu choices.  Since menus can't include math or images or other markup, the text of the choices is protected so that it appears correctly in the menus as well as in the results table.  You can also use numeric values to select the correct answer, just as with the RadioButtons object.

To check, use the problem

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "parserPopUp.pl",
);

TEXT(beginproblem());

$item1 = '"> <b> \ &%{}_^$#~';
$popup = PopUp(["?",$item1,"Item 2","Item 3"],$item1);
BEGIN_TEXT
\{$popup->menu\}
END_TEXT
ANS($popup->cmp);

ENDDOCUMENT();
```

Without the patch, the first menu item will not show the `">`, the `<b>` or the `</b>`, and the rest of the menu item will be repeated.  Selecting the item will not result in a correct answer, and no answer will show in the results table.  With the patch, the menu item will appear correctly in the menu, as well as in the entered, preview, and correct answer columns of the results table.  It will also show correctly in hardcopy.

You can use

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "parserPopUp.pl",
);

TEXT(beginproblem());

$popup = PopUp(["?",["Item 1","Item 2","Item 3"]],1);
BEGIN_TEXT
\{$popup->menu\}
END_TEXT
ANS($popup->cmp);

ENDDOCUMENT();
```

to check that randomization works, and that the numeric selection of correct answers works (the correct answer should be "Item 1" no matter where it falls in the randomization).