### PR TITLE
MathObjects and Pi

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -551,12 +551,20 @@ sub k () {
 }
 
 # ^function pi
+# ^uses $_parser_loaded
 # ^uses &Value::Package
-sub pi () {Value->Package("Formula")->new('pi')->eval}
+sub pi () {
+  if (!eval(q!$main::_parser_loaded!)) {return 4*atan2(1,1)}
+  Value->Package("Formula")->new('pi')->eval;
+}
 
 # ^function Infinity
+# ^uses $_parser_loaded
 # ^uses &Value::Package
-sub Infinity () {Value->Package("Infinity")->new()}
+sub Infinity () {
+  if (!eval(q!$main::_parser_loaded!)) {return 'infinity'}
+  Value->Package("Infinity")->new();
+}
 
 
 # ^function abs

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -5,10 +5,17 @@
 # initialize PGcore and PGrandom
 
 
-	$main::VERSION ="WW2";
+$main::VERSION ="WW2";
 
 sub _PG_init{
-	$main::VERSION ="WW2.9+";
+  $main::VERSION ="WW2.9+";
+  #
+  #  Set up MathObejct context for use in problems
+  #  that don't load MathObjects.pl
+  #
+  %main::context = {};
+  Parser::Context->current(\%main::context);
+
 }
 
 our $PG;  

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -562,7 +562,7 @@ sub pi () {
 # ^uses $_parser_loaded
 # ^uses &Value::Package
 sub Infinity () {
-  if (!eval(q!$main::_parser_loaded!)) {return 'infinity'}
+  if (!eval(q!$main::_parser_loaded!)) {return 'Infinity'}
   Value->Package("Infinity")->new();
 }
 

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -10,7 +10,7 @@ $main::VERSION ="WW2";
 sub _PG_init{
   $main::VERSION ="WW2.9+";
   #
-  #  Set up MathObejct context for use in problems
+  #  Set up MathObject context for use in problems
   #  that don't load MathObjects.pl
   #
   %main::context = {};

--- a/macros/Parser.pl
+++ b/macros/Parser.pl
@@ -132,10 +132,12 @@ that context is set as the current one.  In all three cases, the current context
 # ^uses Parser::Context::current
 # ^uses %context
 sub Context {Parser::Context->current(\%context,@_)}
-# ^variable our %context
-%context = ();  # Locally defined contexts, including 'current' context
-# ^uses Context
-Context();      # Initialize context (for persistent mod_perl)
+unless (%context && $context{current}) {
+  # ^variable our %context
+  %context = ();  # Locally defined contexts, including 'current' context
+  # ^uses Context
+  Context();      # Initialize context (for persistent mod_perl)
+}
 
 ###########################################################################
 #


### PR DESCRIPTION
Change pi and Infinity to be defined by non MathObjects expressions when MathObjects is not loaded.

To test use the problem:  
```
DOCUMENT();      
loadMacros("PG.pl",
           "PGbasicmacros.pl",
);
TEXT(beginproblem());

$a = pi;

BEGIN_TEXT
$a
\{ref($a)\}
END_TEXT
ENDDOCUMENT();
```
Before the patch you should get
```
3.14159265 Value::Real 
```
and after you should get 
```
3.14159265358979 
```
If you add `MathObjects.pl` to the macro list after the patch it should go back to the first answer.  