### PR TITLE
Make sure initial context is Numeric

### DIFF
--- a/macros/Parser.pl
+++ b/macros/Parser.pl
@@ -132,12 +132,10 @@ that context is set as the current one.  In all three cases, the current context
 # ^uses Parser::Context::current
 # ^uses %context
 sub Context {Parser::Context->current(\%context,@_)}
-unless (%context && $context{current}) {
-  # ^variable our %context
-  %context = ();  # Locally defined contexts, including 'current' context
-  # ^uses Context
-  Context();      # Initialize context (for persistent mod_perl)
-}
+#  # ^variable our %context
+%context = () unless %context;  # Locally defined contexts, including 'current' context
+# ^uses Context
+Context("Numeric");  # Set initial context
 
 ###########################################################################
 #


### PR DESCRIPTION
This PR addresses [Alex's comments](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4318) concerning the default MathObject context when no <code>Context()</code> is specified.  It does so by explicitly setting the context to Numeric, which is what was supposed to have happened anyway, but do to a timing problem, that wasn't the case; the PG environment values weren't being added to the context properly.  So `tolerance`, `useBaseTenLog` and some other values were not the same as they would be if `Context("Numeric")` was performed explicitly.

This can be tested by using:

```
DOCUMENT();
loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
);
TEXT(Context()->flag('tolerance'), $BR);
Context("Numeric");
TEXT(Context()->flag('tolerance'), $BR);
ENDDOCUMENT();
```

With the patch, both values should be the same, without the patch, they will be different by a factor of 10.