### PR TITLE
Fix Parser::UOP so that it will add parentheses for implied multiplication when needed

### DIFF
--- a/lib/Parser/BOP/multiply.pm
+++ b/lib/Parser/BOP/multiply.pm
@@ -121,7 +121,7 @@ sub TeX {
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   my $left  = $self->{lop}->TeX($bop->{precedence},$bop->{leftparens},'left',$outerRight);
-  my $right = $self->{rop}->TeX($bop->{precedence},$bop->{rightparens},'right');
+  my $right = $self->{rop}->TeX($bop->{precedence},$bop->{rightparens}||($mult eq "" ? "UOP": undef),'right');
   $mult = $cdot if $right =~ m/^\d/ ||
      ($left =~ m/\d+$/ && $self->{rop}{isConstant} &&
       $self->{rop}->type eq 'Number' && $self->{rop}->class ne 'Constant');

--- a/lib/Parser/UOP.pm
+++ b/lib/Parser/UOP.pm
@@ -201,7 +201,7 @@ sub TeX {
   my $fracparens = ($uop->{nofractionparens}) ? "nofractions" : "";
   my $extraParens = $self->context->flag('showExtraParens');
   my $addparens = ((defined($precedence) && $precedence >= $uop->{precedence}) ||
-                    $position eq 'right' || $outerRight) && $extraParens;
+                    $position eq 'right' || $outerRight) && ($extraParens || $showparens eq "UOP");
   $TeX = (defined($uop->{TeX}) ? $uop->{TeX} : $uop->{string});
   if ($uop->{associativity} eq "right") {
     $TeX = $self->{op}->TeX($uop->{precedence},$fracparens) . $TeX;


### PR DESCRIPTION
This resolves [bugzilla 3463](http://bugs.webwork.maa.org/show_bug.cgi?id=3463).

To test, use

```
$F = Formula("3*(-x)");
BEGIN_TEXT
\(\{$F->TeX\}\)
END_TEXT
```

Without the patch, the output will be "3-x", and with the patch it should be "3(-x)".  (Of course, `$F = Formula("3*(-x)")->reduce` produces a better result.)