### PR TITLE
PGML true display math

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -44,8 +44,8 @@ my $pre = ':   ';
 my $emphasis = '\*+|_+';
 my $chars = '\\\\.|[{}[\]\'"]';
 my $ansrule = '\[(?:_+|[ox^])\]\*?';
-my $open = '\[(?:[!<%@$]|::?|``?|\|+ ?)';
-my $close = '(?:[!>%@$]|::?|``?| ?\|+)\]';
+my $open = '\[(?:[!<%@$]|::?:?|``?`?|\|+ ?)';
+my $close = '(?:[!>%@$]|::?:?|``?`?| ?\|+)\]';
 my $noop = '\[\]';
 
 my $splitPattern =
@@ -454,11 +454,16 @@ my $balanceAll = qr/[\{\[\'\"]/;
 	       parsed=>1, allowStar=>1, allowDblStar=>1, allowTriStar=>1, options=>["context","reduced"]},
   "[::"  => {type=>'math', parseComments=>1, parseSubstitutions=>1,
                terminator=>qr/::\]/, terminateMethod=>'terminateGetString',
+	       parsed=>1, allowStar=>1, allowDblStar=>1, allowTriStar=>1, displaystyle=>1, options=>["context","reduced"]},
+  "[:::"  => {type=>'math', parseComments=>1, parseSubstitutions=>1,
+               terminator=>qr/:::\]/, terminateMethod=>'terminateGetString',
 	       parsed=>1, allowStar=>1, allowDblStar=>1, allowTriStar=>1, display=>1, options=>["context","reduced"]},
   "[`"   => {type=>'math', parseComments=>1, parseSubstitutions=>1,
                terminator=>qr/\`\]/, terminateMethod=>'terminateGetString',},
   "[``"  => {type=>'math', parseComments=>1, parseSubstitutions=>1,
-               terminator=>qr/\`\`\]/, terminateMethod=>'terminateGetString', display=>1},
+               terminator=>qr/\`\`\]/, terminateMethod=>'terminateGetString', displaystyle=>1},
+  "[```"  => {type=>'math', parseComments=>1, parseSubstitutions=>1,
+               terminator=>qr/\`\`\`\]/, terminateMethod=>'terminateGetString', display=>1},
   "[!"   => {type=>'image', parseComments=>1, parseSubstitutions=>1,
                terminator=>qr/!\]/, terminateMethod=>'terminateGetString',
                cancelNL=>1, options=>["title"]},
@@ -966,8 +971,9 @@ sub Math {
     $obj = $obj->reduce if $item->{reduced};
     $math = $obj->TeX;
   }
-  $math = "\\displaystyle{$math}" if $item->{display};
-  return $math;
+  $math = "\\displaystyle{$math}" if $item->{displaystyle};
+  my $mathmode = ($item->{display}) ? 'display' : 'inline' ;
+  return ($math,$mathmode);
 }
 
 sub Answer {
@@ -1188,7 +1194,7 @@ sub Verbatim {
 
 sub Math {
   my $self = shift;
-  return main::math_ev3($self->SUPER::Math(@_));
+  return main::general_math_ev3($self->SUPER::Math(@_));
 }
 
 ######################################################################
@@ -1328,9 +1334,10 @@ sub Verbatim {
   return $text;
 }
 
+
 sub Math {
   my $self = shift;
-  return main::math_ev3($self->SUPER::Math(@_));
+  return main::general_math_ev3($self->SUPER::Math(@_));
 }
 
 ######################################################################
@@ -1456,7 +1463,7 @@ sub Verbatim {
 
 sub Math {
   my $self = shift;
-  return main::math_ev3($self->SUPER::Math(@_));
+  return main::general_math_ev3($self->SUPER::Math(@_));
 }
 
 


### PR DESCRIPTION
This implements display math for PGML. Note that the current delimiters `[::   ::]` and ```[``   ``]``` make inline math preceded by a `\displaystyle`, not actual display math. This commit implements a three-colon (ASCIIMath) or three-backtick (LaTeX) version which really does display math, including centering on a new line.

Test with this file:
```
DOCUMENT();
loadMacros(
  "PGstandard.pl",
  "PGML.pl",
);

BEGIN_PGML
Inline [: sum :]

Displaystyle [:: sum ::]

Display [::: sum :::]

Inline [` \sum `]

Displaystyle [`` \sum ``]

Display [``` \sum ```]

END_PGML

ENDDOCUMENT();
```
