### PR TITLE
Add differentiation to fractions, and add cmp_defaults

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -618,6 +618,8 @@ sub reduce {
 package context::Fraction::Real;
 our @ISA = ('Value::Real');
 
+sub cmp_defaults {Value::Real::cmp_defaults(@_)}
+
 #
 #  Allow Real to convert Fractions to Reals
 #
@@ -829,6 +831,16 @@ sub cos {my $self = shift; $self->make(CORE::cos($self->eval))}
 sub atan2 {
   my ($self,$l,$r,$other) = Value::checkOpOrderWithPromote(@_);
   return $self->inherit($other)->make(CORE::atan2($l->eval,$r->eval));
+}
+
+##################################################
+#
+#  Differentiation
+#
+
+sub D {
+  my $self = shift;
+  return $self->make(0,1);
 }
 
 ##################################################


### PR DESCRIPTION
This adds the `D()` method for differentiation (the inherited one produces fractions of the form 0/0 which throw an error).  Also add `cmp_defaults()` so that if a fraction-valued formula is used in an answer checker, it will work.

To test the differentiation, use

```
loadMacros("contextFraction.pl");
Context("Fraction");
$f = Fraction("1/2");
TEXT($f->D);
```

With the patch, this should output 0; without it, it should produce an error.

To test the second method, use

```
loadMacros("PGML.pl","contextFraction.pl");
Context("Fraction");
$f = Formula("1/2");
BEGIN_PGML
[_____]{$f}
END_PGML
```

Without the patch you should get an error; with the patch, you should get no error (and an answer blank for the fraction);