### PR TITLE
Fix parserRadioButtons.pl to avoid an undesired warning when a radio button is used inside a MultiAnswer group with allowBlankAnswers turned on

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -370,7 +370,12 @@ sub labelFormat {
 #  to be displayed in the results table.
 #
 sub labelText {
-  my $self = shift; my $index = substr(shift,1);
+  my $self = shift;
+  my $index = shift;
+  #warn "index = |$index|";
+  return "Bn" if ( !defined($index) || $index eq "" || length($index) < 2 );
+  $index = substr($index,1);
+#  my $self = shift; my $index = substr(shift,1);
   my $choice = $self->{labels}[$index];
   $choice = $self->{orderedChoices}[$index] unless defined $choice;
   return $choice if length($choice) < $self->{maxLabelSize};


### PR DESCRIPTION
Fix for a bug seen with a radio button used in MultiAnswer with `allowBlankAnswers` set on. 

  * In that case, a warning was issued when the problem is loaded and no radio button is selected. 
  * Submitting an answer with a radio button selected does not issue the warning.
  * However, submitting an answer where no choice was made for the set of radio buttons triggers the warning.

The warning reports:
```
substr outside of string at line 375 of [PG]/macros/parserRadioButtons.pl
Use of uninitialized value $index in array element at line 376 of [PG]/macros/parserRadioButtons.pl
Use of uninitialized value $index in array element at line 377 of [PG]/macros/parserRadioButtons.pl
```

The **only** occur when `allowBlankAnswers` is set (to `1`), which was desired in the original question. The example below was pruned to be minimal.

The root problem is that labelText() is apparently sometimes called with either an empty second ("index") argument or one too short to allow the code
```
	$index = substr(shift,1);
```
to work (when a blank answer is allowed). 

The fix defers the call to substr until it is certain that it will work, and when it would fail - returns a fixed string "Bn".

A hopefully relatively minimal pg file which hits the issue (cut down from something which once had meaning to it) is the following:
```
DOCUMENT();        # This should be the first executable line in the problem.

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "parserRadioButtons.pl",
  "parserMultiAnswer.pl"
);

TEXT(beginproblem());

$radio1 = RadioButtons(
  ["No",
  "Yes"],
  "No" # correct answer
);

$multians1 = MultiAnswer($radio1)->with(
  allowBlankAnswers => 1,
  checker => sub {
      my ( $correct, $student, $self ) = @_;
      my ( $stu1rb  ) = @{$student};
      my ( $corr1rb ) = @{$correct};
      if ( $stu1rb == $corr1rb ) {
        return 1;
      } else {
        return 0;
      }
    }
);

Context()->texStrings;
BEGIN_TEXT
\{ $multians1->ans_rule \}
END_TEXT
Context()->normalStrings;

ANS( $multians1->cmp() );

ENDDOCUMENT();        # This should be the last executable line in the problem.
```

When the line
```
  allowBlankAnswers => 1,
```
is not commented out - the warning will be given, while when this line is commented out - no warning is given.