### PR TITLE
Correct comments in Set and Union MathObjects

### DIFF
--- a/lib/Value/Set.pm
+++ b/lib/Value/Set.pm
@@ -214,7 +214,7 @@ sub reduce {
 }
 
 #
-#  True if a union is reduced.
+#  True if a set is reduced.
 #
 #  (In scalar context, is a pair whose first entry is true or
 #   false, and when true the second value is the reason the

--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -52,7 +52,7 @@ sub new {
 }
 
 #
-#  Make a set (it might not be reduced)
+#  Make a union (it might not be reduced)
 #
 sub make {
   my $self = shift;


### PR DESCRIPTION
This pull request fixes some incorrect comments in the Set and Union MathObject classes.  It is cosmetic only, so there is nothing to test.