### PR TITLE
Fix malformed utf8 copyright errors caused by the © character

### DIFF
--- a/macros/compoundProblem5.pl
+++ b/macros/compoundProblem5.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextAlternateDecimal.pl
+++ b/macros/contextAlternateDecimal.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextAlternateIntervals.pl
+++ b/macros/contextAlternateIntervals.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextComplexExtras.pl
+++ b/macros/contextComplexExtras.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/contextComplexExtras.pl,v 1.0 2012/08/01 11:33:50 dpvc Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextComplexJ.pl
+++ b/macros/contextComplexJ.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextCongruence.pl
+++ b/macros/contextCongruence.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextInequalitySetBuilder.pl
+++ b/macros/contextInequalitySetBuilder.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextInteger.pl
+++ b/macros/contextInteger.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2017 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextMatrixExtras.pl
+++ b/macros/contextMatrixExtras.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/contextMatrixExtras.pl,v 1.0 2012/08/01 11:21:45 dpvc Exp $
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextPartition.pl
+++ b/macros/contextPartition.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextPercent.pl
+++ b/macros/contextPercent.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/contextCurrency.pl,v 1.17 2009/06/25 23:28:44 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextPermutation.pl
+++ b/macros/contextPermutation.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextPermutationUBC.pl
+++ b/macros/contextPermutationUBC.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2014 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader:$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextPolynomialFactors.pl
+++ b/macros/contextPolynomialFactors.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/contextPolynomialFactors.pl,v 1.2 2010/03/31 21:45:42 dpvc Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/contextRationalFunction.pl
+++ b/macros/contextRationalFunction.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2010 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/contextRationalFunction.pl,v 1.1 2010/03/31 21:01:14 dpvc Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserFormulaAnyVar.pl
+++ b/macros/parserFormulaAnyVar.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserFunctionPrime.pl
+++ b/macros/parserFunctionPrime.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserOneOf.pl
+++ b/macros/parserOneOf.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2012 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserParametricPlane.pl
+++ b/macros/parserParametricPlane.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/parserParametricLine.pl,v 1.17 2009/06/25 23:28:44 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserPrime.pl
+++ b/macros/parserPrime.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2009 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2009 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/parserPrime.pl,v 1.2 2009/10/03 15:58:49 dpvc Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/parserRoot.pl
+++ b/macros/parserRoot.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2013 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader$
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/problemPanic.pl
+++ b/macros/problemPanic.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2009 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2009 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: pg/macros/problemPanic.pl,v 1.6 2010/04/27 02:00:37 dpvc Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/macros/scaffold.pl
+++ b/macros/scaffold.pl
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 20014 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 20014 The WeBWorK Project, http://openwebwork.sf.net/
 # $$
 # 
 # This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
Switch from © to &copy; in all pg macro files where this had not been done already.  These can cause malformed utf-8 character errors for problems.  This was seen in problems that use the contextPolynomialFactors.pl macro.

This could probably be considered to be added to the master branch.  This should have been done when the switch to utf-8 was made.
