### PR TITLE
Process LaTeX for all answer blanks, not just array blanks

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1012,8 +1012,7 @@ sub Answer {
         unshift(@options,$item->{name});
         $method = "named_".$method;
       }
-      $rule = $ans->$method(@options);
-      $rule = PGML::LaTeX($rule) if $item->{hasStar};
+      $rule = PGML::LaTeX($ans->$method(@options));
       if (!(ref($ans) eq 'MultiAnswer' && $ans->{part} > 1)) {
         if (defined($item->{name})) {
           main::NAMED_ANS($item->{name} => $ans->cmp);


### PR DESCRIPTION
Process LaTeX for all answer blanks, not just array blanks (since things like stretchy braces can be added around answer rules even if not in array form).

This came from my trying to write a Matrix answer checker that provided an answer box rather than an array of answer rules.  I wanted the matrix brackets around the box, but they were not being processed.

You can test with the following:

```
loadMacros("PGML.pl");

package test;
our @ISA=("Value::Real");
sub ans_rule {
  my $self=shift;
  "\\(xyz\\) " . $self->SUPER::ans_rule(@_);
};

package main;

$r = test->new(5);

BEGIN_PGML
[___]{$r}
END_PGML
```

With the fix, you should get "xyz" in math mode (math italics) before the answer blank.  Without it, you would get `\(xyz\)`.  You will have to test in image mode, not MathJax mode, since MathJax will process the `\(xyz\)` in the browser, so you will not be able to tell that it wasn't processed by WeBWorK internally.