### PR TITLE
Add problem seed to PGalias.

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -100,7 +100,8 @@ sub initialize {
 	$self->{externalGif2EpsPath} = $envir->{externalGif2EpsPath};
 	$self->{externalPng2EpsPath} = $envir->{externalPng2EpsPath};
 	$self->{externalGif2PngPath} = $envir->{externalGif2PngPath};
-	$self->{courseID}            = $envir->{courseName};	
+	$self->{courseID}            = $envir->{courseName};
+	$self->{problemSeed}         = $envir->{problemSeed};
 	
 	$self->{appletPath} = $self->{envir}->{pgDirectories}->{appletPath};
 	#
@@ -110,13 +111,14 @@ sub initialize {
 	
 	$self->{ext}      = "";
 
-	my $unique_id_seed = join("-",   
-							   $self->{studentLogin},
-							   $self->{psvn},
-							   $self->{courseID},
-							   'set'.$self->{setNumber},
-							   'prob'.$self->{probNum},
-	);
+	my $unique_id_seed = join("-",
+				  $self->{studentLogin},
+				  $self->{psvn},
+				  $self->{courseID},
+				  'set'.$self->{setNumber},
+				  'prob'.$self->{probNum},
+				  $self->{problemSeed}
+				 );
 
 ##################################
 # Cached vs. uncached uuid's -- or should the uuid be unique to each file/psvn/login, but always the same?


### PR DESCRIPTION
Add problem seed to string used to generate aliases.  Causes images to be regenerated if seed changes, but also causes some duplication when linking to files that are not seed dependent.

To test:  
-  Look at a problem with an image (say Demo set #7).  Change the seed using Problem Set Detail.  Before the patch the image won't change.  After the patch the image will have a new file name and will be updated. 

This addresses webwork2 issue 644