### PR TITLE
Fix sub createRandomPoints so that when test_at points are included, …

### DIFF
--- a/lib/Value/Formula.pm
+++ b/lib/Value/Formula.pm
@@ -331,6 +331,7 @@ sub createRandomPoints {
   if ($include) {
     push(@{$points},@{$include});
     push(@{$values},@{$self->createPointValues($include,1,$cacheResults,$checkUndef)});
+    $num_points += scalar(@{$include});
   }
   my (@P,@p,$v,$i); my $k = 0;
   while (scalar(@{$points}) < $num_points+$num_undef && $k < 10) {


### PR DESCRIPTION
Fix `sub createRandomPoints` so that when `test_at` points are included it still generates `num_points` random points in addition to the provided points, as intended. This fixes the issue reported in https://github.com/openwebwork/pg/issues/472 so that the `test_at` works as documented in https://webwork.maa.org/wiki/Context_flags .