### PR TITLE
Fix problem with empty lists.

### DIFF
--- a/lib/Value/List.pm
+++ b/lib/Value/List.pm
@@ -38,7 +38,7 @@ sub new {
   return $self->formula($p) if $isFormula;
   my $list = bless {data => $p, type => $type, context=>$context}, $class;
   $list->{correct_ans} = $p->[0]{correct_ans}
-    if $isSingleton && defined scalar(@{$p}) && defined $p->[0]{correct_ans};
+    if $isSingleton && scalar(@{$p}) && defined $p->[0]{correct_ans};
   if (scalar(@{$p}) == 0) {
     $list->{open}  = $def->{nestedOpen};
     $list->{close} = $def->{nestedClose};


### PR DESCRIPTION
This PR fixes a typo in the code that handles empty lists. 

To test it, use

```
$L = List();
TEXT($L->string eq '()' ? "Yes" : "No",$BR);
TEXT($L == List() ? "Yes" : "No", $BR);
TEXT(Parser::Eval(sub {$L->cmp}) ? "OK" : "Error", $BR);
```

Without the patch, you should see
```
No
No
Error
```

With the patch, you should see
```
Yes
Yes
OK
```

The typo causes an empty list to accidentally contain an entry, and that entry is not a MathObject (as it should be).  This causes problems in stringifying (and TeXifying) the list, in comparing the list to other empty lists, and in producing answer checkers for the list.  The patch should resolve all three problems.

---
Resolves issue openwebwork/webwork-open-problem-library#403