### PR TITLE
Make promote() use MathObject Real when converting a decimal.  #429

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -698,8 +698,8 @@ sub promote {
   my $x = (scalar(@_) ? shift : $self);
   if (scalar(@_) == 0) {
     return $x->inContext($context) if ref($x) eq $class;
-    return (bless {data => [$x->value,1], context => $context}, $class) if Value::isReal($x);
-    return (bless {data => [$x,1], context => $context}, $class) if Value::matchNumber($x);
+    return (bless {data => [$x->value,1], context => $context}, $class) if Value::isReal($x) && isInteger($x);
+    return (bless {data => [$x,1], context => $context}, $class) if Value::isReal($x) || Value::matchNumber($x);
   }
   return $x if Value::isValue($x) && $x->classMatch("Infinity");
   return $self->new($context,$x,@_);


### PR DESCRIPTION
This allows comparison to use fuzzy tolerance when comparing fractions to explicit decimals.  So if the correct answer is 1/3 and the student enters .33333, this will be accepted (under standard tolerances).  But 33333/100000 will not, as explicit fractions require exact equality.

To test, use

```
loadMacros("contextFraction.pl");
Context("Fraction");
$f = Fraction(1,3);
TEXT($f->amp->evaluate(".33333")->{score} ? "Correct": "Wrong");
```

With the patch, this should output `Correct`, and without the patch, `Wrong`.

Resolves issue #429