### PR TITLE
Patch PGML

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -504,7 +504,9 @@ sub terminateGetString {
 
 sub terminateBalance {
   my $self = shift; my $token = shift;
-  my $block = $self->{block}; my $stackString = $self->stackString;
+  my $block = $self->{block};
+  if (!$block->{stack} || scalar(@{$block->{stack}}) == 0) {$self->Text("",1)}
+  my $stackString = $self->stackString;
   $self->{block} = $block->{prev}; $self->{block}->popItem;
   if ($block->{token} eq '"' || $block->{token} eq "'") {
     $self->Item("quote",$block->{token});
@@ -726,7 +728,7 @@ sub popItem {
 sub combineTopItems {
   my $self = shift; my $i = shift; $i = -1 unless defined $i;
   my $top = $self->topItem($i); my $prev = $self->topItem($i-1); my $par;
-  if ($prev->{type} eq 'par' && $top->{combine}{par}) {$par = $prev; $prev = $self->topItem($i-2)}
+  for (my $j = $i-1; $prev->{type} eq 'par' && $top->{combine}{par}; $j--) {$par = $prev; $prev = $self->topItem($j)}
   my $id = $top->{combine}{$prev->{type}}; my $value; my $inside = 0;
   if ($id) {
     if (ref($id) eq 'HASH') {($id,$value) = %$id; $inside = 1} else {$value = $prev->{$id}}
@@ -1323,7 +1325,7 @@ sub Format {
   } else {
     $format = '<div class="PGML">'."\n".PGML::Format::html->new($parser)->format.'</div>'."\n";
   }
-  warn join("\n","==================","Errors parsing PGML:",@warnings,"==================\n") if scalar(@warnings);
+  main::WARN_MESSAGE("==================","Errors parsing PGML:",@warnings,"==================") if scalar(@warnings);
   return $format;
 }
 


### PR DESCRIPTION
This patch fixes two issues with PGML and empty strings in `[@ ... @]` substitutions, and also has PGML use `WARN_MESSAGE` rather than `warn` for its error reporting.

The first error was with empty string literals in `[@ ... @]`, as in `[@ "" . "X" @]`, which would produce no output, and would generate

```
==================
Errors parsing PGML:
Error evaluating command: Can't find string terminator '"' anywhere before EOF.

==================
```

in the Apache error log file.  A test case is the problem:

```
DOCUMENT();
loadMacros("PGstandard.pl","PGML");
BEGIN_PGML
No [@ "" . "X" @] output
END_PGML
ENDDOCUMENT();
```

Before the patch, this will generate `No  output` and the warning message in the log file.  With the patch, it should generate `No X output` and no error message in the log.

The second issue is that paragraph breaks are not being combined when an empty `[@ ... @]**` substitution appears between them.  So a test case would be

```
DOCUMENT();
loadMacros("PGstandard.pl","PGML");
BEGIN_PGML
x

[@ @]**

x
END_PGML
ENDDOCUMENT();
```

WIthout the patch, this should produce the error

    Can't locate object method "pushItem" via package "PGML::Item"

in the web page.  After the patch, the problem should display as

    x
    
    x

with no error messages.

To test the use of `WARN_MESSAGE` use

```
DOCUMENT();
loadMacros("PGstandard.pl","PGML.pl");
BEGIN_PGML
[@ xyz() @]
END_PGML
ENDDOCUMENT();
```
With the patch, you should see

```
==================
Errors parsing PGML:
Error evaluating command: Undefined subroutine &main::xyz called. 
==================
```
in the pink PG warning messages area.