### PR TITLE
allow omission of height from image subroutine and preserve aspect ratio

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2689,7 +2689,7 @@ sub image {
 	my %in_options = @opt;
 	my %known_options = (
 		width    => 100,
-		height   => 100,
+		height   => '',
 		tex_size => 800,
 		extra_html_tags => '',
 	);
@@ -2708,6 +2708,11 @@ sub image {
 	my $tex_size    = $out_options{tex_size};
 	my $width_ratio = $tex_size*(.001);
 	my @image_list  = ();
+
+    # if height was explicitly given, create string for height attribute to be used in HTML, LaTeX2HTML
+    # otherwise omit a height attribute and allow the browser to use aspect ratio preservation
+    my $height_attrib = '';
+    $height_attrib = qq{height = "$height"} if ($height);
 
  	if (ref($image_ref) =~ /ARRAY/ ) {
 		@image_list = @{$image_ref};
@@ -2741,7 +2746,7 @@ sub image {
 			}
 		} elsif ($displayMode eq 'Latex2HTML') {
 			my $wid = ($envir->{onTheFlyImageSize} || 0)+ 30;
-			$out = qq!\\begin{rawhtml}\n<A HREF= "$imageURL" TARGET="_blank" onclick="window.open(this.href,this.target, 'width=$wid,height=$wid,scrollbars=yes,resizable=on'); return false;"><IMG SRC="$imageURL"  WIDTH="$width" HEIGHT="$height"></A>\n
+			$out = qq!\\begin{rawhtml}\n<A HREF= "$imageURL" TARGET="_blank" onclick="window.open(this.href,this.target, 'width=$wid,height=$wid,scrollbars=yes,resizable=on'); return false;"><IMG SRC="$imageURL"  WIDTH="$width" $height_attrib></A>\n
 			\\end{rawhtml}\n !
  		} elsif ($displayMode eq 'HTML_MathJax'
 	 || $displayMode eq 'HTML_dpng'
@@ -2754,7 +2759,7 @@ sub image {
 			my $wid = ($envir->{onTheFlyImageSize} || 0) +30;
  			$out = qq!<A HREF= "$imageURL" TARGET="_blank" 
  			         onclick="window.open(this.href,this.target, 'width=$wid,height=$wid,scrollbars=yes,resizable=on'); return false;">
- 			         <IMG SRC="$imageURL"  WIDTH="$width" HEIGHT="$height" $out_options{extra_html_tags} >
+ 			         <IMG SRC="$imageURL"  WIDTH="$width" $height_attrib $out_options{extra_html_tags} >
  			         </A>
  			!
  		} else {


### PR DESCRIPTION
Prior to this commit, when calling the `image()` subroutine, omitting a height specification causes a default of 100 (px) to be used in HTML output. This changes the behavior so that when a height is not specified, it is not specified in the HTML `IMG` tag either. So the specified width (or the default width of 100) will be combined with the image's actual aspect ratio by the browser to define the width that we see.

I tested with:
```
$g = init_graph(-2,-2,2,2,axes=>[0,0],size=>[300,200]);
add_functions($g, "-x for x in <-2,2> " .
    "using color:blue and weight:2");

BEGIN_TEXT
\{image(insertGraph($g))\}

\{image("some-gif.gif")\}

\{image("some-jpg.jpg")\}

END_TEXT
```
where the first image is a dynamically created png, and the second two images were uploaded adjacent to the .pg test file. Best to use images that do not have 1:1 aspect ratios. Then play around with adding `width=>some-number` and see if the width is respected and the aspect ratio is maintained. Then also specify height and see if that is respected.

Test across browsers.

No need to test hard copy output because the code doesn't touch that.

This change in behavior should not affect OPL problems because they _should_ have been specifying a height up to now. The only way this would change OPL problems is if there is a problem that wanted the 100 px height and was obtaining it by letting the default take hold instead of explicitly asking for 100px. And even then, there will be no bad effect unless the problem author intentionally wanted a bad aspect ratio.

The purpose of this commit is to allow authors to only specify a width when using `image()` and not worry about height.

