### PR TITLE
Have PGML change tabs to four spaces at end of formatting

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1484,6 +1484,7 @@ sub Format {
   } else {
     $format = '<div class="PGML">'."\n".PGML::Format::html->new($parser)->format.'</div>'."\n";
   }
+  $format =~ s/\t/    /g;
   main::WARN_MESSAGE("==================","Errors parsing PGML:",@warnings,"==================") if scalar(@warnings);
   return $format;
 }


### PR DESCRIPTION
Prior to this change, PGML like this:

````
BEGIN_PGML
```
    Some code preceded
by four spaces
```
END_PGML
````

will internally replace the four spaces with a tab (recognizing an indent), and then the output (HTML, tex, PTX) will have a leading tab character. That might come out looking like 8 spaces in HTML, but in any case having a tab, so not faithful to the code that was input.

As a final step in PGML processing, this edit converts tab characters back to four spaces.

If I understand correctly, PGML starts out by converting all tabs to four spaces, then leading-four-spaces to a tab. So I don't think this would have unintended consequences because PGML is already controlling tabs. I've done some testing, but not all combinations of multiple depth indentations, lists and sublists, etc.