### PR TITLE
A better fix for the localization problem.  …

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -112,7 +112,8 @@ sub initialize {
 												WARNING_messages => $self->{WARNING_messages},
 												DEBUG_messages   => $self->{DEBUG_messages},                                           
 										);
-	$self->{maketext} =  WeBWorK::Localize::getLoc($self->{envir}->{language});
+	#$self->{maketext} =  WeBWorK::Localize::getLoc($self->{envir}->{language});
+	$self->{maketext} = $self->{envir}->{language_subroutine};
 	#$self->debug_message("PG alias created", $self->{PG_alias} );
     $self->{PG_loadMacros}        = new PGloadfiles($self->{envir});
 	$self->{flags} = {


### PR DESCRIPTION
Requires a change in webwork2/lib/PG  as well.

Passes the localization subroutine into Safe directly so that Gettext module doesn't need to be loaded into Safe
