### PR TITLE
Allow MathObject checker subroutine to provide partial credit.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -221,7 +221,7 @@ sub cmp_equal {
     $self->context->clearError();
     my $equal = $correct->cmp_compare($student,$ans);
     if ($self->context->{error}{flag} != $CMP_MESSAGE &&
-        (defined($equal) || !$ans->{showEqualErrors})) {$ans->score(1) if $equal; return}
+        (defined($equal) || !$ans->{showEqualErrors})) {$ans->score(0+$equal) if $equal; return}
     $self->cmp_error($ans);
   } else {
     return if $ans->{ignoreStrings} && (!Value::isValue($student) || $student->type eq 'String');


### PR DESCRIPTION
This allows the `checker` subroutine to specify that partial credit is award rather than just a score of 0 or 1.

You can test this using the problem

```
DOCUMENT();

loadMacros("PGstandard.pl");

TEXT(beginproblem());

TEXT(ans_rule);
ANS(Real(1)->cmp(checker => sub {
  my ($correct,$student,$ans) = @_;
  return ($correct == $student ? 1 : $student == 0 ? .5 : 0);
}));

ENDDOCUMENT();
```

With the patch, entering 1 will give full credit, entering 0 gives 50% credit, and anything else is no credit.  Without the patch, entering 0 gives full credit rather than half credit.