### PR TITLE
Implement TikZ images for problems.

### DIFF
--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -1,0 +1,163 @@
+#!/bin/perl
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: pg/macros/parserMultiAnswer.pl,v 1.11 2009/06/25 23:28:44 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+# This is a Perl module which simplifies and automates the process of generating
+# simple images using TikZ, and converting them into a web-useable format.  Its
+# typical usage is via the macro PGtikz.pl and is documented there.
+
+use strict;
+use warnings;
+use Carp;
+use WeBWorK::PG::IO;
+use WeBWorK::PG::ImageGenerator;
+
+package TikZImage;
+
+# The constructor (it takes no parameters)
+sub new {
+	my $class = shift;
+	my $data = {
+		tex           => '',
+		tikzOptions   => '',
+		tikzLibraries => '',
+		ext           => 'png',
+        imageName     => ''
+	};
+	my $self = sub {
+		my $field = shift;
+		if (@_) {
+			# The ext field is protected to ensure that unsafe commands can not
+			# be passed to the command line in the system call it is used in.
+			if ($field eq 'ext') {
+				my $ext = shift;
+				$data->{ext} = $ext
+				if ($ext eq 'png' || $ext eq 'gif' || $ext eq 'svg' || $ext eq 'pdf');
+			}
+			else {
+				$data->{$field} = shift;
+			}
+		}
+		return $data->{$field};
+	};
+	return bless $self, $class;
+}
+
+# Accessors
+
+# Set TikZ image code, not including begin and end tags, as a single
+# string parameter.  Works best single quoted.
+sub tex {
+	my $self = shift;
+	return &$self('tex', @_);
+}
+
+# Set TikZ picture options as a single string parameter.
+sub tikzOptions {
+	my $self = shift;
+	return &$self('tikzOptions', @_);
+}
+
+# Set additional TikZ libraries to load as a single string parameter.
+sub tikzLibraries {
+	my $self = shift;
+	return &$self('tikzLibraries', @_);
+}
+
+# Set the image type.  The valid types are 'png', 'gif', 'svg', and 'pdf'.
+# The 'pdf' option should be set for print.
+sub ext {
+	my $self = shift;
+	return &$self('ext', @_);
+}
+
+# Set the file name.
+sub imageName {
+	my $self = shift;
+	return &$self('imageName', @_);
+}
+
+sub header {
+	my $self = shift;
+	my @output = ();
+	push(@output, "\\documentclass{standalone}\n");
+	push(@output, "\\usepackage{tikz}\n");
+	push(@output, "\\usetikzlibrary{" . $self->tikzLibraries . "}") if ($self->tikzLibraries ne "");
+	push(@output, "\\begin{document}\n");
+	push(@output, "\\begin{tikzpicture}");
+	push(@output, "[" . $self->tikzOptions . "]") if ($self->tikzOptions ne "");
+	@output;
+}
+
+sub footer {
+	my $self = shift;
+	my @output = ();
+	push(@output, "\\end{tikzpicture}\n");
+	push(@output, "\\end{document}\n");
+	@output;
+}
+
+# Generate the image file and return the stored location of the image.
+sub draw {
+	my $self = shift;
+
+	my $working_dir = WeBWorK::PG::ImageGenerator::makeTempDirectory(WeBWorK::PG::IO::ww_tmp_dir(), "tikz");
+	my $data;
+
+	my $fh;
+	open($fh, ">", "$working_dir/image.tex")
+		or warn "Can't open $working_dir/image.tex for writing.";
+	chmod(0777, "$working_dir/image.tex");
+	print $fh $self->header;
+	print $fh $self->tex . "\n";
+	print $fh $self->footer;
+	close $fh;
+
+	my $pdflatex_command = "cd " . $working_dir . " && " .
+		WeBWorK::PG::IO::pdflatexCommand() . " > pdflatex.stdout 2> pdflatex.stderr image.tex";
+
+	# Generate the pdf file.
+	system "$pdflatex_command";
+	if (-r "$working_dir/image.pdf" ) {
+		my $ext = $self->ext;
+
+		# Convert the file to the appropriate type of image file
+		system WeBWorK::PG::IO::convertCommand() . " $working_dir/image.pdf $working_dir/image.$ext"
+		if $ext ne 'pdf';
+
+		if (-r "$working_dir/image.$ext") {
+			# Read the generated image file into memory
+			open(my $in_fh,  "<", "$working_dir/image.$ext")
+				or warn "Failed to open $working_dir/image.$ext for reading.", return;
+			local $/;
+			$data = <$in_fh>;
+            close($in_fh);
+		} else {
+			warn "Convert operation failed.";
+		}
+	} else {
+		warn "File $working_dir/image.pdf was not created.";
+	}
+
+	# Delete the files used to generate the image.
+	if (-e $working_dir) {
+		system "rm -rf $working_dir";
+	}
+
+	return $data;
+}
+
+1;

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -150,6 +150,13 @@ sub draw {
 		}
 	} else {
 		warn "File $working_dir/image.pdf was not created.";
+		if (open(my $err_fh, "<", "$working_dir/pdflatex.stdout"))
+		{
+			while (my $error = <$err_fh>) {
+				warn $error;
+			}
+			close($err_fh);
+		}
 	}
 
 	# Delete the files used to generate the image.

