### PR TITLE
Fix problem with context during stratification of answer hash references

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -256,6 +256,7 @@ sub score {
 
 sub stringify_hash {
   my $self = shift;
+  Parser::Context->current(undef,$self->{correct_value}->context) if $self->{correct_value};
   foreach my $key (keys %$self) {
     $self->{$key} = "$self->{$key}" if ref($self->{$key});
   }


### PR DESCRIPTION
Make `stringify_hash()` set the context to that of the correct answer so that if the `string()` method uses the context, it is the right one.  Resolves [bugzilla issue 3449](http://bugs.webwork.maa.org/show_bug.cgi?id=3449).

To test, use the problem

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "contextCurrency.pl",
);

TEXT(beginproblem());

Context("Currency");
$C = Currency(1);
TEXT($C->ans_rule(5));
ANS($C->cmp);

Context("Numeric");

ENDDOCUMENT();
```

Before the patch, this problem will produce the error `No such package 'Value::Currency'` and the problem will not render when a currency answer is submitted.  After the patch, the problem should grade the answer properly.