### PR TITLE
Override cmp_postprocess for PolynomialFactors

### DIFF
--- a/macros/contextPolynomialFactors.pl
+++ b/macros/contextPolynomialFactors.pl
@@ -221,6 +221,13 @@ sub checkPolynomial {
 
 ##############################################
 
+package PolynomialFactors::Formula;
+our @ISA = ('Value::Formula');
+
+sub cmp_postprocess {}
+
+##############################################
+
 package PolynomialFactors;
 our @ISA = ('LimitedPolynomal');
 
@@ -269,6 +276,9 @@ sub Init {
     'u-' => {class => 'PolynomialFactors::UOP::minus'},
   );
   $context->flags->set(strictPowers => 1);
+  $context->{value}{'Formula()'} = "PolynomialFactors::Formula";
+  $context->{value}{'Formula'} = "PolynomialFactors::Formula";
+  $context->{parser}{'Formula'} = "PolynomialFactors::Formula";
 
   #
   #  A context where coefficients can't include operations


### PR DESCRIPTION
Don't do the `cmp_postprocess()` function for PolynomialFactors, since it tries to reduce the student answer, which can cause unwanted errors when `singleFactors` is set.

To test, use

```
loadMacros("contextPolynomialFactors.pl");
Context("PolynomialFactors")->flags->set(singleFactors => 1);
$f = Compute("-(x+1)(x-1)");
TEXT($f->cmp->evaluate("-(x+6)(x+2)")->{ans_message} || 'No Error');
```

Without the patch, you should get `Only one factor or constant can be negated`

With the patch, you should get `No Error`.

This comes originally from [this forum post](
http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4552).