### PR TITLE
Add missing parentheses around vectors in IJK mode.

### DIFF
--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -27,6 +27,7 @@ sub _check {
 sub ijk {
   my $self = shift; my $context = $self->context;
   my $method = shift || ($context->flag("StringifyAsTeX") ? 'TeX': 'string');
+  my $precedence = shift || 0;
   my @coords = @{$self->{coords}};
   $self->Error("Method 'ijk' can only be used on vectors in three-space")
     unless (scalar(@coords) <= 3);
@@ -47,19 +48,20 @@ sub ijk {
     }
   }
   $string = $ijk[3] if $string eq '';
+  $string = '('.$string.')' if $string =~ m/[-+]/ && $precedence > $context->operators->get('+')->{precedence};
   return $string;
 }
 
 sub TeX {
   my $self = shift;
-  return $self->ijk("TeX")
+  return $self->ijk("TeX",@_)
     if $self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk");
   return $self->SUPER::TeX;
 }
 
 sub string {
   my $self = shift;
-  return $self->ijk("string")
+  return $self->ijk("string",@_)
     if $self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk");
   return $self->SUPER::string;
 }


### PR DESCRIPTION
When vectors are printed in IJK mode as part of a formula, parentheses may be needed around them, as in `2(i+3t-k)`, but MathObjects isn't inserting these.  This PR resolves that issue.

To test, use

```
Context("Vector")->flags->set(ijk=>1);
TEXT(Compute("2<1,x,3>"),$BR);
TEXT(Compute("2<0,-x,0>"),$BR);
TEXT(Compute("2<0,x,0>"),$BR);
```

Without the patch, you will get `2*i+xj+3k`, `2*-xj` and `2*xj`.  With the patch, you will get (the correct results) `2*(i+xj+3k)`, `2*(-xj)` and `2*xj`.

See the associated [bug report](http://bugs.webwork.maa.org/show_bug.cgi?id=3702).