### PR TITLE
Fix reduction rule for negative powers

### DIFF
--- a/lib/Parser/BOP/power.pm
+++ b/lib/Parser/BOP/power.pm
@@ -49,8 +49,12 @@ sub _reduce {
     if (($self->{rop}{isZero} && !$self->{lop}{isZero} && $reduce->{'x^0'}) ||
 	($self->{lop}{isOne} && $reduce->{'1^x'}));
   return $self->{lop} if $self->{rop}{isOne} && $reduce->{'x^1'};
-  if ($self->{rop}->isNeg && $self->{rop}->string eq '-1' && $reduce->{'x^(-1)'}) {
-    $self = $self->Item("BOP")->new($equation,'/',$self->Item("Number")->new($equation,1),$self->{lop});
+  if ($self->{rop}->isNeg && $self->{rop}{isConstant} &&
+      $self->{lop}->typeRef->{name} ne "Matrix" && $reduce->{'x^(-a)'}) {
+    my $copy = $self->copy($equation);
+    $copy->{rop} = $self->Item("Number")->new($equation,-($copy->{rop}->eval));
+    $self = $self->Item("BOP")->new($equation,'/',$self->Item("Number")->new($equation,1),
+                                    ($copy->{rop}->string eq '1' ? $copy->{lop} : $copy));
     $self = $self->reduce;
   }
   return $self;
@@ -58,7 +62,7 @@ sub _reduce {
 
 $Parser::reduce->{'x^0'} = 1;
 $Parser::reduce->{'1^x'} = 1;
-$Parser::reduce->{'x^(-1)'} = 1;
+$Parser::reduce->{'x^(-a)'} = 1;
 $Parser::reduce->{'x^1'} = 1;
 
 


### PR DESCRIPTION
This PR fixes the reduction rule for `x^(-1)` to not reduce matrices, which caused errors, and extends it to `x^(-a)` that handles any negative constant power.

To test, use

```
Context("Matrix");
Context()->constants->add(A=>Matrix([1,2],[3,4]));
Context()->variables->add(M=>Matrix([1,2],[3,4]));
TEXT(Formula("A^(-1)")->reduce,$BR);
TEXT(Formula("M^(-1)")->reduce,$BR);
TEXT(Formula("[[x,2],[3,x]]^(-1)")->reduce,$BR);
TEXT(Formula("x^(-1)")->reduce,$BR);
TEXT(Formula("x^(-2)")->reduce,$BR);
```

Without the patch, the first three reductions will produce an error about only being able to divide by a number.  With the patch, all three should succeed, and you should get

```
A^(-1)
M^(-1)
[[x,2],[3,x]]^(-1)
1/x
1/(x^2)
```

as the output.

Note that this does change the name of the reduction rule from `x^(-1)` to `x^(-a)`.  I've checked the macro files and the OPL and don't see any uses of reduction rule `x^(-1)`, so I think this should not be a problem (though some Wiki pages may need to be updated).

This arose from [this issue](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4276).