### PR TITLE
Pgml fixes

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1461,6 +1461,7 @@ END_PREAMBLE
 package main;
 
 sub _PGML_init {
+  PG_restricted_eval('sub PGML {PGML::Format2(@_)}');
   loadMacros("MathObjects.pl");
   my $context = Context(); # prevent Typeset context from becoming active
   loadMacros("contextTypeset.pl");

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -754,6 +754,15 @@ sub combineTopItems {
       $prev->pushItem($top);
       $prev->combineTopItems;
       return;
+    } elsif ($id eq 'indent' && $top->{type} eq 'indent' && $prev->{type} eq 'list') {
+      $prev = $prev->topItem;
+      if ($top->{indent} > $value && $value > 0) {
+        splice(@{$self->{stack}},$i,1);
+        if ($par) {splice(@{$self->{stack}},$i,1); $prev->pushItem($par)}
+        $top->{indent} -= $value;
+        $prev->pushItem($top);
+        $prev->combineTopItems;
+      }
     }
   }
 return;
@@ -1067,8 +1076,8 @@ sub Align {
 }
 
 my %bullet = (
-  bullet  => 'ul',
-  numeric => 'ol',
+  bullet  => 'ul type="disc"',
+  numeric => 'ol type="1"',
   alpha   => 'ol type="a"',
   Alpha   => 'ol type="A"',
   roman   => 'ol type="i"',


### PR DESCRIPTION
This fixes several issues with lists in PGML.  These include:

* Allow Roman lists to include `l` or `L` for 50 (who knew anyone would need lists that long.
* Properly handle alphabetic lists that include `i.`, `v.`, and `x.` and `l.` entries.
* Fix problems with bullets used in nested lists (see [this comment](https://github.com/rbeezer/mathbook/pull/509#issuecomment-282524886)).
* Fix problems with nested lists restarting their numbering incorrectly (see [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4045)).

Finally, this also adds a `PGML()` function so that you can process PGML strings and get their result as a string (for use in tables, popup-lists, and other places where you might want substrings to be processed by PGML).

## Test cases:

For the first bullet:

```
BEGIN_PGML
l.  List with lower-case Roman numbers
l.  List with lower-case Roman numbers
END_PGML
```

```
BEGIN_PGML
L.  List with upper-case Roman numbers
L.  List with upper-case Roman numbers
END_PGML
```

Without the patch, these should produce alpha lists rather than roman lists.

For bullet 2:

```
BEGIN_PGML
a. Item 1.
h. Item 2.
i. Item 3.
j. Item 4.
END_PGML
```

should produce a single alpha list (a., b., c., d.), while

```
BEGIN_PGML
a. Item 1.
a. Item 2.
i. Item 3.
a. Item 4.
END_PGML
```

should produce an alpha list followed by a roman list, followed by an alpha list (a., b., i., a.).

Similar tests with `v.` (preceded by `u.`), `x.` (proceeded by `w.`) and `l.` (proceeded by `k.`) should work similarly.  Changing everyone to upper case should also work the same way.

Without the patch, these should all produce the second results (a., b., i., a.)


For bullet 3:

```
BEGIN_PGML
1.  Main item 1

    a.  Sublist Item 1

        Second Paragraph

    a.  Sublist Item 2

        Second Paragraph

2.  Main Item 2
END_PGML
```

should be properly numbered (1., a., b., 2.).  Without the patch, it would be (1., a., a., 1.)

```
BEGIN_PGML
1. Main item 1
    a. Sublist item 1
        i. Subsublist item
    a. Sublist Item 2
END_PGML
```

should be properly numbered (1., a., i., b.).  Without the patch it would be (1., a., i., a.)

For bullet 4:

```
BEGIN_PGML
* Main List
    * Sub List
END_PGML
```

with the patch, both should produce bullet lists with discs, while without the patch, the inner list will be a different bullet (depending on the CSS).

Finally, for `PGML()`:

```
TEXT(PGML("This is *PGML*"));
```

should output "This is **PGML**".  Without the patch, you should get an error about `PGML()` not being defined.