### PR TITLE
Preserve string case sensitivity in Compute().

### DIFF
--- a/lib/Value/String.pm
+++ b/lib/Value/String.pm
@@ -27,6 +27,14 @@ sub new {
   return $s;
 }
 
+sub make {
+  my $self = shift;
+  my $s = $self->SUPER::make(@_);
+  my $def = $self->context->strings->get($s->{data}[0]);
+  $s->{caseSensitive} = 1 if $def->{caseSensitive};
+  return $s;
+}
+
 #
 #  Return the appropriate data.
 #


### PR DESCRIPTION
Allow strings created by `Compute()` to have their case sensitivity preserved.

In the past, setting a string as case sensitive, and then using `Compute()` to create the Sting object for it would lose the case sensitivity.  This patch fixes that.

To test, use:

```
Context("Numeric")->strings->add(
  "x" => {caseSensitive => 1},
  "X" => {caseSensitive => 1}
);
TEXT(Compute("x") == "X" ? "equal" : "not equal");
```

With the patch, this should produce `not equal`, while without the patch, you should get `equal`.

See [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4473) for original issue.