### PR TITLE
introduce BLTR and ELTR for "left to right" environments

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -402,7 +402,7 @@ sub NAMED_ANS_RULE {
 
 	    # Note: codeshard is used in the css to identify input elements 
 	    # that come from pg
-		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" value="$answer_value"/>\n!.
+		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" dir="auto" value="$answer_value"/>\n!.
 		              $add_html. # added for dragmath
                         qq!<input type=hidden  name="$previous_name" value="$answer_value"/>\n!,
 		
@@ -488,7 +488,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 	MODES(
 		TeX => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=TEXT SIZE=$col NAME="$name" id="$name" VALUE = " ">\n\\end{rawhtml}\n!,
-		HTML => qq!<INPUT TYPE=TEXT CLASS="codeshard" SIZE=$col NAME = "$name" id="$name" aria-label="$label" VALUE = "$answer_value">!.
+		HTML => qq!<INPUT TYPE=TEXT CLASS="codeshard" SIZE=$col NAME = "$name" id="$name" aria-label="$label" dir="auto" VALUE = "$answer_value">!.
                         qq!<INPUT TYPE=HIDDEN  NAME="previous_$name" id="previous_$name" VALUE = "$answer_value">!
 	);
 }

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -77,6 +77,8 @@ my ($PAR,
 	$EUL,
 	$BCENTER,
 	$ECENTER,
+	$BLTR,
+	$ELTR,
 	$HR,
 	$LBRACE,
 	$RBRACE,
@@ -144,6 +146,8 @@ main::PG_restricted_eval( <<'EndOfFile');
 	$main::EUL              = EUL();
 	$main::BCENTER          = BCENTER();
 	$main::ECENTER          = ECENTER();
+	$main::BLTR          = BLTR();
+	$main::ELTR          = ELTR();
 	$main::HR				= HR();
 	$main::LBRACE			= LBRACE();
 	$main::RBRACE			= RBRACE();
@@ -197,6 +201,8 @@ EndOfFile
 	$EUL                 = EUL();
 	$BCENTER             = BCENTER();
 	$ECENTER             = ECENTER();
+	$BLTR             = BLTR();
+	$ELTR             = ELTR();
 	$HR				     = HR();
 	$LBRACE			     = LBRACE();
 	$RBRACE			     = RBRACE();
@@ -1512,6 +1518,8 @@ sub MODES {
 	$EUL    			EUL()  				end underlined type
 	$BCENTER    		BCENTER()   		begin centered environment
 	$ECENTER    		ECENTER()  			end centered environment
+	$BLTR    		BLTR()   		begin left to right environment
+	$ELTR    		ELTR()  			end left to right environment
 	$HR					HR()				horizontal rule
 	$LBRACE				LBRACE()			left brace
 	$LB					LB ()				left brace
@@ -1580,8 +1588,10 @@ sub BITALIC { MODES(TeX => '{\\it ',  Latex2HTML => '{\\it ', HTML => '<I>'); };
 sub EITALIC { MODES(TeX => '} ',  Latex2HTML => '} ', HTML => '</I>'); };
 sub BUL { MODES(TeX => '\\underline{',  Latex2HTML => '\\underline{', HTML => '<U>'); };
 sub EUL { MODES(TeX => '}',  Latex2HTML => '}', HTML => '</U>'); };
-sub BCENTER { MODES(TeX => '\\begin{center} ',  Latex2HTML => ' \\begin{rawhtml} <div align="center"> \\end{rawhtml} ', HTML => '<div align="center">'); };
+sub BCENTER { MODES(TeX => '\\begin{center} ',  Latex2HTML => ' \\begin{rawhtml} <div align="center"> \\end{rawhtml} ', HTML => '<div align="center" dir="ltr">'); };
 sub ECENTER { MODES(TeX => '\\end{center} ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</div>'); };
+sub BLTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} <div dir="ltr"> \\end{rawhtml} ', HTML => '<span dir="ltr">'); };
+sub ELTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</span>'); };
 sub HR { MODES(TeX => '\\par\\hrulefill\\par ', Latex2HTML => '\\begin{rawhtml} <HR> \\end{rawhtml}', HTML =>  '<HR>'); };
 sub LBRACE { MODES( TeX => '\{', Latex2HTML =>   '\\lbrace',  HTML =>  '{' , HTML_tth=> '\\lbrace' ); };
 sub RBRACE { MODES( TeX => '\}', Latex2HTML =>   '\\rbrace',  HTML =>  '}' , HTML_tth=> '\\rbrace',); };


### PR DESCRIPTION
Purpose: In HTML pages with global dir="rtl" setting (for instance in an
Arabic or Hebrew environment) one may still want mathematical formulas
to be printed from left to right. The pull request https://github.com/openwebwork/webwork2/pull/802 provides a theme for a global right-to-left environment.