### PR TITLE
Add code to to track balance of begin/end variable construct in macro in PGbasicmacros.pl and issue warnings on errors / final imbalance.

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -126,7 +126,7 @@ sub initialize {
 		refreshCachedImages       => 0,
 #		ANSWER_ENTRY_ORDER        => [],  # may not be needed if we ue Tie:IxHash
 		comment                   => '',  # implement as array?
-
+		warn_on_internalBalancing_errors => 1,
 	
 	
 	};

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1851,6 +1851,35 @@ sub PG_answer_eval {
 # }
 sub default_preprocess_code {
 	my $evalString = shift//'';
+
+	# Put in calls to do the internalBalancing calls in the preprocess phase
+	$evalString =~ s/\$BBOLD\W/\$BBOLD \\{ internalBalancingIncrement("openBold"); \\}/g;
+	$evalString =~ s/\$EBOLD\W/\$EBOLD \\{ internalBalancingDecrement("openBold"); \\}/g;
+
+	$evalString =~ s/\$BITALIC\W/\$BITALIC \\{ internalBalancingIncrement("openItalic"); \\}/g;
+	$evalString =~ s/\$EITALIC\W/\$EITALIC \\{ internalBalancingDecrement("openItalic"); \\}/g;
+
+	$evalString =~ s/\$BUL\W/\$BUL \\{ internalBalancingIncrement("openUnderline"); \\}/g;
+	$evalString =~ s/\$EUL\W/\$EUL \\{ internalBalancingDecrement("openUnderline"); \\}/g;
+
+	$evalString =~ s/\$BCENTER\W/\$BCENTER \\{ internalBalancingIncrement("openCenter"); \\}/g;
+	$evalString =~ s/\$ECENTER\W/\$ECENTER \\{ internalBalancingDecrement("openCenter"); \\}/g;
+
+	$evalString =~ s/\$BLTR\W/\$BLTR \\{ internalBalancingIncrement("openSpan"); \\}/g;
+	$evalString =~ s/\$ELTR\W/\$ELTR \\{ internalBalancingDecrement("openSpan"); \\}/g;
+
+	$evalString =~ s/\$BM\W/\$BM \\{ internalBalancingTurnOn("inInlineMath"); \\}/g;
+	$evalString =~ s/\$EM\W/\$EM \\{ internalBalancingTurnOff("inInlineMath"); \\}/g;
+
+	$evalString =~ s/\$BDM\W/\$BDM \\{ internalBalancingTurnOn("inDisplayMath"); \\}/g;
+	$evalString =~ s/\$EDM\W/\$EDM \\{ internalBalancingTurnOff("inDisplayMath"); \\}/g;
+
+	$evalString =~ s/\$BEGIN_ONE_COLUMN\W/\$BEGIN_ONE_COLUMN \\{ internalBalancingTurnOn("inOneColumnMode"); \\}/g;
+	$evalString =~ s/\$END_ONE_COLUMN\W/\$END_ONE_COLUMN \\{ internalBalancingTurnOff("inOneColumnMode"); \\}/g;
+
+	$evalString =~ s/\$BLABEL\W/\$BLABEL \\{ internalBalancingTurnOn("inInputLabel"); \\}/g;
+	$evalString =~ s/\$ELABEL\W/\$ELABEL \\{ internalBalancingTurnOff("inInputLabel"); \\}/g;
+
 	# BEGIN_TEXT and END_TEXT must occur on a line by themselves.
 	$evalString =~ s/\n\h*END_TEXT[\h;]*\n/\nEND_TEXT\n/g;
 	$evalString =~ s/\n\h*END_PGML[\h;]*\n/\nEND_PGML\n/g;

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -20,6 +20,8 @@ sub _PG_init{
 
 our $PG;  
 
+%internalBalancing;
+
 sub not_null {$PG->not_null(@_)};
 
 sub pretty_print {$PG->pretty_print(shift,$main::displayMode)};
@@ -55,7 +57,25 @@ sub DOCUMENT {
 	$pgComment                  = '';
 	%gifs_created          		= %{ $PG->{gifs_created}};
 	%external_refs         		= %{ $PG->{external_refs}};
-	
+	$warn_on_internalBalancing_errors = $PG->{flags}->{warn_on_internalBalancing_errors};
+
+
+	# Should not nest, so should stay 0/1 and end at 0.
+	#    inInlineMath inDisplayMath inOneColumnMode inInputLabel inInputLabel
+
+	# Can nest, but should not become negative, and should end at 0.
+	#    openBold openItalic openUnderline openCenter openSpan openDiv
+
+	my $item;
+	my @internalBalancingItems = qw (
+		inInlineMath inDisplayMath inOneColumnMode inInputLabel inInputLabel
+		openBold openItalic openUnderline openCenter openSpan openDiv
+		);
+	foreach $item ( @internalBalancingItems ) {
+	    #$self->{internalBalancing}{$item} = 0;
+	    $internalBalancing{$item} = 0;
+	}
+
 	@KEPT_EXTRA_ANSWERS =();   #temporary hack
 	
 	my %envir              =   %$rh_envir;
@@ -140,6 +160,80 @@ sub HEADER_TEXT {
 
 sub POST_HEADER_TEXT {
 	$PG->POST_HEADER_TEXT(@_);
+}
+
+# Increase/decrease set/unset counter/status in internalBalancing hash where needed
+
+sub internalBalancingTurnOn {
+  my $type = shift;
+  if ( $type =~ /^in[A-Z]/ ) {
+    if( defined( $internalBalancing{ $type } ) ) {
+      if ( ! ( $internalBalancing{ $type } == 0 ) ) {
+        WARN_MESSAGE(" received a request to turn ON the internalBalancing counter called $type when it was not currently set to 0.") if ($warn_on_internalBalancing_errors );
+      } else {
+        $internalBalancing{ $type } = 1;
+	DEBUG_MESSAGE(" received a request to turn ON the internalBalancing counter called $type value is now $internalBalancing{$type} ") if ($warn_on_internalBalancing_errors > 2);
+      }
+    } else {
+      WARN_MESSAGE(" received a request to turn ON an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+    }
+  } else {
+    WARN_MESSAGE(" received a request to turn ON an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+  }
+  '';
+}
+
+sub internalBalancingTurnOff {
+  my $type = shift;
+  if ( $type =~ /^in[A-Z]/ ) {
+    if( defined( $internalBalancing{ $type } ) ) {
+      if ( ! ( $internalBalancing{ $type } == 1 ) ) {
+        WARN_MESSAGE(" received a request to turn OFF the internalBalancing counter called $type when it was not currently set to 1.") if ($warn_on_internalBalancing_errors );
+      } else {
+        $internalBalancing{ $type } = 0;
+	DEBUG_MESSAGE(" received a request to turn OFF the internalBalancing counter called $type  value is now $internalBalancing{$type} ") if ($warn_on_internalBalancing_errors > 2);
+      }
+    } else {
+      WARN_MESSAGE(" received a request to turn OFF an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+    }
+  } else {
+    WARN_MESSAGE(" received a request to turn OFF an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+  }
+  '';
+}
+
+sub internalBalancingIncrement {
+  my $type = shift;
+  if ( $type =~ /^open[A-Z]/ ) {
+    if( defined( $internalBalancing{ $type } ) ) {
+        $internalBalancing{ $type }++;
+	DEBUG_MESSAGE(" received a request to INCREMENT the internalBalancing counter called $type  value is now $internalBalancing{$type} ")if ($warn_on_internalBalancing_errors > 2) ;
+    } else {
+      WARN_MESSAGE(" received a request to INCREMENT an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+    }
+  } else {
+    WARN_MESSAGE(" received a request to INCREMENT an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+  }
+  '';
+}
+
+sub internalBalancingDecrement {
+  my $type = shift;
+  if ( $type =~ /^open[A-Z]/ ) {
+    if( defined( $internalBalancing{ $type } ) ) {
+      if ( $internalBalancing{ $type } > 0 ) {
+	$internalBalancing{ $type }--;
+	DEBUG_MESSAGE(" received a request to DECREMENT the internalBalancing counter called $type  value is now $internalBalancing{$type} ") if ($warn_on_internalBalancing_errors > 2);
+      } else {
+        WARN_MESSAGE(" received a request to DECREMENT the internalBalancing counter called $type when it did not have a POSITIVE value.") if ($warn_on_internalBalancing_errors );
+      }
+    } else {
+      WARN_MESSAGE(" received a request to DECREMENT an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+    }
+  } else {
+    WARN_MESSAGE(" received a request to DECREMENT an INVALID internalBalancing counter called $type") if ($warn_on_internalBalancing_errors );
+  }
+  '';
 }
 
 sub AskSage {
@@ -342,6 +436,17 @@ sub ENDDOCUMENT {
 	$PG->{flags}->{comment}                        = defined($pgComment)?                  $pgComment                 :'' ;  
     $PG->{flags}->{showHintLimit}                  = defined($showHint)?                   $showHint                  : 0 ;  
  
+        # Check the status/counters on tracked begin/end constructs which should balance;
+	{
+	    my $type;
+	    foreach $type ( sort( keys %internalBalancing ) ) {
+		if ( ! ( $internalBalancing{ $type } == 0 ) ) {
+		    warn " The internalBalancing counter called $type is not 0 when ENDDOCUMENT() was called, so there is some INBALANCE in the use of the relevant commands in this PG file. The current value is $internalBalancing{$type} " if ($warn_on_internalBalancing_errors );
+		} else {
+		    DEBUG_MESSAGE( " $type now set to $internalBalancing{$type} ") if ($warn_on_internalBalancing_errors > 1);
+		}
+	    }
+	}
     
 	# install problem grader
 	if (defined($PG->{flags}->{PROBLEM_GRADER_TO_USE})  ) {

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1590,6 +1590,17 @@ sub MODES {
 	$PI					PI()				the number pi
 	$E					E()					the number e
 
+	Note: The begin/end constants are preprocessed in lib/WeBWorK/PG/Translator.pm
+	to add calls to functions which modify tracking variables inside the
+	%internalBalancing hash defined in macros/PG.pl, which are used to detect
+	imbalances in their use. Warnings are issued ONLY when the flag
+	warn_on_internalBalancing_errors is set to 1 or higher in lib/PGcore.pm.
+	When the flag is set to 2 or higher DEBUG_MESSAGE is used to report the
+	final values of the tracking variables at ENDDOCUMENT(). When the flag is set
+	to 3 or higher, DEBUG_MESSAGE will also be issued whenever the tracking
+	variables are modified.
+
+
 =cut
 
 


### PR DESCRIPTION
Add code to to track balance of begin/end variable construct in macro in PGbasicmacros.pl and issue warnings on errors / final imbalance.
 * lib/PGcore.pm
   * Add a new flag warn_on_internalBalancing_errors and currently
     default to 1 (warnings on errors).
 * lib/WeBWorK/PG/Translator.pm
   * Put in calls to do the internalBalancing calls in the preprocess phase
     for the relevant variables. Must be done in the preprocess phase
     as the function which sets the value of these variables is evalualed
     once to define the variable, but no "code" is run when the variables
     are used in a PG file.
 * macros/PG.pl
   * Add the %internalBalancing hash to track the counters/status,
     initialize the local value of $warn_on_internalBalancing_errors
     for the problem, and initialize the value of the counters and
     status variables inside the hash.
   * Add the functions which adjust the counters/status variables, and issue
     warnings on errors and a debug message on valid changes, depending on the
     value of $warn_on_internalBalancing_errors.
   * In ENDDOCUMENT check on the counters/status variables, and warn
     if there is an imbalance error (if $warn_on_internalBalancing_errors > 0).
 * macros/PGbasicmacros.pl
   * Added a comment about this feature to the file, as the relevant constants
     are defined here.
   * Note: Other macros files may be adding HTML or LaTeX code which should be
     properly balanced. Hopefully they balance the tags themselves and do not use
     a begin/end construct which can lead to an imbalance.