### PR TITLE
add correct answer data to answer hash for Math Objects

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -257,9 +257,18 @@ sub score {
 sub stringify_hash {
   my $self = shift;
   Parser::Context->current(undef,$self->{correct_value}->context) if $self->{correct_value};
+  # special treatment for correct_data array
+  my $correct_data;
+  if (ref($self->{correct_data}) eq 'ARRAY') {
+    $correct_data = $self->{correct_data};
+    for my $i (0..$#$correct_data) {
+      $correct_data->[$i] = "$correct_data->[$i]" if ref($correct_data->[$i]);
+    }
+  }
   foreach my $key (keys %$self) {
     $self->{$key} = "$self->{$key}" if ref($self->{$key});
   }
+  $self->{correct_data} = $correct_data if ($correct_data);
 }
 
 # error methods

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -88,6 +88,7 @@ sub cmp {
     correct_ans => $correct,
     correct_ans_latex_string => $correct_latex,
     correct_value => $self,
+    correct_data => $self->{data} || $self,
     $self->cmp_defaults(@_),
     %{$self->{context}{cmpDefaults}{$self->class} || {}},  # context-specified defaults
     @_,


### PR DESCRIPTION
Some Math Objects have a `data` property. The main example I have in mind is a `RadioButtons` object, in which case the `data` is the HTML `value` of the input (type `radio`) that is the correct answer. It's something like `B2`, by default. The answer hash doesn't currently give a way to identify that `value` of the correct option. This PR adds `correct_data` to the answer hash. Since it is an array reference, it's not helpful to stringify it. So in the `stringify` subroutine, we go one level deeper into its contents before stringifying.

@dpvc and others, does this raise any flags? 