### PR TITLE
Scaffold opening reflows MathQuill answer boxes

### DIFF
--- a/macros/scaffold.pl
+++ b/macros/scaffold.pl
@@ -804,6 +804,12 @@ $.fn.canopen = function() {
          .toggleClass("ui-accordion-header-active ui-state-active ui-state-default ui-corner-bottom")
          .find("> .ui-icon").toggleClass("ui-icon-triangle-1-e ui-icon-triangle-1-s").end()
          .next().slideToggle();
+       // Reflow MathQuill answer boxes so that their contents are rendered correctly
+       if ('answerQuills' in window) {
+           Object.keys(answerQuills).forEach(
+               function(key, index) { answerQuills[key].mathField.reflow(); }
+           );
+       }
      }
      return false;
    })


### PR DESCRIPTION
When a scaffold opens iterate through the MathQuill answer boxes on the
page and call reflow on each one so that the contents are properly
displayed.

See http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4666