### PR TITLE
Undo overzealous  definition of undefined quantity.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -652,7 +652,7 @@ sub protectHTML {
 #
 sub preformat {
   my $string = protectHTML(shift);
-  $string = $string//'';
+  return unless defined $string;
   $string =~ s!\n!<br />!g unless eval('$main::displayMode') eq 'TeX';
   $string;
 }


### PR DESCRIPTION


History of discussion explaining this change:

In the process I think I found a minor bug in MathObjects.

I think I found the following  error in Real() answer evaluator.   The answer hash below was created for the second answer blank which has the answer evaluator $two->cmp where $two=Real(2);  It looks like the correct_ans
entry in the ans_hash is not filled in although the correct_value is filled out.

The problem is actually due to a change you made in May:

	https://urldefense.proofpoint.com/v2/url?u=https-3A__github.com_openwebwork_pg_blame_develop_lib_Value_AnswerChecker.pm-23L655&d=BQIFAg&c=kbmfwr1Yojg42sGEpaQh5ofMHBeTl9EI2eaqQZhHbOU&r=C6Pt5AGtImanmAdcooarL-JZO8M5dSFPfs3VweYXYkE&m=rUVB-c_7DjcElz-vuK-5frnGOi5EgTmOcN6_-NAJ6eo&s=6dC0dcZOekPjy4ZtNxZRJore3HPspMJtugupDCXFTlM&e=

which makes the result of protect() be defined when it isn't supposed to be.  That makes the check at line 82
no longer fail (since the value is defined, but empty), and so the correct answer is never applied.
I would recommend removing line 655 and replace it with
	return unless defined($string);

instead.  That should restore the correct answer string.

Davide