### PR TITLE
Develop include filefixes

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -132,7 +132,7 @@ sub read_whole_problem_file {
 
 sub read_whole_file {
 	my $filePath = shift;
-	warn "<br/>Can't read file $filePath<br/>" unless -r $filePath;
+	warn "Can't read file $filePath<br/>" unless -r $filePath;
 	return "" unless -r $filePath;
 	die "File path $filePath is unsafe." 
 	    unless path_is_course_subdir($filePath);

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -102,6 +102,7 @@ sub includePGtext  {
 #	$evalString =~ s/~~/\\/g;   # use ~~ as escape instead, use # for comments
 	no strict;
 	$evalString = eval( q! &{$main::PREPROCESS_CODE}($evalString) !); 
+	$evalString = $evalString||'';
 	# current preprocessing code passed from Translator (see Translator::initialization)
 	my $errors = $@;
 	eval("package main; $evalString") ;
@@ -131,7 +132,8 @@ sub read_whole_problem_file {
 
 sub read_whole_file {
 	my $filePath = shift;
-
+	warn "<br/>Can't read file $filePath<br/>" unless -r $filePath;
+	return "" unless -r $filePath;
 	die "File path $filePath is unsafe." 
 	    unless path_is_course_subdir($filePath);
 	

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2289,7 +2289,7 @@ sub htmlLink {
 	my $text = shift;
 	my $options = shift;
 	$options = "" unless defined($options);
-	return "$BBOLD\[ $text  has broken link: $url \] $EBOLD" unless defined($url);
+	return "$BBOLD [ the link to '$text'  is broken ] $EBOLD" unless defined($url) and $url;
 	MODES( TeX        => "{\\bf \\underline{$text}}",
 	       HTML       => "<A HREF=\"$url\" $options>$text</A>"
 	);


### PR DESCRIPTION
Improve error reporting for PGalias and include files.

Make sure that $evalString is defined -- this prevents a cascade of irrelevant errors which obscure the error which caused the $evalString to be undefined in the first place.

To test:

View a problem which uses alias to reference an external file (say an html page) and check that the error message is understandable if that html page doesn't exist.

