### PR TITLE
Make function parenPrecedence greater than unary negative, postive

### DIFF
--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -82,7 +82,7 @@ $operators = {
            class => 'Parser::BOP::multiply', TeX => ''},
 
    'fn'=> {precedence => 2.9, associativity => 'left', type => 'unary', string => '',
-           parenPrecedence => 5, hidden => 1},
+           parenPrecedence => 6.5, hidden => 1},
 
    ' ' => {precedence => 3.1, associativity => 'left', type => 'bin', string => '*',
            class => 'Parser::BOP::multiply', space => ' *', hidden => 1},


### PR DESCRIPTION
This may be controversial, so consider this PR as up for discussion.

In the forums, there is this thread: https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4790

Prior to this commit, `Formula("-sqrt(x)")` will render as `-\left(\sqrt{x}\right)` because the function application has lower precedence than negation. The commit changes that, so that this example renders as `-\sqrt{x}`. And similarly for any `-function(x)`.

I can't think of a reason to keep it the way it is. The change seems to me to be an aesthetic improvement. And also a pedagogical improvement, since occasionally we get students wondering why WW is printing those parentheses, and asking if they are needed. Of course, I may be missing something.