### PR TITLE
Explanation essays

### DIFF
--- a/macros/PGessaymacros.pl
+++ b/macros/PGessaymacros.pl
@@ -33,6 +33,9 @@ Answer Boxes
 
     To use essay answers just put an essay_box() into your problem file wherever you want the input box to go and then use essay_cmp() for the corresponding checker.  You will then need grade the problem manually.  The grader can be found in the "Detail Set List".
 
+        explanation_box()
+
+    Like an essay_box(), except can be turned off at a configuration level. Intended for two-part questions where the first answer is automatically assessible, and the second part is an explanation or "showing your work". An instructor may want to turn these off to use the problem but without the manual grading component. These necessarily supply their own essay_cmp().
 =cut
 
 sub _PGessaymacros_init {
@@ -152,5 +155,36 @@ sub essay_box {
 	NAMED_ESSAY_BOX($name ,$row,$col);
 
 }
+
+
+# Makes an essay box and calls essay_cmp()
+# Can be turned off using $pg{specialPGEnvironmentVars}{waiveExplanations}
+# Takes options:
+#   row (or height): height of essay box; defaults to 8
+#   col (or width):  width of essay box;  defaults to 75
+#   message: a message preceding the essay box; default is 'Explain.'
+#   help: boolean for whether to display the essay help message; default is true
+sub explanation_box {
+        my %options = @_;
+        my $row = 8;
+        my $col = 75;
+        $row = $options{height} if defined $options{height};
+        $col = $options{width} if defined $options{width};
+        $row = $options{row} if defined $options{row};
+        $col = $options{col} if defined $options{col};
+        my $message = 'Explain.';
+        if (defined $options{message})
+          {$message = $options{message}};
+        my $help = 1;
+        $help = $options{help} if defined $options{help};
+        if ($envir{waiveExplanations}) {}
+        else {
+          ANS(essay_cmp());
+          return $message.$PAR.
+          essay_box($row,$col).
+          ($help ? essay_help() : '');
+        }
+}
+
 
 1;


### PR DESCRIPTION
This adds a special type of essay box (`explanation_box()`) to PGessaymacros.pl.

The purpose is to support exercises like:
```
Use the Squeeze Theorem to find the limit of x sin(1/x) as x approaches 0.
```
There would be one answer for the limit value: 0. How do we know the student actually used the Squeeze Theorem, or used it correctly? There is a follow-up essay field. The first answer blank lets the student know they at least got the final answer right. But now we have an exercise many instructors will not want to use, because of the manual grading incurred.

This `explanation_box()` addresses that issue by making essay boxes that can be turned off using configuration settings. (Perhaps in the future it could also be controlled by a problem set attribute.) There will be a companion PR to webwork2 to make that part of it work.

Here is an example problem. It will "work" even without the companion PR to webwork2. The companion PR is needed in order to use config settings to suppress the second part of the question.

```
DOCUMENT();

loadMacros(
"PGstandard.pl",
"MathObjects.pl",
"PGML.pl",
"PGessaymacros.pl",
);

BEGIN_PGML
Use the Squeeze Theorem to find the [`\lim\limits_{x\to0} x \sin(1/x)`].

[_]{0}{10}

[@ explanation_box(message=>'Show your work') @]*

END_PGML

ENDDOCUMENT();
```

Other options besides `message` include options to set the size of the essay field, and a boolean to show/suppress the essay help text.