### PR TITLE
added nbsp, ndash, and mdash to character display macros

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -64,6 +64,9 @@ my ($PAR,
 	$COMMENT,
 	$US,
 	$SPACE,
+        $NBSP,
+        $NDASH,
+        $MDASH,
 	$BLABEL,
 	$ELABEL,
 	$BBOLD,
@@ -128,6 +131,9 @@ main::PG_restricted_eval( <<'EndOfFile');
 	$main::HINT				= HINT_HEADING();
 	$main::US				= US();
 	$main::SPACE			= SPACE();
+	$main::NBSP			= NBSP();
+	$main::NDASH			= NDASH();
+	$main::MDASH			= MDASH();
 	$main::BLABEL			= BLABEL();
 	$main::ELABEL			= ELABEL();
 	$main::BBOLD			= BBOLD();
@@ -178,6 +184,9 @@ EndOfFile
 	$HINT				 = HINT_HEADING();
 	$US				     = US();
 	$SPACE			     = SPACE();
+	$NBSP			     = NBSP();
+	$NDASH			     = NDASH();
+	$MDASH			     = MDASH();
 	$BLABEL			     = BLABEL();
 	$ELABEL			     = ELABEL();
 	$BBOLD			     = BBOLD();
@@ -1456,6 +1465,9 @@ sub MODES {
 	$HINT				HINT_HEADING()		hint headline
 	$US					US()				underscore character
 	$SPACE				SPACE()				space character (tex and latex only)
+	$NBSP				NBSP()				non breaking space character
+	$NDASH				NDASH()				en dash character
+	$MDASH				MDASH()				em dash character
 	$BLABEL				BLABEL()			begin label (for input)
 	$ELABEL				ELABEL()			end label (for input)
 	$BBOLD				BBOLD()				begin bold typeface
@@ -1523,6 +1535,9 @@ sub SOLUTION_HEADING { MODES( TeX => '\\par {\\bf Solution: }',
 sub HINT_HEADING { MODES( TeX => "\\par {\\bf Hint: }", Latex2HTML => "\\par {\\bf Hint: }", HTML => "<B>Hint:</B> "); };
 sub US { MODES(TeX => '\\_', Latex2HTML => '\\_', HTML => '_');};  # underscore, e.g. file${US}name
 sub SPACE { MODES(TeX => '\\ ',  Latex2HTML => '\\ ', HTML => '&nbsp;');};  # force a space in latex, doesn't force extra space in html
+sub NBSP { MODES(TeX => '~',  Latex2HTML => '~', HTML => '&nbsp;');}; 
+sub NDASH { MODES(TeX => '--',  Latex2HTML => '--', HTML => '&ndash;');}; 
+sub MDASH { MODES(TeX => '---',  Latex2HTML => '---', HTML => '&mdash;');};
 sub BBOLD { MODES(TeX => '{\\bf ',  Latex2HTML => '{\\bf ', HTML => '<B>'); };
 sub EBOLD { MODES( TeX => '}', Latex2HTML =>  '}',HTML =>  '</B>'); };
 sub BLABEL { MODES(TeX => '', Latex2HTML => '', HTML => '<LABEL>'); };


### PR DESCRIPTION
Need nbsp, ndash, and mdash for the MBX project. Adding these to PGbasicmacros alongside space seemed like the right thing to do. I went to each line that related to `$SPACE` and added corresponding lines for these three things. 

Test with:

```
DOCUMENT();

loadMacros(
    "PGstandard.pl",
    "PGML.pl",
);

BEGIN_TEXT
According to Theorem${NBSP}2.  Or Theorem${NDASH}2.  Or Theorem${MDASH}2.
END_TEXT


BEGIN_PGML
According to Theorem[$NBSP]*2.  Or Theorem[$NDASH]*2.  Or Theorem[$MDASH]*2.
END_PGML

ENDDOCUMENT();

```