### PR TITLE
bugfixes for niceTables.pl

### DIFF
--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -142,7 +142,7 @@ sub _niceTables_init {}; # don't reload this file
  #        texpre => tex code,           # For more fussy cell-by-cell alteration of the tex version of the table
  #                                      # TeX code here will precede the cell entry...
  #        texpost => tex code           # and code here will follow the cell entry
- #                                      # The ordering will be: tex texpre data texpost
+ #                                      # The ordering will be: texpre tex data texpost
  #        texencase => array ref        # This is just a shortcut for entering [texpre,texpost] at once.
  #
  #    The "a" in a cell can also be replaced directly with a hash reference {data=>a,options} if somehow that is of use. If you
@@ -364,7 +364,9 @@ sub DataTable {
       if ($htmlalignment[$i] =~ /\|\s*/)
         {my $j = $i; while (!defined($alignmentcolumns[$j]) && $j < $#htmlalignment) {$j += 1;};
           if ($j < $#htmlalignment) {$columnscss->[$alignmentcolumns[$j]] = "border-left:solid 1px; ".$columnscss->[$alignmentcolumns[$j]];};
-          if ($alignmentcolumns[$j] != 0) {$columnscss->[$alignmentcolumns[$j]-1] = "border-right:solid 1px; ".$columnscss->[$alignmentcolumns[$j]-1];}
+	  if (defined $alignmentcolumns[$j]) {
+            if ($alignmentcolumns[$j] != 0) {$columnscss->[$alignmentcolumns[$j]-1] = "border-right:solid 1px; ".$columnscss->[$alignmentcolumns[$j]-1];}
+	  };
           if ($j == $#htmlalignment)
             {if ($j == $i) {$columnscss->[-1] = "border-right:solid 1px; ".$columnscss->[-1];} else {$columnscss->[-1] = "border-left:solid 1px; ".$columnscss->[-1];}}
         };
@@ -574,16 +576,15 @@ sub DataTable {
       {
        if ($rowcolor[$i] ne '') {$textable .= '\rowcolor'.$rowcolor[$i];};
        for my $j (0..$numcols[$i])
-        {if (uc(${$dataref->[$i][$j]}{header}) ~~ ['TH','CH','COLUMN','COL','RH','ROW']) {${$dataref->[$i][$j]}{tex} = '\bfseries '.${$dataref->[$i][$j]}{tex}};
+        {if (uc(${$dataref->[$i][$j]}{header}) ~~ ['TH','CH','COLUMN','COL','RH','ROW'] or ($headerrow[$i] == 1) and !(uc(${$dataref->[$i][$j]}{header}) ~~ ['TD'])) {${$dataref->[$i][$j]}{tex} = '\bfseries '.${$dataref->[$i][$j]}{tex}};
         if (${$dataref->[$i][$j]}{multicolumn} ne '') {$textable .= ${$dataref->[$i][$j]}{multicolumn}};
-        if (($headerrow[$i] == 1) and !(uc(${$dataref->[$i][$j]}{header}) ~~ ['TD'])) {$textable .= '\bfseries '};
-        $textable .= ${$dataref->[$i][$j]}{tex}.' '.${$dataref->[$i][$j]}{texpre}.' '.${$dataref->[$i][$j]}{data}.' '.${$dataref->[$i][$j]}{texpost};
+        $textable .= ${$dataref->[$i][$j]}{texpre}.' '.${$dataref->[$i][$j]}{tex}.' '.${$dataref->[$i][$j]}{data}.' '.${$dataref->[$i][$j]}{texpost};
         if (${$dataref->[$i][$j]}{multicolumn} ne '') {$textable .= '}'};
         $textable .= '&' unless ($j == $numcols[$i]);
         };
       $textable .= '\\\\';
       if ($midrule[$i] == 1) {$textable .= '\midrule '};
-      if ((($midrules == 1) or ($headerrow[$i] == 1)) and (($i != $#{$dataref}) or ($footerline ne ''))) {$textable .= '\midrule '};
+      if ((($midrules == 1) or ($headerrow[$i] == 1)) and ($i != $#{$dataref})) {$textable .= '\midrule '};
       };
     $textable .= '\bottomrule'.$endtabular;
     $textable .= '\end{minipage}\par  \vspace{1pc}';


### PR DESCRIPTION
This patch addresses the two bugs that are described:
http://webwork.maa.org/moodle/mod/forum/discuss.php?d=3998

One issue: variable $footerline was referenced that is not mentioned anywhere else. I think it was an accidental remnant from a feature I tried to add one time but abandoned. Patch simply removes the reference.

Next issue: At line 367, inserted a check that a certain value is defined before using it in a comparison. 

The above two errors address the report at the forum post. Additionally, I discovered my own bug. It was possible for the LaTeX table output to create a cell with content like:
``
&\bfseries \multicolumn{...} &
``

And that construct is not allowed. You can't have something like `\bfseries` outside a `\multicolumn`. So the remaining edits to this file ensure that `\multicolumn` is outermost, if it arises.

Tested all this with the forum post's example problem. Also with all of the problems that the MBX ORCCA OER is using (around 500 at this point) many of which use `niceTables.pl` and all compiled correctly after these edits. If this leads to any issues reported in the forum or bugZilla I'll act quickly to address them.

I'm making this as a PR to `master`. Please advise if I should make a PR to `develop` instead or in addition.