### PR TITLE
Fix problem with using identity matrix as a constant

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -321,9 +321,10 @@ sub I {
   Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
   Value::Error("Dimension must be a positive integer") unless $d =~ m/^[1-9]\d*$/;
   my @M = (); my @Z = split('',0 x $d);
+  my $REAL = $context->Package('Real');
   foreach my $i (0..$d-1) {
     my @row = @Z; $row[$i] = 1;
-    push(@M,$self->make($context,@row));
+    push(@M,$self->make($context, map {$REAL->new($_)} @row));
   }
   return $self->make($context,@M);
 }


### PR DESCRIPTION
The `Value::Matrix->I($n)` method for generating an $n x $n identity matrix ends up using perl reals rather than MathObject Reals for its entries.  This is usually OK, as they should be promoted to MathObjects when needed, but that isn't always the case.  When the identity matrix is added to a formula as a named constant, and when that constant is evaluated, it produces an error.  This PR fixes that issue.

To test, use

```
Context("Matrix")->constants->add(I => Value::Matrix->I(3));
TEXT(Compute('I'));
```

Without the patch, you should get an error.  With the patch, you should see `[[1,0,0],[0,1,0],[0,0,1]]` in the output.

See the associated [bug report](http://bugs.webwork.maa.org/show_bug.cgi?id=3703).