### PR TITLE
PreTeXt support

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -265,7 +265,7 @@ sub make_alias {
 		    or $ext eq 'js'
 		    or $ext eq 'nb'
 		    ) {
-		if ($displayMode =~ /^HTML/ ) {			 
+		if ($displayMode =~ /^HTML/ or $displayMode eq 'PTX') {
 			 $adr_output=$self->alias_for_html($aux_file_id, $ext);
 		} elsif ($displayMode eq 'TeX') {
 			################################################################################

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1858,8 +1858,8 @@ sub default_preprocess_code {
 	$evalString =~ s/\n\h*END_PGML_HINT[\h;]*\n/\nEND_PGML_HINT\n/g;
 	$evalString =~ s/\n\h*END_SOLUTION[\h;]*\n/\nEND_SOLUTION\n/g;
 	$evalString =~ s/\n\h*END_HINT[\h;]*\n/\nEND_HINT\n/g;
-	$evalString =~ s/\n\h*BEGIN_TEXT[\h;]*\n/\nTEXT\(EV3P\(<<'END_TEXT'\)\);\n/g;
-	$evalString =~ s/\n\h*BEGIN_PGML[\h;]*\n/\nTEXT\(PGML::Format2\(<<'END_PGML'\)\);\n/g;
+	$evalString =~ s/\n\h*BEGIN_TEXT[\h;]*\n/\nSTATEMENT\(EV3P\(<<'END_TEXT'\)\);\n/g;
+	$evalString =~ s/\n\h*BEGIN_PGML[\h;]*\n/\nSTATEMENT\(PGML::Format2\(<<'END_PGML'\)\);\n/g;
 	$evalString =~ s/\n\h*BEGIN_PGML_SOLUTION[\h;]*\n/\nSOLUTION\(PGML::Format2\(<<'END_PGML_SOLUTION'\)\);\n/g;
 	$evalString =~ s/\n\h*BEGIN_PGML_HINT[\h;]*\n/\nHINT\(PGML::Format2\(<<'END_PGML_HINT'\)\);\n/g;
 	$evalString =~ s/\n\h*BEGIN_SOLUTION[\h;]*\n/\nSOLUTION\(EV3P\(<<'END_SOLUTION'\)\);\n/g;

--- a/macros/AppletObjects.pl
+++ b/macros/AppletObjects.pl
@@ -334,7 +334,7 @@ sub insertAll {  ## inserts both header text and object text
     # Return HTML or TeX strings to be included in the body of the page
 	##########################
         
-    return main::MODES(TeX=>' {\bf  applet } ', HTML=>$self->insertObject.$main::BR.$state_storage_html_code.$answerBox_code);
+    return main::MODES(TeX=>' {\bf  applet } ', HTML=>$self->insertObject.$main::BR.$state_storage_html_code.$answerBox_code, PTX=>' applet ');
 }
 
 =head3 Example problem

--- a/macros/CanvasObject.pl
+++ b/macros/CanvasObject.pl
@@ -172,7 +172,7 @@ END_HEADER_TEXT
 sub insertCanvas {
     my $myWidth = shift() || 200;
     my $myHeight = shift() ||200;
-	$canvasObject = MODES(TeX=>"canvasObject",HTML=><<END_CANVAS);
+	$canvasObject = MODES(TeX=>"canvasObject", PTX=>" canvas object ", HTML=><<END_CANVAS);
 	<script> var canvasWidth = $myWidth; var canvasHeight = $myHeight;</script>
 	<canvas id="cv" data-src="${webworkHtmlURL}js/sketchgraphhtml5b/SketchGraph.pjs" width="$myWidth" height="$myHeight"></canvas>  
 END_CANVAS
@@ -181,7 +181,7 @@ END_CANVAS
 }
 
 sub insertYvaluesInputBox {
-	$yValuesInput = MODES(TeX=>"yVAluesInput",HTML=><<EOF);
+	$yValuesInput = MODES(TeX=>"yValuesInput", PTX=>" <m>y</m>-values input ", HTML=><<EOF);
 	<p>
 	Y-values: 
 	<input type="text" id="points1" size=50></input>
@@ -193,7 +193,7 @@ EOF
 }
 
 sub insertGridButtons {
-	$gridButtons = MODES(TeX=>"gridButtons",HTML=><<EOF);
+	$gridButtons = MODES(TeX=>"gridButtons", PTX=>" grid buttons ", HTML=><<EOF);
 	<button type="button" id="hideGrid" onClick="toggleGrid();">Toggle Grid</button>
 	<button type="button" id="reset1" onClick="my_reset();">Reset to Zero</button>
 	<button type="button" id="smooth1" onClick="smooth();">Smooth</button>
@@ -406,7 +406,7 @@ EOF
 #  }
 
 sub insertPointsArea {
-	$pointsArea = MODES(TeX=>"pointsArea",HTML=><<EOF);
+	$pointsArea = MODES(TeX=>"pointsArea", PTX=>" points area ", HTML=><<EOF);
 	<button type="button" id="getPts" onClick="getPoints();">Get Points</button><br/>
 	<textarea id="pointDisplay" rows=10 cols=60></textarea>	
 EOF

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1335,6 +1335,133 @@ sub Math {
 ######################################################################
 ######################################################################
 
+package PGML::Format::ptx;
+our @ISA = ('PGML::Format');
+
+sub Escape {
+  my $self = shift;
+  my $string = shift; return "" unless defined $string;
+  $string = main::PTX_special_character_cleanup($string);
+  return $string;
+}
+
+# No indentation for PTX
+sub Indent {
+  my $self = shift; my $item = shift;
+  return $self->string($item);
+}
+
+# No align for PTX
+sub Align {
+  my $self = shift; my $item = shift;
+  return $self->string($item);
+}
+
+my %bullet = (
+  bullet  => 'ul',
+  numeric => 'ol label="1."',
+  alpha   => 'ol label="a."',
+  Alpha   => 'ol label="A."',
+  roman   => 'ol label="i."',
+  Roman   => 'ol label="I."',
+  disc    => 'ul label="disc"',
+  circle  => 'ul label="circle"',
+  square  => 'ul label="square"',
+);
+sub List {
+  my $self = shift; my $item = shift;
+  my $list = $bullet{$item->{bullet}};
+  return
+    $self->nl .
+    '<'.$list.'>'."\n" .
+    $self->string($item) .
+    $self->nl .
+    "</".substr($list,0,2).">\n";
+}
+
+sub Bullet {
+  my $self = shift; my $item = shift;
+  return $self->nl.'<li>'.$self->string($item).'</li>';
+}
+
+sub Code {
+  my $self = shift; my $item = shift;
+  my $class = ($item->{class} ? ' class="'.$item->{class}.'"' : "");
+  return $self->nl .
+    "<cd>\n<cline>" .
+    join("<\/cline>\n<cline>", split(/\n/,$self->string($item))) .
+    "<\/cline>\n<\/cd>\n";
+}
+
+sub Pre {
+  my $self = shift; my $item = shift;
+  return
+    $self->nl .
+    '<pre>' .
+    $self->string($item) .
+    "</pre>\n";
+}
+
+# PreTeXt can't use headings.
+sub Heading {
+  my $self = shift; my $item = shift;
+  my $n = $item->{n};
+  my $text = $self->string($item);
+  $text =~ s/^ +| +$//gm; $text =~ s! +(<br />)!$1!g;
+  return $text."\n";
+}
+
+sub Par {
+  my $self = shift; my $item = shift;
+  return $self->nl."\n";
+}
+
+sub Break {"\n\n"}
+
+sub Bold {
+  my $self = shift; my $item = shift;
+  return '<em>'.$self->string($item).'</em>';
+}
+
+sub Italic {
+  my $self = shift; my $item = shift;
+  return '<em>'.$self->string($item).'</em>';
+}
+
+our %openQuote = ('"' => "<lq />", "'" => "<lsq />");
+our %closeQuote = ('"' => "<rq />", "'" => "<rsq />");
+sub Quote {
+  my $self = shift; my $item = shift; my $string = shift;
+  return $openQuote{$item->{token}} if $string eq "" || $string =~ m/(^|[ ({\[\s])$/;
+  return $closeQuote{$item->{token}};
+}
+
+# No rule for PTX
+sub Rule {
+  my $self = shift; my $item = shift;
+  return $self->nl;
+}
+
+sub Verbatim {
+  my $self = shift; my $item = shift;
+  #Don't escape most content. Just < and &
+  #my $text = $self->Escape($item->{text});
+  my $text = $item->{text};
+  $text =~ s/</&lt;/g;
+  $text =~ s/&/&amp;/g;
+  $text = "<c>$text</c>";
+  return $text;
+}
+
+sub Math {
+  my $self = shift;
+  return main::math_ev3($self->SUPER::Math(@_));
+}
+
+
+######################################################################
+######################################################################
+
 package PGML;
 
 sub Format {
@@ -1343,6 +1470,9 @@ sub Format {
   my $format;
   if ($main::displayMode eq 'TeX') {
     $format = "{\\pgmlSetup\n".PGML::Format::tex->new($parser)->format."\\par}%\n";
+  } elsif ($main::displayMode eq 'PTX') {
+    $format = PGML::Format::ptx->new($parser)->format."\n";
+    $format = main::PTX_cleanup($format);
   } else {
     $format = '<div class="PGML">'."\n".PGML::Format::html->new($parser)->format.'</div>'."\n";
   }

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -405,6 +405,7 @@ sub NAMED_ANS_RULE {
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" dir="auto" value="$answer_value"/>\n!.
 		              $add_html. # added for dragmath
                         qq!<input type=hidden  name="$previous_name" value="$answer_value"/>\n!,
+        PTX => '<fillin name="'."$name".'" characters="'."$col".'" />',
 		
 	);
 }
@@ -445,7 +446,8 @@ sub NAMED_HIDDEN_ANS_RULE { # this is used to hold information being passed into
 		TeX => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
 		Latex2HTML => qq!\\begin{rawhtml}<INPUT TYPE=TEXT SIZE=$col NAME=\"$name\" VALUE = \"\">\\end{rawhtml}!,
 		HTML => qq!<INPUT TYPE=HIDDEN SIZE=$col NAME="$name" id ="$name" VALUE="$answer_value">!.
-                        qq!<INPUT TYPE=HIDDEN  NAME="previous_$name" id = "previous_$name" VALUE="$answer_value">!
+                        qq!<INPUT TYPE=HIDDEN  NAME="previous_$name" id = "previous_$name" VALUE="$answer_value">!,
+        PTX => '',
 	);
 }
 sub NAMED_ANS_RULE_OPTION {   # deprecated
@@ -495,7 +497,8 @@ sub NAMED_ANS_RULE_EXTENSION {
 		TeX => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=TEXT SIZE=$col NAME="$name" id="$name" VALUE = " ">\n\\end{rawhtml}\n!,
 		HTML => qq!<INPUT TYPE=TEXT CLASS="codeshard" SIZE=$col NAME = "$name" id="$name" aria-label="$label" dir="auto" VALUE = "$answer_value">!.
-                        qq!<INPUT TYPE=HIDDEN  NAME="previous_$name" id="previous_$name" VALUE = "$answer_value">!
+                        qq!<INPUT TYPE=HIDDEN  NAME="previous_$name" id="previous_$name" VALUE = "$answer_value">!,
+		PTX => '<fillin name="'."$name".'" characters="'."$col".'" />',
 	);
 }
 
@@ -536,7 +539,8 @@ sub  NAMED_ANS_BOX {
          HTML => qq!<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col"
                WRAP="VIRTUAL">$answer_value</TEXTAREA>
              <INPUT TYPE=HIDDEN  NAME="previous_$name" VALUE = "$answer_value">
-           !
+            !,
+         PTX => '<var name="'."$name".'" height="'."$row".'" width="'."$col".'" />',
          );
 	$out;
 }
@@ -571,7 +575,8 @@ sub NAMED_ANS_RADIO {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=RADIO NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!
+        HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+        PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
 }
@@ -610,7 +615,8 @@ sub NAMED_ANS_RADIO_EXTENSION {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=RADIO NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!
+        HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+        PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
 }
@@ -771,7 +777,8 @@ sub NAMED_ANS_CHECKBOX {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=CHECKBOX NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!
+        HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+        PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
 }
@@ -808,7 +815,8 @@ sub NAMED_ANS_CHECKBOX_OPTION {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=CHECKBOX NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!
+        HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+        PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
 }
@@ -891,6 +899,9 @@ sub ans_radio_buttons {
 	if ($displayMode eq 'TeX') {
 		$radio_buttons[0] = "\n\\begin{itemize}\n" . $radio_buttons[0];
 		$radio_buttons[$#radio_buttons] .= "\n\\end{itemize}\n";
+    } elsif ($displayMode eq 'PTX') {
+        $radio_buttons[0] = '<var form="buttons">' . "\n" . $radio_buttons[0];
+                 $radio_buttons[$#radio_buttons] .= '</var>';
 	}
 
 	(wantarray) ? @radio_buttons: join(" ", @radio_buttons);
@@ -904,6 +915,9 @@ sub ans_checkbox {
 	if ($displayMode eq 'TeX') {
 		$checkboxes[0] = "\n\\begin{itemize}\n" . $checkboxes[0];
 		$checkboxes[$#checkboxes] .= "\n\\end{itemize}\n";
+    } elsif ($displayMode eq 'PTX') {
+        $checkboxes[0] = '<var form="checkboxes">' . "\n" . $checkboxes[0];
+                 $checkboxes[$#checkboxes] .= '</var>'
 	}
 
 	(wantarray) ? @checkboxes: join(" ", @checkboxes);
@@ -924,7 +938,8 @@ sub tex_ans_rule {
                      'Latex2HTML' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
                      'HTML_tth' => '\\begin{rawhtml} '. $answer_rule.'\\end{rawhtml}',
                      'HTML_dpng' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
-                     'HTML'     => $answer_rule
+                     'HTML'     => $answer_rule,
+                     'PTX'      => 'Answer boxes cannot be placed inside typeset equations',
                    );
 
     $out;
@@ -940,7 +955,8 @@ sub tex_ans_rule_extension {
                      'Latex2HTML' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
                      'HTML_tth' => '\\begin{rawhtml} '. $answer_rule.'\\end{rawhtml}',
                      'HTML_dpng' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
-                     'HTML'     => $answer_rule
+                     'HTML'     => $answer_rule,
+                     'PTX'      => 'Answer boxes cannot be placed inside typeset equations',
                    );
 
     $out;
@@ -956,7 +972,8 @@ sub NAMED_TEX_ANS_RULE {
                      'Latex2HTML' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
                      'HTML_tth' => '\\begin{rawhtml} '. $answer_rule.'\\end{rawhtml}',
                      'HTML_dpng' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
-                     'HTML'     => $answer_rule
+                     'HTML'     => $answer_rule,
+                     'PTX'      => 'Answer boxes cannot be placed inside typeset equations',
                    );
 
     $out;
@@ -971,7 +988,8 @@ sub NAMED_TEX_ANS_RULE_EXTENSION {
                      'Latex2HTML' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
                      'HTML_tth' => '\\begin{rawhtml} '. $answer_rule.'\\end{rawhtml}',
                      'HTML_dpng' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
-                     'HTML'     => $answer_rule
+                     'HTML'     => $answer_rule,
+                     'PTX'      => 'Answer boxes cannot be placed inside typeset equations',
                    );
 
     $out;
@@ -1029,6 +1047,13 @@ sub NAMED_POP_UP_LIST {
 		$out .= " \\begin{rawhtml}</SELECT>\\end{rawhtml}\n";
 	} elsif ( $displayMode eq "TeX") {
 			$out .= "\\fbox{?}";
+    } elsif ( $displayMode eq "PTX") {
+        $out = '<var form="popup">' . "\n";
+        my $i;
+        foreach ($i=0; $i< @list; $i=$i+2) {
+            $out .= '<li>'.$list[$i+1].'</li>'."\n";
+        };
+        $out .= '</var>';
 	}
 	$name = RECORD_ANS_NAME($name,$answer_value);   # record answer name
 	$out;
@@ -1054,6 +1079,9 @@ sub pop_up_list {
 		and then at the end moving down one row, just as you would read them.)
 
 		The options are passed on to display_matrix.
+
+        Note (7/21/2107) The above usage does not work. Omitting the \[ \] works, but also must
+        load PGmatrixmacros.pl to get display_matrix used below
 
 
 =cut
@@ -1135,7 +1163,8 @@ sub NAMED_ANS_ARRAY_EXTENSION{
 	MODES(
 		TeX => "\\mbox{\\parbox[t]{10pt}{\\hrulefill}}\\hrulefill\\quad ",
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=TEXT SIZE=$col NAME="$name" id="$name" VALUE = "">\n\\end{rawhtml}\n!,
-		HTML => qq!<INPUT TYPE=TEXT SIZE=$col NAME="$name" id="$name" class="codeshard" aria-label="$label" VALUE = "$answer_value">\n!
+        HTML => qq!<INPUT TYPE=TEXT SIZE=$col NAME="$name" id="$name" class="codeshard" aria-label="$label" VALUE = "$answer_value">\n!,
+        PTX => qq!<fillin name="$name" characters="$col" />!,
 	);
 }
 
@@ -1205,13 +1234,19 @@ sub ans_array_extension{
 
 # end answer blank macros
 
-=head2 Hints and solutions macros
+=head2 Hints, solutions, and statement macros
 
 	solution('text','text2',...);
 	SOLUTION('text','text2',...);   # equivalent to TEXT(solution(...));
 
 	hint('text', 'text2', ...);
 	HINT('text', 'text2',...);      # equivalent to TEXT("$BR$HINT" . hint(@_) . "$BR") if hint(@_);
+
+    statement('text');
+    STATEMENT('text');          # equivalent to TEXT(statement(...));
+
+statement takes a string, probably from EV3P, and possibly wraps opening and closing
+content, paralleling one feature of solution and hint.
 
 Solution prints its concatenated input when the check box named 'ShowSol' is set and
 the time is after the answer date.  The check box 'ShowSol' is visible only after the
@@ -1272,12 +1307,14 @@ sub SOLUTION {
     	              base64 =>1 ) ) if solution(@_);
     } elsif ($displayMode=~/TeX/) {
         TEXT(
-            "\n%%% BEGIN SOLUTION\n",                   #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+            "\n%%% BEGIN SOLUTION\n",                   #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
             $PAR,SOLUTION_HEADING(), solution(@_).$PAR,
-            "\n%%% END SOLUTION\n"                      #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+            "\n%%% END SOLUTION\n"                      #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
         ) if solution(@_) ;
     } elsif ($displayMode=~/HTML/) {
 		TEXT( $PAR.SOLUTION_HEADING().$BR.solution(@_).$PAR) if solution(@_) ;
+    } elsif ($displayMode=~/PTX/) {
+       TEXT( '<solution>',"\n",solution(@_),"\n",'</solution>',"\n\n") if solution(@_) ;
     } else {
 		TEXT( $PAR.solution(@_).$PAR) if solution(@_) ;
 	}
@@ -1315,7 +1352,9 @@ sub hint {
 	 	    ## the second test above prevents a hint being shown if a doctored form is submitted
 		    $out = join(' ',@in);
 		}
-	}    
+    } elsif ($displayMode=~/PTX/) {
+        $out = join(' ',@in);
+    }
 	
   $out ;
 }
@@ -1327,17 +1366,31 @@ sub HINT {
 		                  base64 => 1) ) if hint(@_);
     } elsif ($displayMode=~/TeX/) {
         TEXT(
-            "\n%%% BEGIN HINT\n",                #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+            "\n%%% BEGIN HINT\n",                #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
             $PAR,HINT_HEADING(), hint(@_).$PAR,
-            "\n%%% END HINT\n"                   #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+            "\n%%% END HINT\n"                   #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
         ) if hint(@_) ;
+    } elsif ($displayMode=~/PTX/) {
+        TEXT( '<hint>',"\n",hint(@_),"\n",'</hint>',"\n\n") if hint(@_);
     } else {
     	TEXT($PAR, HINT_HEADING(), $BR. hint(@_) . $PAR) if hint(@_);
     } 
 }
 
 
-# End hints and solutions macros
+sub statement {
+        my @in = @_;
+        my $out = join(' ',@in);
+   $out;
+}
+
+sub STATEMENT {
+if ($displayMode eq 'PTX') { TEXT('<statement>',"\n", statement(@_), "\n", '</statement>',"\n\n"); }
+        else { TEXT( statement(@_) ) };
+}
+
+
+# End hints and solutions and statement macros
 #################################
 
 =head2 Comments to instructors
@@ -1453,6 +1506,7 @@ sub M3 {
 our %DISPLAY_MODE_FAILOVER = (
 	TeX              => [],
 	HTML             => [],
+    PTX              => [ "HTML" ],
 	HTML_tth         => [ "HTML", ],
 	HTML_dpng        => [ "HTML_tth", "HTML", ],
 	HTML_jsMath      => [ "HTML_dpng", "HTML_tth", "HTML", ],
@@ -1554,22 +1608,22 @@ sub ALPHABET  {
 # Some constants which are different in tex and in HTML
 # The order of arguments is TeX, Latex2HTML, HTML
 # Adopted Davide Cervone's improvements to PAR, LTS, GTS, LTE, GTE, LBRACE, RBRACE, LB, RB. 7-14-03 AKP
-sub PAR { MODES( TeX => '\\par ', Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}', HTML => '<P>'); };
+sub PAR { MODES( TeX => '\\par ', Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}', HTML => '<P>', PTX => "\n\n"); };
 #sub BR { MODES( TeX => '\\par\\noindent ', Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}', HTML => '<BR>'); };
 # Alternate definition of BR which is slightly more flexible and gives more white space in printed output
 # which looks better but kills more trees.
-sub BR { MODES( TeX => '\\leavevmode\\\\\\relax ', Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}', HTML => '<BR/>'); };
-sub BRBR { MODES( TeX => '\\leavevmode\\\\\\relax \\leavevmode\\\\\\relax ', Latex2HTML => '\\begin{rawhtml}<BR><BR>\\end{rawhtml}', HTML => '<P>'); };
-sub LQ { MODES( TeX => "\\lq\\lq{}", Latex2HTML =>   '"',  HTML =>  '&quot;' ); };
-sub RQ { MODES( TeX => "\\rq\\rq{}", Latex2HTML =>   '"',   HTML =>  '&quot;' ); };
-sub BM { MODES(TeX => '\\(', Latex2HTML => '\\(', HTML =>  ''); };  # begin math mode
-sub EM { MODES(TeX => '\\)', Latex2HTML => '\\)', HTML => ''); };  # end math mode
-sub BDM { MODES(TeX => '\\[', Latex2HTML =>   '\\[', HTML =>   '<P ALIGN=CENTER>'); };  #begin displayMath mode
-sub EDM { MODES(TeX => '\\]',  Latex2HTML =>  '\\]', HTML => '</P>'); };              #end displayMath mode
-sub LTS { MODES(TeX => '<', Latex2HTML => '\\lt ', HTML => '&lt;', HTML_tth => '<' ); };
-sub GTS { MODES(TeX => '>', Latex2HTML => '\\gt ', HTML => '&gt;', HTML_tth => '>' ); };
-sub LTE { MODES(TeX => '\\le ', Latex2HTML => '\\le ', HTML => '<U>&lt;</U>', HTML_tth => '\\le ' ); };
-sub GTE { MODES(TeX => '\\ge ', Latex2HTML => '\\ge ', HTML => '<U>&gt;</U>', HTML_tth => '\\ge ' ); };
+sub BR { MODES( TeX => '\\leavevmode\\\\\\relax ', Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}', HTML => '<BR/>', PTX => "\n\n"); };
+sub BRBR { MODES( TeX => '\\leavevmode\\\\\\relax \\leavevmode\\\\\\relax ', Latex2HTML => '\\begin{rawhtml}<BR><BR>\\end{rawhtml}', HTML => '<P>', PTX => "\n"); };
+sub LQ { MODES( TeX => "\\lq\\lq{}", Latex2HTML =>   '"',  HTML =>  '&quot;', PTX => '<lq />' ); };
+sub RQ { MODES( TeX => "\\rq\\rq{}", Latex2HTML =>   '"',   HTML =>  '&quot;', PTX => '<rq />' ); };
+sub BM { MODES(TeX => '\\(', Latex2HTML => '\\(', HTML =>  '', PTX => '<m>'); };  # begin math mode
+sub EM { MODES(TeX => '\\)', Latex2HTML => '\\)', HTML => '', PTX => '</m>'); };  # end math mode
+sub BDM { MODES(TeX => '\\[', Latex2HTML =>   '\\[', HTML =>   '<P ALIGN=CENTER>', PTX => '<me>'); };  #begin displayMath mode
+sub EDM { MODES(TeX => '\\]',  Latex2HTML =>  '\\]', HTML => '</P>', PTX => '</me>'); };              #end displayMath mode
+sub LTS { MODES(TeX => '<', Latex2HTML => '\\lt ', HTML => '&lt;', HTML_tth => '<', PTX => '\lt' ); };  #only for use in math mode
+sub GTS { MODES(TeX => '>', Latex2HTML => '\\gt ', HTML => '&gt;', HTML_tth => '>', PTX => '\gt' ); };  #only for use in math mode
+sub LTE { MODES(TeX => '\\le ', Latex2HTML => '\\le ', HTML => '<U>&lt;</U>', HTML_tth => '\\le ', PTX => '\leq' ); };  #only for use in math mode
+sub GTE { MODES(TeX => '\\ge ', Latex2HTML => '\\ge ', HTML => '<U>&gt;</U>', HTML_tth => '\\ge ', PTX => '\geq' ); };  #only for use in math mode
 sub BEGIN_ONE_COLUMN { MODES(TeX => "\\ifdefined\\nocolumns\\else \\end{multicols}\\fi\n",  Latex2HTML => " ", HTML =>   " "); };
 sub END_ONE_COLUMN { MODES(TeX =>
               " \\ifdefined\\nocolumns\\else \\begin{multicols}{2}\n\\columnwidth=\\linewidth \\fi\n",
@@ -1578,34 +1632,35 @@ sub END_ONE_COLUMN { MODES(TeX =>
 };
 sub SOLUTION_HEADING { MODES( TeX => '\\par {\\bf '.maketext('Solution:').' }',
                  Latex2HTML => '\\par {\\bf '.maketext('Solution:').' }',
-          		 HTML =>  '<B>'.maketext('Solution:').'</B> ');
+                 HTML =>  '<B>'.maketext('Solution:').'</B> ',
+                 PTX => '');
 };
-sub HINT_HEADING { MODES( TeX => "\\par {\\bf ".maketext('Hint:')." }", Latex2HTML => "\\par {\\bf ".maketext('Hint:')." }", HTML => "<B>".maketext('Hint:')."</B> "); };
-sub US { MODES(TeX => '\\_', Latex2HTML => '\\_', HTML => '_');};  # underscore, e.g. file${US}name
-sub SPACE { MODES(TeX => '\\ ',  Latex2HTML => '\\ ', HTML => '&nbsp;');};  # force a space in latex, doesn't force extra space in html
-sub NBSP { MODES(TeX => '~',  Latex2HTML => '~', HTML => '&nbsp;');}; 
-sub NDASH { MODES(TeX => '--',  Latex2HTML => '--', HTML => '&ndash;');}; 
-sub MDASH { MODES(TeX => '---',  Latex2HTML => '---', HTML => '&mdash;');};
-sub BBOLD { MODES(TeX => '{\\bf ',  Latex2HTML => '{\\bf ', HTML => '<B>'); };
-sub EBOLD { MODES( TeX => '}', Latex2HTML =>  '}',HTML =>  '</B>'); };
-sub BLABEL { MODES(TeX => '', Latex2HTML => '', HTML => '<LABEL>'); };
-sub ELABEL { MODES(TeX => '', Latex2HTML => '', HTML => '</LABEL>'); };
-sub BITALIC { MODES(TeX => '{\\it ',  Latex2HTML => '{\\it ', HTML => '<I>'); };
-sub EITALIC { MODES(TeX => '} ',  Latex2HTML => '} ', HTML => '</I>'); };
-sub BUL { MODES(TeX => '\\underline{',  Latex2HTML => '\\underline{', HTML => '<U>'); };
-sub EUL { MODES(TeX => '}',  Latex2HTML => '}', HTML => '</U>'); };
-sub BCENTER { MODES(TeX => '\\begin{center} ',  Latex2HTML => ' \\begin{rawhtml} <div align="center"> \\end{rawhtml} ', HTML => '<div align="center" dir="ltr">'); };
-sub ECENTER { MODES(TeX => '\\end{center} ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</div>'); };
-sub BLTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} <div dir="ltr"> \\end{rawhtml} ', HTML => '<span dir="ltr">'); };
-sub ELTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</span>'); };
-sub HR { MODES(TeX => '\\par\\hrulefill\\par ', Latex2HTML => '\\begin{rawhtml} <HR> \\end{rawhtml}', HTML =>  '<HR>'); };
-sub LBRACE { MODES( TeX => '\{', Latex2HTML =>   '\\lbrace',  HTML =>  '{' , HTML_tth=> '\\lbrace' ); };
-sub RBRACE { MODES( TeX => '\}', Latex2HTML =>   '\\rbrace',  HTML =>  '}' , HTML_tth=> '\\rbrace',); };
-sub LB { MODES( TeX => '\{', Latex2HTML =>   '\\lbrace',  HTML =>  '{' , HTML_tth=> '\\lbrace' ); };
-sub RB { MODES( TeX => '\}', Latex2HTML =>   '\\rbrace',  HTML =>  '}' , HTML_tth=> '\\rbrace',); };
-sub DOLLAR { MODES( TeX => '\\$', Latex2HTML => '&#36;', HTML => '&#36;' ); };
-sub PERCENT { MODES( TeX => '\\%', Latex2HTML => '\\%', HTML => '%' ); };
-sub CARET { MODES( TeX => '\\verb+^+', Latex2HTML => '\\verb+^+', HTML => '^' ); };
+sub HINT_HEADING { MODES( TeX => "\\par {\\bf ".maketext('Hint:')." }", Latex2HTML => "\\par {\\bf ".maketext('Hint:')." }", HTML => "<B>".maketext('Hint:')."</B> ", PTX => ''); };
+sub US { MODES(TeX => '\\_', Latex2HTML => '\\_', HTML => '_', PTX => '<underscore />');};  # underscore, e.g. file${US}name
+sub SPACE { MODES(TeX => '\\ ',  Latex2HTML => '\\ ', HTML => '&nbsp;', PTX => ' ');};  # force a space in latex, doesn't force extra space in html
+sub NBSP { MODES(TeX => '~',  Latex2HTML => '~', HTML => '&nbsp;', PTX => '<nbsp />');};
+sub NDASH { MODES(TeX => '--',  Latex2HTML => '--', HTML => '&ndash;', PTX => '<ndash />');};
+sub MDASH { MODES(TeX => '---',  Latex2HTML => '---', HTML => '&mdash;', PTX => '<mdash />');};
+sub BBOLD { MODES(TeX => '{\\bf ',  Latex2HTML => '{\\bf ', HTML => '<B>', PTX => '<em>'); };
+sub EBOLD { MODES( TeX => '}', Latex2HTML =>  '}',HTML =>  '</B>', PTX => '</em>'); };
+sub BLABEL { MODES(TeX => '', Latex2HTML => '', HTML => '<LABEL>', PTX => ''); };
+sub ELABEL { MODES(TeX => '', Latex2HTML => '', HTML => '</LABEL>', PTX => ''); };
+sub BITALIC { MODES(TeX => '{\\it ',  Latex2HTML => '{\\it ', HTML => '<I>', PTX => '<em>'); };
+sub EITALIC { MODES(TeX => '} ',  Latex2HTML => '} ', HTML => '</I>', PTX => '</em>'); };
+sub BUL { MODES(TeX => '\\underline{',  Latex2HTML => '\\underline{', HTML => '<U>', PTX => '<em>'); };
+sub EUL { MODES(TeX => '}',  Latex2HTML => '}', HTML => '</U>', PTX => '</em>'); };
+sub BCENTER { MODES(TeX => '\\begin{center} ',  Latex2HTML => ' \\begin{rawhtml} <div align="center"> \\end{rawhtml} ', HTML => '<div align="center">', PTX => ''); };
+sub ECENTER { MODES(TeX => '\\end{center} ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</div>', PTX => ''); };
+sub BLTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} <div dir="ltr"> \\end{rawhtml} ', HTML => '<span dir="ltr">', PTX => ''); };
+sub ELTR { MODES(TeX => ' ',  Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</span>', PTX => ''); };
+sub HR { MODES(TeX => '\\par\\hrulefill\\par ', Latex2HTML => '\\begin{rawhtml} <HR> \\end{rawhtml}', HTML =>  '<HR>', PTX => ''); };
+sub LBRACE { MODES( TeX => '\{', Latex2HTML =>   '\\lbrace',  HTML =>  '{' , HTML_tth=> '\\lbrace', PTX => '<lbrace />' ); };  #not for use in math mode
+sub RBRACE { MODES( TeX => '\}', Latex2HTML =>   '\\rbrace',  HTML =>  '}' , HTML_tth=> '\\rbrace', PTX => '<rbrace />' ); };  #not for use in math mode
+sub LB { MODES( TeX => '\{', Latex2HTML =>   '\\lbrace',  HTML =>  '{' , HTML_tth=> '\\lbrace', PTX => '<lbrace />' ); };  #not for use in math mode
+sub RB { MODES( TeX => '\}', Latex2HTML =>   '\\rbrace',  HTML =>  '}' , HTML_tth=> '\\rbrace', PTX => '<rbrace />' ); };  #not for use in math mode
+sub DOLLAR { MODES( TeX => '\\$', Latex2HTML => '&#36;', HTML => '&#36;', PTX => '<dollar />' ); };
+sub PERCENT { MODES( TeX => '\\%', Latex2HTML => '\\%', HTML => '%', PTX => '<percent />' ); };
+sub CARET { MODES( TeX => '\\verb+^+', Latex2HTML => '\\verb+^+', HTML => '^', PTX => '<circumflex />' ); };
 sub PI {4*atan2(1,1);};
 sub E {exp(1);};
 
@@ -1946,6 +2001,10 @@ sub general_math_ev3 {
           $in = HTML::Entities::encode_entities($in);
 	  $out = "`$in`" if $mode eq "inline";
 	  $out = '<DIV ALIGN="CENTER">`'.$in.'`</DIV>' if $mode eq "display";
+    } elsif ($displayMode eq "PTX") {
+          $in = HTML::Entities::encode_entities($in);
+      $out = '<m>'."$in".'</m>' if $mode eq "inline";
+      $out = '<me>'."$in".'</me>' if $mode eq "display";
 	} elsif ($displayMode eq "HTML_LaTeXMathML") {
           $in = HTML::Entities::encode_entities($in);
 	  $in = '{'.$in.'}';
@@ -2089,7 +2148,8 @@ sub EV3P {
     $string = ev_substring($string,"\\(","\\)",\&math_ev3);
     $string = ev_substring($string,"\\[","\\]",\&display_math_ev3);
   }
-  
+
+  if ($displayMode eq 'PTX') {$string = PTX_cleanup($string)};
 
   return $string;
 }
@@ -2124,6 +2184,87 @@ sub EV3P_parser {
     elsif ($end{$part}) {$start = $part}
   }
   return join('',@parts);
+}
+
+
+sub PTX_cleanup {
+  my $string = shift;
+  # Wrap <p> tags where necessary, and other cleanup
+  # Nothing else should be creating p tags, so assume all p tags created here
+  # The only supported top-level elements within a statement, hint, or solution in a problem
+  # are p, blockquote, pre, sidebyside
+  if ($displayMode eq 'PTX') {
+    #encase entire string in <p>
+    $string = "<p>".$string."</p>";
+
+    #a <sidebyside> may have been created within a <cell> of a <tabular> as a container of an <image>
+    #so here we clean that up
+    $string =~ s/(?s)(<cell>((?!<\/cell>).)*?)<sidebyside[^>]*>(.*?)<\/sidebyside>(.*?<\/cell>)/$1$3$4/g;
+
+    #inside a sidebyside, the only permissible children are p, image, video, and tabular
+    #insert opening and closing p, to be removed later if they enclose an image, video or tabular
+    $string =~ s/(<sidebyside[^>]*(?<!\/)>)/$1\n<p>/g;
+    $string =~ s/(<\/sidebyside>)/<\/p>\n$1/g;
+    $string =~ s/(<sidebyside[^>]*(?<=\/)>)/<\p>\n$1\n<p>/g;
+    #ditto for li
+    $string =~ s/(<li[^>]*(?<!\/)>)/$1\n<p>/g;
+    $string =~ s/(<\/li>)/<\/p>\n$1/g;
+    $string =~ s/(<li[^>]*(?<=\/)>)/<\p>\n$1\n<p>/g;
+
+    #close p right before any sidebyside, blockquote, or pre, image, video, or tabular
+    #and open p immediately following. Later any potential side effects are cleaned up.
+    $string =~ s/(<(sidebyside|blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
+    $string =~ s/(<\/(sidebyside|blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
+    $string =~ s/(<(sidebyside|blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
+
+    #within a <cell>, we may have an issue if there was an image that had '<\p>' and '<p>' wrapped around
+    #it from the above block. If the '</p>' has a preceding '<p>' within the cell, no problem. Otherwise,
+    #the '</p>' must go. Likewise at the other end.
+    $string =~ s/(?s)(<cell>.*?)<\/p>\n(<image[^>]*(?<=\/)>)\n<p>(.*?<\/cell>)/$1$2$3/g;
+
+    #remove blank lines; assume the intent was to end a p and start a new one
+    #but don't put closing and opening p replacing the blank lines if they precede or follow a <row>
+    #or an <li>
+    $string =~ s/(\r\n?|\n)(\r\n?|\n)+(?!(<row>|<\/tabular>|<li>|\r\n?|\n))/<\/p>\n<p>/g;
+    $string =~ s/(\r\n?|\n)(\r\n?|\n)+(?=(<row>|<\/tabular>|<li>|\r\n?|\n))/\n/g;
+
+    #remove whitespace following <p>
+    $string =~ s/(?s)(<p>)\s*/$1/g;
+
+    #remove whitespace preceding </p>
+    $string =~ s/(?s)\s*(<\/p>)/$1/g;
+
+    #remove empty p
+    $string =~ s/(\r\n?|\n)?<p><\/p>//g;
+
+    #a tabular cell may have <p> and </p> but no corresponding width specification in a col.
+    #if so, remove all <p> and </p> from all cells.
+    my $previous;
+    do {
+    $previous = $string;
+    $string =~ s/(?s)(<tabular>(?:\s|<col (?:(?!width=").)*?>)((?!<\/tabular>).)*?<cell>((?!<\/tabular>).)*?)<p>(((?!<\/tabular>).)*?)<\/p>(((?!<\/tabular>).)*?<\/tabular>)/$1$4$6/g;
+    } until ($previous eq $string);
+
+  };
+  $string;
+}
+
+sub PTX_special_character_cleanup {
+  my $string = shift;
+  $string =~ s/</<less \/>/g;
+  $string =~ s/(?<!\/)>/<greater \/>/g;
+  $string =~ s/&/<ampersand \/>/g;
+  $string =~ s/"/&quot;/g;
+  $string =~ s/\^/<circumflex \/>/g;
+  $string =~ s/#/<hash \/>/g;
+  $string =~ s/\$/<dollar \/>/g;
+  $string =~ s/\%/<percent \/>/g;
+  $string =~ s/\\/<backslash \/>/g;
+  $string =~ s/_/<underscore \/>/g;
+  $string =~ s/{/<lbrace \/>/g;
+  $string =~ s/}/<rbrace \/>/g;
+  $string =~ s/~/<tilde \/>/g;
+  $string;
 }
 
 
@@ -2234,7 +2375,7 @@ sub beginproblem {
 			(defined($effectivePermissionLevel) && defined($PRINT_FILE_NAMES_PERMISSION_LEVEL) && $effectivePermissionLevel >= $PRINT_FILE_NAMES_PERMISSION_LEVEL)
 			 || ( defined($inlist{ $studentLogin }) and ( $inlist{ $studentLogin }>0 )  )?1:0 ;
 	$out .= MODES( TeX =>
-		"\n%%% BEGIN PROBLEM PREAMBLE\n",         #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+        "\n%%% BEGIN PROBLEM PREAMBLE\n",         #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
 		HTML => '<P style="margin: 0">');
 	if ( $print_path_name_flag ) {
 		$out .= &M3("{\\bf ${probNum}. {\\footnotesize ($problemValue $points) \\path|$fileName|}}\\newline ",
@@ -2249,8 +2390,9 @@ sub beginproblem {
 	}
 	$out .= MODES(%{main::PG_restricted_eval(q!$main::problemPreamble!)});
         $out .= MODES( TeX =>
-                "\n%%% END PROBLEM PREAMBLE\n",          #Marker used in MathBook XML extraction; contact alex.jordan@pcc.edu before modifying
+                "\n%%% END PROBLEM PREAMBLE\n",          #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
                 HTML => "");
+    if ($displayMode eq 'PTX') {$out = ''};
 	$out;
 
 }
@@ -2312,12 +2454,12 @@ sub OL {
 	my $i = 0;
 	my @alpha = ('A'..'Z', 'AA'..'ZZ');
 	my $letter;
-	my	$out= 	&M3(
-					"\\begin{enumerate}\n",
-					" \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
+    my $out = MODES(TeX=> "\\begin{enumerate}\n",
+                         Latex2HTML=> " \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
 					# kludge to fix IE/CSS problem
 					#"<OL TYPE=\"A\" VALUE=\"1\">\n"
-					"<BLOCKQUOTE>\n"
+                         HTML=> "<BLOCKQUOTE>\n",
+                         PTX=> '<ol label="A.">'."\n",
 				 	) ;
 	my $elem;
 	foreach $elem (@array) {
@@ -2328,15 +2470,17 @@ sub OL {
                         #HTML=>  "<LI> $elem\n",
                         HTML=>  "<br /> <b>$letter.</b> $elem\n",
                         #HTML_dpng=>     "<LI> $elem <br /> <br /> \n"
-                        HTML_dpng=>     "<br /> <b>$letter.</b> $elem \n"
+                        HTML_dpng=>     "<br /> <b>$letter.</b> $elem \n",
+                        PTX=> "<li><p>$elem</p></li>\n",
                                         );
 		$i++;
 	}
-	$out .= &M3(
-				"\\end{enumerate}\n",
-				" \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
+    $out .= MODES(
+                TeX=> "\\end{enumerate}\n",
+                Latex2HTML=> " \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
 				#"</OL>\n"
-				"</BLOCKQUOTE>\n"
+                HTML=> "</BLOCKQUOTE>\n",
+                PTX=> '</ol>'."\n",
 				) ;
 }
 
@@ -2344,10 +2488,13 @@ sub htmlLink {
 	my $url = shift;
 	my $text = shift;
 	my $options = shift;
+    my $sanitized_url = $url;
+    $sanitized_url =~ s/&/&amp;/g;
 	$options = "" unless defined($options);
 	return "$BBOLD [ the link to '$text'  is broken ] $EBOLD" unless defined($url) and $url;
 	MODES( TeX        => "{\\bf \\underline{$text}}",
-	       HTML       => "<A HREF=\"$url\" $options>$text</A>"
+           HTML       => "<A HREF=\"$url\" $options>$text</A>",
+           PTX    => "<url href=\"$sanitized_url\">$text</url>",
 	);
 }
 
@@ -2389,7 +2536,8 @@ sub knowlLink { # an new syntax for knowlLink that facilitates a local HERE docu
 	}
 	#my $option_string = qq!url = "$options{url}" value = "$options{value}" !;
 	MODES( TeX        => "{\\bf \\underline{$display_text}}",
-	       HTML       => "<a $properties >$display_text</a>"
+           HTML       => "<a $properties >$display_text</a>",
+           PTX        => '<url '. (($options{url})? 'href="'."$options{url}".'"':'')  .' >'.$display_text.'</url>',
 	);
 
 
@@ -2405,6 +2553,7 @@ sub iframe {
 		HTML      => qq!\n <iframe src="$url" $formatted_options>
 		                      Your browser does not support iframes.</p>
 		                   </iframe>\n!,			
+        PTX   => '<url href="'.$url.'" />',
 	);
 }
 
@@ -2508,6 +2657,7 @@ sub appletLink {
  	       Latex2HTML => "\\begin{rawhtml} <APPLET $appletHeader> $options </APPLET>\\end{rawhtml}",
  	       HTML       => "<APPLET\n $appletHeader> \n $options \n </APPLET>",
  	       #HTML       => qq!<OBJECT $appletHeader codetype="application/java"> $options </OBJECT>!
+           PTX        => 'PreTeXt does not support appletLink',
  	);
 }
 
@@ -2517,7 +2667,8 @@ sub oldAppletLink {
 	$options = "" unless defined($options);
 	MODES( TeX        => "{\\bf \\underline{APPLET}  }",
 	       Latex2HTML => "\\begin{rawhtml} <APPLET $url> $options </APPLET>\\end{rawhtml}",
-	       HTML       => "<APPLET $url> $options </APPLET>"
+	       HTML       => "<APPLET $url> $options </APPLET>",
+           PTX        => 'PreTeXt does not support appletLink',
 	    );
 }
 sub spf {
@@ -2600,6 +2751,9 @@ sub begintable {
 	if ($displayMode eq 'TeX') {
 		$out .= "\n\\par\\smallskip\\begin{center}\\begin{tabular}{"  .  "|c" x $number .  "|} \\hline\n";
 		}
+    elsif ($displayMode eq 'PTX') {
+        $out .= "\n".'<sidebyside><tabular top="medium" bottom="medium" left="medium" right="medium">'."\n";
+        }
 	elsif ($displayMode eq 'Latex2HTML') {
 		$out .= "\n\\begin{rawhtml} <TABLE , BORDER=1>\n\\end{rawhtml}";
 		}
@@ -2624,6 +2778,9 @@ sub endtable {
 	if ($displayMode eq 'TeX') {
 		$out .= "\n\\end {tabular}\\end{center}\\par\\smallskip\n";
 		}
+    elsif ($displayMode eq 'PTX') {
+        $out .= "\n".'</tabular></sidebyside>'."\n";
+        }
 	elsif ($displayMode eq 'Latex2HTML') {
 		$out .= "\n\\begin{rawhtml} </TABLE >\n\\end{rawhtml}";
 		}
@@ -2655,6 +2812,13 @@ sub row {
 		 $out .= "\\\\ \\hline \n";
 		 # carriage returns must be added manually for tex
 		}
+    elsif ($displayMode eq 'PTX') {
+        $out .= '<row>'."\n";
+        while (@elements) {
+            $out .= '<cell>'.shift(@elements).'</cell>'."\n";
+            }
+        $out .= '</row>'."\n";
+        }
 	elsif ($displayMode eq 'Latex2HTML') {
 		$out .= "\n\\begin{rawhtml}\n<TR>\n\\end{rawhtml}\n";
 		while (@elements) {
@@ -2778,7 +2942,10 @@ sub image {
  			         <IMG SRC="$imageURL"  WIDTH="$width" $height_attrib $out_options{extra_html_tags} >
  			         </A>
  			!
- 		} else {
+        } elsif ($displayMode eq 'PTX') {
+            my $ptxwidth = 100*$width/600;
+            $out = qq!<sidebyside widths="$ptxwidth%">\n<image source="$imageURL" />\n<\/sidebyside>!
+        } else {
  			$out = "Error: PGbasicmacros: image: Unknown displayMode: $displayMode.\n";
  		}
  		push(@output_list, $out);
@@ -2796,7 +2963,8 @@ sub embedSVG {
 	}
 	return MODES( HTML => q!
    			<img src="! . alias($file_name).$str.q!">!,
-   			TeX => "Can't process svg in tex mode yet \\includegraphics[width=6in]{" . alias( $file_name ) . "}" 
+            TeX => "Can't process svg in tex mode yet \\includegraphics[width=6in]{" . alias( $file_name ) . "}",
+            PTX => '<sidebyside><image source="' . alias($file_name) . '" /></sidebyside>',
 	); 
 }
 
@@ -2809,7 +2977,8 @@ sub embedPDF {
 		   q!  type="application/pdf" 
 		   width="100%" 
 		   height="100%"></object>!, 
-		   TeX => "\\includegraphics[width=6in]{" . alias( $file_name ) . "}" 
+           TeX => "\\includegraphics[width=6in]{" . alias( $file_name ) . "}",
+           PTX => '<sidebyside><image source="'.alias($file_name).'" /></sidebyside>',
 		   ) ; 
 }
 
@@ -2880,6 +3049,9 @@ sub video {
                         ${htmlmessage}\n
                         </VIDEO>\n
  			!
+        } elsif ($displayMode eq 'PTX') {
+            my $ptxwidth = 100*$width/600;
+            $out = qq!<sidebyside><video source="$videoURL" width="$ptxwidth%" /></sidebyside>!
  		} else {
  			$out = "Error: PGbasicmacros: video: Unknown displayMode: $displayMode.\n";
  		}

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2002,7 +2002,9 @@ sub general_math_ev3 {
 	  $out = "`$in`" if $mode eq "inline";
 	  $out = '<DIV ALIGN="CENTER">`'.$in.'`</DIV>' if $mode eq "display";
     } elsif ($displayMode eq "PTX") {
-          $in = HTML::Entities::encode_entities($in);
+          #protect XML control characters
+          $in =~ s/\&(?!([\w#]+;))/\\amp /g;
+          $in =~ s/</\\lt /g;
       $out = '<m>'."$in".'</m>' if $mode eq "inline";
       $out = '<me>'."$in".'</me>' if $mode eq "display";
 	} elsif ($displayMode eq "HTML_LaTeXMathML") {

--- a/macros/PGchoicemacros.pl
+++ b/macros/PGchoicemacros.pl
@@ -296,6 +296,10 @@ sub std_print_q {
 	 		$i++;
 	 	}
 	 	$out .= "\\end{enumerate}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = "<ol>\n<li>";
+        $out .= join("</li>\n<li>",@questions);
+        $out .= "</li>\n</ol>";
 	} else {
 		$out = "Error: PGchoicemacros: std_print_q: Unknown displayMode: $main::displayMode.\n";
 	}
@@ -356,6 +360,10 @@ sub pop_up_list_print_q {
 	 		$i++;
 	 	}
 	 	$out .= "\\end{enumerate}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = "<ol>\n<li>";
+        $out .= join("</li>\n<li>",@questions);
+        $out .= "</li>\n</ol>";
 	} else {
 		$out = "Error: PGchoicemacros: pop_up_list_print_q: Unknown displayMode: $main::displayMode.\n";
 	}
@@ -417,8 +425,12 @@ sub quest_first_pop_up_list_print_q {
 	 		$i++;
 	 	}
 	 	$out .= "\\end{enumerate}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = "<ol>\n<li>";
+        $out .= join("</li>\n<li>",@questions);
+        $out .= "</li>\n</ol>";
 	} else {
-		$out = "Error: PGchoicemacros: pop_up_list_print_q: Unknown displayMode: $main::displayMode.\n";
+		$out = "Error: PGchoicemacros: quest_first_pop_up_list_print_q : Unknown displayMode: $main::displayMode.\n";
 	}
 	$out;
 
@@ -477,8 +489,12 @@ sub ans_in_middle_pop_up_list_print_q {
 	 		$i++;
 	 	}
 	 	$out .= "\\end{enumerate}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = "<ol>\n<li>";
+        $out .= join("</li>\n<li>",@questions);
+        $out .= "</li>\n</ol>";
 	} else {
-		$out = "Error: PGchoicemacros: pop_up_list_print_q: Unknown displayMode: $main::displayMode.\n";
+		$out = "Error: PGchoicemacros: ans_in_middle_pop_up_list_print_q: Unknown displayMode: $main::displayMode.\n";
 	}
 	$out;
 
@@ -537,29 +553,32 @@ sub std_print_a {
 	my $i = 0;
 	my @alpha = ('A'..'Z', 'AA'..'ZZ');
 	my $letter;
-	my	$out= 	&main::M3(
-					"\\begin{enumerate}\n",
-					" \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
+    my  $out=   &main::MODES(
+            TeX=> "\\begin{enumerate}\n",
+            Latex2HTML=> " \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
 					# kludge to fix IE/CSS problem
 					#"<OL COMPACT TYPE=\"A\" START=\"1\">\n"
-					"<BLOCKQUOTE>\n"
+            HTML=> "<BLOCKQUOTE>\n",
+            PTX=> '<ol label="A.">'."\n",
 	) ;
 	my $elem;
 	foreach $elem (@array) {
 		$letter = shift @alpha;
-		$out .= &main::M3(
-					"\\item[$main::ALPHABET[$i].] $elem\n",
-					" \\begin{rawhtml} <LI> \\end{rawhtml} $elem  ",
+        $out .= &main::MODES(
+            TeX=>   "\\item[$main::ALPHABET[$i].] $elem\n",
+            Latex2HTML=> " \\begin{rawhtml} <LI> \\end{rawhtml} $elem  ",
 					#"<LI> $elem</LI>\n"
-					"<br /> <b>$letter.</b> $elem\n"
+            HTML=>"<br /> <b>$letter.</b> $elem\n",
+            PTX=>"<li>$elem</li>\n",
 		) ;
 		$i++;
 	}
-	$out .= &main::M3(
-				"\\end{enumerate}\n",
-				" \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
+    $out .= &main::MODES(
+            TeX=>   "\\end{enumerate}\n",
+            Latex2HTML=>" \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
 				#"</OL>\n"
-				"</BLOCKQUOTE>\n"
+            HTML=> "</BLOCKQUOTE>\n",
+            PTX=> "</ol>",
 	) ;
 	$out;
 
@@ -617,6 +636,10 @@ sub radio_print_a {
 		#$out = "\n\\par\\begin{itemize}\n";
 		$out .= join '', @radio_buttons;
 		#$out .= "\\end{itemize}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = '<var form="buttons">'."\n".'<li>';
+        $out .= join("</li>\n<li>", @answers);
+        $out .= "</li>\n</var>\n";
 	} else {
 		$out = "Error: PGchoicemacros: radio_print_a: Unknown displayMode: $main::displayMode.\n";
 	}
@@ -675,6 +698,10 @@ sub checkbox_print_a {
 		#$out = "\n\\par\\begin{itemize}\n";
 		$out .= join '', @radio_buttons ;
 		#$out .= "\\end{itemize}\n";
+    }  elsif ($main::displayMode eq 'PTX') {
+        $out = '<var form="checkboxes">'."\n".'<li>';
+        $out .= join("</li>\n<li>", @answers);
+        $out .= "</li>\n</var>\n";
 	} else {
 		$out = "Error: PGchoicemacros: checkbox_print_a: Unknown displayMode: $main::displayMode.\n";
 	}

--- a/macros/PGessaymacros.pl
+++ b/macros/PGessaymacros.pl
@@ -112,11 +112,12 @@ sub  NAMED_ESSAY_BOX {
 	my $out = MODES(
 	     TeX => qq!\\vskip $height in \\hrulefill\\quad !,
 	     Latex2HTML => qq!\\begin{rawhtml}<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col" >$answer_value</TEXTAREA>\\end{rawhtml}!,
-	    HTML => qq!
+	     HTML => qq!
          <TEXTAREA NAME="$name" id="$name" aria-label="$label" ROWS="$row" COLS="$col" class="latexentryfield"
                WRAP="VIRTUAL" title="Enclose math expressions with backticks or use LaTeX.">$answer_value</TEXTAREA>
            <INPUT TYPE=HIDDEN  NAME="previous_$name" VALUE = "$answer_value">
-           !
+            !,
+         PTX => '<var form="essay" width="'.$col.'" height="'.$row.'" />',
          );
 
 	$out;
@@ -127,14 +128,15 @@ sub  essay_help {
 	my $out = MODES(
 	     TeX => '',
 	     Latex2HTML => '',
-	    HTML => qq!
+	     HTML => qq!
             <P>  This is an essay answer text box.  You can type your answer in here and, after you hit submit, 
                  it will be saved so that your instructor can grade it at a later date.  If your instructor makes 
                  any comments on your answer those comments will appear on this page after the question has been 
                  graded.  You can use LaTeX to make your math equations look pretty.   
                  LaTeX expressions should be enclosed using the parenthesis notation and not dollar signs. 
             </P> 
-           !
+           !,
+         PTX => '',
          );
 
 	$out;

--- a/macros/PGmatrixmacros.pl
+++ b/macros/PGmatrixmacros.pl
@@ -291,6 +291,9 @@ sub dm_begin_matrix {
                       or $main::displayMode eq 'HTML_img') {
                 $out .= qq!<TABLE class="matrix" BORDER="0" style="border-collapse: separate; border-spacing:10px 0px;">\n!;
         }
+        elsif ( $main::displayMode eq 'PTX' ) {
+                $out .= qq!<sidebyside>\n<tabular>\n!;
+        }
         else {
                 $out = "Error: dm_begin_matrix: Unknown displayMode: $main::displayMode.\n";
                 }
@@ -339,6 +342,8 @@ sub dm_special_tops {
                         $out .= "$brh<td align=\"center\">$erh". ' \('.$j.'\)'."$brh</td>$erh";
                 }
 		$out .= "<td></td>";
+        }
+        elsif ( $main::displayMode eq 'PTX' ) {
         } else {
                 $out = "Error: dm_begin_matrix: Unknown displayMode: $main::displayMode.\n";
         }
@@ -348,7 +353,7 @@ sub dm_special_tops {
 sub dm_mat_left {
         my $numrows = shift;
         my %opts = @_;
-        if ($main::displayMode eq 'TeX' or $opts{'force_tex'}) {
+        if ($main::displayMode eq 'TeX' or $opts{'force_tex'} or $main::displayMode eq 'PTX') {
                 return ""; # left delim is built into begin matrix
         }
         my $out='';
@@ -392,7 +397,7 @@ sub dm_mat_right {
         }
 
 
-        if ($main::displayMode eq 'TeX' or $opts{'force_tex'}) {
+        if ($main::displayMode eq 'TeX' or $opts{'force_tex'} or $main::displayMode eq 'PTX') {
                 return "";
         }
 
@@ -441,6 +446,9 @@ sub dm_end_matrix {
                       or $main::displayMode eq 'HTML'
                       or $main::displayMode eq 'HTML_img') {
                 $out .= "</TABLE>\n";
+                }
+        elsif ( $main::displayMode eq 'PTX') {
+                $out .= qq!</tabular>\n</sidebyside>\n!;
                 }
         else {
                 $out = "Error: PGmatrixmacros: dm_end_matrix: Unknown displayMode: $main::displayMode.\n";
@@ -596,6 +604,16 @@ sub dm_mat_row {
                 }
                         if(not $opts{'isfirst'}) {$out .="$brh</TR>$erh\n";}
         }
+        elsif ($main::displayMode eq 'PTX') {
+                $out .= "<row>\n";
+                while (@elements) {
+                    $colcount++;
+                    $out .= '<cell>';
+                    $out .= shift(@elements);
+                    $out .= "</cell>\n";
+                    }
+                $out .= "</row>\n";
+                }
         else {
                 $out = "Error: dm_mat_row: Unknown displayMode: $main::displayMode.\n";
                 }

--- a/macros/alignedChoice.pl
+++ b/macros/alignedChoice.pl
@@ -62,6 +62,17 @@ sub aligned_print_q {
       $out .= "\\ ". ans_rule($length) . $rest . "\\\\ \\noalign{\\kern $tsep}\n";
     }
     $out .= "\\end{tabular}\n";
+  } elsif ($main::displayMode eq "PTX") {
+    $out = "<sidebyside>\n<tabular>\n";
+    foreach $quest (@questions) {
+      if (ref($quest) eq 'ARRAY') {($quest,$rest) = @{$quest}} else {$rest = ''}
+      $out .= "<row>\n";
+      $out .= "<cell>" . $i++ . ".</cell>\n" if ($numbered);
+      $out .= "<cell>$quest</cell>\n";
+      $out .= "<cell><m>=</m></cell>\n" if ($equals);
+      $out .= "<cell>" . ans_rule($length) . $rest . "</cell>\n</row>\n";
+    }
+    $out .= "</tabular>\n</sidebyside>\n";
   } else {
     $out = "Error: std_aligned_print_q: Unknown displayMode: ".
       $main::displayMode;

--- a/macros/compoundProblem.pl
+++ b/macros/compoundProblem.pl
@@ -520,7 +520,7 @@ sub nextHTML {shift; shift}
 sub part {
   my $self = shift; my $status = $self->{status};
   my $part = shift;
-  return $status->{part} unless defined $part && $main::displayMode ne 'TeX';
+  return $status->{part} unless defined $part && $main::displayMode ne 'TeX' && $main::displayMode ne 'PTX';
   $part = 1 if $part < 1; $part = $self->{parts} if $part > $self->{parts};
   if ($part > $status->{part} && !$main::inputs_ref->{_noadvance}) {
     unless ((lc($self->{nextVisible}) eq 'ifcorrect' && $status->{raw} < 1) ||

--- a/macros/compoundProblem2.pl
+++ b/macros/compoundProblem2.pl
@@ -101,10 +101,11 @@ sub DISPLAY_SECTION {
           <h3  class="" style= "$iscorrect $canshow_bg_color " >Part: $name:</h3>
          <div class="acc-section" style="height: 0px; opacity: 0.004347826086956522;">
          <div class="acc-content"  style="$canshow">
-      !, TeX=>"\\par{\\bf Part: $name }\\par"));
+      !, TeX=>"\\par{\\bf Part: $name }\\par",
+         PTX=>"<stage>\n"));
      my $rendered_text_string = EV3($text_string);
      TEXT( $rendered_text_string ) if $options{canshow}==1;
-     TEXT( MODES(HTML=>"</p></div></div></li>", TeX=>'\\par' ) );
+     TEXT( MODES(HTML=>"</p></div></div></li>", TeX=>'\\par', PTX=>"</stage>\n" ) );
      
      
 }
@@ -112,16 +113,16 @@ sub DISPLAY_SECTION {
    
 # FIXME   we will make a $cp object that keeps track of the part 
 
-sub BEGIN_SECTIONS {TEXT(MODES(HTML=>q!<ul class="acc" id="acc"> !,TeX=>'')); warn "start sections\n\n"; }
+sub BEGIN_SECTIONS {TEXT(MODES(HTML=>q!<ul class="acc" id="acc"> !,TeX=>'',PTX=>'')); warn "start sections\n\n"; }
 sub END_SECTIONS {
 	my $part = shift;
-	TEXT(MODES( HTML=>q!</ul  !,TeX=>''));
+	TEXT(MODES( HTML=>q!</ul  !,TeX=>'',PTX=>''));
 	TEXT(MODES(HTML =>$PAR .qq!
 	<script language="javascript">
 	var parentAccordion=new TINY.accordion.slider("parentAccordion");
 	parentAccordion.init("acc","h3",0,-1);
 	parentAccordion.pr(0,$part)
 	</script>
-	! , TeX=>''));
+	! , TeX=>'',PTX=>''));
 }
 1;

--- a/macros/compoundProblem5.pl
+++ b/macros/compoundProblem5.pl
@@ -441,7 +441,7 @@ sub process_section {
     #  Get the script to open or prevent the section from opening
     #
     my $action = $canshow ? "canshow()" : "cannotshow()";
-    my $scriptpreamble = main::MODES(TeX=>'', HTML=>qq!<script>\$("#section$sectionNo").$action</script>!);
+    my $scriptpreamble = main::MODES(TeX=>'', PTX=>'', HTML=>qq!<script>\$("#section$sectionNo").$action</script>!);
     my $renderedtext = $canshow ? $section->{renderedtext} : '' ;
     $renderedtext = $scriptpreamble . "\n" . $renderedtext;
     $renderedtext .= $section->{solution} if main::not_null($section->{solution});
@@ -453,7 +453,8 @@ sub process_section {
       HTML=> qq!<li class="section-li">
          <h3 id="section$sectionNo" class="$iscorrect_class">Section: $name:</h3>
          <div><p>$renderedtext</p></div></li>
-      !, TeX=>"\\par{\\bf Section: $name}\\par $renderedtext\\par"
+      !, TeX=>"\\par{\\bf Section: $name}\\par $renderedtext\\par",
+      PTX=>"<stage>\n$renderedtext</stage>\n",
     );
     ($iscorrect,$canshow);
 }
@@ -675,7 +676,7 @@ sub openSections {
     my $self = shift; my $script = '';
     $self->HIDE_OTHER_RESULTS(@_);
     foreach my $s (@_) {$script .= qq!\$("#section$s").openSection()\n!;}
-    main::TEXT(main::MODES(TeX=>'', HTML=>qq!<script>\n$script</script>!));
+    main::TEXT(main::MODES(TeX=>'', PTX=>'', HTML=>qq!<script>\n$script</script>!));
 }
 
 

--- a/macros/contextArbitraryString.pl
+++ b/macros/contextArbitraryString.pl
@@ -112,7 +112,7 @@ sub quoteHTML {
   my $self = shift;
   my $s = $self->SUPER::quoteHTML(shift);
   $s = "<pre style=\"text-align:left; padding-left:.2em\">$s</pre>"
-    unless $main::displayMode eq "TeX";
+    unless ($main::displayMode eq "TeX" or $main::displayMode eq "PTX");
   return $s;
 }
 

--- a/macros/contextCurrency.pl
+++ b/macros/contextCurrency.pl
@@ -247,7 +247,7 @@ sub new {
   $context->operators->remove($symbol) if $context->operators->get($symbol);
   $context->operators->add(
     $symbol => {precedence => 10, associativity => $associativity, type => "unary",
-		string => ($main::displayMode eq 'TeX' ? Currency::quoteTeX($symbol) : $symbol),
+		string => (($main::displayMode eq 'TeX' or $main::displayMode eq 'PTX') ? Currency::quoteTeX($symbol) : $symbol),
                 TeX => Currency::quoteTeX($symbol), class => 'Currency::UOP::currency'},
   );
   $context->{parser}{Number} = "Currency::Number";

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -654,7 +654,9 @@ sub DataTable {
 
 sub LayoutTable {
   my $dataref = shift;
-  DataTable($dataref,LaYoUt=>1,@_);
+  if ($main::displayMode eq 'PTX')
+    {DataTable($dataref,@_);}
+    else {DataTable($dataref,LaYoUt=>1,@_);};
 }
 
 

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -36,6 +36,11 @@ sub _niceTables_init {}; # don't reload this file
  #  Generally, you give settings for the hard copy tex version first. Many common such settings are automatically
  #  translated into CSS styling for the on-screen. You can then override or augment the CSS for the on-screen version.
  #
+ #  With PTX output, not all features below are supported. Perhaps they can be added upon request.
+ #  Contact Alex Jordan with questions.
+ #  This version supports the center, caption, midrules, encase, and noencase options in PTX. It also honors the
+ #  horizontal alignment portions of the align option (but not vertical rules or anything found in @{}).
+ #
  #  Options for the WHOLE TABLE
  #
  #      Applies to on-screen *and* hard copy:
@@ -324,7 +329,9 @@ sub DataTable {
     # alignment: p{width}, r, c, l, or X
   my @alignmentcolumns;
     for my $i (0..$#columnalignments) {$alignmentcolumns[$columnalignments[$i]] = $i};
-    # @alignmentcolumns is an array with one element per column, where the elements are each one of p{width}, r, c, l, or X
+    # @alignmentcolumns is an array whose ith element is undefined unless the ith element of @htmlalignment was one
+    # of p{width}, r, c, l, or X. Otherwise it is the index of the entry in @columnalignments that corresponds to
+    # that alignment
 
   # append css to author's columnscss->[$i] that corresponds to the alignemnts in @alignmentcolumns
   for my $i (0..$#columnalignments) {
@@ -441,7 +448,9 @@ sub DataTable {
 
             my @alignmentcolumns;
               for my $k (0..$#columnalignments) {$alignmentcolumns[$columnalignments[$k]] = $k};
-              # @alignmentcolumns is an array with one element per column, where the elements are each one of p{width}, r, c, l, or X
+              # @alignmentcolumns is an array whose ith element is undefined unless the ith element of @htmlalignment was one
+              # of p{width}, r, c, l, or X. Otherwise it is the index of the entry in @columnalignments that corresponds to
+              # that alignment
               # Again, this should only have one entry.
 
             for my $k (0..$#columnalignments) {
@@ -494,15 +503,23 @@ sub DataTable {
   if ($midrules == 1) {$midrulescss = 'border-top:solid 1px; '};
 
   my $table = '';
-  # build html string for the table
+  my $ptxtable = '';
+  # build html and ptx strings for the table (which have structural similarities that distinguish them from tex)
   if ($options{LaYoUt} != 1) {
   $table = '<TABLE style = "'.$tablecss.'">';
-  if ($caption ne '') {$table .= '<CAPTION style = "'.$captioncss.'">'.$caption.'</CAPTION>';}
+  $ptxtable = "<sidebyside" . (($center)?' margins="auto"':'') . ">\n<tabular" . (($midrules)?' top="minor" bottom="minor"':'') . ">\n";
   $table .= '<colgroup>';
   for my $i (0..$#{$columnscss})
     {$columnscss->[$i] = '' unless (defined($columnscss->[$i]));
-     $table .= '<col style = "'.$columnscss->[$i].'">';};
+     $table .= '<col style = "'.$columnscss->[$i].'">';
+    };
   $table .= '</colgroup>';
+  if ($caption ne '') {
+     $table .= '<CAPTION style = "'.$captioncss.'">'.$caption.'</CAPTION>';
+     # Needs to be a better way to incorporate the caption into PTX output
+     # This way makes "captions" that extend past the table
+     #$ptxtable .= "<row>\n".'<cell colspan="'.$numcol.'">'.$caption.'</cell>'."\n</row>\n";
+  }
   my $bodystarted = 0;
   for my $i (0..$#{$dataref})
     {my $midrulecss = ($midrule[$i] == 1) ? 'border-bottom:solid 1px; ' : '';
@@ -510,6 +527,7 @@ sub DataTable {
      if ($headerrow[$i] == 1) {$table .= '<THEAD>'; }
      elsif (!$bodystarted) {$table .= '<TBODY>'; $bodystarted = 1};
     $table .= '<TR>';
+    $ptxtable .= "<row>\n";
     for my $j (0..$numcols[$i])
       {my $colspan = (${$dataref->[$i][$j]}{colspan} eq '') ? '' : 'colspan = "'.${$dataref->[$i][$j]}{colspan}.'" ';
       if (uc(${$dataref->[$i][$j]}{header}) eq 'TH')
@@ -523,12 +541,15 @@ sub DataTable {
         elsif (uc($headerrow[$i]) == 1)
         {$table .= '<TH '.$colspan.'scope = "col" style = "'.$allcellcss.$headercss.$columnscss->[$j].$midrulecss.$midrulescss.$rowcss[$i].${$dataref->[$i][$j]}{cellcss}.'">'.${$dataref->[$i][$j]}{data}.'</TH>';}
         else {$table .= '<TD '.$colspan.'style = "'.$allcellcss.$datacss.$columnscss->[$j].$midrulecss.$midrulescss.$rowcss[$i].${$dataref->[$i][$j]}{cellcss}.'">'.${$dataref->[$i][$j]}{data}.'</TD>';}
+        $ptxtable .= '<cell>' . ${$dataref->[$i][$j]}{data} . '</cell>' . "\n";
       }
     $table .= "</TR>";
+    $ptxtable .= "</row>\n";
     if ($headerrow[$i] == 1) {$table .= '</THEAD>';}
       elsif ($bodystarted and ($i == $#{$dataref})) {$table .= '</TBODY>';};
     };
     $table .= "</TABLE>";
+    $ptxtable .= "</tabular>\n</sidebyside>";
    }# now if it is a Layout Table...
    else {
      $table = '<SECTION style = "display:table;'.$tablecss.'">';
@@ -616,6 +637,7 @@ sub DataTable {
   MODES(
     TeX => $textable,
     HTML => $table,
+    PTX => $ptxtable,
   );
 }
 
@@ -662,7 +684,5 @@ sub TeX_Alignment_to_CSS {
       };
    return $css;
 }
-
-
 
 1;

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -172,6 +172,14 @@ sub MENU {
       $menu .= qq!<option$selected value="$option" class="tex2jax_ignore">$option</option>\n!;
     };
     $menu .= "</select>";
+  } elsif ($main::displayMode eq 'PTX') {
+    $menu = '<var form="popup">' . "\n";
+    foreach my $item (@list) {
+      $menu .= '<li>';
+      my $cleaned_item = main::PTX_special_character_cleanup($item);
+      $menu .= $cleaned_item . '</li>'. "\n";
+    }
+    $menu .= '</var>';
   } elsif ($main::displayMode eq "TeX") {
     # if the total number of characters is not more than
     # 30 and not containing / or ] then we print out

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -556,8 +556,12 @@ sub BUTTONS {
     $radio[0] = "\n\\begin{itemize}\n" . $radio[0];
     $radio[$#radio_buttons] .= "\n\\end{itemize}\n";
   }
+  if ($main::displayMode eq 'PTX') {
+    $radio[0] = '<var form="buttons">' . "\n" . $radio[0];
+    $radio[$#radio_buttons] .= '</var>';
+  };
   @radio = $self->makeUncheckable(@radio) if $self->{uncheckable};
-  (wantarray) ? @radio : join($self->{separator}, @radio);
+  (wantarray) ? @radio : join(($main::displayMode eq 'PTX')?'':$self->{separator}, @radio);
 }
 
 sub protect {

--- a/macros/unionTables.pl
+++ b/macros/unionTables.pl
@@ -59,6 +59,8 @@ sub ColumnTable {
            '\medskip\hbox{\qquad\vtop{'.
            '\advance\hsize by -3em '.$col2.'}}\medskip',
     HTML => $HTMLtable,
+    PTX => qq!\n<sidebyside>\n<tabular valign="! . lc($valign) . qq!">\n<row>\n<cell>$col1</cell>\n<cell>$col2</cell>\n</row>\n</tabular>\n</sidebyside>\n!,
+
   );
 }
 
@@ -113,11 +115,13 @@ sub BeginTable {
      ($center,$tcenter) = ('','') if (!$options{center});
   my $table = 
     qq{<TABLE BORDER="$bd" CELLPADDING="$pd" CELLSPACING="$sp"$center>};
+  my $ptxborder=0; if($bd==1){$ptxborder="minor"}elsif($bd==2){$ptxborder="medium"}elsif($bd>=3){$ptxborder="major"};
 
   MODES(
     TeX => '\par\medskip'.$tcenter.'{\kern '.$tbd.
            '\vbox{\halign{#\hfil&&\kern '.$tsp.' #\hfil',
     HTML => $table."\n",
+    PTX => qq!\n<sidebyside>\n<tabular top="$ptxborder" bottom="$ptxborder" left="$ptxborder" right="$ptxborder">\n!,
   );
 }
 
@@ -139,6 +143,7 @@ sub EndTable {
   MODES(
     TeX => '\cr}}\kern '.$tbd.'}\medskip'."\n",
     HTML => '</TABLE>'."\n",
+    PTX => "\n</tabular>\n</sidebyside>\n",
   );
 }
 
@@ -193,6 +198,7 @@ sub Row {
     TeX => '\cr'.$vspace."\n". $fill . join('& ',@row),
     HTML => "<TR VALIGN=\"$valign\">$ind<TD ALIGN=\"$align\">" .
       join("</TD>$sep<TD>",@row) . '</TD></TR>'."\n",
+    PTX => qq!<row halign="! . lc($align) . qq!" valign="! . lc($valign) . qq!">\n<cell>! . join("</cell>\n<cell>",@row) . "</cell>\n</row>\n",
   );
 }
 
@@ -244,6 +250,7 @@ sub AlignedRow {
     TeX => '\cr'.$vspace."\n". $fill . join('&'.$fill,@row),
     HTML => "<TR VALIGN=\"$valign\">\n$ind<TD ALIGN=\"$align\">\n" .
       join("</TD>\n$sep<TD ALIGN=\"$align\">", @row) . "</TD>\n</TR>\n",
+    PTX => qq!<row halign="! . lc($align) . qq!" valign="! . lc($valign) . qq!">\n<cell>! . join("</cell>\n<cell>",@row) . "</cell>\n</row>\n",
   );
 }
 
@@ -268,6 +275,7 @@ sub TableSpace {
   MODES(
     TeX => '\vadjust{\kern '.$rsep.'pt}' . "\n",
     HTML => "<TR><TD HEIGHT=\"$rsep\"></TD>\n</TR>\n",
+    PTX => '',
   );
 }
 
@@ -285,6 +293,7 @@ sub TableLine {
   MODES(
     TeX => '\vadjust{\kern2pt\hrule\kern2pt}',
     HTML =>'<TR><TD COLSPAN="10"><HR NOSHADE SIZE="1"></TD></TR>'."\n",
+    PTX => ''
   );
 }
 


### PR DESCRIPTION
This PR adds a `PTX` display mode, which makes XML source for a PreTeXt document. (http://mathbook.pugetsound.edu/)
There is a companion PR to webwork2.

The purpose is for WeBWorK to render a problem (with a seed) into XML content that could be pasted into a PTX document. Or, more likely, harvested by some script and inserted into a PTX document. To appreciate what this means before starting a review, you might visit [this eBook](http://spot.pcc.edu/math/orcca/section-arithmetic-with-negative-numbers.html) and scroll to the bottom where the exercises come from OPL problems. Those exercises have simultaneously made it into this [PDF version](http://spot.pcc.edu/~ajordan/orcca.pdf) of the same book. And this [demonstration WeBWorK course](https://webwork.pcc.edu/webwork2/orcca-demonstration/) shows the same exercises as live, randomized WeBWorK questions.

Nothing here should interfere with any of the ways that WeBWorK is currently used, so testers should have that in mind and raise an alert if they discover something changes with regular WeBWorK usage.

[Here is a .pg file](http://spot.pcc.edu/~ajordan/pretext.pg) I used for testing. To test, you need to first set up a course as laid out [here](http://mathbook.pugetsound.edu/doc/author-guide/html/section-82.html). Then place the .pg file in that course's templates folder. Then use a web browser to visit:
https://your.ww.server/webwork2/html2xml?&answersSubmitted=0&sourceFilePath=pretext.pg&problemSeed=1234&displayMode=PTX&courseID=anonymous&userID=anonymous&course_password=anonymous&outputformat=ptx
Then view the source (not what the web browser renders it as). What you should be seeing is valid PreTeXt XML code. (You may not know how to check that it is valid, but comments are welcome regarding the file headers and footers.)


There's a lot to look at here in the code, but most of it is easy to review quickly. The bulk of these edits just add a `PTX` key to places where `MODES` is used, or other places where `$displayStyle` is checked as this or that type. So a strategy for reviewing this code is to go through the diff and see that each change is only effective when `$displayMode eq 'PTX'`. Beyond that, here are noteworthy file edits:

In Translator.pm, a STATEMENT macro is used that is analogous to the HINT and SOLUTION macros. It's definition is in PGbasicmacros.pl. This should not be noticeable for existing uses of WW, but the explicit demarcation of where non-hint, non-solution content is printed was important for PTX.

`PGML.pl` has an entire section devoted to PTX, analogous to its HTML and TeX sections.

`PGbasicmacros.pl` has a cleanup subroutine to format output.





