### PR TITLE
PopUp extended answer fix

### DIFF
--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -159,7 +159,7 @@ sub randomOrder {
 #
 sub menu {shift->MENU(0,@_)}
 sub MENU {
-  my $self = shift; my $extend = shift; my $name = shift;
+  my $self = shift; my $extend = shift; my $name = shift; my $size = shift; my %options = @_;
   my @list = @{$self->{choices}}; my $menu = "";
   $name = main::NEW_ANS_NAME() unless $name;
   my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
@@ -201,6 +201,7 @@ sub MENU {
     }
   }
   main::RECORD_ANS_NAME($name,$answer_value) unless $extend;   # record answer name
+  main::INSERT_RESPONSE($options{answer_group_name}, $name, $answer_value) if $extend;
   $menu;
 }
 


### PR DESCRIPTION
Add a missing call to INSERT_RESPONSE to the PopUp MENU method in the case that it is an extended answer.
    
Currently, if a PopUp answer is used as a later answer in a MultiAnswer problem with the singleResult option, then the answer for that part is not saved.  When answers are submitted the selected answer initially displays when the page reloads, but if you navigate away from the problem and come back, the answer to that part is no longer there.  The reason for this is that the answer name is never appended to the response group as is done in the NAMED_ANS_RULE_EXTENSION method.