### PR TITLE
'digits' tolType

### DIFF
--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -61,6 +61,8 @@ like equality are "fuzzy", meaning that two items are equal when they are "close
     tolType      => 'relative',
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
+    tolTruncation => 1,
+    tolDigits    => 6,
     #
     #  For Formulas:
     #
@@ -114,6 +116,8 @@ $defaultContext = Value::Context->new(
     tolType      => 'relative',
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
+    tolTruncation => 1,
+    tolDigits    => 6,
     #
     #  For Formulas:
     #

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -62,7 +62,7 @@ like equality are "fuzzy", meaning that two items are equal when they are "close
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
     tolTruncation => 1,
-    tolDigits    => 6,
+    tolExtraDigits => 3,
     #
     #  For Formulas:
     #
@@ -117,7 +117,7 @@ $defaultContext = Value::Context->new(
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
     tolTruncation => 1,
-    tolDigits    => 6,
+    tolExtraDigits => 3,
     #
     #  For Formulas:
     #

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -143,10 +143,10 @@ sub compare {
       my $digitsDepth = ($tolerance < $self->getFlag('tolDigits')) ? $self->getFlag('tolDigits') : $tolerance;
       for my $tol ($tolerance..$digitsDepth) {
         my $shift = $tol-$order-1;
-        my $rounda = ($a > 0) ? int($a*10**$shift + 0.5)/10**$shift : int($a*10**$shift - 0.5)/10**$shift;
-        my $roundb = ($b > 0) ? int($b*10**$shift + 0.5)/10**$shift : int($b*10**$shift - 0.5)/10**$shift;
-        my $trunca = ($a > 0) ? int($a*10**$shift      )/10**$shift : int($a*10**$shift      )/10**$shift;
-        my $truncb = ($b > 0) ? int($b*10**$shift      )/10**$shift : int($b*10**$shift      )/10**$shift;
+        my $rounda = int($a*10**$shift + 0.5*($a <=> 0))/10**$shift;
+        my $roundb = int($b*10**$shift + 0.5*($b <=> 0))/10**$shift;
+        my $trunca = int($a*10**$shift)/10**$shift;
+        my $truncb = int($b*10**$shift)/10**$shift;
         return 1 if ($rounda ne $roundb and (!$self->getFlag('tolTruncation') or $trunca ne $truncb));
         #don't continue if we've reached the last digit of one of them
         last if ($a == $rounda or $b == $roundb);

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -130,9 +130,10 @@ sub compare {
   my ($a,$b) = ($l->{data}[0],$r->{data}[0]);
   if ($self->getFlag('useFuzzyReals')) {
     my $tolerance = $self->getFlag('tolerance');
+    my $zeroLevel = $self->getFlag('zeroLevel');
     if ($self->getFlag('tolType') eq 'digits') {
-      return 0 if ($a == 0 and $b == 0);
-      return $a <=> $b if ($a == 0 or $b == 0);
+      return 0 if (abs($a) < $zeroLevel and abs($b) < $zeroLevel);
+      return $a <=> $b if (abs($a) < $zeroLevel or abs($b) < $zeroLevel);
       # convert tolerance values meant for relative to a digits tolerance
       $tolerance = -log($tolerance)/log(10) if ($tolerance > 0 and $tolerance < 1);
       # make sure nonsensical tolerances are converted to a natural number

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -155,7 +155,6 @@ sub compare {
       return 0;
     }
     if ($self->getFlag('tolType') eq 'relative') {
-      my $zeroLevel = $self->getFlag('zeroLevel');
       if (CORE::abs($a) < $zeroLevel || CORE::abs($b) < $zeroLevel) {
 	$tolerance = $self->getFlag('zeroLevelTol');
       } else {

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -136,7 +136,7 @@ sub compare {
       # convert tolerance values meant for relative to a digits tolerance
       $tolerance = -log($tolerance)/log(10) if ($tolerance > 0 and $tolerance < 1);
       # make sure nonsensical tolerances are converted to a natural number
-      $tolerance = (1 > int($tolerance)) ? 1 : int($tolerance);
+      $tolerance = (1 > int($tolerance)) ? 1 : int($tolerance + 0.5);
       my $order = int(log(abs($a))/log(10)); $order-- if (abs($a) < 1 ); # act as floor
       # compare $a to $b at deeper tolerances than just $tolerance
       # for example to detect that 3.1419926 is not pi, even when $tolerance is 3

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -149,7 +149,7 @@ sub compare {
         my $truncb = int($b*10**$shift)/10**$shift;
         return $a <=> $b if ($rounda ne $roundb and (!$self->getFlag('tolTruncation') or $trunca ne $truncb));
         #don't continue if we've reached the last digit of one of them
-        last if ($a == $rounda or $b == $roundb);
+        last if ($a eq $rounda or $b eq $roundb);
       }
       return 0;
     }

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -132,7 +132,7 @@ sub compare {
     my $tolerance = $self->getFlag('tolerance');
     if ($self->getFlag('tolType') eq 'digits') {
       return 0 if ($a == 0 and $b == 0);
-      return 1 if ($a == 0 or $b == 0);
+      return $a <=> $b if ($a == 0 or $b == 0);
       # convert tolerance values meant for relative to a digits tolerance
       $tolerance = -log($tolerance)/log(10) if ($tolerance > 0 and $tolerance < 1);
       # make sure nonsensical tolerances are converted to a natural number
@@ -147,7 +147,7 @@ sub compare {
         my $roundb = int($b*10**$shift + 0.5*($b <=> 0))/10**$shift;
         my $trunca = int($a*10**$shift)/10**$shift;
         my $truncb = int($b*10**$shift)/10**$shift;
-        return 1 if ($rounda ne $roundb and (!$self->getFlag('tolTruncation') or $trunca ne $truncb));
+        return $a <=> $b if ($rounda ne $roundb and (!$self->getFlag('tolTruncation') or $trunca ne $truncb));
         #don't continue if we've reached the last digit of one of them
         last if ($a == $rounda or $b == $roundb);
       }


### PR DESCRIPTION
This adds `tolType=>'digits'` as an option for a context flag. Documentation will be required, but I am not 100% sure of design decisions I made here. This PR may lead to discussion that changes the design, and then I can make documentation.

As implemented right now, when this is set, the `tolerance` flag should be a natural number 1, 2, 3, etc. Roughly, the idea is that if two numbers "match" for their first so many significant digits, then the `compare` subroutine will see no difference between them. (And if `tolerance` is something like 0.001, the default with relative tolerance, then that gets converted to 3 automatically using log10.)

It doesn't distinguish things like 1.2 and 1.200, so I decided not to call this a `sigfig` tolType.

If `tolerance` is 3 and the answer is pi, should 3.14177 count as equal? I've decided it should not, even though it matches on the first 3 digits. This kind of extra checking is done up to the 6th significant digit, where 6 is a new context flag `tolDigits`. 6 is the default, because that is the default number of digits MathObjects show (because the number format is `%g`, which uses 6 as its default.)

If `tolerance` is 4 and the answer is pi, should 3.141 count as equal? Because rounding pi would give 3.142. So I added another flag `tolTruncation` that tolerates truncation. It is true by default, and both 3.141 and 3.142 would be equal to pi. If it's set to false, only 3.142 is equal to pi.

Below is a PG file I used to do some testing.


```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",  
  "PGML.pl",
  "niceTables.pl",
  "PGcourse.pl",
);

TEXT(beginproblem());

Context("Numeric")->flags->set(tolType=>'digits',tolerateTruncation=>0);
# Note the default tolerance of 0.001 is converted to tolerance of 3

@a = (
Real(pi),
Real(3.14),
Real(3.15),
Real(3.13),
Real(3.141),
Real(3.142),
Real(3.14159),
Real(3.14149),
Real(0.1055),
Real(0.105),
Real(0.106),
Real(0.1155),
Real(0.115),
Real(0.116),
Real(-0.1055),
Real(-0.105),
Real(-0.106),
Real(-0.1155),
Real(-0.115),
Real(-0.116),
Real(1234e20),
Real(123000000000000000000000),
);

BEGIN_PGML
With 'digits' tolerance, with 'tolerance' 3, and 'tolTruncation' true.
[@ DataTable(
  [
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[1] . '\)',
      ($a[0] == $a[1]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[2] . '\)',
      ($a[0] == $a[2]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[3] . '\)',
      ($a[0] == $a[3]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[4] . '\)',
      ($a[0] == $a[4]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[5] . '\)',
      ($a[0] == $a[5]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[6] . '\)',
      ($a[0] == $a[6]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[7] . '\)',
      ($a[0] == $a[7]) ? 'True' : 'False'],
    ['\(' . $a[8] . '\stackrel{?}{=}' . $a[9] . '\)',
      ($a[8] == $a[9]) ? 'True' : 'False'],
    ['\(' . $a[8] . '\stackrel{?}{=}' . $a[10] . '\)',
      ($a[8] == $a[10]) ? 'True' : 'False'],
    ['\(' . $a[11] . '\stackrel{?}{=}' . $a[12] . '\)',
      ($a[11] == $a[12]) ? 'True' : 'False'],
    ['\(' . $a[11] . '\stackrel{?}{=}' . $a[13] . '\)',
      ($a[11] == $a[13]) ? 'True' : 'False'],
    ['\(' . $a[14] . '\stackrel{?}{=}' . $a[15] . '\)',
      ($a[14] == $a[15]) ? 'True' : 'False'],
    ['\(' . $a[14] . '\stackrel{?}{=}' . $a[16] . '\)',
      ($a[14] == $a[16]) ? 'True' : 'False'],
    ['\(' . $a[17] . '\stackrel{?}{=}' . $a[18] . '\)',
      ($a[17] == $a[18]) ? 'True' : 'False'],
    ['\(' . $a[17] . '\stackrel{?}{=}' . $a[19] . '\)',
      ($a[17] == $a[19]) ? 'True' : 'False'],
    ['\(' . $a[20] . '\stackrel{?}{=}' . $a[21] . '\)',
      ($a[20] == $a[21]) ? 'True' : 'False'],
  ],
  center=>0,
  align=>'ll',
) @]*
----
END_PGML

Context()->flags->set(tolTruncation=>0);

BEGIN_PGML
Now with 'tolTruncation' false.
[@ DataTable(
  [
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[1] . '\)',
      ($a[0] == $a[1]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[2] . '\)',
      ($a[0] == $a[2]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[3] . '\)',
      ($a[0] == $a[3]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[4] . '\)',
      ($a[0] == $a[4]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[5] . '\)',
      ($a[0] == $a[5]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[6] . '\)',
      ($a[0] == $a[6]) ? 'True' : 'False'],
    ['\(' . $a[0] . '\stackrel{?}{=}' . $a[7] . '\)',
      ($a[0] == $a[7]) ? 'True' : 'False'],
    ['\(' . $a[8] . '\stackrel{?}{=}' . $a[9] . '\)',
      ($a[8] == $a[9]) ? 'True' : 'False'],
    ['\(' . $a[8] . '\stackrel{?}{=}' . $a[10] . '\)',
      ($a[8] == $a[10]) ? 'True' : 'False'],
    ['\(' . $a[11] . '\stackrel{?}{=}' . $a[12] . '\)',
      ($a[11] == $a[12]) ? 'True' : 'False'],
    ['\(' . $a[11] . '\stackrel{?}{=}' . $a[13] . '\)',
      ($a[11] == $a[13]) ? 'True' : 'False'],
    ['\(' . $a[14] . '\stackrel{?}{=}' . $a[15] . '\)',
      ($a[14] == $a[15]) ? 'True' : 'False'],
    ['\(' . $a[14] . '\stackrel{?}{=}' . $a[16] . '\)',
      ($a[14] == $a[16]) ? 'True' : 'False'],
    ['\(' . $a[17] . '\stackrel{?}{=}' . $a[18] . '\)',
      ($a[17] == $a[18]) ? 'True' : 'False'],
    ['\(' . $a[17] . '\stackrel{?}{=}' . $a[19] . '\)',
      ($a[17] == $a[19]) ? 'True' : 'False'],
    ['\(' . $a[20] . '\stackrel{?}{=}' . $a[21] . '\)',
      ($a[20] == $a[21]) ? 'True' : 'False'],
  ],
  center=>0,
  align=>'ll',
) @]*
END_PGML

ENDDOCUMENT();

```

