### PR TITLE
Don't inherit non-inheritable properties when doing a union reduction.

### DIFF
--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -212,7 +212,7 @@ sub reduce {
   foreach my $x ($self->value) {
     if ($x->type eq 'Set') {push(@singletons,$x->value)}
     elsif ($x->{data}[0] == $x->{data}[1]) {push(@singletons,$x->{data}[0])}
-    else {push(@intervals,$x->copy)}
+    else {push(@intervals,$x->inherit)}
   }
   my @union = (); my @set = (); my $prevX;
   @intervals = (CORE::sort {$a <=> $b} @intervals);


### PR DESCRIPTION
This PR makes sure that the intervals used in a union that is being reduced don't inherit any of the non-inheritable properties.

To test, use

```
Context("Interval");

$I = Compute("(0,2]") + Compute("(-1,1)");
TEXT($I->{correct_ans_latex_string} ? "Inherited" : "Not Inherited");
```

Without the patch, you should see `Inherited`; with the patch you should see `Not Inherited`.

This comes originally from [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4516).