--- a/lib/WWPlot.pm
+++ b/lib/WWPlot.pm
@@ -687,6 +687,10 @@ sub imageName {
 	}
 }
 
+sub ext {
+	return $WWPlot::use_png ? 'png' : 'ext';
+}
+
 sub position {
 	my $self = shift;
 	my $type = ref($self) || die "$self is not an object";

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -18,6 +18,7 @@ use utf8;
 my $CE = new WeBWorK::CourseEnvironment({
     webwork_dir => $ENV{WEBWORK_ROOT},
 					});
+
 =head1 NAME
 
 WeBWorK::PG::IO - Private functions used by WeBWorK::PG::Translator for file IO.
@@ -268,9 +269,54 @@ Checks to see if the given path is a sub directory of the courses directory
 =cut
 
 sub path_is_course_subdir {
-    
     return path_is_subdir(shift,$CE->{webwork_courses_dir},1);
 }
+
+sub ww_tmp_dir {
+	return $CE->{webworkDirs}{tmp};
+}
+
+
+=item curlCommand
+
+	curl -- path to curl defined in site.conf
+
+=cut
+
+sub curlCommand {
+	return $CE->{externalPrograms}{curl};
+}
+
+=item convertCommand
+
+	convert -- path to convert defined in site.conf
+
+=cut
+
+sub convertCommand {
+	return $CE->{externalPrograms}{convert};
+}
+
+=item pdflatexCommand
+
+	pdflatex -- path to pdflatex defined in site.conf
+
+=cut
+
+sub pdflatexCommand {
+	return $CE->{externalPrograms}{pdflatex};
+}
+
+=item copyCommand
+
+	copyCommand -- path to cp defined in site.conf
+
+=cut
+
+sub copyCommand {
+	return $CE->{externalPrograms}{cp};
+}
+
 
 #
 # isolate the call to the sage server in case we have to jazz it up

--- a/macros/PGgraphmacros.pl
+++ b/macros/PGgraphmacros.pl
@@ -51,12 +51,6 @@ See F<PGbasicmacros> for definitions of C<image> and C<caption>
                                  # of MathObjects since that can mess up 
                                  # problems that don't use MathObjects but use Matrices.
 
-our %images_created = ();  # this keeps track of the base names of the images created during this session.
-                     #  We tack on
-                     # $imageNum  = ++$images_created{$imageName} to keep from overwriting files
-                     # when we don't want to.
-
-
 
 
 =head2 init_graph
@@ -115,26 +109,7 @@ sub init_graph {
 
     my $graphRef = new WWPlot(@size);
 	# select a  name for this graph based on the user, the psvn and the problem
-	my $setName = $main::setNumber;
-	# replace dots, commmas and @ signs in set and user names to keep latex and html happy
-	# this should be abstracted and placed in PGalias.pm or PGcore.pm or perhaps PG.pm
-	#FIXME
-	$setName =~ s/Q/QQ/g;
-	$setName =~ s/\./-Q-/g;
-	my $studentLogin = $main::studentLogin;
-	$studentLogin =~ s/Q/QQ/g;
-	$studentLogin =~ s/\./-Q-/g;
-	$studentLogin =~ s/\,/-Q-/g;
-	$studentLogin =~ s/\@/-Q-/g;
-	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
-	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
-	my $imageNum  = ++$images_created{$imageName};
-	# this provides a unique name for the graph -- it does not include an extension.
-	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
-	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
-	$resource->path("__");  # some kind of path is required in order for create_unique_id to work
-	# the only role of the resource object is to create the UUID -- the object is then discarded.
-	$graphRef->imageName($resource->create_unique_id);
+	$graphRef->imageName($main::PG->getUniqueName($graphRef->ext));
 
 	# Set the initial/default bounds for the graph.
 	$graphRef->xmin($xmin) if defined($xmin);
@@ -241,15 +216,7 @@ sub init_graph_no_labels {
 	}
     my $graphRef = new WWPlot(@size);
 	# select a  name for this graph based on the user, the psvn and the problem
-	my $imageName = "$main::studentLogin-$main::problemSeed-set${main::setNumber}prob${main::probNum}";
-	# $imageNum counts the number of graphs with this name which have been created since PGgraphmacros.pl was initiated.
-	my $imageNum  = ++$images_created{$imageName};
-	# this provides a unique name for the graph -- it does not include an extension.
-	# PG_alias->make_resource_object(fileName, type) --> returns a UUID
-	my $resource = $main::PG->{PG_alias}->make_resource_object("image$imageNum","png");
-	$resource->path("__");  # some kind of path is required in order for create_unique_id to work
-	# the only role of the resource object is to create the UUID -- the object is then discarded.
-	$graphRef->imageName($resource->create_unique_id);
+	$graphRef->imageName($main::PG->getUniqueName($graphRef->ext));
 
 	$graphRef->xmin($xmin) if defined($xmin);
 	$graphRef->xmax($xmax) if defined($xmax);
@@ -416,7 +383,7 @@ sub plot_functions {
 
 B<Note:> insertGraph is defined in PGcore.pl, because it involves writing to the disk.
 
-insertGraph(graphObject) writes a image file to the C<html/tmp/gif> directory of the current course.
+insertGraph(graphObject) writes a image file to the C<html/tmp/images> directory of the current course.
 The file name is obtained from the graphObject.  Warnings are issued if errors occur while writing to
 the file.
 
@@ -427,7 +394,7 @@ B<Returns:>   A string containing the full path to the temporary file containing
 
 
 
-InsertGraph draws the object $graph, stores it in "${tempDirectory}gif/$imageName.gif (or .png)" where
+InsertGraph draws the object $graph, stores it in "${tempDirectory}images/$imageName.png (or .gif)" where
 the $imageName is obtained from the graph object.  ConvertPath and surePathToTmpFile are used to insure
 that the correct directory separators are used for the platform and that the necessary directories
 are created if they are not already present.  The directory address to the file is the result.

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -1,0 +1,74 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
+# $CVSHeader: pg/macros/parserMultiAnswer.pl,v 1.11 2009/06/25 23:28:44 gage Exp $
+# 
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+PGtikz.pl - Insert images into problems that are generated using LaTeX and TikZ.
+
+=head1 DESCRIPTION
+
+This is a convenience macro for utilizing the TikZImage object to insert TikZ
+images into problems.  Create a TikZ image as follows:
+
+	$image = createTikZImage();
+	$image->tex(<<END_TIKZ);
+	\draw (-2,0) -- (2,0);
+	\draw (0,-2) -- (0,2);
+	\draw (0,0) circle[radius=1.5];
+	END_TIKZ
+
+Then insert the image into the problem with
+
+	image(insertGraph($image));
+
+=head1 DETAILED USAGE
+
+There are several TikZImage parameters that may need to be set for the
+TikZImage object return by createTikZImage to generate the desired image.
+
+	$image->tex()              Add the tikz commands that define the image.
+							   This takes a single string parameter.  It is
+							   generally best to use single quotes around the
+							   string.  Escaping of special characters may be
+                               needed in some cases.
+
+	$image->tikzOptions()      Add options that will be passed to
+							   \begin{tikzpicture}.  This takes a single
+                               string parameter.
+
+	$image->tikzLibraries()    Add additional tikz libraries to load.  This
+                               takes a single string parameter.
+
+	$image->ext()              Set the file type to be used for the image.
+							   The valid image types are 'png', 'gif', 'svg',
+							   and 'pdf'.  The default is a 'png' image.  This
+							   macro sets this to 'pdf' when a hardcopy is
+                               generated.
+
+=cut
+
+sub _PGtikz_init {}
+
+# Not much needs to be done here.  The real work is done in TikZImage.pm.
+sub createTikZImage
+{
+	my $image = new TikZImage;
+	$image->ext('pdf') if $main::displayMode eq 'TeX';
+	$image->imageName($main::PG->getUniqueName($image->ext));
+	return $image;
+}
+
+1;

--- a/macros/answerDiscussion.pl
+++ b/macros/answerDiscussion.pl
@@ -798,7 +798,7 @@ sub Read {
   my $self = shift; my $filename = shift;
   die "You must supply a problem file name" unless $filename;
   delete $self->{error};
-  $filename = $main::PG->surePathToTmpFile('gif/'.$self->dataFilePath($filename).$self->{extension});
+  $filename = $main::PG->surePathToTmpFile('images/'.$self->dataFilePath($filename).$self->{extension});
   my ($text,$error) = main::PG_restricted_eval("read_whole_file('$filename')");
   return $$text unless $error;
   ###  FIXME:  return generic error for students
@@ -813,7 +813,7 @@ sub Read {
 #
 #  Perform the actual writing of the file, using a hack that
 #  takes advantage of the fact that insertGraph() can write files
-#  in the html/tmp/gif directory.
+#  in the html/tmp/images directory.
 #
 sub Write {
   my $self = shift; $self->{file} = shift; $self->{data} = shift;
@@ -838,12 +838,13 @@ sub Write {
 }
 
 #
-#  The answerDiscussion object mimics the WWPlot object by defining draw() and
-#  imageName() methods.  These are used by insertGraph() to write image
-#  files, and we can use that to write the data files that we need.
+#  The answerDiscussion object mimics the WWPlot object by defining draw(),
+#  imageName(), and ext() methods.  These are used by insertGraph() to write
+#  image files, and we can use that to write the data files that we need.
 #
 sub draw {shift->{data}}
 sub imageName {shift->{file}}
+sub ext { return $WWPlot::use_png ? 'png' : 'ext'; }
 
 ######################################################################
 #

--- a/t/tikz_test/tikz_test1.pg
+++ b/t/tikz_test/tikz_test1.pg
@@ -1,0 +1,43 @@
+##DESCRIPTION
+# TEST tikz from a pg problem
+##ENDDESCRIPTION
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",
+    "MathObjects.pl",
+    "PGtikz.pl"
+);
+
+TEXT(beginproblem());
+
+##############################################################
+#  Setup
+##############################################################
+
+$drawing = createTikZImage();
+$drawing->tex(<<END_TIKZ);
+\draw (-4,0) -- (4,0);
+\draw (0,-2) -- (0,2);
+\draw (0,0) circle[radius=1.5];
+\draw (0, 1.5) node[anchor=south]{N} -- (2.5,0) node[above]{y};
+\draw (1.2,0.9) node[right]{\((\vec x, x_{n})\)};
+END_TIKZ
+
+$path = insertGraph($drawing);
+
+Context("Numeric");
+
+##############################################################
+#  Text
+##############################################################
+
+BEGIN_TEXT
+\{protect_underbar("path = $path")\};
+$BR alias = \{protect_underbar(alias($path))\}
+$PAR image = \{image($path, width => 228, height => 114, tex_size => 400)\}
+$PAR svg = \{embedSVG($path)\}
+END_TEXT
+
+ENDDOCUMENT();

--- a/t/tikz_test/tikz_test2.pg
+++ b/t/tikz_test/tikz_test2.pg
@@ -1,0 +1,48 @@
+##DESCRIPTION
+# TEST tikz from a pgml problem
+##ENDDESCRIPTION
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",
+    "MathObjects.pl",
+    "PGML.pl",
+    "PGtikz.pl"
+);
+
+TEXT(beginproblem());
+
+##############################################################
+#  Setup
+##############################################################
+
+
+$drawing = createTikZImage();
+$drawing->tikzOptions("main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt}");
+$drawing->tex(<<END_TIKZ);
+\node[main_node] (1) at (0,0) {1};
+\node[main_node] (2) at (-1, -1.5)  {2};
+\node[main_node] (3) at (1, -1.5) {3};
+\draw (1) -- (2) -- (3) -- (1);
+END_TIKZ
+
+$path = insertGraph($drawing);
+
+Context("Numeric");
+
+##############################################################
+#  Text
+##############################################################
+
+BEGIN_PGML
+path = [$path]
+[@ $BR @]*
+alias = [@ alias($path) @]*
+
+image = [@ image($path, width => 100, tex_size => 400) @]*
+
+svg = [@ embedSVG($path) @]*
+END_PGML
+
+ENDDOCUMENT();


### PR DESCRIPTION
I am submitting this now so that others can take a look and at Michael Gage's request in issue #418.  There is a matching pull request to the webwork2 code (https://github.com/openwebwork/webwork2/pull/1030) that loads the module and sets the external convert program.

The general implementation is that a uniquely named working directory is created in the general webwork tmp location.  Then a tex file is written and pdflatex run.  Then convert is called to convert the pdf to a png, gif, or svg image.  The image data is read, and then written to disk by the insertGraph method.

I also added a simple macro that basically does the same thing the PGgraphmacros.pl macro does for images generated with GD in terms of setting up the file name.

I changed the output directory of that method from the gif directory to the images directory (inside the course temporary html location).  That part can be reverted if needed, but it seems silly to write what are almost always png images to a gif directory, and have a separate general image directory.