### PR TITLE
Fix issue with radio buttons and numeric correct answers.

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -32,7 +32,9 @@ To create a RadioButtons object, use
 where "choices" are the strings for the items in the radio buttons,
 "correct" is the choice that is the correct answer for the group (or
 its index, with 0 being the first one), and options are chosen from
-among those listed below.
+among those listed below.  If the correct answer is a number, it is
+interpretted as an index, even if the array of choices are also
+numbers.  (See the C<noindex> below for more details.)
 
 The entries in the choices array can either be strings that are the
 text to use for the choice buttons, or C<{label=>text}> where C<label>
@@ -138,6 +140,13 @@ Determines whether the radio buttons can be unchecked (requires
 JavaScript).  To uncheck, click a second time; when set to "shift",
 unchecking requires the shift key to be pressed.  Default: 0
 
+=item C<S<< noindex => 0 or 1 >>>
+
+Determines whether a numeric value for the correct answer is
+interpretted as an index into the choice array or not.  If set to 1,
+then the number is treated as the literal correct answer, not an index
+to it.  Default: 0
+
 =back
 
 The following options are deprecated, but are available for backward
@@ -236,6 +245,7 @@ sub new {
     first => undef,
     last => undef,
     order => undef,
+    noindex => 0,
     @_,
     checkedI => -1,
   );
@@ -306,7 +316,11 @@ sub addLabels {
 #
 sub getCorrectChoice {
   my $self = shift; my $value = shift;
-  $value = ($self->flattenChoices)[$value] if $value =~ m/^\d+$/;
+  if ($value =~ m/^\d+$/ && !$self->{noindex}) {
+    $value = ($self->flattenChoices)[$value];
+    Value::Error("The correct anser index is outside the range of choices provided")
+      if !defined($value);
+  }
   my @choices = @{$self->{orderedChoices}};
   foreach my $i (0..$#choices) {
     if ($value eq $choices[$i] || $value eq ($self->{labels}[$i]||"")) {


### PR DESCRIPTION
Fix issue with radio buttons not giving an error if the index is out of range, and add noindex option to prevent numeric value from being used as an index.

http://bugs.webwork.maa.org/show_bug.cgi?id=3718

includes one example of this.  You can also test it by using

```
loadMacros("parserRadioButtons.pl");
TEXT(RadioButtons([1,2,3],2)->{data}[0],",");
TEXT(RadioButtons([1,2,3],2,noindex=>1)->{data}[0]);
```

This should give you `B2,B1` as the result after the patch (before it should be `B2,B2`).

Also

```
loadMacros("parserRadioButtons.pl");
TEXT(RadioButtons([1,2,3],5));
```

shovel produce an error about the correct answer index being outside the range of choices.  (Before the patch, it produces a warning about `$value` not being defined).

