### PR TITLE
Add partial sanity checks for begin/end formatting constructs - revised code

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -126,7 +126,7 @@ sub initialize {
 		refreshCachedImages       => 0,
 #		ANSWER_ENTRY_ORDER        => [],  # may not be needed if we ue Tie:IxHash
 		comment                   => '',  # implement as array?
-
+		warn_on_internalBalancing_errors => 1,
 	
 	
 	};

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -437,7 +437,7 @@ sub ENDDOCUMENT {
 	$PG->{flags}->{showHintLimit}                  = defined($showHint)?                   $showHint                  : 0 ;
 
         # Check the status/counters on tracked begin/end constructs which should balance;
-	{
+	if ( $warn_on_internalBalancing_errors ) {
 	    my $sawError = 0;
 	    my $type;
 	    foreach $type ( sort( keys %internalBalancing ) ) {

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2147,7 +2147,9 @@ sub EV3P {
   # the internalBalancing sanity checks in a preprocess phase
   # Note: This is being done after default_preprocess_code() from lib/WeBWorK/PG/Translator.pm
   #       replaced "\\" by "\\\\" so we need 4 backslashes before the start/end braces below.
+  my $warn_on_internalBalancing_errors = PG_restricted_eval(q!$main::warn_on_internalBalancing_errors!);
 
+  if ( $warn_on_internalBalancing_errors ) {
     $string =~ s/\$BBOLD(\W)/\$BBOLD \\\\{ internalBalancingIncrement("openBold"); \\\\}\1/g;
     $string =~ s/\$EBOLD(\W)/\$EBOLD \\\\{ internalBalancingDecrement("openBold"); \\\\}\1/g;
 
@@ -2177,7 +2179,7 @@ sub EV3P {
     # allow LTR text inside an RTL context.
     $string =~ s/\$BLTR(\W)/\$BLTR \\\\{ internalBalancingIncrement("openSpan"); \\\\}\1/g;
     $string =~ s/\$ELTR(\W)/\$ELTR \\\\{ internalBalancingDecrement("openSpan"); \\\\}\1/g;
-
+  }
   # End preprocessing for internalBalancing sanity checks
 
   $string = ev_substring($string,"\\\\{","\\\\}",\&safe_ev) if $options{processCommands};

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2150,35 +2150,35 @@ sub EV3P {
   my $warn_on_internalBalancing_errors = PG_restricted_eval(q!$main::warn_on_internalBalancing_errors!);
 
   if ( $warn_on_internalBalancing_errors ) {
-    $string =~ s/\$BBOLD(\W)/\$BBOLD \\\\{ internalBalancingIncrement("openBold"); \\\\}\1/g;
-    $string =~ s/\$EBOLD(\W)/\$EBOLD \\\\{ internalBalancingDecrement("openBold"); \\\\}\1/g;
+    $string =~ s/\$BBOLD(?=\W)/\$BBOLD \\\\{ internalBalancingIncrement("openBold"); \\\\}/g;
+    $string =~ s/\$EBOLD(?=\W)/\$EBOLD \\\\{ internalBalancingDecrement("openBold"); \\\\}/g;
 
-    $string =~ s/\$BITALIC(\W)/\$BITALIC \\\\{ internalBalancingIncrement("openItalic"); \\\\}\1/g;
-    $string =~ s/\$EITALIC(\W)/\$EITALIC \\\\{ internalBalancingDecrement("openItalic"); \\\\}\1/g;
+    $string =~ s/\$BITALIC(?=\W)/\$BITALIC \\\\{ internalBalancingIncrement("openItalic"); \\\\}/g;
+    $string =~ s/\$EITALIC(?=\W)/\$EITALIC \\\\{ internalBalancingDecrement("openItalic"); \\\\}/g;
 
-    $string =~ s/\$BUL(\W)/\$BUL \\\\{ internalBalancingIncrement("openUnderline"); \\\\}\1/g;
-    $string =~ s/\$EUL(\W)/\$EUL \\\\{ internalBalancingDecrement("openUnderline"); \\\\}\1/g;
+    $string =~ s/\$BUL(?=\W)/\$BUL \\\\{ internalBalancingIncrement("openUnderline"); \\\\}/g;
+    $string =~ s/\$EUL(?=\W)/\$EUL \\\\{ internalBalancingDecrement("openUnderline"); \\\\}/g;
 
-    $string =~ s/\$BCENTER(\W)/\$BCENTER \\\\{ internalBalancingIncrement("openCenter"); \\\\}\1/g;
-    $string =~ s/\$ECENTER(\W)/\$ECENTER \\\\{ internalBalancingDecrement("openCenter"); \\\\}\1/g;
+    $string =~ s/\$BCENTER(?=\W)/\$BCENTER \\\\{ internalBalancingIncrement("openCenter"); \\\\}/g;
+    $string =~ s/\$ECENTER(?=\W)/\$ECENTER \\\\{ internalBalancingDecrement("openCenter"); \\\\}/g;
 
-    $string =~ s/\$BM(\W)/\$BM \\\\{ internalBalancingTurnOn("inInlineMath"); \\\\}\1/g;
-    $string =~ s/\$EM(\W)/\$EM \\\\{ internalBalancingTurnOff("inInlineMath"); \\\\}\1/g;
+    $string =~ s/\$BM(?=\W)/\$BM \\\\{ internalBalancingTurnOn("inInlineMath"); \\\\}/g;
+    $string =~ s/\$EM(?=\W)/\$EM \\\\{ internalBalancingTurnOff("inInlineMath"); \\\\}/g;
 
-    $string =~ s/\$BDM(\W)/\$BDM \\\\{ internalBalancingTurnOn("inDisplayMath"); \\\\}\1/g;
-    $string =~ s/\$EDM(\W)/\$EDM \\\\{ internalBalancingTurnOff("inDisplayMath"); \\\\}\1/g;
+    $string =~ s/\$BDM(?=\W)/\$BDM \\\\{ internalBalancingTurnOn("inDisplayMath"); \\\\}/g;
+    $string =~ s/\$EDM(?=\W)/\$EDM \\\\{ internalBalancingTurnOff("inDisplayMath"); \\\\}/g;
 
-    $string =~ s/\$BEGIN_ONE_COLUMN(\W)/\$BEGIN_ONE_COLUMN \\\\{ internalBalancingTurnOn("inOneColumnMode"); \\\\}\1/g;
-    $string =~ s/\$END_ONE_COLUMN(\W)/\$END_ONE_COLUMN \\\\{ internalBalancingTurnOff("inOneColumnMode"); \\\\}\1/g;
+    $string =~ s/\$BEGIN_ONE_COLUMN(?=\W)/\$BEGIN_ONE_COLUMN \\\\{ internalBalancingTurnOn("inOneColumnMode"); \\\\}/g;
+    $string =~ s/\$END_ONE_COLUMN(?=\W)/\$END_ONE_COLUMN \\\\{ internalBalancingTurnOff("inOneColumnMode"); \\\\}/g;
 
-    $string =~ s/\$BLABEL(\W)/\$BLABEL \\\\{ internalBalancingTurnOn("inInputLabel"); \\\\}\1/g;
-    $string =~ s/\$ELABEL(\W)/\$ELABEL \\\\{ internalBalancingTurnOff("inInputLabel"); \\\\}\1/g;
+    $string =~ s/\$BLABEL(?=\W)/\$BLABEL \\\\{ internalBalancingTurnOn("inInputLabel"); \\\\}/g;
+    $string =~ s/\$ELABEL(?=\W)/\$ELABEL \\\\{ internalBalancingTurnOff("inInputLabel"); \\\\}/g;
 
     # The following two lines are related to new formatting variables added to development
     # versions of PG by https://github.com/openwebwork/pg/pull/323 which use an HTML span to
     # allow LTR text inside an RTL context.
-    $string =~ s/\$BLTR(\W)/\$BLTR \\\\{ internalBalancingIncrement("openSpan"); \\\\}\1/g;
-    $string =~ s/\$ELTR(\W)/\$ELTR \\\\{ internalBalancingDecrement("openSpan"); \\\\}\1/g;
+    $string =~ s/\$BLTR(?=\W)/\$BLTR \\\\{ internalBalancingIncrement("openSpan"); \\\\}/g;
+    $string =~ s/\$ELTR(?=\W)/\$ELTR \\\\{ internalBalancingDecrement("openSpan"); \\\\}/g;
   }
   # End preprocessing for internalBalancing sanity checks
 


### PR DESCRIPTION
**Do NOT merge this - major rework is needed.**


---

This is a revised version of what had been attempted in https://github.com/openwebwork/webwork2/pull/851.
  * It was fixed after the feedback from @dpvc and following the suggested approach he indicated. 
    * Thanks Davide.
  * The code rewriting is done now only inside `EV3P` parsed blocks (and done somewhat more carefully) so the bugs which would have been triggered when the code rewriting was done inside `default_preprocess_code()` from `lib/WeBWorK/PG/Translator.pm` should not occur now.
  * The parity sanity check is far from perfect, but in my opinion still better than nothing.
    * Some comments on the currently unavoidable limitations of this parity sanity check code is in https://github.com/openwebwork/pg/pull/383#discussion_r243436461 .

Add code to to track balance of begin/end variables which are used as formatting constructs that open/close structures which require a parity check in HTML and/or in LaTeX.
  * Ex: `$BBOLD` and `$EBOLD`.
The variables of this sort which may lead to parity errors are defined in `PGbasicmacros.pl`.

The tracking is done by using substitutions early in the `EV3P()` parsing code forcing calls to adjust the counters/status settings. However, this only tracks usage processed by `EV3P`, namely inside `BEGIN_TEXT`/`END_TEXT`, `BEGIN_HINT`/`END_HINT`, and `BEGIN_SOLUTION`/`END_SOLUTION` blocks. Thus, there may be false positives and/or false negatives.

 * `lib/PGcore.pm`
   * Add a new flag warn_on_internalBalancing_errors and currently default to 1 (warnings on errors).
 * `macros/PG.pl`
   * Add the `%internalBalancing` hash to track the counters/status, initialize the local value of `$warn_on_internalBalancing`_errors for the problem, and initialize the value of the counters and
     status variables inside the hash.
   * Add the functions which adjust the counters/status variables, and issue warnings on errors and a debug message on valid changes, depending on the value of `$warn_on_internalBalancing_errors`.
  * In `ENDDOCUMENT` check on the counters/status variables, and warn if there is an imbalance error (if `$warn_on_internalBalancing_errors` > 0).
 * `macros/PGbasicmacros.pl`
   * Added a comment about this feature to the file, as the relevant constants are defined here.
   * Add a preprocessing phase to `EV3P()` to insert the calls to do the functions
     which adjust the internalBalancing counters/status variables. This must be
     done in a preprocessing phase as the function which sets the value of these
     variables are evaluated once to define the variable, but no "code" is run
     when the variables in a PG file.
   * Since the use is only traced inside `EV3P()` managed environments, false
     positives and negatives may occur if such formatting variables (or similar
     output code is pushed to the output stream) in a manner not tracked by the
     sanity check code added in this commit.
     * Without deep parsing of the PG files, I doubt that such can be avoided, but the warning messages 
        triggered in `ENDDOCUMENT()` will be amended to remark on the possibility of false positives.
   * Note: Other macros files may be adding HTML or LaTeX code which should be
     properly balanced. Hopefully they balance the tags themselves and do not use
     a begin/end construct which can lead to an imbalance.

Another weakness of this partial sanity check approach is that it cannot detect "out of order" pairings such as `$BUL $BBOLD $EUL $EBOLD`. But that too is something which would be very challenging to fix without a real parser doing detailed validation.

However, even with these limitations, I hope that an updated version of the (incomplete) sanity check for the balancing of these pairs will help limit the number of cases where an imbalance will break either the validity of the HTML code (needed to meet WCAG 2.0/2.1) or the LaTeX code (which will break PDF generation).

I also want to give credit to @Alex-Jordan  who raised the issue of the failure to enforce parity of these begin/end formatting variables in  https://github.com/openwebwork/pg/pull/323#issuecomment-353538792 which led me to try to add the sanity check code.

My motivation is related to plans which will add new methods of creating potential parity/nesting errors in the generated HTML (and probably other) output. The reason is that I am working to add a method to insert more flexible `<span>` and `<div>` tags into the HTML output that what `$BLTR` and `$ELTR` of https://github.com/openwebwork/pg/pull/323 were designed to do. The goal Is to allow:
  * setting the current text direction (what `$BLTR` and `$ELTR` of https://github.com/openwebwork/pg/pull/323 were intended to do),
  * changing the text language as need inline with `<span>` and at the block level with `<div>`,
  * allowing the code to provide class names to be included, to allow additional formatting via CSS where it may be desired.
  * Proving a manner to insert alternate "output" code for LaTeX mode, and hopefully also for PreTeXt mode.
For better or worse, it seems to me that the code to do this will also be using begin/end pairs (but as Perl functions rather than variables which just insert the output text for the correct context, so that the output can be built using parameters passed into the functions). As this will be new code, the balance tracking and sanity checks can be included in the code from the start.