### PR TITLE
implement PGML explicit disc

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -357,7 +357,7 @@ sub Rule {
 sub Bullet {
   my $self = shift; my $token = shift; my $bullet = shift;
   return $self->Text($token) unless $self->{atLineStart};
-  $bullet = {'*'=>'bullet', '+'=>'square', 'o'=>'circle', '-'=>'bullet'}->{substr($token,0,1)} if $bullet eq 'bullet';
+  $bullet = {'*'=>'disc', '+'=>'square', 'o'=>'circle', '-'=>'bullet'}->{substr($token,0,1)} if $bullet eq 'bullet';
   my $block = $self->{block};
   if ($block->{type} ne 'root' && !$block->{align}) {
     while ($block->{type} ne 'root' && !$block->{prev}{align}) {$block = $block->{prev}}
@@ -1094,6 +1094,7 @@ my %bullet = (
   Alpha   => 'ol type="A"',
   roman   => 'ol type="i"',
   Roman   => 'ol type="I"',
+  disc    => 'ul type="disc"',
   circle  => 'ul type="circle"',
   square  => 'ul type="square"',
 );
@@ -1531,6 +1532,7 @@ our $preamble = <<'END_PREAMBLE';
 
 \def\pgmlIndent{\par\advance\leftskip by 2em \advance\pgmlPercent by .02em \pgmlCount=0}%
 \def\pgmlbulletItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
+\def\pgmldiscItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
 \def\pgmlcircleItem{\par\indent\llap{$\circ$ }\ignorespaces}%
 \def\pgmlsquareItem{\par\indent\llap{\vrule height 1ex width .75ex depth -.25ex\ }\ignorespaces}%
 \def\pgmlnumericItem{\par\indent\advance\pgmlCount by 1 \llap{\the\pgmlCount. }\ignorespaces}%


### PR DESCRIPTION
In PGML, currently both `*` and `-` effectively create a filled-in-disc as a bullet in a list. But neither options leads to that getting written as an attribute to the `ul` (in the same way that `type="circle"` and `type="square"` get written as attributes). This means that the CSS that controls bullet styling can override the author's choice to make a disc, which will generally happen if the list is a sublist. 

With the change, `*` makes an explicit disc bullet, and `-` remains generic.  