### PR TITLE
Fix incorrect requirement for extraParens in stringification of UOP.

### DIFF
--- a/lib/Parser/UOP.pm
+++ b/lib/Parser/UOP.pm
@@ -181,8 +181,8 @@ sub string {
   my ($self,$precedence,$showparens,$position,$outerRight) = @_;
   my $string; my $uop = $self->{def}; $position = '' unless defined($position);
   my $extraParens = $self->context->flag('showExtraParens');
-  my $addparens = ((defined($precedence) && $precedence >= $uop->{precedence}) ||
-                    $position eq 'right' || $outerRight) && $extraParens;
+  my $addparens = (defined($precedence) && $precedence >= $uop->{precedence}) ||
+                    (($position eq 'right' || $outerRight) && $extraParens);
   if ($uop->{associativity} eq "right") {
     $string = $self->{op}->string($uop->{precedence}).$uop->{string};
   } else {
@@ -200,8 +200,8 @@ sub TeX {
   my $TeX; my $uop = $self->{def}; $position = '' unless defined($position);
   my $fracparens = ($uop->{nofractionparens}) ? "nofractions" : "";
   my $extraParens = $self->context->flag('showExtraParens');
-  my $addparens = ((defined($precedence) && $precedence >= $uop->{precedence}) ||
-                    $position eq 'right' || $outerRight) && ($extraParens || $showparens eq "UOP");
+  my $addparens = (defined($precedence) && $precedence >= $uop->{precedence}) ||
+                    (($position eq 'right' || $outerRight) && ($extraParens || $showparens eq "UOP"));
   $TeX = (defined($uop->{TeX}) ? $uop->{TeX} : $uop->{string});
   if ($uop->{associativity} eq "right") {
     $TeX = $self->{op}->TeX($uop->{precedence},$fracparens) . $TeX;


### PR DESCRIPTION
This fixes the [parenthesis problem](http://bugs.webwork.maa.org/show_bug.cgi?id=3547) reported by Mike. To test, use

```
Context("Numeric");
$f = Compute("(-1)^x");
BEGIN_TEXT
\(\{$f->TeX\}\) = \{$f->ans_rule(20)\}
END_TEXT
ANS($f->cmp);
```

and check the correct answer to see if it has parentheses or not. With the patch, the parentheses should be there; without the patch, the parens will be missing.