### PR TITLE
Fix parserRadioButtons.pl to avoid an undesired warning when a radio button is used inside a MultiAnswer group with allowBlankAnswers turned on - revised fix

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -395,7 +395,7 @@ sub string {
 #
 sub cmp_preprocess {
   my $self = shift; my $ans = shift;
-  if (defined $ans->{student_value}) {
+  if (defined $ans->{student_value} && $ans->{student_value} ne '') {
     my $label = $self->labelText($ans->{student_value}->value);
     $ans->{preview_latex_string} = $self->quoteTeX($label);
     $ans->{student_ans} = $self->quoteHTML($label);


### PR DESCRIPTION
This replaces https://github.com/openwebwork/pg/pull/405 and adopts the bug fix recommended by @dpvc  instead of the original proposal which was not an optimal fix for the issue.

It fix `parserRadioButtons.pl` to avoid an undesired warning when a radio button is used inside a MultiAnswer group with `allowBlankAnswers` set to 1.

In such cases, on problem load, and when no radio button was selected on an answer submission the following warning message was issued:

```
substr outside of string at line 375 of [PG]/macros/parserRadioButtons.pl
Use of uninitialized value $index in array element at line 376 of [PG]/macros/parserRadioButtons.pl
Use of uninitialized value $index in array element at line 377 of [PG]/macros/parserRadioButtons.pl
```

The root problem is that when no buttom has been selected, labelText() is being called with a second ("index") argument which cannot be handled by the code
```
	$index = substr(shift,1);
```
which expects a string of the format Bn where n in an integer index.

An initial fix I proposed as https://github.com/openwebwork/pg/pull/405 was rejected as being a bad solution to the problem.

The revised fix was proposed by Davide P. Cervone and avoids the call to `labelText()` when no answer was selected.

It has been tested and solves the problem, and the sample code provided in https://github.com/openwebwork/pg/pull/405 will no longer trigger the warning message.