### PR TITLE
Allow PGalias to make an alias for a pdf file in HTML type modes.

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -261,6 +261,7 @@ sub make_alias {
 	} elsif (   $ext eq 'gif'  
 		     or $ext eq 'jpg' 
 		     or $ext eq 'png'
+		     or $ext eq 'pdf'
 		    ) {
 		if ($displayMode =~ /^HTML/ ) {
 			################################################################################
@@ -290,14 +291,14 @@ sub make_alias {
 			die "Error in alias: PGalias.pm: unrecognizable displayMode = $displayMode";
 		}
 	
-	} elsif ($ext eq 'pdf') {
-		if ($displayMode =~/HTML/) {
-			$self->warning_message("The image $aux_file_id of type pdf cannot yet be displayed in HTML mode");
-		} elsif ($displayMode eq 'TeX') {
-			$adr_output=$self->alias_for_image_in_tex_mode($aux_file_id, $ext);
-		} else {
-			die "Error in alias: PGalias.pm: unrecognizable displayMode = $displayMode";
-		}
+	#} elsif ($ext eq 'pdf') {
+	#	if ($displayMode =~/HTML/) {
+	#		$self->warning_message("The image $aux_file_id of type pdf cannot yet be displayed in HTML mode");
+	#	} elsif ($displayMode eq 'TeX') {
+	#		$adr_output=$self->alias_for_image_in_tex_mode($aux_file_id, $ext);
+	#	} else {
+	#		die "Error in alias: PGalias.pm: unrecognizable displayMode = $displayMode";
+	#	}
 	
 	} else { # $ext is not recognized
 		################################################################################


### PR DESCRIPTION
There are valid situations where PGalias should make an alias to a pdf file when the user is in an HTML mode, namely when the user wants to create a link to a pdf file in their templates directory.  This allows it.

Below is a test pg file.  You also need to have a pdf file in the same directory called mlt.pdf .

DOCUMENT();        # This should be the first executable line in the problem.

loadMacros(
"PG.pl",
"PGbasicmacros.pl",
"PGanswermacros.pl",
);

TEXT(beginproblem());

BEGIN_TEXT
Consider the pdf file
\{ htmlLink( alias('mlt.pdf'), "Click on me", "TARGET='_blank'" ) \}.
Type 5:
$BR$BR
	Answer = \{ans_rule(40)\}
END_TEXT

ANS(num_cmp(5));

ENDDOCUMENT();
