### PR TITLE
Tikz -- proof of concept only -- don't pull into develop (yet) on openwebwork

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -759,7 +759,7 @@ sub AskSage {
 	my $self = shift;
 	my $python = shift;
 	my $options = shift;
-	$options->{curlCommand} = $self->{envir}->{externalCurlCommand};
+	$options->{curlCommand} = WeBWorK::PG::IO::curlCommand();  #FIXME just changed from alternate source
 	WeBWorK::PG::IO::AskSage($python, $options);
 }
  

--- a/lib/TikZ_Image2.pm
+++ b/lib/TikZ_Image2.pm
@@ -10,6 +10,7 @@ use Carp;
 
 package TikZ_Image2;
 
+use WeBWorK::PG::IO;
 #The constructor is meant to be called with no parameters
 sub new {
 	my $class = shift;
@@ -22,10 +23,10 @@ sub new {
 			working_dir      => '',
 			file_name 		 => '',
 			destination_path => '',
-			pdflatex_command => $rh_envir->{externalPrograms}->{pdflatex},
-			convert_command  => $rh_envir->{externalPrograms}->{convert},
-			copy_command     => $rh_envir->{externalPrograms}->{cp},
-			rh_envir         => $rh_envir,   # pointer to the environment
+			pdflatex_command => WeBWorK::PG::IO::pdflatexCommand(),
+			convert_command  => WeBWorK::PG::IO::convertCommand(),
+			copy_command     => WeBWorK::PG::IO::copyCommand(),
+			# rh_envir       => $rh_envir,   # pointer to the environment
 			displayMode      => $rh_envir->{displayMode},
 	};
 	return bless $self, $class;
@@ -91,6 +92,7 @@ sub header {
 	my @output=();
 	push @output, "\\documentclass{standalone}\n";
 	push @output, "\\usepackage{tikz}\n";
+	push @output, "\\usepackage{comment}\n"; # often used in tikz graphs
 	push @output, "\\begin{document}\n";
 #	push @output, "\\begin{tikzpicture}[".$self->{tikz_options}."]\n";
 	@output;

--- a/lib/TikZ_Image2.pm
+++ b/lib/TikZ_Image2.pm
@@ -1,0 +1,182 @@
+#!/bin/perl
+
+#This is a Perl Module which simplifies and automates the process of generating
+# simple images using TikZ, and converting them into a Web-Useable format
+# MV; March 2014
+
+use strict; 
+use warnings;
+use Carp;
+
+package TikZ_Image2;
+
+#The constructor is meant to be called with no parameters
+sub new {
+	my $class = shift;
+	my $tex=();
+	my $tikz_options = shift;
+	my $self = {
+			code			 =>	$tex, 
+			tikz_options	 =>	$tikz_options,
+			working_dir      => '',
+			file_name 		 => '',
+			destination_path => '',
+			pdflatex_command => '',
+			convert_command  => '',
+			copy_command     => '',
+	};
+	return bless $self, $class;
+}
+
+#FIXME -- passing in the actual commands to TikZ_Image2.pm
+#FIXME -- is extremely dangerous.  It gives command line access
+#FIXME -- to authors to insert just about any command.
+
+#typical values for command line apps
+
+
+# how should this module get the pdflatex command
+# and the convert command -- it needs access to site.conf
+# or else those locations need to be shared with PGcore
+# Call this method in the location where you want to generate your HTML code
+# OR, comment out print HTML $self->include() and use it when your image is 
+# complete
+
+#tempDirectory	=>	 /Volumes/WW_test/opt/webwork/webwork2/htdocs/tmp/daemon_course/
+# tempURL	=>	 /webwork2_files/tmp/daemon_course/
+# templateDirectory	=>	 /Volumes/WW_test/opt/webwork/courses/daemon_course/templates/
+
+
+# these should all be in $envir->{externalPdflatexPath} etc.
+# externalLaTeXPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/latex
+# externalDvipngPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/dvipng
+# externalcp	=>	 /bin/cp
+# externalPdflatexPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/pdflatex --shell-escape
+# externalConvert	=>	 
+
+my $extern_pdflatex='';
+sub set_commandline_mode {
+	my $self = shift;
+	my $commandline_mode = shift;    #FIXME this section is temporary
+	my $working_dir = $self->{working_dir};
+	if ($commandline_mode eq 'wwtest') {		
+		$extern_pdflatex="/Volumes/WW_test/opt/local/bin/pdflatex --shell-escape";
+		$self->{convert_command}  = "convert $working_dir/hardcopy.pdf "; #add destination file later
+		$self->{copy_command}     = "cp ";
+	} elsif ( $commandline_mode eq 'macbook') {
+		$extern_pdflatex ="/Library/TeX/texbin/pdflatex --shell-escape";
+		$self->{convert_command}  = "/usr/local/bin/convert $working_dir/hardcopy.pdf ";
+		$self->{copy_command}     = "cp ";
+	}
+	$self->{pdflatex_command} =  "cd " . $working_dir . " && "
+		. $extern_pdflatex. " >pdflatex.stdout 2>pdflatex.stderr hardcopy";
+}
+# Insert your TikZ image code, not including begin and end tags, as a single
+# string parameter for this method. Works best single quoted.
+sub addTex {
+	my $self= shift;
+	$self->{code} .= shift;
+}
+
+
+sub header {
+	my $self = shift;
+	my @output=();
+	push @output, "\\documentclass{standalone}\n";
+	push @output, "\\usepackage{tikz}\n";
+	push @output, "\\begin{document}\n";
+#	push @output, "\\begin{tikzpicture}[".$self->{tikz_options}."]\n";
+	@output;
+}
+
+sub footer {
+	my $self = shift;
+	my @output=();
+#	push @output, "\\end{tikzpicture}\n";
+	push @output, "\\end{document}\n";
+	@output;
+}
+
+# how should this module get the pdflatex command
+# and the convert command -- it needs access to site.conf
+# or else those locations need to be shared with PGcore
+# Call this method in the location where you want to generate your HTML code
+# OR, comment out print HTML $self->include() and use it when your image is 
+# complete
+sub render {
+	my $self = shift;
+	my $working_dir =  $self->{working_dir};
+	my $file_name = $self->{file_name};
+	my $file_path = "$working_dir/hardcopy";
+	my $html_directory   = $self->{html_temp};
+	my $fh;
+	open( $fh, ">", "$file_path.tex" ) or warn "Can't open $file_path.tex for writing<br/>\n";
+	chmod( 0777, "$file_path.tex");
+	print $fh $self->header();
+	print $fh $self->{code}."\n";	
+	print $fh $self->footer();
+	close $fh;	
+	my $pdflatex_command = $self->{pdflatex_command};
+	warn "render:  $pdflatex_command <br/>\n";
+	system "$pdflatex_command ";  # produces a .pdf file
+	unless (-r "$working_dir/hardcopy.pdf" ) {
+		warn "file $working_dir/hardcopy.pdf was not created<br/>\n";
+	} else {
+		warn "file $working_dir/hardcopy.pdf created<br/>\n";
+		unless ($self->convert) {
+			warn "convert operation failed<br/>\n";
+		} else {
+			warn "convert operation success<br/>\n";	
+			unless ($self->copy) {
+				warn "copy operation failed<br/>\n";
+			} else {
+				warn "copy operation succeeded<br/>\n";
+			}
+		}
+	}
+	#$self->clean_up;
+
+#here I'm assuming there's some file open which generates the HTML code for the
+# problem and its page, so render() should be called in the problem text portion
+# of a PG file.
+	#print HTML $self->include();
+}
+sub convert {
+	my $self = shift;
+	my $working_dir =  $self->{working_dir};
+	my $file_name = $self->{file_name};
+	my $file_path = "$working_dir/$file_name";
+	my $convert_command = $self->{convert_command};
+	warn "converting: ","$convert_command  $file_path.png","\n"; 
+	system "$convert_command  $file_path.png";
+	return -r "$file_path.png";
+}
+
+sub clean_up {
+	my $self = shift;
+	my $working_dir =  $self->{working_dir};
+	my $file_name = $self->{file_name};
+	my $file_path = "$working_dir/$file_name";
+	if (-e "$file_path.tex") {
+		# warn "clean up rm -f $working_dir/*";
+		system "rm -f $working_dir/*";
+	}
+}
+sub copy {
+	my $self = shift;
+	my $working_dir =  $self->{working_dir};
+	my $file_name = $self->{file_name};
+	my $file_path = "$working_dir/$file_name";
+	my $destination_path = $self->{destination_path};
+	my $copy_command = $self->{copy_command};
+	warn "copy: $copy_command $working_dir/$file_name.png $destination_path.png\n";	
+	system "$copy_command $working_dir/$file_name.png $destination_path.png";
+	return -r "$destination_path.png";
+}
+
+#Separating out the html so as not to get confused
+sub include {
+	my $html= qq|<img src=img.png alt="TikZ Image">|;
+	return $html;
+}
+1;

--- a/lib/TikZ_Image2.pm
+++ b/lib/TikZ_Image2.pm
@@ -28,6 +28,7 @@ sub new {
 			copy_command     => WeBWorK::PG::IO::copyCommand(),
 			# rh_envir       => $rh_envir,   # pointer to the environment
 			displayMode      => $rh_envir->{displayMode},
+			ext              => 'png',  # or svg or png or gif
 	};
 	return bless $self, $class;
 }
@@ -35,7 +36,7 @@ sub new {
 #FIXME -- passing in the actual commands to TikZ_Image2.pm
 #FIXME -- is extremely dangerous.  It gives command line access
 #FIXME -- to authors to insert just about any command.
-
+#FIXME -- allow ext to be overridden
 #typical values for command line apps
 
 
@@ -59,26 +60,26 @@ sub new {
 # externalConvert	=>	 
 
 my $extern_pdflatex='';
-sub set_commandline_mode {
-	my $self = shift;
-	my $commandline_mode = shift;    #FIXME this section is temporary
-	my $working_dir = $self->{working_dir};
-	if ($commandline_mode eq 'wwtest') {		
-		$extern_pdflatex="/Volumes/WW_test/opt/local/bin/pdflatex --shell-escape";
-		$self->{convert_command}  = "convert $working_dir/hardcopy.pdf "; #add destination file later
-		$self->{copy_command}     = "cp ";
-	} elsif ( $commandline_mode eq 'macbook') {
-		$extern_pdflatex ="/Library/TeX/texbin/pdflatex --shell-escape";
-		$self->{convert_command}  = "/usr/local/bin/convert $working_dir/hardcopy.pdf ";
-		$self->{copy_command}     = "cp ";
-	} elsif ( $commandline_mode eq 'hosted2') {
-		$extern_pdflatex="/usr/local/bin/pdflatex --shell-escape";
-		$self->{convert_command}  = "/usr/local/bin/convert $working_dir/hardcopy.pdf "; #add destination file later
-		$self->{copy_command}     = "cp ";
-	}
-	$self->{pdflatex_command} =  "cd " . $working_dir . " && "
-		. $extern_pdflatex. " >pdflatex.stdout 2>pdflatex.stderr hardcopy.tex";
-}
+# sub set_commandline_mode {
+# 	my $self = shift;
+# 	my $commandline_mode = shift;    #FIXME this section is temporary
+# 	my $working_dir = $self->{working_dir};
+# 	if ($commandline_mode eq 'wwtest') {		
+# 		$extern_pdflatex="/Volumes/WW_test/opt/local/bin/pdflatex --shell-escape";
+# 		$self->{convert_command}  = "convert $working_dir/hardcopy.pdf "; #add destination file later
+# 		$self->{copy_command}     = "cp ";
+# 	} elsif ( $commandline_mode eq 'macbook') {
+# 		$extern_pdflatex ="/Library/TeX/texbin/pdflatex --shell-escape";
+# 		$self->{convert_command}  = "/usr/local/bin/convert $working_dir/hardcopy.pdf ";
+# 		$self->{copy_command}     = "cp ";
+# 	} elsif ( $commandline_mode eq 'hosted2') {
+# 		$extern_pdflatex="/usr/local/bin/pdflatex --shell-escape";
+# 		$self->{convert_command}  = "/usr/local/bin/convert $working_dir/hardcopy.pdf "; #add destination file later
+# 		$self->{copy_command}     = "cp ";
+# 	}
+# 	$self->{pdflatex_command} =  "cd " . $working_dir . " && "
+# 		. $extern_pdflatex. " >pdflatex.stdout 2>pdflatex.stderr hardcopy.tex";
+# }
 # Insert your TikZ image code, not including begin and end tags, as a single
 # string parameter for this method. Works best single quoted.
 sub addTex {
@@ -86,7 +87,15 @@ sub addTex {
 	$self->{code} .= shift;
 }
 
+sub ext {
+	my $self = shift;
+	if (@_) {
+		return $self->{ext} = shift;
+	} else {
+		return $self->{ext};
+	}
 
+}
 sub header {
 	my $self = shift;
 	my @output=();
@@ -155,10 +164,11 @@ sub convert {
 	my $working_dir =  $self->{working_dir};
 	my $file_name = $self->{file_name};
 	my $file_path = "$working_dir/$file_name";
+	my $ext = $self->{ext};   # or png or gif
 	my $convert_command = $self->{convert_command};
-	warn "converting: ","$convert_command  $file_path.png","\n"; 
-	system "$convert_command  $file_path.png";
-	return -r "$file_path.png";
+	warn "converting: ","$convert_command  $file_path.$ext","\n"; 
+	system "$convert_command  $file_path.$ext";
+	return -r "$file_path.$ext";
 }
 
 sub clean_up {
@@ -178,11 +188,12 @@ sub copy {
 	my $file_path = "$working_dir/$file_name";
 	my $destination_path = $self->{destination_path};
 	my $copy_command = $self->{copy_command};
+	my $ext = $self->{ext};
 	if ($self->{displayMode} ne 'TeX') {
-		warn "copy: $copy_command $working_dir/$file_name.png $destination_path.png\n";	
-		system "$copy_command $working_dir/$file_name.png $destination_path.png";
-		$self->{final_destination_path}= "$destination_path.png";
-		return -r "$destination_path.png";
+		warn "copy: $copy_command $working_dir/$file_name.$ext $destination_path.$ext\n";	
+		system "$copy_command $working_dir/$file_name.$ext $destination_path.$ext";
+		$self->{final_destination_path}= "$destination_path.$ext";
+		return -r "$destination_path.$ext";
 	} else {
 		warn "copy: $copy_command $working_dir/hardcopy.pdf $destination_path.pdf\n";	
 		system "$copy_command $working_dir/hardcopy.pdf $destination_path.pdf";

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -13,6 +13,8 @@ use WeBWorK::CourseEnvironment;
 my $CE = new WeBWorK::CourseEnvironment({
     webwork_dir => $ENV{WEBWORK_ROOT},
 					});
+
+
 =head1 NAME
 
 WeBWorK::PG::IO - Private functions used by WeBWorK::PG::Translator for file IO.
@@ -250,10 +252,55 @@ Checks to see if the given path is a sub directory of the courses directory
 
 =cut
 
-sub path_is_course_subdir {
-    
+sub path_is_course_subdir {  
     return path_is_subdir(shift,$CE->{webwork_courses_dir},1);
 }
+
+
+
+
+=item curlCommand 
+
+	curl -- path to curl defined in site.conf
+
+=cut
+
+#FIXME change {curlCommand} to {curl}, here, and site.conf 
+
+sub WeBWorK::PG::IO::curlCommand {
+	# $CE->{externalPrograms}->{curlCommand};
+	$CE->{externalPrograms}->{curl};
+}
+=item convertCommand
+
+	convert -- path to convert defined in site.conf
+
+=cut
+
+sub WeBWorK::PG::IO::convertCommand {
+	$CE->{externalPrograms}->{convert};
+}
+
+=item pdflatexCommand
+
+	pdflatex -- path to pdflatex defined in site.conf
+
+=cut
+
+sub WeBWorK::PG::IO::pdflatexCommand {
+	$CE->{externalPrograms}->{pdflatex};
+}
+
+=item copyCommand
+
+	copyCommand -- path to cp defined in site.conf
+	
+=cut
+
+sub WeBWorK::PG::IO::copyCommand {
+	$CE->{externalPrograms}->{cp};
+}
+
 
 #
 # isolate the call to the sage server in case we have to jazz it up

--- a/lib/WeBWorK/PG/ImageGenerator.pm
+++ b/lib/WeBWorK/PG/ImageGenerator.pm
@@ -238,7 +238,7 @@ sub add {
 	my $url      = $self->{url};
 	my $basename = $self->{basename};
 	my $useCache = $self->{useCache};
-	my $depths  = $self->{depths};
+	my $depths   = $self->{depths};
 	
 	# if the string came in with delimiters, chop them off and set the mode
 	# based on whether they were \[ .. \] or \( ... \). this means that if

--- a/t/tikz_test/tikz_test1.pg
+++ b/t/tikz_test/tikz_test1.pg
@@ -1,0 +1,110 @@
+##DESCRIPTION
+
+# TEST from the tikz from a pg problem
+
+##ENDDESCRIPTION
+
+
+DOCUMENT();        # This should be the first executable line in the problem.
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   "PGinfo.pl",
+   #"source.pl",         # used to display problem source button
+   "PGcourse.pl",      # Customization file for the course
+);
+
+TEXT(beginproblem());
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+
+
+$working_dir = "$envir{templateDirectory}tikz_build";
+$file_name    = "potato2";
+$destination_path = "$envir{templateDirectory}set$setNumber/$file_name";
+# this destination_path is still a little fragile.
+
+my( $pdflatex_command, $copy_command, $copy_command);
+sub tikz_graph{
+	my $drawing = TikZ_Image2->new();
+	# initialize
+		$drawing->{working_dir}=$working_dir;
+		$drawing->{file_name}=$file_name;
+		$drawing->{destination_path}= $destination_path;
+		$drawing->set_commandline_mode("wwtest"); # "wwtest" or "macbook" or "hosted2"
+	# end initialize
+	# debugging /development
+	$copy_command=$drawing->{copy_command};
+	$pdflatex_command =$drawing->{pdflatex_command};
+	$convert_command = $drawing->{convert_command};
+	# end debugging
+	$drawing->addTex(shift);
+	$drawing->render();
+	return $drawing->{destination_path};
+}
+ 
+$path = tikz_graph(<<END_TIKZ);
+\begin{tikzpicture}[main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt]}] 
+\draw (-4,0) -- (4,0);
+\draw (0,-2) -- (0,2);
+\draw (0,0) circle (1.5);
+\draw (0, 1.5) node[anchor=south]{N} -- (2.5,0)node [above]{y};
+\draw (1.2,0.9) node[right]{\((\vec x, x_{n})\)};
+\end{tikzpicture}
+END_TIKZ
+
+
+Context("Numeric");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+	Print hi 
+	$BR working_dir = $working_dir;
+	$BR file_name = $file_name
+	$BR destination_path = $destination_path.pdf;
+	$BR path = $path.png;
+	$BR alias = \{alias("$path.png")\}
+	$PAR image = \{image("$path.png", width=>227, height=>114)\}
+	$PAR
+	More stuff
+	$BR pdflatex\{$pdflatex_command\}
+	$BR convert \{$convert_command\}
+	$BR copy    \{$copy_command\}
+	$BR 
+	envir  \{pretty_print(~~%envir)\}
+	
+	
+	$PAR end this
+END_TEXT
+Context()->normalStrings;
+
+#tempDirectory	=>	 /Volumes/WW_test/opt/webwork/webwork2/htdocs/tmp/daemon_course/
+# tempURL	=>	 /webwork2_files/tmp/daemon_course/
+# templateDirectory	=>	 /Volumes/WW_test/opt/webwork/courses/daemon_course/templates/
+
+#externalLaTeXPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/latex
+#externalDvipngPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/dvipng
+# externalcp	=>	 /bin/cp
+# externalPdflatexPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/pdflatex --shell-escape
+# externalConvert	=>	 
+##############################################################
+#
+#  Answers
+#
+#
+
+
+
+ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/t/tikz_test/tikz_test1.pg
+++ b/t/tikz_test/tikz_test1.pg
@@ -30,9 +30,9 @@ $file_name    = "potato2";
 $destination_path = "$envir{templateDirectory}set$setNumber/$file_name";
 # this destination_path is still a little fragile.
 
-my( $pdflatex_command, $copy_command, $copy_command);
+( $pdflatex_command, $copy_command, $copy_command, $displayMode);
 sub tikz_graph{
-	my $drawing = TikZ_Image2->new();
+	my $drawing = TikZ_Image2->new(~~%envir);
 	# initialize
 		$drawing->{working_dir}=$working_dir;
 		$drawing->{file_name}=$file_name;
@@ -43,10 +43,11 @@ sub tikz_graph{
 	$copy_command=$drawing->{copy_command};
 	$pdflatex_command =$drawing->{pdflatex_command};
 	$convert_command = $drawing->{convert_command};
+    $display_mode = $drawing->{displayMode};
 	# end debugging
-	$drawing->addTex(shift);
+	$drawing->addTex(join(" ",@_));
 	$drawing->render();
-	return $drawing->{destination_path};
+	return $drawing->{final_destination_path};
 }
  
 $path = tikz_graph(<<END_TIKZ);
@@ -68,26 +69,25 @@ Context("Numeric");
 #
 #
 
+$pdflatex_command=~s/~~&/~~~~&/g;
 Context()->texStrings;
 BEGIN_TEXT
 	Print hi 
-	$BR working_dir = $working_dir;
-	$BR file_name = $file_name
-	$BR destination_path = $destination_path.pdf;
-	$BR path = $path.png;
-	$BR alias = \{alias("$path.png")\}
-	$PAR image = \{image("$path.png", width=>227, height=>114)\}
+	$BR \{protect_underbar("working_dir = $working_dir")\}
+	$BR \{protect_underbar("file_name = $file_name")\}
+	$BR \{protect_underbar("destination_path = $destination_path")\}
+	$BR \{protect_underbar("path = $path")\};
+	$BR alias = \{protect_underbar(alias("$path"))\}
+	$PAR image = \{image("$path", width=>227, height=>114)\}
 	$PAR
-	More stuff
-	$BR pdflatex\{$pdflatex_command\}
-	$BR convert \{$convert_command\}
-	$BR copy    \{$copy_command\}
-	$BR 
-	envir  \{pretty_print(~~%envir)\}
+	$BR pdflatex \{protect_underbar("$pdflatex_command")\}
+	$BR convert \{protect_underbar("$convert_command")\}
+	$BR copy    \{protect_underbar("$copy_command")\}
 	
 	
 	$PAR end this
 END_TEXT
+
 Context()->normalStrings;
 
 #tempDirectory	=>	 /Volumes/WW_test/opt/webwork/webwork2/htdocs/tmp/daemon_course/

--- a/t/tikz_test/tikz_test1.pg
+++ b/t/tikz_test/tikz_test1.pg
@@ -37,7 +37,8 @@ sub tikz_graph{
 		$drawing->{working_dir}=$working_dir;
 		$drawing->{file_name}=$file_name;
 		$drawing->{destination_path}= $destination_path;
-		$drawing->set_commandline_mode("wwtest"); # "wwtest" or "macbook" or "hosted2"
+        $drawing->ext('png');
+		#$drawing->set_commandline_mode("wwtest"); # "wwtest" or "macbook" or "hosted2"
 	# end initialize
 	# debugging /development
 	$copy_command=$drawing->{copy_command};
@@ -79,6 +80,7 @@ BEGIN_TEXT
 	$BR \{protect_underbar("path = $path")\};
 	$BR alias = \{protect_underbar(alias("$path"))\}
 	$PAR image = \{image("$path", width=>227, height=>114)\}
+    $PAR svg   = \{embedSVG($path)\}
 	$PAR
 	$BR pdflatex \{protect_underbar("$pdflatex_command")\}
 	$BR convert \{protect_underbar("$convert_command")\}

--- a/t/tikz_test/tikz_test2.pg
+++ b/t/tikz_test/tikz_test2.pg
@@ -11,6 +11,7 @@ loadMacros(
    "PGstandard.pl",     # Standard macros for PG language
    "MathObjects.pl",
    "PGinfo.pl",
+   "PGML.pl",
    #"source.pl",         # used to display problem source button
    "PGcourse.pl",      # Customization file for the course
 );
@@ -30,23 +31,23 @@ $file_name    = "potato4";
 $destination_path = "$envir{templateDirectory}set$setNumber/$file_name";
 # this destination_path is still a little fragile.
 
-my( $pdflatex_command, $copy_command, $copy_command);
+ ($pdflatex_command, $copy_command, $copy_command);
 sub tikz_graph{
-	my $drawing = TikZ_Image2->new();
+	my $drawing = TikZ_Image2->new(~~%envir);
 	# initialize
 		$drawing->{working_dir}=$working_dir;
 		$drawing->{file_name}=$file_name;
 		$drawing->{destination_path}= $destination_path;
-		$drawing->set_commandline_mode("wwtest"); # "wwtest" or "macbook" or "hosted2"
+		$drawing->set_commandline_mode("hosted2"); # "wwtest" or "macbook" or "hosted2"
 	# end initialize
 	# debugging /development
-	$copy_command=$drawing->{copy_command};
+	$copy_command = $drawing->{copy_command};
 	$pdflatex_command =$drawing->{pdflatex_command};
 	$convert_command = $drawing->{convert_command};
 	# end debugging
 	$drawing->addTex(shift);
 	$drawing->render();
-	return $drawing->{destination_path};
+	return $drawing->{final_destination_path};
 }
  
 $path = tikz_graph("
@@ -61,7 +62,7 @@ $path = tikz_graph("
 \draw (0,-2) -- (0,2);
 \draw (0,0) circle (1.5);
 \draw (0, 1.5) node[anchor=south]{N} -- (2.5,0)node [above]{y};
-\draw (1.2,0.9) node[right]{$(\vec x, \x n)$};
+\draw (1.2,0.9) node[right]{\( ( x, x_n)\)};
 \end{tikzpicture}
 "
 );
@@ -75,26 +76,30 @@ Context("Numeric");
 #
 #
 
+
 Context()->texStrings;
-BEGIN_TEXT
-	Print hi 
-	$BR working_dir = $working_dir;
-	$BR file_name = $file_name
-	$BR destination_path = $destination_path.pdf;
-	$BR path = $path.png;
-	$BR alias = \{alias("$path.png")\}
-	$PAR image = \{image("$path.png")\}
-	$PAR
+BEGIN_PGML
+	Print hi   
+	working_dir =[$working_dir]     
+	file_name = [$file_name]   
+    destination_path = [$destination_path]      
+	path = [$path.png]    
+	alias = [@ alias("$path") @]*         
+    
+    image = [@ image("$path") @]*  
+
 	More stuff
-	$BR pdflatex\{$pdflatex_command\}
-	$BR convert \{$convert_command\}
-	$BR copy    \{$copy_command\}
-	$BR 
-	envir  \{pretty_print(~~%envir)\}
+	pdflatex = [$pdflatex_command]      
+	convert [$convert_command]      
+	copy    [$copy_command]      
+ 
 	
 	
-	$PAR end this
-END_TEXT
+	
+end this
+END_PGML
+
+
 Context()->normalStrings;
 
 #tempDirectory	=>	 /Volumes/WW_test/opt/webwork/webwork2/htdocs/tmp/daemon_course/

--- a/t/tikz_test/tikz_test2.pg
+++ b/t/tikz_test/tikz_test2.pg
@@ -1,0 +1,117 @@
+##DESCRIPTION
+
+# TEST from the tikz from a pg problem
+
+##ENDDESCRIPTION
+
+
+DOCUMENT();        # This should be the first executable line in the problem.
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   "PGinfo.pl",
+   #"source.pl",         # used to display problem source button
+   "PGcourse.pl",      # Customization file for the course
+);
+
+TEXT(beginproblem());
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+
+
+$working_dir = "$envir{templateDirectory}tikz_build";
+$file_name    = "potato4";
+$destination_path = "$envir{templateDirectory}set$setNumber/$file_name";
+# this destination_path is still a little fragile.
+
+my( $pdflatex_command, $copy_command, $copy_command);
+sub tikz_graph{
+	my $drawing = TikZ_Image2->new();
+	# initialize
+		$drawing->{working_dir}=$working_dir;
+		$drawing->{file_name}=$file_name;
+		$drawing->{destination_path}= $destination_path;
+		$drawing->set_commandline_mode("wwtest"); # "wwtest" or "macbook" or "hosted2"
+	# end initialize
+	# debugging /development
+	$copy_command=$drawing->{copy_command};
+	$pdflatex_command =$drawing->{pdflatex_command};
+	$convert_command = $drawing->{convert_command};
+	# end debugging
+	$drawing->addTex(shift);
+	$drawing->render();
+	return $drawing->{destination_path};
+}
+ 
+$path = tikz_graph("
+\begin{tikzpicture}[main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt]}] 
+\node[main_node] (1) at (0,0) {1}; 
+\node[main_node] (2) at (-1, -1.5)  {2};
+\node[main_node] (3) at (1, -1.5) {3}; 
+\draw (1) -- (2) -- (3) -- (1); 
+\end{tikzpicture}
+\begin{tikzpicture}[main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt]}]
+\draw (-4,0) -- (4,0);
+\draw (0,-2) -- (0,2);
+\draw (0,0) circle (1.5);
+\draw (0, 1.5) node[anchor=south]{N} -- (2.5,0)node [above]{y};
+\draw (1.2,0.9) node[right]{$(\vec x, \x n)$};
+\end{tikzpicture}
+"
+);
+
+
+Context("Numeric");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+	Print hi 
+	$BR working_dir = $working_dir;
+	$BR file_name = $file_name
+	$BR destination_path = $destination_path.pdf;
+	$BR path = $path.png;
+	$BR alias = \{alias("$path.png")\}
+	$PAR image = \{image("$path.png")\}
+	$PAR
+	More stuff
+	$BR pdflatex\{$pdflatex_command\}
+	$BR convert \{$convert_command\}
+	$BR copy    \{$copy_command\}
+	$BR 
+	envir  \{pretty_print(~~%envir)\}
+	
+	
+	$PAR end this
+END_TEXT
+Context()->normalStrings;
+
+#tempDirectory	=>	 /Volumes/WW_test/opt/webwork/webwork2/htdocs/tmp/daemon_course/
+# tempURL	=>	 /webwork2_files/tmp/daemon_course/
+# templateDirectory	=>	 /Volumes/WW_test/opt/webwork/courses/daemon_course/templates/
+
+#externalLaTeXPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/latex
+#externalDvipngPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/dvipng
+# externalcp	=>	 /bin/cp
+# externalPdflatexPath	=>	 /Volumes/WW_test/opt/local/texlive/2010/bin/x86_64-darwin/pdflatex --shell-escape
+# externalConvert	=>	 
+##############################################################
+#
+#  Answers
+#
+#
+
+
+
+ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/t/tikz_test/tikz_test2.pg
+++ b/t/tikz_test/tikz_test2.pg
@@ -38,7 +38,7 @@ sub tikz_graph{
 		$drawing->{working_dir}=$working_dir;
 		$drawing->{file_name}=$file_name;
 		$drawing->{destination_path}= $destination_path;
-		$drawing->set_commandline_mode("hosted2"); # "wwtest" or "macbook" or "hosted2"
+		#$drawing->set_commandline_mode("hosted2"); # "wwtest" or "macbook" or "hosted2"
 	# end initialize
 	# debugging /development
 	$copy_command = $drawing->{copy_command};


### PR DESCRIPTION
This is pull request illustrates proof of concept for rendering tikz code within a WeBWorK project. 

This branch is NOT ready for prime time and should not be pulled into develop(yet). We've place it here so you can take a look at it as it is developed. You can pull it into your local instances of WeBWorK ( split off from the develop branch) and see what you think of it. 

There are two example problems in pg/t/tikz_test that show how it is used (at present).  The user front end will probably change significantly as we get feedback. 

```
$path = tikz_graph(<<END_TIKZ);
\begin{tikzpicture}[main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt]}] 
\draw (-4,0) -- (4,0);
\draw (0,-2) -- (0,2);
\draw (0,0) circle (1.5);
\draw (0, 1.5) node[anchor=south]{N} -- (2.5,0)node [above]{y};
\draw (1.2,0.9) node[right]{\((\vec x, x_{n})\)};
\end{tikzpicture}
END_TIKZ
```
This is work of Mike Gage and Peter Peluso at U. of Rochester, based on the initial perl script developed by Mathew Vassair working under the direction of Dr. Sternin and Dr. D'Agostino at Brock University. 