### PR TITLE
Prevent images from being regenerated again under a new alias

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -725,7 +725,7 @@ PGtikz.pl.
 =cut
 
 # Keep track of the names created during this session.
-our %names_created;
+our %names_created = ();
 
 # Generate a unique file name in a problem based on the user, seed, set
 # number, and problem number.


### PR DESCRIPTION
Make sure that the `%names_created` variable is initialized.  Otherwise the value of that variable from a previous run can carry over, and number of images that are generated for a problem can end up being incorrectly incremented.  This causes excessive regeneration of images under new aliases.