### PR TITLE
Make named answer rules work properly with MathObject answers in PGML

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -985,7 +985,13 @@ sub Answer {
       }
       $rule = $ans->$method(@options);
       $rule = PGML::LaTeX($rule) if $item->{hasStar};
-      main::ANS($ans->cmp) unless ref($ans) eq 'MultiAnswer' && $ans->{part} > 1;
+      if (!(ref($ans) eq 'MultiAnswer' && $ans->{part} > 1)) {
+        if (defined($item->{name})) {
+          main::NAMED_ANS($item->{name} => $ans->cmp);
+        } else {
+          main::ANS($ans->cmp);
+        }
+      }
     }
   } else {
     if (defined($item->{name})) {


### PR DESCRIPTION
This fixes a problem where named answer rules didn't work with answers in PGML that come from MathObjects.  To test, use

```
loadMacros("PGML.pl");

BEGIN_PGML
[______]{1}{name=>"myAnswer"}
END_PGML
```

Before the patch, this should produce an error about the answer with label "myAnswer" not having an associated answer checker.  With the patch, the problem should produce no error and will properly grade student answers.

You can also try

```
loadMacros("PGML.pl");

BEGIN_PGML
[______]{name=>"myAnswer"}
END_PGML
NAMED_ANS(myAnswer => Real(1)->cmp);
```
