### PR TITLE
Fix crash when preformatted text is used in a list

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -276,7 +276,7 @@ sub ForceBreak {
 
 sub Par {
   my $self = shift; my $token = shift;
-  $self->End;
+  $self->End(null, shift);
   $self->Item("par",$token,{noIndent => 1});
   $self->{atLineStart} = $self->{ignoreNL} = 1;
   $self->{indent} = $self->{actualIndent} = 0;
@@ -537,7 +537,7 @@ sub terminatePre {
   my $self = shift; my $token = shift;
   $self->{block}{terminator} = ''; # we add the ending token to the text below
   if ($token =~ m/\n\n/) {
-    $self->Par($token);
+    $self->Par($token, $self->{block});
     $self->{block} = $self->{block}{prev};
   } else {
     $self->Text($token);


### PR DESCRIPTION
This PR fixes a problem reported in [this post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4427#p12826).

To test, use

```
loadMacros("PGML.pl");

BEGIN_PGML
1.  Item 1
    :   pre-formatted

2. Item 2
END_PGML
```

Without the patch, this will produce an error about not being able to use `combineTopItems` on an undefined reference.  With the patch, this should format as a list with a preformatted section within it.

