### PR TITLE
Added check to see if Livegraphics defined

### DIFF
--- a/macros/LiveGraphics3D.pl
+++ b/macros/LiveGraphics3D.pl
@@ -156,8 +156,10 @@ sub LiveGraphics3D {
 		    vars : $ind_vars,
     };
 
+    if (typeof LiveGraphics3D !== 'undefined') {
+        var graph = new LiveGraphics3D(thisTD[0],options);
+    }
 
-    var graph = new LiveGraphics3D(thisTD[0],options);
     </script>
 EOS
 


### PR DESCRIPTION
This is a small change to fix a bug in ProblemSetDetail2.  To reproduce it: 

1.  Add a problem with LiveGraphics3D to a homework set `Library/Union/setMVlevelsets/levels-5/levels-5b.pg` for example. 
2.  Click the "Automatically render problems on page load" option and save settings. 
3.  The page should load with broken javascript and be non-functional. 

After this patch the page should load correctly, but the LiveGraphics3D will not actually run.   You should also check that LiveGraphics3D works when you actually view the problem. 