### PR TITLE
Rewrite lcm() and gcf() to handle more than two arguments

### DIFF
--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -25,9 +25,9 @@ loadMacros("PGcommonFunctions.pl");
 #  max(@listNumbers)
 #  min(@listNumbers)
 #  round($number)
-#  lcm($number1,$number2)
-#  gfc($number1,$number2)
-#  gcd($number1,$number2)  
+#  lcm(@listNumbers)
+#  gcf(@listNumbers)
+#  gcd(@listNumbers)
 #  isPrime($number)
 #  reduce($numerator,$denominator)
 #  preformat($scalar, "QuotedString")
@@ -107,71 +107,37 @@ sub Round {
 
 #least common multiple
 #VS 6/29/2000
+# made recursive to handle the gcf of any number of inputs 5/16/2020
 # ^function lcm
 sub lcm {
-	my $a = shift;
-	my $b = shift;
-
-	#reorder such that $a is the smaller number
-	if ($a > $b) {
-		my $temp = $a;
-		$a = $b;
-		$b = $temp;
-	}
-
-	my $lcm = 0;
-	my $curr = $b;;
-
-	while($lcm == 0) {
-		$lcm = $curr if ($curr % $a == 0);
-		$curr += $b;
-	}
-
-	$lcm;
-
+        if (scalar @_ == 0) {warn 'Cannot take lcm of the empty set'; return;}
+        my $a = abs(shift);
+        if ($a == 0) {return 0;}
+        if (scalar @_ == 0) {return $a;}
+        my $b = abs(shift);
+        if ($b == 0) {return 0;}
+        return lcm($a*$b/gcf($a,$b),@_);
 }
 
 
 # greatest common factor
-# takes in two scalar values and uses the Euclidean Algorithm to return the gcf
-#VS 6/29/2000
+# takes in scalar values and uses the Euclidean Algorithm to return the gcf
+# VS 6/29/2000
+# made recursive to handle the gcf of any number of inputs 5/16/2020
 # ^function gcf
 sub gcf {
-        my $a = abs(shift);	# absolute values because this will yield the same gcd,
-        my $b = abs(shift);	# but allows use of the mod operation
-
-	# reorder such that b is the smaller number
-	if ($a < $b) {
-		my $temp = $a;
-		$a = $b;
-		$b = $temp;
-	}
-
-	return $a if $b == 0;
-
-	my $q = int($a/$b);	# quotient
-	my $r = $a % $b;	# remainder
-
-	return $b if $r == 0;
-
-	my $tempR = $r;
-
-	while ($r != 0) {
-
-		#keep track of what $r was in the last loop, as this is the value
-		#we will want when $r is set to 0
-		$tempR = $r;
-
-		$a = $b;
-		$b = $r;
-		$q = $a/$b;
-		$r = $a % $b;
-
-	}
-
-	$tempR;
+        if (scalar @_ == 0) {warn 'Cannot take gcf of the empty set or an all-zero set'; return;}
+        my $a = abs(shift);
+        if ($a == 0) {return gcf(@_);}
+        if (scalar @_ == 0) {return $a;}
+        my $b = abs(shift);
+        if ($b == 0) {return gcf($a,@_);}
+        ($a,$b) = ($b,$a) if $a > $b;
+        while ($a) {
+          ($a, $b) = ($b % $a, $a);
+        }
+        return gcf($b,@_);
 }
-
 
 #greatest common factor.
 #same as gcf, but both names are sufficiently common names

--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -106,28 +106,35 @@ sub Round {
 }
 
 #least common multiple
+# should be passed a nonempty array of integers
+# checks if passed an empty array, but otherwise does not validate input
+# returns their least common multiple
 # ^function lcm
 sub lcm {
         do {warn 'Cannot take lcm of the empty set'; return;} unless (@_);
         my $a = abs(shift);
-        if ($a == 0) {return 0;}
+        return 0 unless $a;
         return $a unless (@_);
         my $b = abs(shift);
-        if ($b == 0) {return 0;}
-        else {return lcm($a*$b/gcf($a,$b),@_);};
+        return 0 unless $b;
+        return lcm($a*$b/gcf($a,$b),@_);
 }
 
 
 # greatest common factor
-# takes in scalar values and uses the Euclidean Algorithm to return the gcf
+# should be passed a nonempty array of integers
+# checks if passed an empty array, but otherwise does not validate input
+# returns their greatest common factor
 # ^function gcf
 sub gcf {
+        # An empty argument array is either from the user or has been filtered down
+        # from previous iterations where the user submitted an all-zero array
         do {warn 'Cannot take gcf of the empty set or an all-zero set'; return;} unless (@_);
         my $a = abs(shift);
-        if ($a == 0) {return gcf(@_);}
+        return gcf(@_) unless $a;
         return $a unless (@_);
         my $b = abs(shift);
-        if ($b == 0) {return gcf($a,@_);}
+        # Swap if needed to make sure $a is smaller
         ($a,$b) = ($b,$a) if $a > $b;
         while ($a) {
           ($a, $b) = ($b % $a, $a);

--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -106,8 +106,6 @@ sub Round {
 }
 
 #least common multiple
-#VS 6/29/2000
-# made recursive to handle the gcf of any number of inputs 5/16/2020
 # ^function lcm
 sub lcm {
         if (scalar @_ == 0) {warn 'Cannot take lcm of the empty set'; return;}
@@ -122,8 +120,6 @@ sub lcm {
 
 # greatest common factor
 # takes in scalar values and uses the Euclidean Algorithm to return the gcf
-# VS 6/29/2000
-# made recursive to handle the gcf of any number of inputs 5/16/2020
 # ^function gcf
 sub gcf {
         if (scalar @_ == 0) {warn 'Cannot take gcf of the empty set or an all-zero set'; return;}

--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -147,7 +147,7 @@ sub gcf {
 # ^function gcd
 # ^uses gcf
 sub gcd {
-        return gcf($_[0], $_[1]);
+        return gcf(@_);
 }
 
 #returns 1 for a prime number, else 0

--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -108,13 +108,13 @@ sub Round {
 #least common multiple
 # ^function lcm
 sub lcm {
-        if (scalar @_ == 0) {warn 'Cannot take lcm of the empty set'; return;}
+        do {warn 'Cannot take lcm of the empty set'; return;} unless (@_);
         my $a = abs(shift);
         if ($a == 0) {return 0;}
-        if (scalar @_ == 0) {return $a;}
+        return $a unless (@_);
         my $b = abs(shift);
         if ($b == 0) {return 0;}
-        return lcm($a*$b/gcf($a,$b),@_);
+        else {return lcm($a*$b/gcf($a,$b),@_);};
 }
 
 
@@ -122,10 +122,10 @@ sub lcm {
 # takes in scalar values and uses the Euclidean Algorithm to return the gcf
 # ^function gcf
 sub gcf {
-        if (scalar @_ == 0) {warn 'Cannot take gcf of the empty set or an all-zero set'; return;}
+        do {warn 'Cannot take gcf of the empty set or an all-zero set'; return;} unless (@_);
         my $a = abs(shift);
         if ($a == 0) {return gcf(@_);}
-        if (scalar @_ == 0) {return $a;}
+        return $a unless (@_);
         my $b = abs(shift);
         if ($b == 0) {return gcf($a,@_);}
         ($a,$b) = ($b,$a) if $a > $b;


### PR DESCRIPTION
This extends lcm() and gcf() to handle more than two arguments. For example, lcm(2,3,4)=12, or gcf(0,4,6,8)=2. The current versions ignore arguments beyond the second.