### PR TITLE
wantarray issue

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1012,7 +1012,8 @@ sub Answer {
         unshift(@options,$item->{name});
         $method = "named_".$method;
       }
-      $rule = PGML::LaTeX($ans->$method(@options));
+      $rule = $ans->$method(@options);
+      $rule = PGML::LaTeX($rule);
       if (!(ref($ans) eq 'MultiAnswer' && $ans->{part} > 1)) {
         if (defined($item->{name})) {
           main::NAMED_ANS($item->{name} => $ans->cmp);


### PR DESCRIPTION
The issue is explained in the thread for d61e0c7. Before the change here, `$ans->$method(@options)` is the argument to `PGML::LaTeX()`, therefore an array. Within certain methods, wantarray is present, and detects that `$ans->$method(@options)` is supposed to be an array, and behaves differently. This edit makes `$ans->$method(@options)` used in scalar context, changing the reaction from wantarray. And this reverts the behavior to how it was before d61e0c7.