### PR TITLE
Fix checks for scalar multiplication to not have to stringify the val…

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -209,7 +209,7 @@ sub mult {
   #
   #  Constant multiplication
   #
-  if (Value::matchNumber($r) || Value::isComplex($r)) {
+  if (Value::isNumber($r)) {
     my @coords = ();
     foreach my $x (@{$l->data}) {push(@coords,$x*$r)}
     return $self->make(@coords);
@@ -247,8 +247,7 @@ sub mult {
 sub div {
   my ($l,$r,$flag) = @_; my $self = $l;
   Value::Error("Can't divide by a Matrix") if $flag;
-  Value::Error("Matrices can only be divided by Numbers")
-    unless (Value::matchNumber($r) || Value::isComplex($r));
+  Value::Error("Matrices can only be divided by Numbers") unless Value::isNumber($r);
   Value::Error("Division by zero") if $r == 0;
   my @coords = ();
   foreach my $x (@{$l->data}) {push(@coords,$x/$r)}

--- a/lib/Value/Point.pm
+++ b/lib/Value/Point.pm
@@ -81,8 +81,7 @@ sub sub {
 
 sub mult {
   my ($l,$r) = @_; my $self = $l;
-  Value::Error("Points can only be multiplied by Numbers")
-    unless (Value::matchNumber($r) || Value::isComplex($r));
+  Value::Error("Points can only be multiplied by Numbers") unless Value::isNumber($r);
   my @coords = ();
   foreach my $x ($l->value) {push(@coords,$x*$r)}
   return $self->make(@coords);
@@ -91,8 +90,7 @@ sub mult {
 sub div {
   my ($l,$r,$flag) = @_; my $self = $l;
   Value::Error("Can't divide by a Point") if $flag;
-  Value::Error("Points can only be divided by Numbers")
-    unless (Value::matchNumber($r) || Value::isComplex($r));
+  Value::Error("Points can only be divided by Numbers") unless Value::isNumber($r);
   Value::Error("Division by zero") if $r == 0;
   my @coords = ();
   foreach my $x ($l->value) {push(@coords,$x/$r)}

--- a/lib/Value/Vector.pm
+++ b/lib/Value/Vector.pm
@@ -92,8 +92,7 @@ sub sub {
 
 sub mult {
   my ($l,$r,$flag) = @_; my $self = $l;
-  Value::Error("Vectors can only be multiplied by Numbers")
-    unless (Value::matchNumber($r) || Value::isComplex($r));
+  Value::Error("Vectors can only be multiplied by Numbers") unless Value::isNumber($r);
   my @coords = ();
   foreach my $x ($l->value) {push(@coords,$x*$r)}
   return $self->make(@coords);
@@ -102,8 +101,7 @@ sub mult {
 sub div {
   my ($l,$r,$flag) = @_; my $self = $l;
   Value::Error("Can't divide by a Vector") if $flag;
-  Value::Error("Vectors can only be divided by Numbers")
-    unless (Value::matchNumber($r) || Value::isComplex($r));
+  Value::Error("Vectors can only be divided by Numbers") unless Value::isNumber($r);
   Value::Error("Division by zero") if $r == 0;
   my @coords = ();
   foreach my $x ($l->value) {push(@coords,$x/$r)}


### PR DESCRIPTION
Fix checks for scalar multiplication (for points, vectors, and matrices) to not have to stringify the value if it is already a Real or Complex number.  This resolves [bug 3991](http://bugs.webwork.maa.org/show_bug.cgi?id=3991).  The issue was that when `Context()->texStrings` is in effect, the string match that was used to decide if the coefficient is a number would match against the TeX version of the number.  When the number is large enough for scientific notation (i.e., more than 6 digits), then the TeX version of scientific notation would not match as a number, and would give an error.

To test the patch, use

```
Context("Matrix")->texStrings;
$P = Point(1,2,3);
$V = Vector(1,2,3);
$M = Matrix([1,2],[3,4]);
$a = Real(1230000);
$b = Real(123000);

sub TEST {
  my $test = shift;
  my ($result, $error) = PG_restricted_eval($test);
  TEXT($error? "$test: $error" : "$test: OK", $BR);
}

TEST('$a*$P');
TEST('$P/$a');
TEST('$a*$V');
TEST('$V/$a');
TEST('$a*$M');
TEST('$M/$a');

TEXT($HR);

TEST('$b*$P');
TEST('$P/$b');
TEST('$b*$V');
TEST('$V/$b');
TEST('$b*$M');
TEST('$M/$b');
```

Without the patch, all the lines involving `$a` should produce an error, but the ones with `$b` should be marked `OK`.  With the patch, all the lines should be `OK`.