### PR TITLE
Fix a typo in lib/PGcore.pm

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -31,7 +31,7 @@ use MIME::Base64();
 use PGUtil();
 use Encode qw(encode_utf8 decode_utf8);
 use utf8;
-binmode(STDOUT, ":uft8");
+binmode(STDOUT, ":utf8");
 ##################################
 # PGcore object
 ##################################


### PR DESCRIPTION
Fix a typo in `lib/PGcore.pm`. Had `":uft8"` where `":utf8"` is needed.

Due to the error, the error message
```
  Unknown PerlIO layer "uft8" at /opt/webwork/webwork2/../pg//lib/PGcore.pm line 34.
```
would be reported (when errors were visible) such as when using `sendXMLRPC.pl`.

The sample below used `sendXMLRPC.pl` from inside a Docker container (where I could get it to work), and using the `--help` option, but the same error message was reported for other uses of `sendXMLRPC.pl`.

```
docker container exec -it webwork2_app_1 bash 

cd webwork2/clients
./sendXMLRPC.pl --help     
Unknown PerlIO layer "uft8" at /opt/webwork/webwork2/../pg//lib/PGcore.pm line 34.
"our" variable @path_list redeclared at ./sendXMLRPC.pl line 400.
"my" variable $credentials_string masks earlier declaration in same scope at ./sendXMLRPC.pl line 402.
"our" variable $UNIT_TESTS_ON redeclared at ./sendXMLRPC.pl line 567.
```