### PR TITLE
Make sure ImplicitPlane retains its full precision

### DIFF
--- a/macros/parserImplicitPlane.pl
+++ b/macros/parserImplicitPlane.pl
@@ -116,8 +116,8 @@ sub new {
     $vars = [$vars] unless ref($vars) eq 'ARRAY';
     $type = 'line' if scalar(@{$vars}) == 2;
     my @terms = (); my $i = 0;
-    foreach my $x (@{$vars}) {push @terms, $N->{data}[$i++]->string.$x}
-    $plane = $formula->new(join(' + ',@terms).' = '.$d->string)->reduce(@_);
+    foreach my $x (@{$vars}) {push @terms, $N->{data}[$i++]->value.$x}
+    $plane = $formula->new(join(' + ',@terms).' = '.$d->value)->reduce(@_);
   } else {
     #
     #  Determine the normal vector and d value from the equation


### PR DESCRIPTION
Make sure ImplicitPlane retains its full precision (i.e., don't go through Real to string conversion).

An implicit plane created from a coefficient array and constant is created by producing a string version of the plane that is then parsed.  If the array was of MathObject Reals, when stringified, they would reduce to 6 digits of precision, so the resulting plane might not be exactly the one intended.  Since this was used to check if the student answer is in fact a linear one, that could lead to an incorrect message that the students answer was non linear (due to a comparison failing because of the loss of precision).  See [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4515) for an example.

To test, you can use

```
loadMacros("parserImplicitPlane.pl");
Context("ImplicitPlane")->variables->are(x=>"Real", y=>"Real");
$f = ImplicitPlane([1/6,1],1/3);
TEXT(Formula($f->{tree}{lop})->eval(x=>1, y=>0)->value, $BR);
TEXT(Formula($f->{tree}{rop})->eval(x=>1, y=>0)->value, $BR);
```

With the patch, you should get 16 or 17 digits of output.  Without the patch, you should get only 6.