### PR TITLE
encode string as octets before passing to md5_hex()

### DIFF
--- a/lib/WeBWorK/EquationCache.pm
+++ b/lib/WeBWorK/EquationCache.pm
@@ -87,7 +87,7 @@ sub lookup {
 	# Option 2 (the old default): remove all whitespace
 	# $tex =~ s/\s+//g;
 
-	my $md5 = md5_hex(encode_utf8($tex));
+	my $md5 = md5_hex(utf8::is_utf8($tex) ? encode_utf8($tex) : $tex);
 	
 	my $db = $self->{cacheDB};
 	unless($db) { return($md5 ."1"); }

--- a/lib/WeBWorK/EquationCache.pm
+++ b/lib/WeBWorK/EquationCache.pm
@@ -87,7 +87,7 @@ sub lookup {
 	# Option 2 (the old default): remove all whitespace
 	# $tex =~ s/\s+//g;
 
-	my $md5 = md5_hex(utf8::is_utf8($tex) ? encode_utf8($tex) : $tex);
+	my $md5 = md5_hex(encode_utf8($tex));
 	
 	my $db = $self->{cacheDB};
 	unless($db) { return($md5 ."1"); }

--- a/lib/WeBWorK/EquationCache.pm
+++ b/lib/WeBWorK/EquationCache.pm
@@ -37,6 +37,7 @@ extending to the end of the line is also ignored.
 use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
+use Encode qw(encode_utf8 decode_utf8 decode);
 use Fcntl qw(:DEFAULT :flock);
 BEGIN { my @_junk = (O_RDWR,O_CREAT,LOCK_EX) } # get rid of "subroutine redefined" warnings
 
@@ -86,7 +87,7 @@ sub lookup {
 	# Option 2 (the old default): remove all whitespace
 	# $tex =~ s/\s+//g;
 
-	my $md5 = md5_hex($tex);
+	my $md5 = md5_hex(encode_utf8($tex));
 	
 	my $db = $self->{cacheDB};
 	unless($db) { return($md5 ."1"); }

--- a/lib/WeBWorK/EquationCache.pm
+++ b/lib/WeBWorK/EquationCache.pm
@@ -37,7 +37,7 @@ extending to the end of the line is also ignored.
 use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
-use Encode qw(encode_utf8 decode_utf8 decode);
+use Encode qw(encode_utf8 );
 use Fcntl qw(:DEFAULT :flock);
 BEGIN { my @_junk = (O_RDWR,O_CREAT,LOCK_EX) } # get rid of "subroutine redefined" warnings
 


### PR DESCRIPTION
The string might have utf8 characters which md5_hex() can't handle. 

See https://perldoc.perl.org/Digest/MD5.html near the bottom of the page.