### PR TITLE
Solution Hardcopy Bug

### DIFF
--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -174,7 +174,7 @@ sub loadMacros {
 	    	my $pgDirectory       = $self->{envir}->{pgDirectories}->{macros};
 	    	my $templateDirectory = $self->{envir}->{templateDirectory};
 		my @shortenedPaths = @{$macrosPath};
-	    	my @shortenedPaths = map {$_ =~ s|^$templateDirectory|[TMPL]/|; $_ } @shortenedPaths;
+	    	@shortenedPaths = map {$_ =~ s|^$templateDirectory|[TMPL]/|; $_ } @shortenedPaths;
 	    	@shortenedPaths = map {$_ =~ s|^$pgDirectory|[PG]/macros/|; $_ } @shortenedPaths;
 	        warn "Can't locate macro file |$fileName| via path: |".join("|,<br/> |",@shortenedPaths)."|\n";
 	    }

--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -173,7 +173,8 @@ sub loadMacros {
 	    } else {
 	    	my $pgDirectory       = $self->{envir}->{pgDirectories}->{macros};
 	    	my $templateDirectory = $self->{envir}->{templateDirectory};
-	    	my @shortenedPaths = map {$_ =~ s|^$templateDirectory|[TMPL]/|; $_ } @{$macrosPath};
+		my @shortenedPaths = @{$macrosPath};
+	    	my @shortenedPaths = map {$_ =~ s|^$templateDirectory|[TMPL]/|; $_ } @shortenedPaths;
 	    	@shortenedPaths = map {$_ =~ s|^$pgDirectory|[PG]/macros/|; $_ } @shortenedPaths;
 	        warn "Can't locate macro file |$fileName| via path: |".join("|,<br/> |",@shortenedPaths)."|\n";
 	    }

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1531,11 +1531,11 @@ sub END_ONE_COLUMN { MODES(TeX =>
                             Latex2HTML => ' ', HTML => ' ');
 
 };
-sub SOLUTION_HEADING { MODES( TeX => '\\par {\\bf'.maketext('Solution:').' }',
-                 Latex2HTML => '\\par {\\bf'.maketext('Solution:').' }',
+sub SOLUTION_HEADING { MODES( TeX => '\\par {\\bf '.maketext('Solution:').' }',
+                 Latex2HTML => '\\par {\\bf '.maketext('Solution:').' }',
           		 HTML =>  '<B>'.maketext('Solution:').'</B> ');
 };
-sub HINT_HEADING { MODES( TeX => "\\par {\\bf Hint: }", Latex2HTML => "\\par {\\bf Hint: }", HTML => "<B>Hint:</B> "); };
+sub HINT_HEADING { MODES( TeX => "\\par {\\bf ".maketext('Hint:')." }", Latex2HTML => "\\par {\\bf ".maketext('Hint:')." }", HTML => "<B>".maketext('Hint:')."</B> "); };
 sub US { MODES(TeX => '\\_', Latex2HTML => '\\_', HTML => '_');};  # underscore, e.g. file${US}name
 sub SPACE { MODES(TeX => '\\ ',  Latex2HTML => '\\ ', HTML => '&nbsp;');};  # force a space in latex, doesn't force extra space in html
 sub NBSP { MODES(TeX => '~',  Latex2HTML => '~', HTML => '&nbsp;');}; 

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1223,7 +1223,7 @@ sub solution {
 	PG_restricted_eval(q!$main::solutionExists = 1!);  # set solution exists variable.--don't need PGeval??
    
     if ($printSolutionForInstructor) {  # always print solutions for instructor types 
-		$out = join(' ', $BITALIC, "(", maketext("Instructor solution preview: show the student solution after due date. "),"$BR",$EITALIC, @in);
+		$out = join(' ', $BITALIC, "(", maketext("Instructor solution preview: show the student solution after due date.")," )$BR",$EITALIC, @in);
 	} elsif ( $displaySolution ) 	{
 		$out = join(' ',@in);  # display solution
 	}    


### PR DESCRIPTION
There is a bug in develop where hardcopies with solutions don't compile because of a \bfSolution command.  This fixes that and adds maketext to Hint for good measure. 
-  To Test:  Generate a hardcopy with a problem that has a solution and a hint.  Before the patch it will fail and after the patch both the solution and hint will work.

I also found another really subtle bug where Hardcopy was failing to find macro files under very specific circumstances.  Basically if it failed to find one particular file then it was replacing parts of the paths with abbreviations and it would then fail to find more files as a result. 

