### PR TITLE
Ln e reduction

### DIFF
--- a/lib/Parser/Function/numeric.pm
+++ b/lib/Parser/Function/numeric.pm
@@ -52,6 +52,16 @@ sub log   {
   CORE::log($_[0]);
 }
 
+sub _reduce {
+  my $self = shift;
+  return $self unless $self->context->flag('reduceConstantFunctions');
+  my $base10 = $self->context->flag('useBaseTenLog');
+  my $s = $self->string;
+  return $self->Item('Value')->new($self->{equation}, [$self->eval])
+    if $s eq 'ln(e)' || $s eq 'log10(10)' || $s eq ($base10 ? 'log(10)' : 'log(e)');
+  return $self;
+}
+
 #
 #  Handle absolute values as a special case
 #

--- a/lib/Parser/Function/numeric.pm
+++ b/lib/Parser/Function/numeric.pm
@@ -58,7 +58,7 @@ sub _reduce {
   my $base10 = $self->context->flag('useBaseTenLog');
   my $s = $self->string;
   return $self->Item('Value')->new($self->{equation}, [$self->eval])
-    if $s eq 'ln(e)' || $s eq 'log10(10)' || $s eq ($base10 ? 'log(10)' : 'log(e)');
+    if $s eq 'ln(e)' || ($s eq 'log(e)' && $base10);
   return $self;
 }
 


### PR DESCRIPTION
This introduces a reduction rule for `ln(e)`, `log(e)` (when `useBaseTonLog` is false).

You can test this by using

    TEXT(Formula("ln(e)")->reduce,$BR);
    TEXT(Formula("log(e)")->reduce,$BR);

Without the patch, the formula will be unchanged.  With the patch, you should get the number 1 from both of them.  