### PR TITLE
Fix typos, and make Unions report more uncombined sets

### DIFF
--- a/lib/Parser/Differentiation.pm
+++ b/lib/Parser/Differentiation.pm
@@ -100,7 +100,8 @@ sub Parser::BOP::divide::D {
         $BOP->new($equation,'*',
           $self->{lop}->copy($equation),$self->{rop}->D($x))
       ),
-      $BOP->new($equation,'^',$self->{rop},$self->Item("Number")->new($equation,2))
+      $BOP->new($equation,'^',$self->{rop}->copy($equation),
+        $self->Item("Number")->new($equation,2))
     );
   return $self->reduce;
 }

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -157,7 +157,7 @@ sub cmp_parse {
 	$ans->{student_ans} = preformat($ans->{student_formula}->substitute()->string);
 	contextSet($context,%{$oldFags}); last;
       };
-      warn "Unkown student answer format |$ans->{formatStudentAnswer}|";
+      warn "Unknown student answer format |$ans->{formatStudentAnswer}|";
     }
     if ($self->cmp_collect($ans)) {
       $self->cmp_preprocess($ans);
@@ -1023,7 +1023,7 @@ sub typeMatch {
   my $self = shift; my $other = shift; my $ans = shift;
   return 0 unless ref($other) && !$other->isFormula;
   return $other->type eq 'Matrix' ||
-    ($other->type =~ m/^(Point|list)$/ &&
+    ($other->type =~ m/^(Point|List)$/ &&
      $other->{open}.$other->{close} eq $self->{open}.$self->{close});
 }
 

--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -268,6 +268,12 @@ sub isReduced {
     if ($x->intersects($y)) {$error = "overlaps"; last}
     if (($x + $y)->reduce->type ne 'Union') {$error = "uncombined intervals"; last}
   }
+  if ($S.length) {
+    foreach my $x (@{$sU->{data}}) {
+      my $y = ($x + $S)->reduce;
+      if ($y->type ne 'Union' || $y->length != $S->length) {$error = "uncombined sets"; last}
+    }
+  }
   $error = "overlaps in sets" if !$error && $S->intersects($U);
   $error = "uncombined sets" if !$error && $Sn > 1 && !$self->getFlag('reduceSets');
   $error = "repeated elements in set" if !$error && !$S->isReduced;


### PR DESCRIPTION
This fixes a couple of typos in `AnswerCheckers.pm`, makes sure that the derivative of a fraction copies the denominator when squaring it (otherwise the derivative shares a tree node with the original), and fixes an error in `isReduced()` for Union objects where unions like `[0,1) U {1}` would be reported as reduced (rather than requiring it to be `[0,1]`).

The latter can be checked using

```
Context("Interval")->flags->set(
  reduceUnions => 0,
  reduceSets => 0,
);

($reduced,$reason) = Union("[0,1) U {1}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason");
```

Without the patch, this should report "Reduced = 0, Reason = uncombined sets", while without the patch, it should be "Reduced = 1, Reason = " with no reason.