### PR TITLE
Develop beginproblem bugfix

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2181,7 +2181,6 @@ sub beginproblem {
 	my $print_path_name_flag = 
 			(defined($effectivePermissionLevel) && defined($PRINT_FILE_NAMES_PERMISSION_LEVEL) && $effectivePermissionLevel >= $PRINT_FILE_NAMES_PERMISSION_LEVEL)
 			 || ( defined($inlist{ $studentLogin }) and ( $inlist{ $studentLogin }>0 )  )?1:0 ;
-	#$print_path_name_flag = $print_path_name_flag && (($envir->{setNumber})=~/\S/); 
 	$out .= MODES( TeX => '', HTML => '<P style="margin: 0">');
 	if ( $print_path_name_flag ) {
 		$out .= &M3("{\\bf ${probNum}. {\\footnotesize ($problemValue $points) \\path|$fileName|}}\\newline ",

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2180,19 +2180,19 @@ sub beginproblem {
 	my $studentLogin = $envir->{studentLogin};
 	my $print_path_name_flag = 
 			(defined($effectivePermissionLevel) && defined($PRINT_FILE_NAMES_PERMISSION_LEVEL) && $effectivePermissionLevel >= $PRINT_FILE_NAMES_PERMISSION_LEVEL)
-			 || ( defined($inlist{ $studentLogin }) and ( $inlist{ $studentLogin }>0 )  ) ;
-
+			 || ( defined($inlist{ $studentLogin }) and ( $inlist{ $studentLogin }>0 )  )?1:0 ;
+	#$print_path_name_flag = $print_path_name_flag && (($envir->{setNumber})=~/\S/); 
 	$out .= MODES( TeX => '', HTML => '<P style="margin: 0">');
 	if ( $print_path_name_flag ) {
 		$out .= &M3("{\\bf ${probNum}. {\\footnotesize ($problemValue $points) \\path|$fileName|}}\\newline ",
 		" \\begin{rawhtml} ($problemValue $points) <B>$l2hFileName</B><BR>\\end{rawhtml}",
 		 "($problemValue $points) <B>$fileName</B><BR>"
-	 	   ) if ($problemValue >=0 );
+	 	   ) if ($problemValue >=0 and ($envir->{setNumber})=~/\S/ and ($envir->{setNumber}) ne 'Undefined_Set' );
 	} else {
 		$out .= &M3("{\\bf ${probNum}.} ($problemValue $points) ",
 		"($problemValue $points) ",
 		 "($problemValue $points) "
-	 	   ) if ($problemValue  >= 0);
+	 	   ) if ($problemValue  >= 0 and ($envir->{setNumber})=~/\S/ and ($envir->{setNumber}) ne 'Undefined_Set');
 	}
 	$out .= MODES(%{main::PG_restricted_eval(q!$main::problemPreamble!)});
 	$out;


### PR DESCRIPTION
Prevents beginproblem() from printing points and file path when question is viewed independently
such as after clicking on the "eye" in the library browser. 

To test:
View files in library and check that the path is not displayed within the problem even after randomizing
the problem. 

File paths are still shown when the problem is rendered within homework sets detail 2 which is a bit redundant but not too obnoxious.