### PR TITLE
Fix problem reported by Alex at 4973307a4e7c50b6e4f1afdc6f2c44433f7e6f8f#commitcomment-23035223

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -732,8 +732,8 @@ sub combineTopItems {
   my $id = $top->{combine}{$prev->{type}}; my $value; my $inside = 0;
   if ($id) {
     if (ref($id) eq 'HASH') {($id,$value) = %$id; $inside = 1} else {$value = $prev->{$id}}
-    my $topList = substr(($top->topItem || {})->{token} || '',0,2);
-    my $prevList = substr(($prev->topItem || {})->{token} || '',0,2);
+    my $topList = (Value::isa($top,'PGML::Block') ? substr(($top->topItem || {})->{token} || '',0,2) : '');
+    my $prevList = (Value::isa($prev,'PGML::Block') ? substr(($prev->topItem || {})->{token} || '',0,2) : '');
     if (
         $top->{$id} eq $value ||
         ($top->{type} eq 'list' && $top->{bullet} eq 'roman' &&


### PR DESCRIPTION
Fix problem reported by Alex at 4973307a4e7c50b6e4f1afdc6f2c44433f7e6f8f#commitcomment-23035223.  The issue is due to trying to set `$topList` when `$top` is not a block-level element.

Here is a reduced test case:

```
BEGIN_PGML
* Item
    continued
END_PGML
```

Without the patch, this should produce an error message (about not being able to use `topItem` on `PGML::Text`).  With the patch, it should produce the usual output (a list item with "item continued" as the text).

Once this is pulled to PG-2.13, I will make a PR to develop to make sure the change is reflected there as well.