### PR TITLE
loadFiles subdirectory bug

### DIFF
--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -141,7 +141,6 @@ sub loadMacros {
    
     while (@files) {
         $fileName = shift @files;
-        $fileName = WeBWorK::PG::IO::fileFromPath($fileName);
 
         next  if ($fileName =~ /^PG.pl$/) ;    # the PG.pl macro package is already loaded.
 

--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -142,7 +142,9 @@ sub loadMacros {
     while (@files) {
         $fileName = shift @files;
 
-        next  if ($fileName =~ /^PG.pl$/) ;    # the PG.pl macro package is already loaded.
+        next  if ($fileName =~ /^PG\.pl$/) ;    # the PG.pl macro package is already loaded.
+
+	next unless ($fileName =~ /\.(pl|pg)$/); # dont try to parse files without macro extensions
 
         my $macro_file_name = $fileName;
 	$macro_file_name =~s/\.pl//;  # trim off the extension


### PR DESCRIPTION
This was an extra line left over from some testing which prevented `loadModules` from using paths.  Test by trying to load setOrientation problem 14.  Before the pull you should get a missing macro warning and after you shouldn't.  