### PR TITLE
a fix for convert_to_array_ref  for develop.

### DIFF
--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -355,7 +355,7 @@ sub classMatch {
   my $class = class($self)//''; my $ref = ref($self);
   #my $isHash = ($ref && $ref ne 'ARRAY' && $ref ne 'CODE');
   #warn "hash $isHash $ref";
-  my $isHash = isHash($self);
+  my $isHash = Value::isHash($self);
   my $context = ($isHash ? $self->{context} || Value->context : Value->context);
   foreach my $name (@_) {
     my $isName = "is".$name;

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -284,6 +284,10 @@ sub isHash {
 
 }
 
+
+# example: return Boolean:  Value->subclassed($self,"classMatch")
+# if $self has the method 'classMath' and 'Value' has the method 'classMatch'
+# and  the reference to these methods don't agree then the method 'classMatch' has been subclassed. 
 sub subclassed {
   my $self = shift; my $obj = shift; my $method = shift;
   my $code = UNIVERSAL::can($obj,$method);
@@ -352,9 +356,7 @@ sub Package {(shift)->context->Package(@_)}
 sub classMatch {
   my $self = shift;
   return $self->classMatch(@_) if Value->subclassed($self,"classMatch");
-  my $class = class($self)//''; my $ref = ref($self);
-  #my $isHash = ($ref && $ref ne 'ARRAY' && $ref ne 'CODE');
-  #warn "hash $isHash $ref";
+  my $class = Value::class($self)//''; my $ref = ref($self);
   my $isHash = Value::isHash($self);
   my $context = ($isHash ? $self->{context} || Value->context : Value->context);
   foreach my $name (@_) {

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -353,7 +353,9 @@ sub classMatch {
   my $self = shift;
   return $self->classMatch(@_) if Value->subclassed($self,"classMatch");
   my $class = class($self)//''; my $ref = ref($self);
-  my $isHash = ($ref && $ref ne 'ARRAY' && $ref ne 'CODE');
+  #my $isHash = ($ref && $ref ne 'ARRAY' && $ref ne 'CODE');
+  #warn "hash $isHash $ref";
+  my $isHash = isHash($self);
   my $context = ($isHash ? $self->{context} || Value->context : Value->context);
   foreach my $name (@_) {
     my $isName = "is".$name;

--- a/macros/PGmatrixmacros.pl
+++ b/macros/PGmatrixmacros.pl
@@ -768,10 +768,12 @@ seeking.
 
 sub convert_to_array_ref {
 	my $input = shift;
-	if (Value::classMatch($input,"Matrix")) {
+	if (Value::isValue($input) && Value::classMatch($input,"Matrix")) {
 		$input = [$input->value];
+		warn "assuming a Value object";
 	} elsif (ref($input) eq 'Matrix' ) {
 		$input = $input->array_ref;
+		warn "assuming wwMatrix";
 	} elsif (ref($input) =~/ARRAY/) {
 		# no change to input value
 	} else {

--- a/macros/PGmatrixmacros.pl
+++ b/macros/PGmatrixmacros.pl
@@ -769,11 +769,9 @@ seeking.
 sub convert_to_array_ref {
 	my $input = shift;
 	if (Value::isValue($input) && Value::classMatch($input,"Matrix")) {
-		$input = [$input->value];
-		warn "assuming a Value object";
+		$input = [$input->value];		
 	} elsif (ref($input) eq 'Matrix' ) {
 		$input = $input->array_ref;
-		warn "assuming wwMatrix";
 	} elsif (ref($input) =~/ARRAY/) {
 		# no change to input value
 	} else {


### PR DESCRIPTION
This is a companion to the hot fix #461 submitted to master.

@dpvc  I'm trying to understand the long term fix for this.  Should it be necessary to check
that $input satisfies Value::isValue($input) before calling Value::checkMath($input, "Matrix");?

I realize there might be an issue in case Value is subclassed, but I'm not sure what it is. 

Also i modified the check to make sure that $input is a hash to use Value::isHash() so that the definitions are uniform in the file.  Is that ok? or is that part of the problem.


