### PR TITLE
PGmatrixmacros and "cellspacing"

### DIFF
--- a/macros/PGmatrixmacros.pl
+++ b/macros/PGmatrixmacros.pl
@@ -289,7 +289,7 @@ sub dm_begin_matrix {
                       or $main::displayMode eq 'HTML_LaTeXMathML'
                       or $main::displayMode eq 'HTML'
                       or $main::displayMode eq 'HTML_img') {
-                $out .= qq!<TABLE class="matrix" BORDER="0" Cellspacing="8">\n!;
+                $out .= qq!<TABLE class="matrix" BORDER="0" style="border-collapse: separate; border-spacing:10px;">\n!;
         }
         else { 
                 $out = "Error: dm_begin_matrix: Unknown displayMode: $main::displayMode.\n";


### PR DESCRIPTION
PGmatrixmacros uses the "cellspacing" attribute to put space between the table cells it uses to build matrices.  This attribute is not supported in HTML5 and this patch replaces that attribute with inline css.  

To test:  Look at the problem `Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.12.pg` and check that the spacing of the matrix is OK. 
