### PR TITLE
Patch BOP to add needed parentheses

### DIFF
--- a/lib/Parser/BOP.pm
+++ b/lib/Parser/BOP.pm
@@ -283,7 +283,7 @@ sub string {
       defined($precedence) &&
       ($showparens eq 'all' || (($showparens eq 'extra' || $bop->{fullparens}) && $extraParens > 1) ||
        $precedence > $bop->{precedence} || ($precedence == $bop->{precedence} &&
-        ($bop->{associativity} eq 'right' || ($showparens eq 'same' && $extraParens))));
+        ($bop->{associativity} eq 'right' || $showparens eq 'same')));
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   $string = $self->{lop}->string($bop->{precedence},$bop->{leftparens},'left',$outerRight).
@@ -307,7 +307,7 @@ sub TeX {
       defined($precedence) &&
       (($showparens eq 'all' && $extraParens > 1) || $precedence > $bop->{precedence} ||
       ($precedence == $bop->{precedence} &&
-        ($bop->{associativity} eq 'right' || ($showparens eq 'same' && $extraParens))));
+        ($bop->{associativity} eq 'right' || $showparens eq 'same')));
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   $TeX = $self->{lop}->TeX($bop->{precedence},$bop->{leftparens},'left',$outerRight).

--- a/lib/Parser/BOP/equality.pm
+++ b/lib/Parser/BOP/equality.pm
@@ -63,7 +63,7 @@ sub string {
   my $addparens =
       defined($precedence) &&
       ($precedence > $bop->{precedence} || ($precedence == $bop->{precedence} &&
-        ($bop->{associativity} eq 'right' || ($showparens eq 'same' && $extraParens))));
+        ($bop->{associativity} eq 'right' || $showparens eq 'same')));
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   $string = $self->{lop}->string($bop->{precedence}).
@@ -83,7 +83,7 @@ sub TeX {
   my $addparens =
       defined($precedence) &&
       ($precedence > $bop->{precedence} || ($precedence == $bop->{precedence} &&
-        ($bop->{associativity} eq 'right' || ($showparens eq 'same' && $extraParens))));
+        ($bop->{associativity} eq 'right' || $showparens eq 'same')));
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   $TeX = $self->{lop}->TeX($bop->{precedence}).

--- a/lib/Parser/BOP/power.pm
+++ b/lib/Parser/BOP/power.pm
@@ -75,7 +75,7 @@ sub TeX {
       defined($precedence) &&
       (($showparens eq 'all' && $extraParens > 1) || $precedence > $bop->{precedence} ||
       ($precedence == $bop->{precedence} &&
-        ($bop->{associativity} eq 'right' || ($showparens eq 'same' && $extraParens))));
+        ($bop->{associativity} eq 'right' || $showparens eq 'same')));
   $outerRight = !$addparens && ($outerRight || $position eq 'right');
 
   my $symbol = (defined($bop->{TeX}) ? $bop->{TeX} : $bop->{string});


### PR DESCRIPTION
This fixes the [parenthesis problem](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=3793) reported by Gavin.  To test, use

```
Context("Numeric");
$f = Compute("x - (x-3)");
BEGIN_TEXT
\(\{$t->TeX\}\) = \{$f->ans_rule(20)\}
END_TEXT
ANS($f->cmp);
```
and check the correct answer to see if it has parentheses or not.  With the patch, the parentheses should be there; without the patch, the parens will be missing.