### PR TITLE
Remove stray "}" from <script> url

### DIFF
--- a/macros/sage.pl
+++ b/macros/sage.pl
@@ -244,7 +244,7 @@ package main;
 sub sageCalculatorHeader {
 $CellServer = 'https://sagecell.sagemath.org';
 main::HEADER_TEXT(main::MODES(TeX=>"", HTML=><<"END_OF_FILE"));
-<script src="$CellServer}/static/jquery.min.js"></script>
+<script src="$CellServer/static/jquery.min.js"></script>
     <script src="$CellServer/static/embedded_sagecell.js"></script>
     <script>\$(function () {
     // Make *any* div with class 'sage-compute' a Sage cell


### PR DESCRIPTION
This PR uses the same branch Andrew used to get 4d6aae4 into `master`. This branch also has two merge commits, and commit 5e634d6 that edits scaffold.pl. The content of 5e634d6 is already in develop, via commit d881134.

In addition to bringing 4d6aae4 into `develop`, this would clear up the network diagram a little, gathering all the commits that are officially in `master` right now but not in `develop`, and adding them.

Apologies if this is bad git practice, and we can close this PR and do something else. Trying to clean up the mess I made by merging #438 without checking the target branch.