### PR TITLE
WIP Fix Rserve connections

### DIFF
--- a/macros/RserveClient.pl
+++ b/macros/RserveClient.pl
@@ -139,7 +139,10 @@ sub rserve_eval {
     
     my $query = shift;
     
-    rserve_start unless $rserve;
+    if (! $rserve) {
+        # no existing r session. redirect to single-use call
+        return rserve_query($query);
+    }
     
     my $result = Rserve::try_eval($rserve, $query);
     Rserve::unref_rexp($result)


### PR DESCRIPTION
- if rserve_eval is called without first calling rserve_start, it
  creates a new connection without closing it.  This causes dangling
connections.