### PR TITLE
Use proper closing markers for inequalities using 'and x != ...'

### DIFF
--- a/macros/contextInequalities.pl
+++ b/macros/contextInequalities.pl
@@ -696,6 +696,7 @@ sub display {
 	  push(@points,$X.$ne.$x->{data}[0]->$method($equation));
 	  $interval = $interval->with(isCopy=>1, data=>[$interval->value]) unless $interval->{isCopy};
 	  $interval->{data}[1] = $x->{data}[1];
+          $interval->{close} = $x->{close};
 	  $interval->{rightInfinite} = 1 if $x->{rightInfinite};
 	  next;
 	}


### PR DESCRIPTION
When displaying some inequalities, the type of the right-hand endpoint (open or closed) can be displayed incorrectly.  See the original [forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4162) for details.  Note that the display is wrong, but the internal representation is correct, and answers will be marked correctly even with the current code.

To test the patch, use

```
loadMacros("contextInequalities.pl");
Context("Inequalities");
TEXT(Compute("0 <= x <= 2 and x != 1"))
```

Without the patch, you will see the incorrect result `0 <= x < 2 and x != 1` (the `x <= 2` has become `x < 2`).  With the patch, you should see `0 <= x <= 2 and x != 1`.