### PR TITLE
Improve error messages for non-invertible matrices

### DIFF
--- a/lib/Parser/BOP.pm
+++ b/lib/Parser/BOP.pm
@@ -176,6 +176,23 @@ sub checkMatrixSize {
 }
 
 #
+#  Check if a matrix is square
+#
+sub checkMatrixSquare {
+  my $self = shift;
+  my $m = shift; my $type = $m->{entryType};
+  if ($type->{entryType}{name} eq 'Number') {
+    my ($r,$c) = ($m->{length},$type->{length});
+    if ($r == $c) {
+      my $rowType = Value::Type('Matrix',$r,$Value::Type{number},formMatrix=>1);
+      $self->{type} = Value::Type('Matrix',$r,$rowType,formMatrix=>1);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+#
 #  Promote point operands to vectors or matrices.
 #
 sub promotePoints {

--- a/lib/Parser/BOP/power.pm
+++ b/lib/Parser/BOP/power.pm
@@ -17,7 +17,9 @@ sub _check {
   return if $self->checkNumbers();
   my ($ltype,$rtype) = $self->promotePoints('Matrix');
   if ($rtype->{name} eq 'Number') {
-    if ($ltype->{name} eq 'Matrix') {$self->checkMatrixSize($ltype,$ltype)}
+    if ($ltype->{name} eq 'Matrix') {
+      $self->Error("Only square matrices can be raised to a power") if !$self->checkMatrixSquare($ltype);
+    }
     elsif ($self->context->flag("allowBadOperands")) {$self->{type} = $Value::Type{number}}
     else {$self->Error("You can only raise a Number to a power")}
   }

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -260,7 +260,10 @@ sub power {
   Value::Error("Can't use Matrices in exponents") if $flag;
   Value::Error("Only square matrices can be raised to a power") unless $l->isSquare;
   $r = Value::makeValue($r,context=>$context);
-  if ($r->isNumber && $r =~ m/^-\d+$/) {$l = $l->inverse; $r = -$r}
+  if ($r->isNumber && $r =~ m/^-\d+$/) {
+    $l = $l->inverse; $r = -$r;
+    $self->Error("Matrix is not invertible") unless defined($l);
+  }
   Value::Error("Matrix powers must be non-negative integers") unless $r->isNumber && $r =~ m/^\d+$/;
   return $context->Package("Matrix")->I($l->length,$context) if $r == 0;
   my $M = $l; foreach my $i (2..$r) {$M = $M*$l}
@@ -436,7 +439,8 @@ sub det {
 sub inverse {
   my $self = shift; $self->wwMatrixLR;
   Value->Error("Can't take inverse of non-square matrix") unless $self->isSquare;
-  return $self->new($self->{lrM}->invert_LR);
+  my $I = $self->{lrM}->invert_LR;
+  return (defined($I) ? $self->new($I) : $I);
 }
 
 sub decompose_LR {
@@ -477,7 +481,9 @@ sub solve_LR {
   my $self = shift;
   my $v = $self->wwColumnVector(shift);
   my ($d,$b,$M) = $self->wwMatrixLR->solve_LR($v);
-  return ($d,$self->new($b),$self->new($M));
+  $b = $self->new($b) if defined($b);
+  $M = $self->new($M) if defined($M);
+  return ($d,$b,$M);
 }
 
 sub condition {


### PR DESCRIPTION
This PR fixes several bad error messages about non-invertible matrices.  To test it, use

```
Context("Matrix");
Context()->constants->add(
  A => Matrix([[1,2,3],[4,5,6]]),
  B => Matrix([0,0],[0,0]),
);
Context()->variables->add(
  M => Matrix([[1,2,3],[4,5,6]]),
  N => Matrix([[1,2],[3,4]]),
);

Formula("A^(-1)");
Formula("M^(-1)");
Formula("[[1,2,3],[4,5,x]]^(-1)");
Formula("[[1,2,3],[4,5,6]]^(-1)");

Formula("B^(-1)")->eval;
Formula("N^(-1)")->eval(N => Matrix([[0,0],[0,0]]));
Formula("[[0,0],[0,0]]^(-1)");
Formula("[[x,0],[0,x]]^(-1)")->eval(x => 0);
Matrix([[0,0],[0,0]]) ** -1;

Matrix([[0,0],[0,0])->inverse;
Matrix([[0,0],[0,0]])->solve_LR(Vector(1,1));
```

Without the patch, the first four should produce errors about 2x3 and 2x3 matrixes not being able to be multiplied, while the next five and final two should produce errors about matrices needing at least one entry.

With the patch, the first four should produce messages that only a square matrix can be inverted, the next five should say that the matrix is not invertible, and the last two should produce an undefined value and a list of three undefined values, respectively.
