### PR TITLE
Fix problem with correct_ans being incorrectly set

### DIFF
--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -568,7 +568,7 @@ sub formula {
 sub make {
   my $self = shift; my $class = ref($self) || $self;
   my $context = (Value::isContext($_[0]) ? shift : $self->context);
-  bless {$self->hash, data => [@_], context => $context}, $class;
+  bless {$self->hashNoInherit, data => [@_], context => $context}, $class;
 }
 
 #
@@ -600,6 +600,13 @@ sub hash {
   my $self = shift;
   return %$self if isHash($self);
   return ();
+}
+
+sub hashNoInherit {
+  my $self = shift;
+  my %hash = $self->hash;
+  foreach my $id ($self->noinherit) {delete $hash{$id}}
+  return %hash;
 }
 
 #

--- a/lib/Value/Complex.pm
+++ b/lib/Value/Complex.pm
@@ -39,7 +39,7 @@ sub make {
   my $self = shift; my $class = ref($self) || $self;
   my $context = (Value::isContext($_[0]) ? shift : $self->context);
   while (scalar(@_) < 2) {push(@_,0)}
-  my $c = bless {$self->hash, data => [@_[0,1]], context => $context}, $class;
+  my $c = bless {$self->hashNoInherit, data => [@_[0,1]], context => $context}, $class;
   foreach my $x (@{$c->{data}}) {$x = $context->Package("Real")->make($context,$x) unless Value::isValue($x)}
   return $c;
 }

--- a/lib/Value/Interval.pm
+++ b/lib/Value/Interval.pm
@@ -53,7 +53,7 @@ sub new {
     if $a == $b && ($open ne '[' || $close ne ']');
   return $context->Package("Set")->new($context,$a) if $a == $b;
   bless {
-    $self->hash,
+    $self->hashNoInherit,
     data => [$a,$b], open => $open, close => $close,
     leftInfinite => $nia, rightInfinite => $ib,
     context => $context,


### PR DESCRIPTION
This patch uses of the `noInherit` list to remove unwanted fields from propagating to copies of existing objects.  This affects the MathObject's Value class' `make()` method (and the overridden ones in the Complex and Interval objects).  This means that it is fairly far reaching, so we should keep an eye out for unexpected consequences, though I don't think there should be any.

This resolves [bug 3550](http://bugs.webwork.maa.org/show_bug.cgi?id=3550), and the unreported but similarly caused problems in Complex and Interval objects.

To test, use

```
$f = Compute("sin(x)");
$a = Compute("pi");
$b = $f->eval(x=>$a);

BEGIN_TEXT
\(\sin(\pi)\) = \{$b->ans_rule(5)\}
END_TEXT

ANS($b->cmp());
```

Without the patch, the correct answer will show up as pi rather than the correct value of 0.  With the patch, the correct value should be shown.

To test the Complex object, use

```
Context("Complex");
$f = Compute("sin(z)");
$a = Compute("pi+i");
$b = $f->eval(z=>$a);

BEGIN_TEXT
\(\sin(\pi+i)\) = \{$b->ans_rule(5)\}
END_TEXT

ANS($b->cmp());
```

and for the corresponding Interval situation, use

```
Context("Interval");
$I = Compute("[1,5]")->new(2,3);

BEGIN_TEXT
\((2,3)\) = \{$I->ans_rule(10)\}
END_TEXT

ANS($I->cmp());
```

Here, make sure the correct answer shows as `(2,3)` rather than `[1,5]`.