### PR TITLE
Correct version setting in macros/PG.pl in two places.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -5,10 +5,10 @@
 # initialize PGcore and PGrandom
 
 
-$main::VERSION ="PG-2.13+";
+$main::VERSION ="PG-2.14";
 
 sub _PG_init{
-  $main::VERSION ="PG-2.13+";
+  $main::VERSION ="PG-2.14";
   #
   #  Set up MathObject context for use in problems
   #  that don't load MathObjects.pl


### PR DESCRIPTION
I think this is a small fix which may need to be in the new master branch of PG (ver 2.14).

It fixes the value of `$main::VERSION` in `macros/PG.pl` from "PG-2.13+" to "PG-2.14"  in 2 places.