### PR TITLE
Prevent images from being regenerated again under a new alias

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -90,7 +90,7 @@ sub new {
 		envir                     => $envir,
 		WARNING_messages		  => [],
 		DEBUG_messages            => [],
-		names_created              => {},
+		names_created              => 0,
 		external_refs             => {},      # record of external references 
 		%options,                                   # allows overrides and initialization	
 	};
@@ -729,10 +729,8 @@ PGtikz.pl.
 sub getUniqueName {
 	my $self = shift;
 	my $ext = shift;
-	my $prob_name = "$self->{envir}{studentLogin}-$self->{envir}{problemSeed}" .
-		"-set$self->{envir}{setNumber}prob$self->{envir}{probNum}";
-	my $num  = ++$self->{names_created}{$prob_name};
-	my $resource = $self->{PG_alias}->make_resource_object("$prob_name$num", $ext);
+	my $num  = ++$self->{names_created};
+	my $resource = $self->{PG_alias}->make_resource_object("name$num", $ext);
 	$resource->path("__");
 	return $resource->create_unique_id;
 }

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -90,7 +90,7 @@ sub new {
 		envir                     => $envir,
 		WARNING_messages		  => [],
 		DEBUG_messages            => [],
-		gifs_created              => {},
+		names_created              => {},
 		external_refs             => {},      # record of external references 
 		%options,                                   # allows overrides and initialization	
 	};
@@ -724,9 +724,6 @@ PGtikz.pl.
 
 =cut
 
-# Keep track of the names created during this session.
-our %names_created;
-
 # Generate a unique file name in a problem based on the user, seed, set
 # number, and problem number.
 sub getUniqueName {
@@ -734,7 +731,7 @@ sub getUniqueName {
 	my $ext = shift;
 	my $prob_name = "$self->{envir}{studentLogin}-$self->{envir}{problemSeed}" .
 		"-set$self->{envir}{setNumber}prob$self->{envir}{probNum}";
-	my $num  = ++$names_created{$prob_name};
+	my $num  = ++$self->{names_created}{$prob_name};
 	my $resource = $self->{PG_alias}->make_resource_object("$prob_name$num", $ext);
 	$resource->path("__");
 	return $resource->create_unique_id;

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -51,7 +51,6 @@ sub DOCUMENT {
 	$solutionExists        		= $PG->{flags}->{solutionExists};
 	$hintExists            		= $PG->{flags}->{hintExists};
 	$pgComment                  = '';
-	%gifs_created          		= %{ $PG->{gifs_created}};
 	%external_refs         		= %{ $PG->{external_refs}};
 	
 	@KEPT_EXTRA_ANSWERS =();   #temporary hack


### PR DESCRIPTION
Make names_created in PGcore.pm a property of the PGcore object rather than a package variable.  Since the new method is called and initializes this property to the empty hash on each successive run, this prevents carry over of old values.  That carry over caused unnecessary regeneration of images under new aliases.

Note, that I have removed the gifs_created property of the PGcore object that was completely unused.