### PR TITLE
Make sure saved correct answer has units in NumberWithUnits()

### DIFF
--- a/lib/Parser/Legacy/NumberWithUnits.pm
+++ b/lib/Parser/Legacy/NumberWithUnits.pm
@@ -59,8 +59,6 @@ sub new {
     }
   }
 
-  
-  
   Value::Error("You must provide a ".$self->name) unless defined($num);
   ($num,$units) = splitUnits($num) unless $units;
   Value::Error("You must provide units for your ".$self->name) unless $units;
@@ -71,6 +69,8 @@ sub new {
   $num->{units} = $units;
   $num->{units_ref} = \%Units;
   $num->{isValue} = 1;
+  $num->{correct_ans} .= ' '.$units if defined $num->{correct_ans};
+  $num->{correct_ans_latex_string} .= ' '.TeXunits($units) if defined $num->{correct_ans_latex_string};
   bless $num, $class;
 }
 


### PR DESCRIPTION
This fixes a problem with `NumberWithUnits()` when passed a Real MathObject created by `Compute()` reported in [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4441).

To test, use

```
loadMacros("parserNumberWithUnits.pl");
$v = Compute("sqrt(23)");
$n = NumberWithUnits($v, "m/s");

BEGIN_TEXT
$n->{correct_ans} and \($n->{correct_ans_latex_string}\)
END_TEXT
```

With the patch, both values should include units; without the patch, they will just be the square root with no units.