### PR TITLE
Add problemUUID to the identifiers used to create $unique_id_seed

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -102,6 +102,7 @@ sub initialize {
 	$self->{externalGif2PngPath} = $envir->{externalGif2PngPath};
 	$self->{courseID}            = $envir->{courseName};
 	$self->{problemSeed}         = $envir->{problemSeed};
+	$self->{problemUUID}         = $envir->{problemUUID}//0;
 	
 	$self->{appletPath} = $self->{envir}->{pgDirectories}->{appletPath};
 	#
@@ -117,7 +118,8 @@ sub initialize {
 				  $self->{courseID},
 				  'set'.$self->{setNumber},
 				  'prob'.$self->{probNum},
-				  $self->{problemSeed}
+				  $self->{problemSeed},
+				  $self->{problemUUID},
 				 );
 
 ##################################


### PR DESCRIPTION
This, and the companion pull request for webwork2 (https://github.com/openwebwork/webwork2/pull/976) add the value of the variable problemUUID to the list of items used to create a unique UUID for a problem. Its use case is for submissions via the webservice where the problem is not part of a homework set framework which help identify the problem and its auxiliary files uniquely. Specifying problemUUID=>3245 (for example) in the form or iframe request for the problem will do this. problemUUID replaces problemIdentifierPref as the name of the identifying variable being submitted although to insure backward compatibility the latter will still work.