### PR TITLE
Fix the MultiAnswer macro when the namedRules option is used.

### DIFF
--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -411,22 +411,21 @@ sub setMessage {
 ######################################################################
 
 #
-#  Produce the name for a named answer blank
-#  (Use the standard name for the first one, and
-#   create the prefixed names for the rest.)
+#  Produce the name for a named answer blank.
+#  (When the singleResult option is true, use the standard name for the first
+#  one, and create the prefixed names for the rest.)
 #
 sub ANS_NAME {
-  my $self = shift; my $i = shift; my $name;
+  my $self = shift; my $i = shift;
+  $self->{answerNames} = {} if !defined($self->{answerNames});
+  return $self->{answerNames}->{$i} if defined($self->{answerNames}->{$i});
   if ($self->{singleResult}) {
-    if (!$self->{id}) {
-      $name = $self->{answerName} = main::NEW_ANS_NAME();
-      $self->{id} = $answerPrefix.$name;
-    }
-    $name = $self->{id}."_".$i unless $i == 0;
+    $self->{answerNames}->{0} = main::NEW_ANS_NAME() if (!$self->{answerNames}->{0});
+    $self->{answerNames}->{$i} = $answerPrefix.$self->{answerNames}->{0}."_".$i unless $i == 0;
   } else {
-    $name = main::NEW_ANS_NAME();
+    $self->{answerNames}->{$i} = main::NEW_ANS_NAME();
   }
-  return $name;
+  return $self->{answerNames}->{$i};
 }
 
 #
@@ -453,7 +452,7 @@ sub ans_rule {
   if ($self->{singleResult} && $self->{part} > 1) {
   	 my $extension_ans_rule = 
   	 	$data->named_ans_rule_extension(
-  	 	$name,$size, answer_group_name => $self->{answerName}, 
+  	 	$name,$size, answer_group_name => $self->{answerNames}->{0},
   	 	@_);
   	 # warn "extension rule created: $extension_ans_rule for ", ref($data);
   	 return $extension_ans_rule; 
@@ -474,12 +473,12 @@ sub ans_array {
   if ($self->{singleResult} && $self->{part} == 1) {
       my $label = main::generate_aria_label($answerPrefix.$name."_0");
       return $data->named_ans_array($name,$size,
-             answer_group_name => $self->{answerName},
+             answer_group_name => $self->{answerNames}->{0},
              @_,aria_label=>$label);
   }
   if ($self->{singleResult} && $self->{part} > 1) {
     $HTML = $data->named_ans_array_extension($self->NEW_NAME($name),$size,
-      answer_group_name => $self->{answerName}, @_);
+      answer_group_name => $self->{answerNames}->{0}, @_);
     # warn "array extension rule created: $HTML for ", ref($data);
   } else {
     $HTML = $data->named_ans_array($name,$size,@_);

--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -417,15 +417,14 @@ sub setMessage {
 #
 sub ANS_NAME {
   my $self = shift; my $i = shift;
-  $self->{answerNames} = {} if !defined($self->{answerNames});
-  return $self->{answerNames}->{$i} if defined($self->{answerNames}->{$i});
+  return $self->{answerNames}{$i} if defined($self->{answerNames}{$i});
   if ($self->{singleResult}) {
-    $self->{answerNames}->{0} = main::NEW_ANS_NAME() if (!$self->{answerNames}->{0});
-    $self->{answerNames}->{$i} = $answerPrefix.$self->{answerNames}->{0}."_".$i unless $i == 0;
+    $self->{answerNames}{0} = main::NEW_ANS_NAME() unless defined($self->{answerNames}{0});
+    $self->{answerNames}{$i} = $answerPrefix.$self->{answerNames}{0}."_".$i unless $i == 0;
   } else {
-    $self->{answerNames}->{$i} = main::NEW_ANS_NAME();
+    $self->{answerNames}{$i} = main::NEW_ANS_NAME();
   }
-  return $self->{answerNames}->{$i};
+  return $self->{answerNames}{$i};
 }
 
 #
@@ -452,7 +451,7 @@ sub ans_rule {
   if ($self->{singleResult} && $self->{part} > 1) {
   	 my $extension_ans_rule = 
   	 	$data->named_ans_rule_extension(
-  	 	$name,$size, answer_group_name => $self->{answerNames}->{0},
+  	 	$name,$size, answer_group_name => $self->{answerNames}{0},
   	 	@_);
   	 # warn "extension rule created: $extension_ans_rule for ", ref($data);
   	 return $extension_ans_rule; 
@@ -473,12 +472,12 @@ sub ans_array {
   if ($self->{singleResult} && $self->{part} == 1) {
       my $label = main::generate_aria_label($answerPrefix.$name."_0");
       return $data->named_ans_array($name,$size,
-             answer_group_name => $self->{answerNames}->{0},
+             answer_group_name => $self->{answerNames}{0},
              @_,aria_label=>$label);
   }
   if ($self->{singleResult} && $self->{part} > 1) {
     $HTML = $data->named_ans_array_extension($self->NEW_NAME($name),$size,
-      answer_group_name => $self->{answerNames}->{0}, @_);
+      answer_group_name => $self->{answerNames}{0}, @_);
     # warn "array extension rule created: $HTML for ", ref($data);
   } else {
     $HTML = $data->named_ans_array($name,$size,@_);


### PR DESCRIPTION
The problem is that the ANS_NAME method is called first when an answer rule
is created (in the ans_rule method), and then again when answer
evaluators are created (in the cmp method).  Both times the NEW_ANS_NAME
method is called and different answer names are recorded.

This fix caches the answer names when they are first created in the
ANS_NAME method, and then subsequent calls just return the recorded
name.