### PR TITLE
Don't force the result of adding two sets to be a Union.  #280

### DIFF
--- a/lib/Value/Set.pm
+++ b/lib/Value/Set.pm
@@ -95,7 +95,7 @@ sub promote {
 #
 sub add {
   my ($self,$l,$r) = Value::checkOpOrderWithPromote(@_);
-  $self->Package("Union")->new($l,$r);
+  return Value::Union::form($self->context,$l,$r);
 }
 sub dot {my $self = shift; $self->add(@_)}
 


### PR DESCRIPTION
Don't force the result of adding two sets to be a Union (in particular, let it be a Set).  Resolves issue #280.  That issue includes a test case.  Alternatively, use

```
TEXT((Set(1) + Set(2))->type);
```

Before the patch it should produce `Union`, but after the patch it should produce `Set`.