### PR TITLE
Fix powers of functions so they dont become limits in display mode.

### DIFF
--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -174,8 +174,8 @@ $functions = {
    'asinh'  => {class => 'Parser::Function::hyperbolic', TeX => '\sinh^{-1}'},
    'acosh'  => {class => 'Parser::Function::hyperbolic', TeX => '\cosh^{-1}'},
    'atanh'  => {class => 'Parser::Function::hyperbolic', TeX => '\tanh^{-1}'},
-   'asech'  => {class => 'Parser::Function::hyperbolic', TeX => '\mathop{\rm sech}^{-1}'},
-   'acsch'  => {class => 'Parser::Function::hyperbolic', TeX => '\mathop{\rm csch}^{-1}'},
+   'asech'  => {class => 'Parser::Function::hyperbolic', TeX => '\mathop{\rm sech}\nolimits^{-1}'},
+   'acsch'  => {class => 'Parser::Function::hyperbolic', TeX => '\mathop{\rm csch}\nolimits^{-1}'},
    'acoth'  => {class => 'Parser::Function::hyperbolic', TeX => '\coth^{-1}'},
 
    'ln'    => {class => 'Parser::Function::numeric', inverse => 'exp',

--- a/lib/Parser/Function.pm
+++ b/lib/Parser/Function.pm
@@ -300,7 +300,7 @@ sub TeX {
   my @pstr = (); my $fn_precedence = $fn->{precedence};
   $fn_precedence = $fn->{parenPrecedence} if $fn->{parenPrecedence};
   $fn = $self->{def};
-  my $name = '\mathop{\rm '.$self->{name}.'}';
+  my $name = '\mathop{\rm '.$self->{name}.'}\nolimits';
   $name = $fn->{TeX} if defined($fn->{TeX});
   foreach my $x (@{$self->{params}}) {push(@pstr,$x->TeX)}
   if ($fn->{braceTeX}) {$TeX = $name.'{'.join(',',@pstr).'}'}

--- a/macros/parserFormulaUpToConstant.pl
+++ b/macros/parserFormulaUpToConstant.pl
@@ -312,6 +312,14 @@ sub cmp_postprocess {
     if $result == -1 && $self->getFlag("showLinearityHints") && !$student->D($student->{constant})->isConstant;
 }
 
+#
+#  Don't perform equivalence check
+#
+sub cmp_postfilter {
+  my $self = shift;
+  return shift;
+}
+
 ##################################################
 #
 #  Get the name of the constant


### PR DESCRIPTION
This fixes a problem with functions like `sech(x)` where `sech^2(x)` would appear with the `2` over top of the `sech(x)` in display mode.

To test, use

```
$f = Compute("sech^2(x)");
$g = Compute("asech(x)");

Context()->texStrings;
BEGIN_TEXT
\[$f \hbox{ and } $g\]
END_TEXT
Context()->normalStrings;
```

Without the patch, the 2 and -1 will appear above the sech(x).  With the patch, they should appear as superscripts.

This comes originally from [this forum post](http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4550)