### PR TITLE
Correct aria label

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -541,7 +541,7 @@ sub BUTTONS {
     $tag = $self->labelFormat($self->{labels}[$i]).$tag if $self->{displayLabels};
     if ($i > 0) {
       push(@radio,main::NAMED_ANS_RADIO_EXTENSION($name, $value, $tag,
-           aria_label => $label."option $i ", @_));
+           aria_label => $label."option " . ($i+1) . " ", @_));
     } else {
       push(@radio, main::NAMED_ANS_RADIO($name, $value, $tag, $extend, @_));
     }


### PR DESCRIPTION
Prior to this commit, if you use `parserRadioButtons.pl` to make a RadioButtons answer, the aria-labels on the buttons come out as:

- answer 1 option 1 
- answer 1 option 1 
- answer 1 option 2 
- answer 1 option 3

This commit corrects that to:

- answer 1 option 1 
- answer 1 option 2 
- answer 1 option 3 
- answer 1 option 4