### PR TITLE
Matrix bugs

### DIFF
--- a/macros/MatrixCheckers.pl
+++ b/macros/MatrixCheckers.pl
@@ -144,7 +144,7 @@ sub concatenate_columns_into_matrix {
   for my $column (@c) {
     push(@temp,Matrix($column)->transpose->row(1));    
   }
-  return Matrix(@temp)->transpose;
+  return Matrix(\@temp)->transpose;
 
 }
 
@@ -314,8 +314,8 @@ sub basis_checker_rows {
       return 0 if scalar(@s) < scalar(@c);  # count the number of vector inputs
 
       # These two lines are what is different from basis_checker_columns
-      my $C = Matrix(@c)->transpose; # put the rows of @c into columns of $C.
-      my $S = Matrix(@s)->transpose; # put the rows of @s into columns of $S.
+      my $C = Matrix(\@c)->transpose; # put the rows of @c into columns of $C.
+      my $S = Matrix(\@s)->transpose; # put the rows of @s into columns of $S.
 
       # Put $C and $S into the local context so that
       # all of the computations that follow will also be in
@@ -362,8 +362,8 @@ sub orthonormal_basis_checker_rows {
       return 0 if scalar(@s) < scalar(@c);  # count the number of vector inputs
 
       # These two lines are what is different from basis_checker_columns
-      my $C = Matrix(@c)->transpose; # put the rows of @c into columns of $C.
-      my $S = Matrix(@s)->transpose; # put the rows of @s into columns of $S.
+      my $C = Matrix(\@c)->transpose; # put the rows of @c into columns of $C.
+      my $S = Matrix(\@s)->transpose; # put the rows of @s into columns of $S.
 
       # Put $C and $S into the local context so that
       # all of the computations that follow will also be in

--- a/macros/MatrixReduce.pl
+++ b/macros/MatrixReduce.pl
@@ -26,9 +26,9 @@ computations using MathObjects matrices.
 
 =item Construct an n x n elementary matrix that will permute rows i and j: C<$E = elem_matrix_row_switch(5,2,4);> creates a 5 x 5 identity matrix and swaps rows 2 and 4.
 
-=item Construct an n x n elementary matrix that will multiply row i by s: C<$E = elem_matrix_row_mult(5,2,4);> creates a 5 x 5 identity matrix and swaps puts 4 in the second spot on the diagonal.
+=item Construct an n x n elementary matrix that will multiply row i by s: C<$E = elem_matrix_row_mult(5,2,4);> creates a 5 x 5 identity matrix and puts 4 in the second spot on the diagonal.
 
-=item Construct an n x n elementary matrix that will multiply row i by s: C<$E3 = elem_matrix_row_add(5,3,1,35);> creates a 5 x 5 identity matrix and swaps puts 35 in the (3,1) position.
+=item Construct an n x n elementary matrix that will add s times row j to row i: C<$E3 = elem_matrix_row_add(5,3,1,35);> creates a 5 x 5 identity matrix and puts 35 in the (3,1) position.
 
 =item Perform the row switch transform that swaps (row i) with (row j): C<$Areduced = row_switch($A,2,4);> swaps rows 2 and 4 in matrix $A.
 

--- a/macros/MatrixReduce.pl
+++ b/macros/MatrixReduce.pl
@@ -134,14 +134,14 @@ sub rref {
   my $M = shift;
   my @m = $M->value;
   my @m_reduced = rref_perl_array(@m);
-  return Matrix(@m_reduced);
+  return Matrix(\@m_reduced);
 }
 
 sub rcef {
   my $M = shift;
   my @m = $M->transpose->value;
   my @m_reduced = rref_perl_array(@m);
-  return Matrix(@m_reduced)->transpose;
+  return Matrix(\@m_reduced)->transpose;
 }
 
 sub rref_perl_array {
@@ -212,7 +212,7 @@ sub elem_matrix_row_switch {
 	my $M = Value::Matrix->I($n); # construct identity matrix
 	my @m = $M->value;
 	@m[$i - 1, $j - 1] = @m[$j - 1, $i - 1]; # switch rows
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -234,7 +234,7 @@ sub elem_matrix_row_mult {
 	my $M = Value::Matrix->I($n); # construct identity matrix
 	my @m = $M->value;
 	foreach my $rowval ( @{$m[$i - 1]} ) { $rowval *= $s; }
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -256,7 +256,7 @@ sub elem_matrix_row_add {
 	my $M = Value::Matrix->I($n); # construct identity matrix
 	my @m = $M->value;
 	$m[$i - 1][$j - 1] = $s;
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -290,7 +290,7 @@ sub row_add {
 	foreach my $k (0..$c-1) {
 		$m[$i - 1][$k] += $s * $m[$j - 1][$k];
 	}
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -308,7 +308,7 @@ sub row_switch {
 	}
 	my @m = $M->value;
 	@m[$i1 - 1,$i2 - 1] = @m[$i2 - 1,$i1 - 1];
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -327,7 +327,7 @@ sub row_mult {
 	if ($s == 0 and $permissionLevel >= 10) { warn "Scaling a row by zero is not a valid row operation.  (This warning is only shown to professors.)"; }
 	my @m = $M->value;
 	foreach my $rowval ( @{$m[$i - 1]} ) { $rowval *= $s; } # row multiplication
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 
@@ -341,7 +341,7 @@ sub apply_fraction_to_matrix_entries {
 	foreach my $i (0..$r-1) {
 		foreach my $rowval ( @{$m[$i]} ) { $rowval = Fraction("$rowval"); }
 	}
-	return Matrix(@m);
+	return Matrix(\@m);
 
 }
 

--- a/macros/MatrixUnits.pl
+++ b/macros/MatrixUnits.pl
@@ -38,7 +38,7 @@ than by multiplication of elementary matrices).
 Note that the indexing on MathObject matrices starts at 1, while the indexing 
 on perl arrays starts at 0, so that C<$A-<gt>element(1,1);> corresponds to
 C<$a[0][0];>.  The perl arrays can be made into MathObject matrices by
-C<$A = Matrix(@a);>, and this is, in fact, what the C<GLnZ()> and C<SLnZ()>
+C<$A = Matrix(\@a);>, and this is, in fact, what the C<GLnZ()> and C<SLnZ()>
 subroutines do for you.  The perl versions C<@a = GLnZ_perl()> and 
 C<@a = SLnZ_perl()> are useful if you want to have quick access to the matrix 
 values (as perl reals stored in C<@a>) without having to pull them out of a 
@@ -65,7 +65,7 @@ loadMacros("MathObjects.pl",);
 
 sub GL2Z {
   my @a = GL2Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 sub GL2Z_perl {
@@ -88,7 +88,7 @@ sub GL2Z_perl {
 
 sub SL2Z {
   my @a = SL2Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 sub SL2Z_perl {
@@ -116,7 +116,7 @@ sub SL2Z_perl {
 
 sub GL3Z {
   my @a = GL3Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 sub GL3Z_perl {
@@ -151,7 +151,7 @@ sub GL3Z_perl {
 
 sub SL3Z {
   my @a = SL3Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 sub SL3Z_perl {
@@ -190,7 +190,7 @@ sub SL3Z_perl {
 
 sub GL4Z {
   my @a = GL4Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 
@@ -243,7 +243,7 @@ sub GL4Z_perl {
 
 sub SL4Z {
   my @a = SL4Z_perl();
-  return Matrix(@a);
+  return Matrix(\@a);
 }
 
 sub SL4Z_perl {


### PR DESCRIPTION
This is my first pull request; I am starting with something uncontroversial just to see how the process works. It fixes some real bugs though.

Summary: this fixes a bug in the functions rref, elem_matrix_row_mult, row_mult, apply_fraction_to_matrix_entries, and possibly others, in MatrixReduce.pl and similar places. These functions do not work correctly in case of a 1xm-matrix. The bug is caused by calling Matrix(@m) instead of Matrix(\\@m). While the Matrix constructor can either accept an array reference or an array, the behavior is not correct when the matrix happens to have a single row.

In other words, while Matrix([[1,2,3],[4,5,6]]) and Matrix([1,2,3],[4,5,6]) are equivalent, Matrix([[1,2,3]]) and  Matrix([1,2,3]) are not equivalent (and the latter gives the wrong result, namely, a vector instead of a matrix).

Therefore, one should never call Matrix(@m) programmatically when the length of @m could be 1.
One should always call Matrix(\\@m). Even in cases where the length of @m is known (e.g., the function GL2Z), the form Matrix(\\@m) is preferable, because someone might repurpose the code for a different @m.

This patch fixes the issue.