### PR TITLE
Fix error with checking for uncombined sets.

### DIFF
--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -268,10 +268,13 @@ sub isReduced {
     if ($x->intersects($y)) {$error = "overlaps"; last}
     if (($x + $y)->reduce->type ne 'Union') {$error = "uncombined intervals"; last}
   }
-  if ($S.length) {
+  if ($S->length) {
     foreach my $x (@{$sU->{data}}) {
       my $y = ($x + $S)->reduce;
-      if ($y->type ne 'Union' || $y->length != $S->length) {$error = "uncombined sets"; last}
+      if ($y->type ne 'Union' && ($y->type ne 'Set' || $y->length == $S->length)) {
+        $error = "uncombined sets";
+        last;
+      }
     }
   }
   $error = "overlaps in sets" if !$error && $S->intersects($U);


### PR DESCRIPTION
This fixes a problem with PR #306, which caused too many errors to be reported.  The main error was that `$S.length` should have been `$s->length` (I've been doing too much javascript programming), but there was also an issue with the condition for sets that aren't combined.

To test, use

```
Context("Interval")->flags->set(
  reduceUnions => 0,
  reduceSets => 0,
);

($reduced,$reason) = Union("[0,1) U (1,2]")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason",$HR);
($reduced,$reason) = Union("{1,2} U {3,4}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason",$HR,$HR);

($reduced,$reason) = Union("[0,1) U {1}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason",$HR);
($reduced,$reason) = Union("{1} U {1}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason",$HR);
($reduced,$reason) = Union("{1,2} U {1}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason",$HR);
($reduced,$reason) = Union("{1} U {1,2}")->isReduced();
TEXT("Reduced = $reduced",$BR,"Reason = $reason");
```

The first two (above the double lines) should produce "Reduced = 1, Reason =", while the others should all produce "Reduced = 0, Reason = uncombined sets".

Sorry about the errors!
