### PR TITLE
Don't try to convert MathObjects to complex numbers in Matrix->copy()

### DIFF
--- a/lib/Matrix.pm
+++ b/lib/Matrix.pm
@@ -377,9 +377,8 @@ sub new_from_col_vecs
 
 sub cp  { # MEG  makes new copies of complex number
 	my $z = shift;
-	return $z unless ref($z);
-	my $w = Complex1::cplx($z->Re,$z->Im);
-	return $w;
+	return $z unless ref($z) eq 'Complex1';
+	Complex1::cplx($z->Re,$z->Im);
 }
 
 =head4

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -186,7 +186,7 @@ sub numberMatrix {  #internal
   my @M = (); my $isFormula = 0;
   foreach my $x (@_) {
     $x = Value::makeValue($x,context=>$context);
-    Value::Error("Matrix row entries must be numbers") unless Value::isNumber($x);
+    Value::Error("Matrix row entries must be numbers") unless _isNumber($x);
     push(@M,$x); $isFormula = 1 if Value::isFormula($x);
   }
   return $self->formula([@M]) if $isFormula;
@@ -275,6 +275,11 @@ sub isZero {
   return 1;
 }
 
+sub _isNumber {
+  my $n = shift;
+  return Value::isNumber($n) || Value::classMatch($n, 'Fraction');
+}
+
 #
 #  Make arbitrary data into a matrix, if possible
 #
@@ -327,7 +332,7 @@ sub mult {
   #
   #  Constant multiplication
   #
-  if (Value::isNumber($r)) {
+  if (_isNumber($r)) {
     my @coords = ();
     foreach my $x (@{$l->data}) {push(@coords,$x*$r)}
     return $self->make(@coords);
@@ -365,7 +370,7 @@ sub mult {
 sub div {
   my ($l,$r,$flag) = @_; my $self = $l;
   Value::Error("Can't divide by a Matrix") if $flag;
-  Value::Error("Matrices can only be divided by Numbers") unless Value::isNumber($r);
+  Value::Error("Matrices can only be divided by Numbers") unless _isNumber($r);
   Value::Error("Division by zero") if $r == 0;
   my @coords = ();
   foreach my $x (@{$l->data}) {push(@coords,$x/$r)}
@@ -377,11 +382,11 @@ sub power {
   Value::Error("Can't use Matrices in exponents") if $flag;
   Value::Error("Only square matrices can be raised to a power") unless $l->isSquare;
   $r = Value::makeValue($r,context=>$context);
-  if ($r->isNumber && $r =~ m/^-\d+$/) {
+  if (_isNumber($r) && $r =~ m/^-\d+$/) {
     $l = $l->inverse; $r = -$r;
     $self->Error("Matrix is not invertible") unless defined($l);
   }
-  Value::Error("Matrix powers must be non-negative integers") unless $r->isNumber && $r =~ m/^\d+$/;
+  Value::Error("Matrix powers must be non-negative integers") unless _isNumber($r) && $r =~ m/^\d+$/;
   return $context->Package("Matrix")->I($l->length,$context) if $r == 0;
   my $M = $l; foreach my $i (2..$r) {$M = $M*$l}
   return $M;


### PR DESCRIPTION
The (non-MathObject) Matrix object has a function to try to copy its entries as complex ones if they are complex, but it doesn't really check if they are complex, only that they are objects (assuming that that means they are (non-MathObject) Complex objects.  Since MathObject Matrix object use the older Matrix (and MatrixReal) objects to perform some computations (like inverse), if the MathObject Matrix has entries that are Fraction objects, for example, then the Matrix copy function will assume these are complex numbers.  This fix should prevent that.

To test, use

```
loadMacros("contextFraction.pl");
Context("Fraction");

BEGIN_TEXT
\(\{Matrix([Fraction(1,2),Fraction(2,1)],[Fraction(2,3), Fraction(3,2)])->inverse)\}\)
END_TEXT
```

With the patch, you should get a matrix with fractional entries.  Without the patch, you should get an error like 

```
Can't locate object method "Re" via package "context::Fraction::Fraction" at lib/Matrix.pm line 381
```
