### PR TITLE
Add an ADD_CSS_FILE() method

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -193,6 +193,16 @@ sub SET_PROBLEM_TEXTDIRECTION {
   }
 }
 
+# Request that the problem HTML page also include additional CSS files
+# from the webwork2/htdocs/css/ directory.
+sub ADD_CSS_FILE {
+  my $file = shift ;
+  if ( !defined( $PG->{flags}{extra_css_files} ) ) {
+    $PG->{flags}{extra_css_files} = [ "$file" ];
+  } else {
+    push( @{$PG->{flags}{extra_css_files}}, $file );
+  }
+}
 
 sub AskSage {
     my $python = shift;


### PR DESCRIPTION
The pg side of an attempt to address the need to modify CSS code for right to left languages in a convenient manner. but will provide a mechanism to request a special CSS file at the problem level.

The webwork2 side of the code also provides a mechanism to add CSS files via `course.conf` (or even via `conf/localOverrides.conf`).

See: http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4624

---

Add an `ADD_CSS_FILE()` method, to request the inclusion of additional CSS files from `webwork2/htdocs/css/` in the HTML generate for this problem.

The `webwork2` side code to support this is added inhttps://github.com/openwebwork/webwork2/pull/1018.

---

Sample PG file:

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
  "parserRadioButtons.pl",
  "PGcourse.pl"
);

TEXT(beginproblem());

ADD_CSS_FILE("rtl.css");
ADD_CSS_FILE("rtl2.css");

SET_PROBLEM_TEXTDIRECTION("rtl");
SET_PROBLEM_LANGUAGE("he-IL");

Context("Numeric");

$radio1 = RadioButtons(
  [  {"1"=>"1"}, 
     {"2"=>"2"},
     {"3"=>"3"},
     {"4"=>"4"},
  ],
   "2" # correct answer
);

BEGIN_TEXT
\{ $radio1->buttons() \}
END_TEXT

ANS( $radio1->cmp() );

ENDDOCUMENT();
```


---

The following sample CSS file (expected at `webwork2/htdocs/css/rtl.css`) has code to move the radio buttons from the left side of the text of the option to the right side (where it would usually be wanted in a right-to-left language).

```
input[type="radio"], input[type="checkbox"] {
  float: right !important;
}
```