### PR TITLE
Add lang and direction to pg flags

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -189,7 +189,7 @@ sub SET_PROBLEM_TEXTDIRECTION {
   if ( $requested_dir =~ /^ltr$/i ) {
     $PG->{flags}->{"textdirection"} = "ltr";
   } elsif ( $requested_dir =~ /^rtl$/i ) {
-    $PG->{flags}->{"textdirection"} = "trl";
+    $PG->{flags}->{"textdirection"} = "rtl";
   } elsif ( $requested_dir =~ /^auto$/i ) {
     $PG->{flags}->{"textdirection"} = "auto"; # NOT RECOMMENDED
   } else {

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -142,6 +142,62 @@ sub POST_HEADER_TEXT {
 	$PG->POST_HEADER_TEXT(@_);
 }
 
+# We expect valid HTML language codes, but there can also include a region code, or other
+# settings.
+#    See https://www.w3.org/International/questions/qa-choosing-language-tags
+# Example settings: en-US, en-UK, he-IL
+# Some special language codes (zh-Hans) are longer
+#    http://www.rfc-editor.org/rfc/bcp/bcp47.txt
+#    https://www.w3.org/International/articles/language-tags/
+#    https://www.w3.org/International/questions/qa-lang-2or3.en.html
+#    http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+#    https://www.w3schools.com/tags/ref_language_codes.asp
+#    https://www.w3schools.com/tags/ref_country_codes.asp
+# Tester at https://r12a.github.io/app-subtags/
+
+sub SET_PROBLEM_LANGUAGE {
+  my $requested_lang = shift;
+
+  # Clean it up for safety
+  my $selected_lang = $requested_lang;
+  $selected_lang =~ s/[^a-zA-Z0-9-]//g ; # Drop any characters not permitted.
+
+  if ( $selected_lang ne $requested_lang ) {
+    warn "PROBLEM_LANGUAGE was edited. Requested: $requested_lang which was replaced by $selected_lang";
+  }
+  $PG->{flags}->{"language"} = $selected_lang;
+}
+
+# SET_PROBLEM_TEXTDIRECTION to set the HTML DIRection attribute to be applied
+# to the DIV element containing this problem.
+
+# We only permit valid settings for the HTML direction attribute:
+#      dir="ltr|rtl|auto"
+# https://www.w3schools.com/tags/att_global_dir.asp
+
+# It is likely that only problems written in RTL scripts
+# will need to call the following function to set the base text direction
+# for the problem.
+
+# Note the flag may not be set, and then webwork2 will use default behavior.
+
+sub SET_PROBLEM_TEXTDIRECTION {
+  my $requested_dir = shift;
+
+  # Only allow valid values:
+
+  if ( $requested_dir =~ /^ltr$/i ) {
+    $PG->{flags}->{"textdirection"} = "ltr";
+  } elsif ( $requested_dir =~ /^rtl$/i ) {
+    $PG->{flags}->{"textdirection"} = "trl";
+  } elsif ( $requested_dir =~ /^auto$/i ) {
+    $PG->{flags}->{"textdirection"} = "auto"; # NOT RECOMMENDED
+  } else {
+    warn " INVALID setting for PROBLEM_TEXTDIRECTION: $requested_dir was DROPPED.";
+  }
+}
+
+
 sub AskSage {
     my $python = shift;
     my $options = shift;


### PR DESCRIPTION
This is a pull request which is intended to allow WebWork to receive information about the (primary) language and text direction of a problem via the PG flags, which can be accessed by the ContentGenerator code to set HTML language and direction attributes for each specific problem.

The primary need for this is likely to be in courses in right-to-left (RTL)  languages such as Hebrew and Arabic where the main HTML direction will be RTL, but when viewing problems from the library browser to be selected for translation - those problems should be displayed in the LTR (left-to-right) direction. The opposite case of viewing RTL problems in a LTR course is likely to be pretty rare.

The capability of setting the language of a problem, would allow problems in multiple languages to be used in a single course, while setting the language of the block containing a problem to match that of the problem rather than the course-wide default. This is something desirable in terms of accessibility for screen-reader users, even if a typical user would not be aware of there being an issue.

Details: the functions SET_PROBLEM_LANGUAGE() and SET_PROBLEM_TEXTDIRECTION() were added to macros/PG.pl which set the flags expected by the code being written to process the data they pass on.

The flag values set in the problem are processed by a new utility function get_problem_lang_and_dir() which passed on an array of data used to set the relevant HTML tags in the various ContentGenerator modules. That code also checks a new configuration variable added to webwork2/conf/defaults.config which can force specific fixed behavior, set defaults to use when there are no PG set flags, or disable to addition of the attributes which would normally be done by the new code.