### PR TITLE
Fix applets in gateway quizzes

### DIFF
--- a/lib/Applet.pm
+++ b/lib/Applet.pm
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader$
-# 
+# Copyright &copy; 2000-2020 The WeBWorK Project, http://openwebwork.sf.net/
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -16,60 +15,51 @@
 
 =head1 NAME
 
-Applet.pl - Provides code for inserting FlashApplets and JavaApplets into webwork problems
+Applet.pl - Provides code for inserting FlashApplets, JavaApplets, CanvasApplets, and
+GeogebraWebApplets into webwork problems
 
 =head1 SYNPOSIS
 
-  ###################################
-  # Create  link to applet 
-  ###################################
- $appletName = "PointGraph";
-$applet =  FlashApplet(
-   codebase              => findAppletCodebase("$appletName.swf"),
-   appletName            => $appletName,
-   appletId              => $appletName,
-   setStateAlias         => 'setXML',
-   getStateAlias         => 'getXML',
-   setConfigAlias        => 'config',
-   answerBoxAlias        => 'answerBox',
-   submitActionScript    => qq{ getQE('answerBox').value = getApplet("$appletName").getAnswer() },
-);
+    ###################################
+    # Create link to applet
+    ###################################
+    $appletName = "PointGraph";
+    $applet = FlashApplet(
+        codebase           => findAppletCodebase("$appletName.swf"),
+        appletName         => $appletName,
+        appletId           => $appletName,
+        setStateAlias      => 'setXML',
+        getStateAlias      => 'getXML',
+        setConfigAlias     => 'config',
+        answerBoxAlias     => 'answerBox',
+        submitActionScript => qq{ getQE('answerBox').value = getApplet("$appletName").getAnswer() },
+    );
 
-###################################
-# Configure applet
-###################################
+    ###################################
+    # Configure applet
+    ###################################
 
-#data to set up the equation
-$applet->configuration(qq{<XML expr='(x - $a)^3 + $b/$a * x' />});
-# initial points
-$applet->intialState(qq{<XML> </XML>});
-###################################
-#insert applet into body
-###################################
+    # Data to set up the equation
+    $applet->configuration(qq{<XML expr='(x - $a)^3 + $b/$a * x' />});
+    # Initial points
+    $applet->intialState(qq{<XML> </XML>});
 
-TEXT( MODES(TeX=>'object code', HTML=>$applet->insertAll(
-  includeAnswerBox => 1
-  debug=>0,
-  reinitialize_button=>1,
- )));
+    ###################################
+    # Insert applet into body
+    ###################################
 
+    TEXT(MODES(TeX => 'object code', HTML => $applet->insertAll(
+        includeAnswerBox => 1
+        debug => 0,
+        reinitialize_button => 1
+    )));
 
 =head1 DESCRIPTION
 
-This file provides an object to store in one place
-all of the information needed to call an applet.
+This file provides an object to store in one place all of the information needed to call an
+applet.
 
 The object FlashApplet has defaults for inserting flash applets.
-
-=over
-
-=item *
-
-=item *
-
-=back
-
-(not yet completed)
 
 The module JavaApplet has defaults for inserting java applets.
 
@@ -77,14 +67,12 @@ The module Applet stores common code for the two types of applet.
 
 =head1 USAGE
 
-These modules are activate by listing it in the modules section of global.conf and rebooting the server.
-The companion file to this one is macros/AppletObjects.pl
+These modules are activate by listing it in the modules section of global.conf and rebooting the
+server.  The companion file to this one is macros/AppletObjects.pl
 
 qw(Applet FlashApplet JavaApplet)
 
 =cut
-
-
 
 package Applet;
 use URI::Escape;
@@ -92,385 +80,422 @@ use MIME::Base64 qw( encode_base64 decode_base64);
 use PGcore;
 @ISA = qw(PGcore);
 
-=head2 Default javaScript functions placed in header
+=head2 Default JavaScript functions placed in header
 
 =pod
 
-These functions are automatically defined for use for 
-any javaScript placed in the text of a PG question.
+These functions are automatically defined for use for any JavaScript placed in the text of a PG
+question.
 
-    getApplet(appletName)     -- finds the applet path in the DOM
+    getApplet(appletName)    -- finds the applet path in the DOM
 
-    submitAction()            -- calls the submit action of the applets
+    submitAction()           -- calls the submit action of the applets
 
-    initializeWWquestion()    -- calls the initialize action of the applets
+    initializeWWquestion()   -- calls the initialize action of the applets
 
-    getQE(name)               -- gets an HTML element of the question by name
-                                 or by id.  Be sure to keep all names and ids
-                                 unique within a given PG question.
+    getQE(name)              -- gets an HTML element of the question by name or by id.  Be sure
+                                to keep all names and ids unique within a given PG question.
 
-    getQuestionElement(name)  -- long form of getQE(name)
+    getQuestionElement(name) -- long form of getQE(name)
 
-    listQuestionElements()    -- for discovering the names of inputs in the 
-                                 PG question.  An alert dialog will list all
-                                 of the elements.
-                                 
+    listQuestionElements()   -- for discovering the names of inputs in the PG question.  An
+                                alert dialog will list all of the elements.
+
         Usage: Place this at the END of the question, just before END_DOCUMENT():
 
-                TEXT(qq!<script> listQuestionElements() </script>!);
+                TEXT(qq!<script>listQuestionElements()</script>!);
                 ENDDOCUMENT();
-             to obtain a list of all of the HTML elements in the question
-    
+
+        to obtain a list of all of the HTML elements in the question
+
     ----------------------------------------------------------------------------
-    
-    
-    List of  accessor methods made available by the FlashApplet class:
+
+    List of accessor methods made available by the Applet class:
+
         Usage:  $current_value = $applet->method(new_value or empty)
-        These can also be set when creating the class -- for exampe:
-             $applet = new FlashApplet( 
-                       # can be replaced by $applet =FlashApplet() when using AppletObjects.pl
-                       codebase   => findAppletCodebase("$appletName.swf"),
-                       appletName => $appletName,
-                       appletId   => $appletName,
-                       submitActionAlias => 'checkAnswer',
+
+        These can also be set when creating the class.  For example:
+            $applet = new FlashApplet(
+                codebase          => findAppletCodebase("$appletName.swf"),
+                appletName        => $appletName,
+                appletId          => $appletName,
+                submitActionAlias => 'checkAnswer'
             );
 
+        When using AppletObjects.pl this can be replaced by $applet = FlashApplet(...).
 
-        appletId     for simplicity and reliability appletId and appletName are always the same
+        appletId     For simplicity and reliability appletId and appletName should always be the
+                     same
         appletName
-        archive      the name of the .jar file containing the applet code
-        code         the name of the applet code in the .jar archive
-        codebase     a prefix url used to find the archive and the applet itself
-        
-        params       an anonymous array containing name/value pairs 
-                     to configure the applet [name =>'value, ...]
-                     
-        width        rectangle alloted in the html page for displaying the applet
+        archive      The name of the .jar file containing the applet code
+        code         The name of the applet code in the .jar archive
+        codebase     A prefix url used to find the archive and the applet itself
+
+        params       A reference to a hash containing name/value pairs to configure the applet
+                     { name => 'value', ... }
+
+        width        Rectangle alloted in the html page for displaying the applet
         height
 
-		bgcolor      background color of the applet rectangle
-		
-        header       stores the text to be added to the header section of the html page
-        object       stores the text which places the applet on the html page
+        bgcolor      Background color of the applet rectangle
 
+        header       Stores the text to be added to the header section of the html page
+        object       Stores the text which places the applet on the html page
 
-        configuration  configuration contains those customizable attributes of the applet which don't 
-                     change as it is used.  When stored in hidden answer fields 
-                     it is usually stored in base64 encoded format.
-        initialState  the state consists of those customizable attributes of the applet which change
-                     as the applet is used by the student.  It is stored by the calling .pg question so that 
-                     when revisiting the question the applet will be restored to the same state it was 
-                     left in when the question was last viewed.
-                     
-        getStateAlias  (default: getState) alias for command called to read the current state of the applet.
-                       The state is passed in plain text xml format with outer tags: <xml>....</xml>
-        setStateAlias  (default: setState) alias for the command called to reset the  state of the applet.
-                       The state is passed in plain text in xml format with outer tags: <xml>....</xml>
+        configuration  Configuration contains those customizable attributes of the applet which
+                       don't change as it is used.  When stored in hidden answer fields it is
+                       usually stored in base64 encoded format.
 
-        configAlias   (deprecated) -- a synonym for configAlias
-        
-        getConfigAlias (default: getConfig) -- retrieves the configuration from the applet.  This is used
-                     mainly for debugging.  In principal the configuration remains the same for a given instance
-                     of the applet -- i.e. for the homework question for a single student.  The state however
-                     will change depending on the interactions between the student and the applet.
-        setConfigAlias (default: setConfig ) names the applet command called with the contents of $self->config
-                     to configure the applet.  The parameters are passed to the applet in plain text using <xml>
-                     The outer tags must be   <xml> .....   </xml>
+        initialState   The state consists of those customizable attributes of the applet which
+                       change as the applet is used by the student.  It is stored by the calling
+                       pg question so that when revisiting the question the applet will be
+                       restored to the same state it was left in when the question was last
+                       viewed.
 
+        getStateAlias  (default: getState) Alias for command called to read the current state of
+                       the applet.  The state is passed in plain text xml format with outer
+                       tags: <xml>...</xml>
 
-        initializeActionAlias  -- (default: initializeAction) the name of the javaScript subroutine called 
-                                  to initialize the applet (some overlap with config/ and setState
-        maxInitializationAttempts -- (default: 5) number attempts to test applet to see if it is installed.
-                                     If isActive() exists then the WW question waits until the return value is 1 before
-                                     calling the applet's confguration commands.
-                                     Because some applets have isActive return 0 even when they are ready, 
-                                     if isActive() exists but does not return 1 then the applet's configuration commands
-                                     are called after maxInitializationAttempts number of times.  If none of the configuration commands
-                                     of the applet can be detected then the WW question gives up after maxInitializationAttempts.
-                                     
-        submitActionAlias      -- (default: getXML) applet subroutine called when the submit button of the
-                                  .pg question is pressed.
-        submitActionScript     -- (default: qq{ getQE('answerBox').value = getApplet("$appletName").getAnswer() },
-        
-        answerBoxAlias         -- name of answer box to return answer to: default defaultAnswerBox 
-        returnFieldName        -- (deprecated) synonmym for answerBoxAlias
-       
-       
-        debugMode              (default: 0) for debugMode==1 the answerBox and the box preserving the applet state 
-                               between questions are made visible along with some buttons for manually getting the state of
-                               the applet and setting the state of the applet.
-                               
-                               for debugMode==2, in addition to the answerBox and stateBox there are several alerts 
-                               which mark progress through the procedures of calling the applet.  Useful for troubleshooting
-                               where in the chain of command a communication failure occurs
+        setStateAlias  (default: setState) Alias for the command called to reset the state of
+                       the applet.  The state is passed in plain text in xml format with outer
+                       tags: <xml>...</xml>
 
-       
-   Methods:
-       
-        insertHeader          -- inserts text in header section of HTML page 
-        insertObject          -- inserts <object></object> or <applet></applet>  tag in body of the HTML page
-        insertAll             -- (defined in AppletObjects.pl) installs applet by inserting both header text and the object text
+        getConfigAlias (default: getConfig) Retrieves the configuration from the applet.
+                       This is used mainly for debugging.  In principal the configuration
+                       remains the same for a given instance of the applet -- i.e. for the
+                       homework question for a single student.  The state however will change
+                       depending on the interactions between the student and the applet.
+
+        setConfigAlias (default: setConfig ) Names the applet command called with the contents
+                       of $self->config to configure the applet.  The parameters are passed to
+                       the applet in plain text using <xml>.  The outer tags must be
+                       <xml>...</xml>.
+
+        initializeActionAlias  (default: initializeAction) The name of the JavaScript subroutine
+                               called to initialize the applet (some overlap with config/ and
+                               setState).
+
+        maxInitializationAttempts  (default: 5) Number attempts to test applet to see if it is
+                                   installed.  If isActive() exists then the WW question waits
+                                   until the return value is 1 before calling the applet's
+                                   confguration commands.  Because some applets have isActive
+                                   return 0 even when they are ready, if isActive() exists but
+                                   does not return 1 then the applet's configuration commands
+                                   are called after maxInitializationAttempts number of times.
+                                   If none of the configuration commands of the applet can be
+                                   detected then the WW question gives up after
+                                   maxInitializationAttempts.
+
+        submitActionAlias  (default: getXML) Applet subroutine called when the submit button of
+                           the pg question is pressed.
+
+        submitActionScript (default: '') Javascript code to be execute when problem answers are
+                           submitted.  For example:
+                               qq{ getQE('answerBox').value = getApplet("$appletName").getAnswer() }
+
+        answerBoxAlias    (default: 'answerBox') Name of answer box to return answer to.
+
+        debugMode         (default: 0)
+                          For debugMode == 1 the answerBox and the box preserving the applet
+                          state between questions are made visible along with some buttons for
+                          manually getting the state of the applet and setting the state of the
+                          applet.
+
+                          For debugMode==2, in addition to the answerBox and stateBox there are
+                          several alerts which mark progress through the procedures of calling
+                          the applet.  Useful for troubleshooting where in the chain of command
+                          a communication failure occurs
+
+    Methods:
+
+        insertHeader    Inserts text in header section of HTML page
+        insertObject    Inserts <article></article> tag in body of the HTML page
+        insertAll       (defined in GeogebraAppletObject.pl) Installs applet by inserting both
+                        header text and the object text
+
             Usage:    $applet->insertAll(
                               includeAnswerBox     => 0,
                               debugMode            => 0,
-                              reinitialize_button  =>0,
+                              reinitialize_button  => 0
                       );
-
 
 =cut
 
-=head4 More details 
+=head4 More details
 
-There are three different "images" of the applet.  The first is the java or flash applet itself.  The object that actually does the work.
-The second is a perl image of the applet -- henceforth the perlApplet -- which is configured in the .pg file and allows a WeBWorK question
-to communicate with the applet.  The third image is a javaScript image of the applet -- henceforth the jsApplet which is a mirror of the perlApplet
-but is available to the javaScript code setup and executed in the virtual HTML page defined by the .pg file of the WeBWorK question. One can think of 
-the jsApplet as a runtime version of the perlApplet since it can be accessed and modified after the virtual HTML page has been created by 
-the PG rendering process.
+There are three different "images" of the applet.  The first is the applet itself.  The object
+that actually does the work.  The second is a perl image of the applet (henceforth the
+perlApplet) which is configured in the pg file and allows a WeBWorK question to communicate with
+the applet.  The third image is a JavaScript image of the applet (henceforth the jsApplet) which
+is a mirror of the perlApplet but is available to the JavaScript code setup and executed in the
+virtual HTML page defined by the pg file of the WeBWorK question. One can think of the jsApplet
+as a runtime version of the perlApplet since it can be accessed and modified after the virtual
+HTML page has been created by the PG rendering process.
 
-The perlApplet is initialized by   $newApplet = new flashApplet( appletName=>'myApplet',..... ); The jsApplet is automatically defined in 
-ww_applet_list["myApplet"] by copying the instance variables of $newApplet to a corresponding javaScript object.  So  $newApplet->{appletName}
-corresponds to ww_applet_list["myApplet"].appletName.  (This paragraph is not yet fully implemented :-().
+The perlApplet is initialized by
+    $newApplet = new flashApplet( appletName=>'myApplet',... );
+The jsApplet is automatically defined in ww_applet_list["myApplet"] by copying the instance
+variables of $newApplet to a corresponding JavaScript object.  So $newApplet->{appletName}
+corresponds to ww_applet_list["myApplet"].appletName.  (This paragraph is not yet fully
+implemented :-().
 
-Currently all messages read by the applet are xml text.  If some of the code needs to be printed in the HTML header than it is converted
-to a base64 constant and then converted back to text form when it is read by a javaScript subroutine.
+Currently all messages read by the applet are xml text.  If some of the code needs to be printed
+in the HTML header than it is converted to a base64 constant and then converted back to text
+form when it is read by a JavaScript subroutine.
 
-The perlApplet has  methods that help place the jsApplet code on the HTML page and create the link to the applet itself. 
-In particular instance variables such as "setStateAlias", "getStateAlias" connect the WW default of "setState" to subroutine
-name chosen by the applet designer.  The aim is to make it easier to connect to applets previously designed to work 
-with javaScript in an HTML page or other  systems.
+The perlApplet has  methods that help place the jsApplet code on the HTML page and create the
+link to the applet itself.  In particular instance variables such as "setStateAlias",
+"getStateAlias" connect the WW default of "setState" to subroutine name chosen by the applet
+designer.  The aim is to make it easier to connect to applets previously designed to work with
+JavaScript in an HTML page or other  systems.
 
-
-The jsApplet acts as an intermediary for commands directed at the applet.  
-It is not necessary for the minimal operations of 
-configuring the applet and maintaining
-state from one viewing of the WW question to address the applet directly.  
-The methods such as "setState", "getState", "setConfig" which are part of the jsApplet 
-take care of the book keeping details.
-It is also possible to make direct calls to the applet from handcrafted javaScript subroutines, 
-but it may be convenient to store these as additional methods in the
-jsApplet. 
+The jsApplet acts as an intermediary for commands directed at the applet.  It is not necessary
+for the minimal operations of configuring the applet and maintaining state from one viewing of
+the WW question to address the applet directly.  The methods such as "setState", "getState",
+"setConfig" which are part of the jsApplet take care of the book keeping details.  It is also
+possible to make direct calls to the applet from handcrafted JavaScript subroutines, but it may
+be convenient to store these as additional methods in the jsApplet.
 
 =cut
 
 =head4 Detecting that the applet is ready
 
-Timing issues are among the pitfalls awaiting when using flash or java applets in WW questions.  It is important that the WW question
-does not issue any commands to the applet until the applet is fully loaded, including the uploading of any additional configuration
-information from XML files.  This can be tricky since the timing issues usually don't arise when initiating the applet from an HTML page.
+Timing issues are among the pitfalls awaiting when using flash or java applets in WW questions.
+It is important that the WW question does not issue any commands to the applet until the applet
+is fully loaded, including the uploading of any additional configuration information from XML
+files.  This can be tricky since the timing issues usually don't arise when initiating the
+applet from an HTML page.
 
 The WW API performs the following actions to determine if the applet is loaded:
 
-	check the ww_applet_list[appletName].isReady flag (1== applet is ready)
-	                    -- this caches the readiness information so that it doesn't 
-	                       have to be repeated within a given viewing of a WW question
-	                       If this is 1 then the applet is ready.
-	determine whether the applet's isActive subroutine is defined AND returns 1 when called. 
-	                    -- if the return value is 1 the applet is ready, if it is zero or no response then the applet is NOT ready
-	                    -- If the applet has an isActive() subroutine -- there is no alias for this --
-	                       then it must return 1 as soon as the applet is ready.  Otherwise
-	                       the applet will timeout.
-	determine whether the applet's setConfig subroutine is defined. 
-	                    -- applet.{setConfigAlias}.  
-	determine whether the applet's setState subroutine is defined.	
-	determine whether the  jsApplets ww_applet_list[appletName].reportsLoaded flag is set to 1
-	                    -- this can be set by the applet if it calls the javaScript function 
-	                       "applet_loaded(appletName, loaded_status).  The loaded_status is 1 or 0
-	                       
-	Logic for determining applet status: if any one of the above checks succeeds (or returns 1) then the applet is 
-	                      consdered to be ready  UNLESS the isActive() exists and the call returns a 0 or no response. In this case 
-	                      the applet is assumed to be loading additional data and is not yet ready. 
-	                      
-	                      For this reason if the isActive subroutine
-	                      is defined in the applet it must return a 1 once the applet is prepared to accept additional commands.
-	                      (Since there are some extent flashApplets with non-functioning isActive() subroutines a temporary workaround
-	                       assuems that after C<maxInitializationAttempts> -- 5 by default -- the applet is in fact ready but the 
-	                       isActive() subroutine is non functioning.  This can give rise to false "readiness" signals if the applet
-	                       takes a long time to load auxiliary files.)
+    Check the ww_applet_list[appletName].isReady flag (1 == applet is ready).
+        -- This caches the readiness information so that it doesn't have to be repeated within a
+           given viewing of a WW question If this is 1 then the applet is ready.
 
-The applet itself can take measures to insure that the setConfig subroutine is prepared to respond immediately once the applet is loaded.
-It can include timers that delay execution of the configuring actions until all of the auxiliary files needed by the applet are loaded.
+    Determine whether the applet's isActive subroutine is defined AND returns 1 when called.
+        -- If the return value is 1 the applet is ready, if it is zero or no response then the
+           applet is NOT ready
+        -- If the applet has an isActive() subroutine (there is no alias for this) then it must
+           return 1 as soon as the applet is ready.  Otherwise the applet will timeout.
 
+    Determine whether the applet's setConfig subroutine is defined.
+        -- $applet->{setConfigAlias}
+
+    Determine whether the applet's setState subroutine is defined.
+
+    Determine whether the jsApplet's ww_applet_list[appletName].reportsLoaded flag is set to 1
+        -- This can be set by the applet if it calls the JavaScript function
+           applet_loaded(appletName, loaded_status).  The loaded_status is 1 or 0.
+
+    Logic for determining applet status:
+        If any one of the above checks succeeds (or returns 1) then the applet is consdered to
+        be ready UNLESS the isActive() exists and the call returns a 0 or no response. In this
+        case the applet is assumed to be loading additional data and is not yet ready.
+
+        For this reason if the isActive subroutine is defined in the applet it must return a 1
+        once the applet is prepared to accept additional commands.
+
+        (Since there are some extent flashApplets with non-functioning isActive() subroutines a
+        temporary workaround assumes that after C<maxInitializationAttempts> (5 by default) the
+        applet is in fact ready but the isActive() subroutine is non functioning.  This can give
+        rise to false "readiness" signals if the applet takes a long time to load auxiliary
+        files.)
+
+The applet itself can take measures to insure that the setConfig subroutine is prepared to
+respond immediately once the applet is loaded.  It can include timers that delay execution of
+the configuring actions until all of the auxiliary files needed by the applet are loaded.
 
 =cut
 
+=head4 Instance variables in the JavaScript applet ww_applet_list[appletName]
 
+    Most of the instance variables in the perl version of the applet are transferred to the
+    JavaScript applet
 
-
-=head4 Instance variables in the javaScript applet   ww_applet_list[appletName]
-
-       Most of the instance variables in the perl version of the applet are transferred to the javaScript applet
-       
 =cut
 
-
-=head4 Methods defined for the javaScript applet   ww_applet_list[appletName]
+=head4 Methods defined for the JavaScript applet ww_applet_list[appletName]
 
 This is not a comprehensive list
 
-	setConfig         -- transmits the information for configuring the applet
-	
-	getConfig         -- retrieves the configuration information -- this is used mainly for debugging and may not be defined in most applets
-	
-	
-	setState          -- sets the current state (1) from the appletName_state HTML element if this contains an <xml>...</xml> string
-	                  -- if the value contains <xml>restart_applet</xml> then set the current state to ww_applet_list[appletName].initialState
-	                  -- if the value is a blank string set the current state to ww_applet_list[appletName].initialState
-	
-	
-	getState          -- retrieves the current state and stores in the appletName_state HTML element.
-	
-	
+    setConfig  -- Transmits the information for configuring the applet.
+
+    getConfig  -- Retrieves the configuration information -- this is used mainly for debugging
+                  and may not be defined in most applets.
+
+    setState   -- Sets the current state (1) from the appletName_state HTML element if this
+                  contains an <xml>...</xml> string.
+               -- If the value contains <xml>restart_applet</xml> then set the current state to
+                  ww_applet_list[appletName].initialState
+               -- If the value is a blank string set the current state to
+                  ww_applet_list[appletName].initialState
+
+    getState   -- Retrieves the current state and stores in the appletName_state HTML element.
+
 =cut
 
 =head4 Requirements for applets
 
-The following methods are desirable in an applet that preserves state in a WW question.  None of them are required.
+The following methods are desirable in an applet that preserves state in a WW question.  None of
+them are required.
 
-	setState(str)   (default: setXML)  
-	                   -- set the current state of the applet from an xml string
-	                   -- should be able to accept an empty string or a string of
-	                      the form <XML>.....</XML> without creating errors
-	                   -- can be designed to receive other forms of input if it is 
-	                      coordinated with the WW question.
-	getState()      (default: getXML)
-	     	           -- return the current state of the applet in an xml string.
-	                   -- an empty string or a string of the form <XML>.....</XML> 
-	                      are the standard responses.
-	                   -- can be designed to return other strings if it is 
-	                      coordinated with the WW question.
-	setConfig(str) (default: setConfig) 
-	                   -- If the applet allows configuration this configures the applet
-	                      from an xml string
-      	               -- should be able to accept an empty string or a string of the 
-      	                  form <XML>.....</XML> without creating errors
-	                   -- can be designed to receive other forms of input if it is 
-	                      coordinated with the WW question.
-    getConfig      (default: getConfig) 
-	                   -- This returns a string defining the configuration of the 
-	                      applet in an xml string
-  	                   -- an empty string or a string of the form <XML>.....</XML> 
-  	                      are the standard responses.
-	                   -- can be designed to return other strings if it is 
-	                      coordinated with the WW question.
-	                   -- this method is used for debugging to ensure that 
-	                      the configuration was set as expected.
-	getAnswer      (default: getAnswer)
-	                   -- Returns a string (usually NOT xml) which is the 
-	                      response that the student is effectvely submitting to answer
-	                      the WW question.
+    setState(str)   (default: setXML)
+                    -- Set the current state of the applet from an xml string.
+                    -- Should be able to accept an empty string or a string of the form
+                       <XML>...</XML> without creating errors.
+                    -- Can be designed to receive other forms of input if it is coordinated with
+                       the WW question.
 
+    getState()      (default: getXML)
+                    -- Return the current state of the applet in an xml string.
+                    -- An empty string or a string of the form <XML>...</XML> are the standard
+                       responses.
+                    -- Can be designed to return other strings if it is coordinated with the WW
+                       question.
+
+    setConfig(str)  (default: setConfig)
+                    -- If the applet allows configuration this configures the applet from an xml
+                       string.
+                    -- Should be able to accept an empty string or a string of the form
+                       <xml>...</xml> without creating errors.
+                    -- Can be designed to receive other forms of input if it is coordinated with
+                       the WW question.
+
+    getConfig       (default: getConfig)
+                    -- This returns a string defining the configuration of the applet in an xml
+                       string.
+                    -- An empty string or a string of the form <XML>...</XML> are the standard
+                       responses.
+                    -- Can be designed to return other strings if it is coordinated with the WW
+                       question.
+                    -- This method is used for debugging to ensure that the configuration was
+                       set as expected.
+
+    getAnswer       (default: getAnswer)
+                    -- Returns a string (usually NOT xml) which is the response that the student
+                    is effectvely submitting to answer the WW question.
 
 =cut
 
 =head4 Initialization sequence
 
-When the WW question is loaded the C<initializeWWquestion> javaScript subroutine calls each of the applets used in the question asking them
-to initialize themselves.
+When the WW question is loaded the C<initializeWWquestion> JavaScript subroutine calls each of
+the applets used in the question asking them to initialize themselves.
 
 The applets initialization method is as follows:
-                   
-                       -- wait until the applet is loaded and the applet has loaded all of its auxiliary files.
-                       -- set the debugMode in the applet
-                       -- call the setConfig  method in the javaScript applet  -- (configuration parameters are "permanent" for the life of the applet
-                       -- call the setInitialization method in the javaScript applet -- this often calls the setState method in the applet                      
+
+    -- Wait until the applet is loaded and the applet has loaded all of its auxiliary files.
+    -- Set the debugMode in the applet.
+    -- Call the setConfig method in the JavaScript applet
+       (configuration parameters are "permanent" for the life of the applet).
+    -- Call the setInitialization method in the JavaScript applet.  This often calls the
+       setState method in the applet
 
 =cut
 
+=head4 Submit sequence
 
-=head Submit sequence
+When the WW question submit button is pressed the form containing the WW question calles the
+JavaScript "submitAction()" which then asks each of the applets on the page to perform its
+submit action which consists of
 
-When the WW question submit button is pressed the form containing the WW question calles the javaScript "submitAction()" which then asks
-each of the applets on the page to perform its submit action which consists of 
-
-	-- if the applet is to be reinitialized (appletName_state contains <xml>restart_applet</xml>) then 
-	   the HTML elements appletName_state and previous_appletName_state are set to <xml>restart_applet</xml>
-	   to be interpreted by the next setState command
-	-- Otherwise getState() from the applet and save it to the  HTML input element appletName_state
-	-- Perform the javaScript commands in .submitActionScript (default: '' )
-	   a typical submitActionScript looks like getQE(this.answerBox).value = getApplet(appletName).getAnswer()  )
+    -- If the applet is to be reinitialized (appletName_state contains
+       <xml>restart_applet</xml>) then the HTML elements appletName_state and
+       previous_appletName_state are set to <xml>restart_applet</xml> to be interpreted by the
+       next setState command.
+    -- Otherwise getState() from the applet and save it to the HTML input element
+       appletName_state.
+    -- Perform the JavaScript commands in submitActionScript (default: '').
+       A typical submitActionScript looks like:
+           getQE(this.answerBox).value = getApplet(appletName).getAnswer()
 
 =cut
-
 
 sub new {
-	 my $class = shift; 
-	 my $self = { 
-		appletName  => '',
-		appletId    => '',   #always use identical applet Id's and applet Names
-        archive     => '',
-		code        => '',
-		codebase    => '',
-		params    =>undef,
-		width     => 550,
-		height    => 400,
-		bgcolor   => "#869ca7",
-		type      => '',
-		visible   => 0,
-		configuration      => '',         # configuration defining the applet
-		initialState       => '',         # initial state.  
-		getStateAlias      =>  'getXML',
-		setStateAlias      =>  'setXML',
-		configAlias        =>  '',        # deprecated
-		getConfigAlias     =>  'getConfig',
-		setConfigAlias     =>  'setConfig',
-		initializeActionAlias => 'setXML',
-		maxInitializationAttempts => 5,   # number of attempts to initialize applet
-		submitActionAlias  =>  'getXML',
-		submitActionScript  => '',        # script executed on submitting the WW question
-		answerBoxAlias     =>  'answerBox',
-		answerBox          =>  '',        # deprecated
-		returnFieldName    => '',         # deprecated
-		headerText         =>  DEFAULT_HEADER_TEXT(),
-		objectText         => '',
-		debugMode          => 0,
-		selfLoading        => 0,
+	my $class = shift;
+	my $self = {
+		appletName                => '',
+		appletId                  => '', # Always use identical applet Id's and applet Names
+		archive                   => '',
+		code                      => '',
+		codebase                  => '',
+		params                    => undef,
+		width                     => 550,
+		height                    => 400,
+		bgcolor                   => "#869ca7",
+		type                      => '',
+		visible                   => 0,
+		configuration             => '', # configuration defining the applet
+		initialState              => '', # initial state.
+		getStateAlias             => 'getXML',
+		setStateAlias             => 'setXML',
+		configAlias               => '', # deprecated
+		getConfigAlias            => 'getConfig',
+		setConfigAlias            => 'setConfig',
+		initializeActionAlias     => 'setXML',
+		maxInitializationAttempts => 5, # number of attempts to initialize applet
+		submitActionAlias         => 'getXML',
+		submitActionScript        => '', # script executed on submitting the WW question
+		answerBoxAlias            => 'answerBox',
+		answerBox                 => '', # deprecated
+		returnFieldName           => '', # deprecated
+		headerText                => DEFAULT_HEADER_TEXT(),
+		objectText                => '',
+		debugMode                 => 0,
+		selfLoading               => 0,
 		@_,
 	};
 	bless $self, $class;
 	$self->initialState('<xml></xml>');
-	if ($self->{returnFieldName} or $self->{answerBox} ) { # backward compatibility
+	# Backward compatibility and deprecation warnings.
+	if ($self->{returnFieldName} || $self->{answerBox}) {
 		warn "use answerBoxAlias instead of returnFieldName or answerBox";
-		$self->{answerBox}='';
-		$self->{returnFieldName}='';
+		$self->{answerBox} = '';
+		$self->{returnFieldName} = '';
 	}
-	if ($self->{configAlias}) { # backward compatibility
+	if ($self->{configAlias}) {
 		warn "use setConfigAlias instead of configAlias";
-		$self->{configAlias}='';
+		$self->{configAlias} = '';
 	}
 	$self->configuration('<xml></xml>');
 	return $self;
 }
-sub appletId {  
+
+# Accessor methods
+
+sub appletId {
 	appletName(@_);
 }
+
 sub appletName {
 	my $self = shift;
-	$self->{appletName} = shift ||$self->{appletName}; # replace the current appletName if non-empty
-    $self->{appletName};
+	$self->{appletName} = shift || $self->{appletName};
+	$self->{appletName};
 }
+
 sub archive {
 	my $self = shift;
-	$self->{archive} = shift ||$self->{archive}; # replace the current archive if non-empty
-    $self->{archive};
+	$self->{archive} = shift || $self->{archive};
+	$self->{archive};
 }
+
 sub code {
 	my $self = shift;
-	$self->{code} = shift ||$self->{code}; # replace the current code if non-empty
-    $self->{code};
+	$self->{code} = shift || $self->{code};
+	$self->{code};
 }
+
 sub codebase {
 	my $self = shift;
-	$self->{codebase} = shift ||$self->{codebase}; # replace the current codebase if non-empty
-    $self->{codebase};
+	$self->{codebase} = shift || $self->{codebase};
+	$self->{codebase};
 }
+
 sub params {
 	my $self = shift;
-	if (ref($_[0]) =~/HASH/) {
+	if (ref($_[0]) =~ /HASH/) {
 		$self->{params} = shift;
-	} elsif ( !defined($_[0]) or $_[0] =~ '') {
-		# do nothing (read)
-	} else {
+	} elsif (defined($_[0])) {
 		warn "You must enter a reference to a hash for the parameter list";
 	}
 	$self->{params};
@@ -478,101 +503,111 @@ sub params {
 
 sub width {
 	my $self = shift;
-	$self->{width} = shift ||$self->{width}; # replace the current width if non-empty
-    $self->{width};
+	$self->{width} = shift || $self->{width};
+	$self->{width};
 }
+
 sub height {
 	my $self = shift;
-	$self->{height} = shift ||$self->{height}; # replace the current height if non-empty
-    $self->{height};
+	$self->{height} = shift || $self->{height};
+	$self->{height};
 }
+
 sub bgcolor {
 	my $self = shift;
-	$self->{bgcolor} = shift ||$self->{bgcolor}; # replace the current background color if non-empty
-    $self->{bgcolor};
+	$self->{bgcolor} = shift || $self->{bgcolor};
+	$self->{bgcolor};
 }
 
 sub  header {
 	my $self = shift;
-	if ($_[0] eq "reset") {  # $applet->header('reset');  erases default header text.
-		$self->{headerText}='';
-	} else {	
-		$self->{headerText} .= join("",@_);  # $applet->header(new_text); concatenates new_text to existing header.
+	# $applet->header('reset'); erases default header text.
+	if ($_[0] eq "reset") {
+		$self->{headerText} = '';
+	} else {
+		# $applet->header(new_text); concatenates new_text to existing header.
+		$self->{headerText} .= join("", @_);
 	}
-    $self->{headerText};
+	$self->{headerText};
 }
+
 sub  object {
 	my $self = shift;
 	if ($_[0] eq "reset") {
-		$self->{objectText}='';
-	} else {	
-		$self->{objectText} .= join("",@_);
+		$self->{objectText} = '';
+	} else {
+		$self->{objectText} .= join("", @_);
 	}
-    $self->{objectText};
+	$self->{objectText};
 }
+
 sub configuration {
 	my $self = shift;
 	my $str = shift;
-	$self->{configuration} =  $str   || $self->{configuration}; # replace the current string if non-empty
+	$self->{configuration} =  $str || $self->{configuration};
 	$self->{configuration} =~ s/\n//g;
-    $self->{configuration};
+	$self->{configuration};
 }
 
 sub initialState {
 	my $self = shift;
 	my $str = shift;
-	$self->{initialState} = $str   ||$self->{initialState}; # replace the current string if non-empty
-    $self->{initialState};
+	$self->{initialState} = $str || $self->{initialState};
+	$self->{initialState};
 }
 
 sub getStateAlias {
 	my $self = shift;
-	$self->{getStateAlias} = shift ||$self->{getStateAlias}; # replace the current contents if non-empty
-    $self->{getStateAlias};
+	$self->{getStateAlias} = shift || $self->{getStateAlias};
+	$self->{getStateAlias};
 }
 
 sub setStateAlias {
 	my $self = shift;
-	$self->{setStateAlias} = shift ||$self->{setStateAlias}; # replace the current contents if non-empty
-    $self->{setStateAlias};
+	$self->{setStateAlias} = shift ||$self->{setStateAlias};
+	$self->{setStateAlias};
 }
 
 sub getConfigAlias {
 	my $self = shift;
-	$self->{getConfigAlias} = shift ||$self->{getConfigAlias}; # replace the current contents if non-empty
-    $self->{getConfigAlias};
+	$self->{getConfigAlias} = shift || $self->{getConfigAlias};
+	$self->{getConfigAlias};
 }
+
 sub setConfigAlias {
 	my $self = shift;
-	$self->{setConfigAlias} = shift ||$self->{setConfigAlias}; # replace the current contents if non-empty
-    $self->{setConfigAlias};
+	$self->{setConfigAlias} = shift || $self->{setConfigAlias};
+	$self->{setConfigAlias};
 }
 
 sub initializeActionAlias {
 	my $self = shift;
-	$self->{initializeActionAlias} = shift ||$self->{initializeActionAlias}; # replace the current contents if non-empty
-    $self->{initializeActionAlias};
+	$self->{initializeActionAlias} = shift || $self->{initializeActionAlias};
+	$self->{initializeActionAlias};
 }
+
 sub maxInitializationAttempts {
 	my $self = shift;
 	$self->{maxInitializationAttempts} = shift || $self->{maxInitializationAttempts};
 	$self->{maxInitializationAttempts};
-}	
+}
+
 sub submitActionAlias {
 	my $self = shift;
-	$self->{submitActionAlias} = shift ||$self->{submitActionAlias}; # replace the current contents if non-empty
-    $self->{submitActionAlias};
+	$self->{submitActionAlias} = shift || $self->{submitActionAlias};
+	$self->{submitActionAlias};
 }
+
 sub submitActionScript {
 	my $self = shift;
-	$self->{submitActionScript} = shift ||$self->{submitActionScript}; # replace the current contents if non-empty
-    $self->{submitActionScript};
+	$self->{submitActionScript} = shift || $self->{submitActionScript};
+	$self->{submitActionScript};
 }
 
 sub answerBoxAlias {
 	my $self = shift;
-	$self->{answerBox} = shift ||$self->{answerBox}; # replace the current contents if non-empty
-    $self->{answerBox};
+	$self->{answerBox} = shift || $self->{answerBox};
+	$self->{answerBox};
 }
 
 sub debugMode {
@@ -582,7 +617,6 @@ sub debugMode {
 	$self->{debugMode};
 }
 
-
 #######################
 # soon to be deprecated?
 #######################
@@ -590,277 +624,231 @@ sub debugMode {
 sub config {
 	my $self = shift;
 	my $str = shift;
-	warn "use $self->configuration instead of $self->config.  Internally this string is ascii, not base64 encoded", join(' ', caller());
-# 	$self->{base64_config} =  encode_base64($str)   || $self->{base64_config}; # replace the current string if non-empty
-# 	$self->{base64_config} =~ s/\n//g;
-#     decode_base64($self->{base64_config});
+	warn "use $self->configuration instead of $self->config.  " .
+		"Internally this string is ascii, not base64 encoded", join(' ', caller());
 }
-sub state {    #deprecated
+
+# deprecated
+sub state {
 	my $self = shift;
 	my $str = shift;
-	warn "use $self->initialState instead of $self->state.  Internally this string is ascii, not base64 encoded", join(' ', caller());
-# 	$self->{base64_state} =  encode_base64($str)   ||$self->{base64_state}; # replace the current string if non-empty
-# 	$self->{base64_state} =~ s/\n//g;
-#     decode_base64($self->{base64_state});
+	warn "use $self->initialState instead of $self->state.  " .
+		"Internally this string is ascii, not base64 encoded", join(' ', caller());
 }
+
 sub base64_state{
 	my $self = shift;
-	warn "use $self->InitialState instead of $self->state.  Internally this string is ascii, not base64 encoded", join(' ', caller());
-
-
+	warn "use $self->InitialState instead of $self->state.  " .
+		"Internally this string is ascii, not base64 encoded", join(' ', caller());
 }
 
 sub base64_config {
 	my $self = shift;
-	warn "use $self->configuration instead of $self->config.  Internally this string is ascii, not base64 encoded";
+	warn "use $self->configuration instead of $self->config.  " .
+		"Internally this string is ascii, not base64 encoded";
 }
 
 sub returnFieldName {
 	my $self = shift;
-    warn "use  answerBoxName  instead of returnFieldName";
+	warn "use answerBoxName instead of returnFieldName";
 }
+
 sub answerBox {
 	my $self = shift;
-    warn "use  answerBoxAlias  instead of AnswerBox";
+	warn "use answerBoxAlias instead of AnswerBox";
 }
+
 sub configAlias {
 	my $self = shift;
-    warn "use setConfigAlias instead of configAlias";
+	warn "use setConfigAlias instead of configAlias";
 }
-#########################
+
 #FIXME
 # need to be able to adjust header material
 
 sub insertHeader {
-    my $self = shift;
+	my $self = shift;
 
-    my $codebase              =  $self->codebase;
-    my $appletId              =  $self->appletId;
-    my $appletName            =  $self->appletName;
-    my $initializeActionAlias =  $self->initializeActionAlias;
-    my $submitActionScript    =  $self->submitActionScript;
-    my $setStateAlias         =  $self->setStateAlias;
-    my $getStateAlias         =  $self->getStateAlias;
+	my $codebase              = $self->codebase;
+	my $appletId              = $self->appletId;
+	my $appletName            = $self->appletName;
+	my $initializeActionAlias = $self->initializeActionAlias;
+	# Replace newlines and returns with spaces. These can cause trouble in the JavaScript.
+	my $submitActionScript    = $self->submitActionScript =~ s/\n|\r/ /gr;
+	my $setStateAlias         = $self->setStateAlias;
+	my $getStateAlias         = $self->getStateAlias;
 
-    my $setConfigAlias        =  $self->setConfigAlias;
-    my $getConfigAlias        =  $self->getConfigAlias;
-    my $maxInitializationAttempts = $self->maxInitializationAttempts;
-    my $debugMode             =  ($self->debugMode) ? "1": "0";
-    my $answerBoxAlias        =  $self->{answerBoxAlias};
-    my $onInit                =  $self->{onInit};   # function to indicate that applet is loaded (for geogebra:   ggbOnInit
-    my $headerText            =  $self->header();
-    my $selfLoading           =  $self->{selfLoading};
-    
-    #$submitActionScript =~ s/"/\\"/g;    # escape quotes for ActionScript
-                                         # other variables should not have quotes.
-                                         
-    $submitActionScript =~ s/\n/ /g;     # replace returns with spaces -- returns in the wrong spot can cause trouble with javaScript
-    $submitActionScript =~ s/\r/ /g;     # replace returns with spaces -- returns can cause trouble
-    my  $base64_submitActionScript =     encode_base64($submitActionScript);
-    my $base64_configuration  =  encode_base64($self->configuration);
-    my $base64_initialState   =  encode_base64($self->initialState);
- 
-    $base64_submitActionScript =~s/\n//g;
-    $base64_initialState  =~s/\n//g;  # base64 encoded xml
-    $base64_configuration =~s/\n//g;  # base64 encoded xml
-    
-    $headerText =~ s/(\$\w+)/$1/gee;   # interpolate variables p17 of Cookbook
-  
-    return $headerText;
+	my $setConfigAlias        = $self->setConfigAlias;
+	my $getConfigAlias        = $self->getConfigAlias;
+	my $maxInitializationAttempts = $self->maxInitializationAttempts;
+	my $debugMode             = ($self->debugMode) ? "1": "0";
+	my $answerBoxAlias        = $self->{answerBoxAlias};
+	# Function to indicate that applet is loaded (for geogebra:  ggbOnInit)
+	my $onInit                = $self->{onInit};
+	my $headerText            = $self->header();
+	my $selfLoading           = $self->{selfLoading};
 
+	my $base64_submitActionScript = encode_base64($submitActionScript) =~ s/\n//gr;
+	# These are base64 encoded xml.
+	my $base64_configuration = encode_base64($self->configuration) =~ s/\n//gr;
+	my $base64_initialState = encode_base64($self->initialState) =~ s/\n//gr;
 
+	$headerText =~ s/(\$\w+)/$1/gee;
+
+	return $headerText;
 }
 
-
 ########################################################
-# HEADER material for one flash or java applet
+# HEADER material for a flash or java applet
 ########################################################
 
-use constant DEFAULT_HEADER_TEXT =><<'END_HEADER_SCRIPT';
-  	<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript">
-    </script> 	
-  	<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript">
-  	    //upload functions stored in /opt/webwork/webwork2/htdocs/js ...
-  	    
-     </script>
-	<script language="JavaScript">
-	
-     function getApplet(appletName) {
-	 	  var isIE = navigator.appName.indexOf("Microsoft") != -1;  // ie8 uses this for java and firefox uses it for flash.
-	 	  var obj = (isIE) ? window[appletName] : window.document[appletName];
-	 	  //return window.document[appletName];
-	 	  if (!obj) { obj = document.getElementById(appletName) }
-	 	  if (obj ) {   //RECENT FIX to ==
-	 		  return( obj );
-	 	  } else {
-		      // Commented out because if the applet is in a hint
-		      // this might be run with no applet
-		      // alert ("can't find applet " + appletName);		  
-	 	  }
-	  }	
-		
-   	//////////////////////////////////////////////////////////
-	//TEST code
-	//
-    // 
-    //////////////////////////////////////////////////////////
-   
-    ww_applet_list["$appletName"]                  = new ww_applet("$appletName");
-    
-    
-	ww_applet_list["$appletName"].code             = "$code";
-	ww_applet_list["$appletName"].codebase         = "$codebase";
-    ww_applet_list["$appletName"].appletID         = "$appletID";
-	ww_applet_list["$appletName"].base64_state     = "$base64_initialState";
-	ww_applet_list["$appletName"].initialState     =  Base64.decode("$base64_initialState");
-	ww_applet_list["$appletName"].configuration    =  Base64.decode("$base64_configuration");;
-	ww_applet_list["$appletName"].getStateAlias    = "$getStateAlias";
-	ww_applet_list["$appletName"].setStateAlias    = "$setStateAlias";
-	ww_applet_list["$appletName"].setConfigAlias   = "$setConfigAlias";
-	ww_applet_list["$appletName"].getConfigAlias   = "$getConfigAlias";
-	ww_applet_list["$appletName"].initializeActionAlias = "$initializeActionAlias";
-	ww_applet_list["$appletName"].submitActionAlias = "$submitActionAlias";
-	ww_applet_list["$appletName"].submitActionScript = Base64.decode("$base64_submitActionScript");
-	ww_applet_list["$appletName"].answerBoxAlias     = "$answerBoxAlias";
-	ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
-	ww_applet_list["$appletName"].debugMode          = "$debugMode";
-	ww_applet_list["$appletName"].onInit             = "$onInit";	
+use constant DEFAULT_HEADER_TEXT => <<'END_HEADER_SCRIPT';
+<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript"></script>
+<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript"></script>
+<script language="JavaScript">
+function getApplet(appletName) {
+	var obj = window.document[appletName];
+	if (!obj) { obj = document.getElementById(appletName) }
+	if (obj) {
+		return( obj );
+	} else {
+		// Commented out because if the applet is in a hint
+		// this might be run with no applet
+		// alert ("can't find applet " + appletName);
+	}
+}
 
+// TEST code
 
-    </script>
-	
+ww_applet_list["$appletName"] = new ww_applet("$appletName");
+
+ww_applet_list["$appletName"].code                      = "$code";
+ww_applet_list["$appletName"].codebase                  = "$codebase";
+ww_applet_list["$appletName"].appletID                  = "$appletID";
+ww_applet_list["$appletName"].base64_state              = "$base64_initialState";
+ww_applet_list["$appletName"].initialState              = Base64.decode("$base64_initialState");
+ww_applet_list["$appletName"].configuration             = Base64.decode("$base64_configuration");;
+ww_applet_list["$appletName"].getStateAlias             = "$getStateAlias";
+ww_applet_list["$appletName"].setStateAlias             = "$setStateAlias";
+ww_applet_list["$appletName"].setConfigAlias            = "$setConfigAlias";
+ww_applet_list["$appletName"].getConfigAlias            = "$getConfigAlias";
+ww_applet_list["$appletName"].initializeActionAlias     = "$initializeActionAlias";
+ww_applet_list["$appletName"].submitActionAlias         = "$submitActionAlias";
+ww_applet_list["$appletName"].submitActionScript        = Base64.decode("$base64_submitActionScript");
+ww_applet_list["$appletName"].answerBoxAlias            = "$answerBoxAlias";
+ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
+ww_applet_list["$appletName"].debugMode                 = "$debugMode";
+ww_applet_list["$appletName"].onInit                    = "$onInit";
+</script>
 END_HEADER_SCRIPT
 
-
-
 sub insertObject {
-    my $self       = shift;
-    my $code       = $self->{code};
-    my $codebase   = $self->{codebase};
-    my $appletId   = $self->{appletName};
-    my $appletName = $self->{appletName};
-    my $archive    = $self->{archive};
-    my $width      = $self->{width};
-    my $height     = $self->{height};
-    my $applet_bgcolor = $self->{bgcolor};
-    my $selfLoading = $self->{selfLoading};
-    my $javaParameters = '';
-    my $flashParameters = '';
-    my $webgeogebraParameters = '';
-    if (PGUtil::not_null($self->{parameter_string}) ) {
-    	$javaParameters = $self->{parameter_string};
-    	$flashParameters = $self->{parameter_string};
-    	$webgeogebraParameters = $self->{parameter_string};
-    } else {
+	my $self = shift;
+
+	my $code           = $self->{code};
+	my $codebase       = $self->{codebase};
+	my $appletId       = $self->{appletName};
+	my $appletName     = $self->{appletName};
+	my $archive        = $self->{archive};
+	my $width          = $self->{width};
+	my $height         = $self->{height};
+	my $applet_bgcolor = $self->{bgcolor};
+	my $selfLoading    = $self->{selfLoading};
+
+	my $javaParameters = '';
+	my $flashParameters = '';
+	my $webgeogebraParameters = '';
+
+	if (PGUtil::not_null($self->{parameter_string})) {
+		$javaParameters = $self->{parameter_string};
+		$flashParameters = $self->{parameter_string};
+		$webgeogebraParameters = $self->{parameter_string};
+	} else {
 		my %param_hash = %{$self->params()};
 
 		foreach my $key (keys %param_hash) {
-			$javaParameters .= qq!<param name ="$key"  value = "$param_hash{$key}">\n!;
-			$flashParameters .= uri_escape($key).'='.uri_escape($param_hash{$key}).'&';
+			$javaParameters .= qq!<param name="$key" value="$param_hash{$key}">\n!;
+			$flashParameters .= uri_escape($key) . '=' . uri_escape($param_hash{$key}) . '&';
 			$webgeogebraParameters .= qq!data-param-$key = "$param_hash{$key}"\n!;
 		}
-		$flashParameters =~ s/\&$//;    # trim last &
+		$flashParameters =~ s/\&$//; # trim last &
 		$webgeogebraParameters = qq!<article class="geogebraweb"
-		 data-param-id     = "$appletName"
-		 data-param-width  = "$width"
-		 data-param-height = "$height"
-		 !. $webgeogebraParameters . 
-		 qq!\n
-		> </article> !;
+			data-param-id     = "$appletName"
+			data-param-width  = "$width"
+			data-param-height = "$height"
+			!. $webgeogebraParameters . qq!\n></article>!;
 	}
-  
-   
-    $objectText = $self->{objectText};
-    $objectText =~ s/(\$\w+)/$1/gee;  # interpolate values into object text 
-    $objectText .=qq{<script language="javascript">ww_applet_list["$appletName"].visible = 1;</script>}; # don't submit things if not visible
-    return $objectText;
+
+	$objectText = $self->{objectText};
+	$objectText =~ s/(\$\w+)/$1/gee;
+	# Don't submit things if not visible
+	$objectText .= qq{<script language="javascript">ww_applet_list["$appletName"].visible = 1;</script>};
+	return $objectText;
 }
 
-
-###############################################################################################################
-#
-# FLASH APPLET  PACKAGE
-#
-###############################################################################################################
+################################################################################################
+# FLASH APPLET PACKAGE
+################################################################################################
 
 package FlashApplet;
 @ISA = qw(Applet);
-
 
 =head2 Insertion HTML code for FlashApplet
 
 =pod
 
-The secret to making this applet work with IE in addition to normal browsers
-is the addition of the C(<form></form>) construct just before the object.
-
-For some reason IE has trouble locating a flash object which is contained
-within a form.  Adding this second blank form with the larger problemMainForm
-seems to solve the problem.  
-
-This follows method2 of the advice given in url(http://kb.adobe.com/selfservice/viewContent.do?externalId=kb400730&sliceId=2)
-Method1 and methods involving SWFObject(Geoff Stearns) and SWFFormFix (Steve Kamerman) have yet to be fully investigated:
-http://devel.teratechnologies.net/swfformfix/swfobject_swfformfix_source.js
-http://www.teratechnologies.net/stevekamerman/index.php?m=01&y=07&entry=entry070101-033933
-
-		use constant DEFAULT_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-		  <form></form>
-		  <object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
-					 id="$appletName" width="500" height="375"
-					 codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab">
-				 <param name="movie" value="$codebase/$appletName.swf" />
-				 <param name="quality" value="high" />
-				 <param name="bgcolor" value="$applet_bgcolor" />
-				 <param name="allowScriptAccess" value="sameDomain" />
-				 <embed src="$codebase/$appletName.swf" quality="high" bgcolor="$applet_bgcolor"
-					 width="$width" height="$height" name="$appletName" align="middle" id="$appletName"
-					 play="true" loop="false" quality="high" allowScriptAccess="sameDomain"
-					 type="application/x-shockwave-flash"
-					 pluginspage="http://www.macromedia.com/go/getflashplayer">
-				 </embed>
-		
-			 </object>
-		END_OBJECT_TEXT
-
+    use constant FLASH_OBJECT_TEXT =><<'END_OBJECT_TEXT';
+    <object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
+            id="$appletName"  width="500" height="375"
+            codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab">
+    <param name="movie" value="$codebase/$appletName.swf" />
+    <param name="quality" value="high" />
+    <param name="bgcolor" value="$applet_bgcolor" />
+    <param name="allowScriptAccess" value="sameDomain" />
+    <param name="FlashVars" value="$flashParameters"/>
+    <embed src="$codebase/$appletName.swf" quality="high" bgcolor="$applet_bgcolor"
+           width="$width" height="$height" name="$appletName"  align="middle" id="$appletName"
+           play="true" loop="false" quality="high" allowScriptAccess="sameDomain"
+           type="application/x-shockwave-flash"
+           pluginspage="http://www.macromedia.com/go/getflashplayer"
+           FlashVars="$flashParameters">
+    </embed>
+    </object>
+    END_OBJECT_TEXT
 
 =cut
 
-use constant DEFAULT_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-
-
-  <object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" 
-             id="$appletName"  width="500" height="375"
-             codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab">
-         <param name="movie" value="$codebase/$appletName.swf" />
-         <param name="quality" value="high" />
-         <param name="bgcolor" value="$applet_bgcolor" />
-         <param name="allowScriptAccess" value="sameDomain" />
-         <param name="FlashVars" value="$flashParameters"/>
-         <embed src="$codebase/$appletName.swf" quality="high" bgcolor="$applet_bgcolor"
-             width="$width" height="$height" name="$appletName"  align="middle" id="$appletName"
-             play="true" loop="false" quality="high" allowScriptAccess="sameDomain"
-             type="application/x-shockwave-flash"
-             pluginspage="http://www.macromedia.com/go/getflashplayer"
-             FlashVars="$flashParameters">
-         </embed>
-
-     </object>
+use constant FLASH_OBJECT_TEXT =><<'END_OBJECT_TEXT';
+<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"
+        id="$appletName"  width="500" height="375"
+        codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab">
+<param name="movie" value="$codebase/$appletName.swf" />
+<param name="quality" value="high" />
+<param name="bgcolor" value="$applet_bgcolor" />
+<param name="allowScriptAccess" value="sameDomain" />
+<param name="FlashVars" value="$flashParameters"/>
+<embed src="$codebase/$appletName.swf" quality="high" bgcolor="$applet_bgcolor"
+       width="$width" height="$height" name="$appletName"  align="middle" id="$appletName"
+       play="true" loop="false" quality="high" allowScriptAccess="sameDomain"
+       type="application/x-shockwave-flash"
+       pluginspage="http://www.macromedia.com/go/getflashplayer"
+       FlashVars="$flashParameters">
+</embed>
+</object>
 END_OBJECT_TEXT
 
 sub new {
-    my $class = shift;
-	$class -> SUPER::new(	objectText   => DEFAULT_OBJECT_TEXT(),
-	                        type         => 'flash',
-		        			@_
+	my $class = shift;
+	$class->SUPER::new(
+		objectText => FLASH_OBJECT_TEXT(),
+		type       => 'flash',
+		@_
 	);
-
 }
 
-###############################################################################################################
-#
-# JAVA APPLET  PACKAGE
-#
-###############################################################################################################
+################################################################################################
+# JAVA APPLET PACKAGE
+################################################################################################
 
 package JavaApplet;
 @ISA = qw(Applet);
@@ -869,312 +857,220 @@ package JavaApplet;
 
 =pod
 
-The secret to making this applet work with IE in addition to normal browsers
-is the addition of the C(<form></form>) construct just before the object.
+    use constant JAVA_OBJECT_TEXT => <<'END_OBJECT_TEXT';
 
-For some reason IE has trouble locating a flash object which is contained
-within a form.  Adding this second blank form with the larger problemMainForm
-seems to solve the problem.  
+    <applet
+        code     = "$code"
+        codebase = "$codebase"
+        archive  = "$archive"
+        name     = "$appletName"
+        id       = "$appletName"
+        width    = "$width"
+        height   = "$height"
+        bgcolor  = "$applet_bgcolor"
+        mayscript = "true";
+    >
+    $javaParameters
 
-This follows method2 of the advice given in url(http://kb.adobe.com/selfservice/viewContent.do?externalId=kb400730&sliceId=2)
-Method1 and methods involving SWFObject(Geoff Stearns) and SWFFormFix (Steve Kamerman) have yet to be fully investigated:
-http://devel.teratechnologies.net/swfformfix/swfobject_swfformfix_source.js
-http://www.teratechnologies.net/stevekamerman/index.php?m=01&y=07&entry=entry070101-033933
-
-		use constant DEFAULT_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-		 <applet
-			code     = "$code"
-			codebase = "$codebase"
-			archive  = "$archive"
-			name     = "$appletName"
-			id       = "$appletName"
-			width    = "$width"
-			height   = "$height"
-			MAYSCRIPT
-		 >
-		  $javaParameters
-		 </applet>
-		END_OBJECT_TEXT
+    Sorry, the Applet could not be started. Please make sure that
+    Java 1.4.2 (or later) is installed and activated.
+    (<a href="http://java.sun.com/getjava">click here to install Java now</a>)
+    </applet>
+    END_OBJECT_TEXT
 
 =cut
 
-
-=pod
-
-use constant DEFAULT_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-
- <applet
- 	code     = "$code"
- 	codebase = "$codebase"
- 	archive  = "$archive"
- 	name     = "$appletName"
+use constant JAVA_OBJECT_TEXT => <<'END_OBJECT_TEXT';
+<applet
     id       = "$appletName"
-    width    = "$width"
+    name     = "$appletName"
+    code      = "$code"
+    type     = "application/x-java-applet"
+    codebase = "$codebase"
+    archive  = "$archive"
     height   = "$height"
+    width    = "$width"
     bgcolor  = "$applet_bgcolor"
-    mayscript = "true";
- >
-  $javaParameters
-  
-  Sorry, the Applet could not be started. Please make sure that
-Java 1.4.2 (or later) is installed and activated. 
+    mayscript = "true"
+>
+<PARAM NAME="MAYSCRIPT" VALUE="true">
+$javaParameters
+
+Sorry, the Applet could not be started. Please make sure that
+Java 1.4.2 (or later) is installed and activated.
 (<a href="http://java.sun.com/getjava">click here to install Java now</a>)
- </applet>
-END_OBJECT_TEXT
-
-=cut
-
-#  classid  = "java:MyApplet.class"
-
-
-use constant DEFAULT_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-
-<applet 
-     id       = "$appletName"
-     name     = "$appletName"
-     code      = "$code"
-     type     = "application/x-java-applet"
-     codebase = "$codebase"
-	 archive  = "$archive" 
-	 height   = "$height" 
-	 width    = "$width"
-	 bgcolor  = "$applet_bgcolor"
-	 mayscript = "true"
-	>
-	  <PARAM NAME="MAYSCRIPT" VALUE="true">
-	  $javaParameters
-
-	 Sorry, the Applet could not be started. Please make sure that
-	Java 1.4.2 (or later) is installed and activated. 
-	(<a href="http://java.sun.com/getjava">click here to install Java now</a>)
 </applet>
 END_OBJECT_TEXT
 
-
-
 sub new {
-    my $class = shift;
-	$class -> SUPER::new(	objectText   => DEFAULT_OBJECT_TEXT(),
-	                        type         => 'java',
-		        			@_
+	my $class = shift;
+	$class->SUPER::new(
+		objectText => JAVA_OBJECT_TEXT(),
+		type       => 'java',
+		@_
 	);
-
 }
 
 ###############################################################################################################
-#
-# CANVAS APPLET  PACKAGE
-#
+# CANVAS APPLET PACKAGE
 ###############################################################################################################
 
 package CanvasApplet;
 @ISA = qw(Applet);
 
-
 =head2 Insertion HTML code for CanvasApplet
 
 =pod
 
-The secret to making this applet work with IE in addition to normal browsers
-is the addition of the C(<form></form>) construct just before the object.
-
-For some reason IE has trouble locating a flash object which is contained
-within a form.  Adding this second blank form with the larger problemMainForm
-seems to solve the problem.  
-
-This follows method2 of the advice given in url(http://kb.adobe.com/selfservice/viewContent.do?externalId=kb400730&sliceId=2)
-Method1 and methods involving SWFObject(Geoff Stearns) and SWFFormFix (Steve Kamerman) have yet to be fully investigated:
-http://devel.teratechnologies.net/swfformfix/swfobject_swfformfix_source.js
-http://www.teratechnologies.net/stevekamerman/index.php?m=01&y=07&entry=entry070101-033933
-
-use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-  <form></form>
-	<script> var width = 200; var height = 200;</script>
-	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
-END_OBJECT_TEXT
-
-
+    use constant CANVAS_OBJECT_TEXT => <<'END_OBJECT_TEXT';
+    <canvas name="cv" id="cv"
+            data-src="/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs"
+            width="$width" height="$height">
+    </canvas>
+    END_OBJECT_TEXT
 
 =cut
 
+use constant CANVAS_OBJECT_HEADER_TEXT => <<'END_HEADER_SCRIPT';
+<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript"></script>
+<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript"></script>
+<script language="JavaScript">
+//CANVAS OBJECT HEADER CODE
 
-use constant CANVAS_OBJECT_HEADER_TEXT =><<'END_HEADER_SCRIPT';
-  	<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript">
-    </script> 	
-  	<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript">
-  	    //upload functions stored in /opt/webwork/webwork2/htdocs/js ...
-  	    
-     </script>
-	<script language="JavaScript">
-	
+ww_applet_list["$appletName"] = new ww_applet("$appletName");
 
-		
-   	//////////////////////////////////////////////////////////
-	//CANVAS OBJECT HEADER CODE
-    // 
-    //////////////////////////////////////////////////////////
-   
-    ww_applet_list["$appletName"] = new ww_applet("$appletName");
-    
-    
-	ww_applet_list["$appletName"].code             = "$code";
-	ww_applet_list["$appletName"].codebase         = "$codebase";
-    ww_applet_list["$appletName"].appletID         = "$appletID";
-	ww_applet_list["$appletName"].base64_state     = "$base64_initializationState";
-	ww_applet_list["$appletName"].initialState     = Base64.decode("$base64_initialState");
-	ww_applet_list["$appletName"].configuration    = Base64.decode("$base64_configuration");;
-	ww_applet_list["$appletName"].getStateAlias    = "$getStateAlias";
-	ww_applet_list["$appletName"].setStateAlias    = "$setStateAlias";
-	ww_applet_list["$appletName"].setConfigAlias   = "$setConfigAlias";
-	ww_applet_list["$appletName"].getConfigAlias   = "$getConfigAlias";
-	ww_applet_list["$appletName"].initializeActionAlias = "$initializeActionAlias";
-	ww_applet_list["$appletName"].submitActionAlias = "$submitActionAlias";
-	ww_applet_list["$appletName"].submitActionScript = Base64.decode("$base64_submitActionScript");
-	ww_applet_list["$appletName"].answerBoxAlias = "$answerBoxAlias";
-	ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
-	ww_applet_list["$appletName"].debugMode = "$debugMode";	
-    ww_applet_list["$appletName"].reportsLoaded = "$selfLoading";
-    ww_applet_list["$appletName"].onInit             = "$onInit";	
-    ww_applet_list["$appletName"].object = $appletName;
-    
-    function getApplet(appletName) {
-	 	  var obj = ww_applet_list[appletName].object;   // define fake applet for this object
-	 	  if (obj && (obj.name == appletName)) {   //RECENT FIX to ==
-	 	      //alert("getting fake applet " + obj.name);
-	 		  return( obj );
-	 	  } else {
-	 		  //alert ("can't find fake applet " + appletName + " in object "+obj.name);		  
-	 	  }
-	  }	
-    </script>
-	
+ww_applet_list["$appletName"].code                      = "$code";
+ww_applet_list["$appletName"].codebase                  = "$codebase";
+ww_applet_list["$appletName"].appletID                  = "$appletID";
+ww_applet_list["$appletName"].base64_state              = "$base64_initializationState";
+ww_applet_list["$appletName"].initialState              = Base64.decode("$base64_initialState");
+ww_applet_list["$appletName"].configuration             = Base64.decode("$base64_configuration");;
+ww_applet_list["$appletName"].getStateAlias             = "$getStateAlias";
+ww_applet_list["$appletName"].setStateAlias             = "$setStateAlias";
+ww_applet_list["$appletName"].setConfigAlias            = "$setConfigAlias";
+ww_applet_list["$appletName"].getConfigAlias            = "$getConfigAlias";
+ww_applet_list["$appletName"].initializeActionAlias     = "$initializeActionAlias";
+ww_applet_list["$appletName"].submitActionAlias         = "$submitActionAlias";
+ww_applet_list["$appletName"].submitActionScript        = Base64.decode("$base64_submitActionScript");
+ww_applet_list["$appletName"].answerBoxAlias            = "$answerBoxAlias";
+ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
+ww_applet_list["$appletName"].debugMode                 = "$debugMode";
+ww_applet_list["$appletName"].reportsLoaded             = "$selfLoading";
+ww_applet_list["$appletName"].onInit                    = "$onInit";
+ww_applet_list["$appletName"].object                    = $appletName;
+
+function getApplet(appletName) {
+	var obj = ww_applet_list[appletName].object; // Define fake applet for this object
+	if (obj && obj.name == appletName) {
+		return obj;
+	}
+}
+</script>
 END_HEADER_SCRIPT
 
-
 #FIXME   need to get rid of hardcoded url
-
-
-use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-    <script language="javascript">ww_applet_list["$appletName"].visible = 1; // don't submit things if not visible
-    </script>
-	<canvas name="cv" id="cv" data-src="/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="$width" height="$height"></canvas>  
+use constant CANVAS_OBJECT_TEXT => <<'END_OBJECT_TEXT';
+<canvas name="cv" id="cv"
+        data-src="/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs"
+        width="$width" height="$height">
+</canvas>
 END_OBJECT_TEXT
 
 sub new {
-    my $class = shift;
-	$class -> SUPER::new(	objectText   => CANVAS_OBJECT_TEXT(),
-			                headerText   => CANVAS_OBJECT_HEADER_TEXT(),
-			                type         => 'html5canvas',
-		        			@_
+	my $class = shift;
+	$class->SUPER::new(
+		objectText => CANVAS_OBJECT_TEXT(),
+		headerText => CANVAS_OBJECT_HEADER_TEXT(),
+		type       => 'html5canvas',
+		@_
 	);
-
 }
 
 ###############################################################################################################
-#
-# GeogebraWeb APPLET  PACKAGE
-#
+# GeogebraWeb APPLET PACKAGE
 ###############################################################################################################
 
 package GeogebraWebApplet;
 @ISA = qw(Applet);
 
-
 =head2 Insertion HTML code for GeogebraWebApplet
 
 =pod
 
-
-use constant CANVAS_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-  <form></form>
-	<script> var width = 200; var height = 200;</script>
-	<canvas name="cv" id="cv" data-src="http://localhost/webwork2_files/js/legacy/sketchgraphhtml5b/SketchGraph.pjs" width="400" height="400"></canvas>  
-END_OBJECT_TEXT
-
-
+    use constant GEOGEBRAWEB_OBJECT_TEXT => <<'END_OBJECT_TEXT';
+    <div class="enclose_geogebra_object">
+    <div class="geogebra_object">
+    <script type="text/javascript" language="javascript"
+            src="//web.geogebra.org/4.4/web/web.nocache.js"></script>
+    $webgeogebraParameters
+    </div>
+    </div>
+    END_OBJECT_TEXT
 
 =cut
 
+use constant GEOGEBRAWEB_OBJECT_HEADER_TEXT => <<'END_HEADER_SCRIPT';
+<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript"></script>
+<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript"></script>
+<script language="JavaScript">
+// GEOGEBRAWEB OBJECT HEADER CODE
 
-use constant GEOGEBRAWEB_OBJECT_HEADER_TEXT =><<'END_HEADER_SCRIPT';
-  	<script src="/webwork2_files/js/apps/Base64/Base64.js" language="javascript">
-    </script> 	
-  	<script src="/webwork2_files/js/apps/AppletSupport/ww_applet_support.js" language="javascript">
-  	    //upload functions stored in /opt/webwork/webwork2/htdocs/js ...
-  	    
-     </script>
-	<script language="JavaScript">
-	
+ww_applet_list["$appletName"] = new ww_applet("$appletName");
 
-		
-   	//////////////////////////////////////////////////////////
-	//GEOGEBRAWEB OBJECT HEADER CODE
-    // 
-    //////////////////////////////////////////////////////////
-   
-    ww_applet_list["$appletName"] = new ww_applet("$appletName");
-    
-    
-	ww_applet_list["$appletName"].code             = "$code";
-	ww_applet_list["$appletName"].codebase         = "$codebase";
-    ww_applet_list["$appletName"].appletID         = "$appletID";
-	ww_applet_list["$appletName"].base64_state     = "$base64_initializationState";
-	ww_applet_list["$appletName"].initialState     = Base64.decode("$base64_initialState");
-	ww_applet_list["$appletName"].configuration    = Base64.decode("$base64_configuration");;
-	ww_applet_list["$appletName"].getStateAlias    = "$getStateAlias";
-	ww_applet_list["$appletName"].setStateAlias    = "$setStateAlias";
-	ww_applet_list["$appletName"].setConfigAlias   = "$setConfigAlias";
-	ww_applet_list["$appletName"].getConfigAlias   = "$getConfigAlias";
-	ww_applet_list["$appletName"].initializeActionAlias = "$initializeActionAlias";
-	ww_applet_list["$appletName"].submitActionAlias = "$submitActionAlias";
-	ww_applet_list["$appletName"].submitActionScript = Base64.decode("$base64_submitActionScript");
-	ww_applet_list["$appletName"].answerBoxAlias = "$answerBoxAlias";
-	ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
-	ww_applet_list["$appletName"].debugMode           = "$debugMode";	
-    ww_applet_list["$appletName"].reportsLoaded       = "$selfLoading";
-    ww_applet_list["$appletName"].isReady             = "$selfLoading";
-    ww_applet_list["$appletName"].onInit              = "$onInit";	
-    
-    function getApplet(appletName) {
-	 	  var obj = document.$appletName;
-	 	  ww_applet_list[appletName].object = obj ;   // define fake applet for this object
-	 	  return(obj);
-	  }	
-    </script>
-	
+ww_applet_list["$appletName"].code                      = "$code";
+ww_applet_list["$appletName"].codebase                  = "$codebase";
+ww_applet_list["$appletName"].appletID                  = "$appletID";
+ww_applet_list["$appletName"].base64_state              = "$base64_initializationState";
+ww_applet_list["$appletName"].initialState              = Base64.decode("$base64_initialState");
+ww_applet_list["$appletName"].configuration             = Base64.decode("$base64_configuration");;
+ww_applet_list["$appletName"].getStateAlias             = "$getStateAlias";
+ww_applet_list["$appletName"].setStateAlias             = "$setStateAlias";
+ww_applet_list["$appletName"].setConfigAlias            = "$setConfigAlias";
+ww_applet_list["$appletName"].getConfigAlias            = "$getConfigAlias";
+ww_applet_list["$appletName"].initializeActionAlias     = "$initializeActionAlias";
+ww_applet_list["$appletName"].submitActionAlias         = "$submitActionAlias";
+ww_applet_list["$appletName"].submitActionScript        = Base64.decode("$base64_submitActionScript");
+ww_applet_list["$appletName"].answerBoxAlias            = "$answerBoxAlias";
+ww_applet_list["$appletName"].maxInitializationAttempts = $maxInitializationAttempts;
+ww_applet_list["$appletName"].debugMode                 = "$debugMode";
+ww_applet_list["$appletName"].reportsLoaded             = "$selfLoading";
+ww_applet_list["$appletName"].isReady                   = "$selfLoading";
+ww_applet_list["$appletName"].onInit                    = "$onInit";
+
+function getApplet(appletName) {
+	var obj = document.$appletName;
+	ww_applet_list[appletName].object = obj;
+	return(obj);
+}
+</script>
 END_HEADER_SCRIPT
 
-# Some changes in the way geogebra javaScript works make it important
-# That the object and the script that calls it are contained in some <div>
-# (otherwise geogebra adds height and width values to the second enclosing <div> 
-# (i.e. the div enclosing the enclosing div) and 
-# if the div contains more than just the geogebra applet this size will be incorrect. )
-# (This behavior is probably a bug in geogebra -- 
-# but I don't have a precise statement of the API.)
-# The <div class="enclose_geogebra_object> and <div class="geogebra_object" do nothing for now
-# but perhaps they might have a use later. style="height:306 ptx,width: 486 ptx" is inserted in 
-# the class="enclose_geogebra_object" div by the geogebra applet. 
+# Some changes in the way geogebra JavaScript works make it important That the object and the
+# script that calls it are contained in some <div> (otherwise geogebra adds height and width
+# values to the second enclosing <div> (i.e. the div enclosing the enclosing div) and if the div
+# contains more than just the geogebra applet this size will be incorrect. ) (This behavior is
+# probably a bug in geogebra -- but I don't have a precise statement of the API.) The <div
+# class="enclose_geogebra_object> and <div class="geogebra_object" do nothing for now but
+# perhaps they might have a use later. style="height:306 ptx,width: 486 ptx" is inserted in the
+# class="enclose_geogebra_object" div by the geogebra applet.
 
-use constant GEOGEBRAWEB_OBJECT_TEXT =><<'END_OBJECT_TEXT';
-    <div class="enclose_geogebra_object">
-    <div class="geogebra_object">
-    <script language="javascript">ww_applet_list["$appletName"].visible = 1; // don't submit things if not visible
-    </script>
+use constant GEOGEBRAWEB_OBJECT_TEXT => <<'END_OBJECT_TEXT';
+<div class="enclose_geogebra_object">
+<div class="geogebra_object">
 <script type="text/javascript" language="javascript" src="//web.geogebra.org/4.4/web/web.nocache.js"></script>
-
 $webgeogebraParameters
-	</div>
-	</div>
+</div>
+</div>
 END_OBJECT_TEXT
 
 sub new {
-    my $class = shift;
-	$class -> SUPER::new(	objectText   => GEOGEBRAWEB_OBJECT_TEXT(),
-			                headerText   => GEOGEBRAWEB_OBJECT_HEADER_TEXT(),
-			                type         => 'geogebraweb',
-		        			@_
+	my $class = shift;
+	$class->SUPER::new(
+		objectText => GEOGEBRAWEB_OBJECT_TEXT(),
+		headerText => GEOGEBRAWEB_OBJECT_HEADER_TEXT(),
+		type       => 'geogebraweb',
+		@_
 	);
-
 }
 
 1;

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -86,7 +86,6 @@ sub new {
 		ARRAY_PREFIX              => 'ArRaY',
 		vec_num                   => 0,     # for distinguishing matrices
 		QUIZ_PREFIX               => $envir->{QUIZ_PREFIX},
-		SECTION_PREFIX            => '',  # might be used for sequential (compound) questions?
 		PG_VERSION                => $ENV{PG_VERSION},
 		PG_ACTIVE                 => 1,   # toggle to zero to stop processing
 		submittedAnswers          => 0,   # have any answers been submitted? is this the first time this session?
@@ -335,7 +334,6 @@ sub LABELED_ANS{
   my @in = @_;
   while (@in ) {
   	my $label    = shift @in;
-  	#$label       = join("", $self->{QUIZ_PREFIX}, $self->{SECTION_PREFIX}, $label);
   	my $ans_eval = shift @in;
   	$self->warning_message("<BR><B>Error in LABELED_ANS:|$label|</B>
   	      -- inputs must be references to AnswerEvaluator objects or subroutines<BR>")

--- a/macros/AppletObjects.pl
+++ b/macros/AppletObjects.pl
@@ -1,13 +1,12 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: pg/macros/AppletObjects.pl,v 1.24 2010/01/03 17:13:46 gage Exp $
-# 
+# Copyright &copy; 2000-2020 The WeBWorK Project, http://openwebwork.sf.net/
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -18,66 +17,46 @@
 
 AppletObjects.pl - Macro-based front end for the Applet.pm module.
 
-
 =head1 DESCRIPTION
 
-This subroutines in this 
-file provide mechanisms to insert Flash applets (and  Java applets)
-into a WeBWorK problem.
-
+This subroutines in this file provide mechanisms to insert Flash applets (and Java applets) into
+a WeBWorK problem.
 
 See also L<http://webwork.maa.org/pod/pg_TRUNK/lib/Applet.html>.
 
 =cut
 
-#########################################################################
-#
 # Add basic functionality to the header of the question
-#
-# don't reload this file
-#########################################################################
-
-sub _AppletObjects_init{ 
-
+sub _AppletObjects_init{
 main::HEADER_TEXT(<<'END_HEADER_TEXT');
-  <script language="javascript">AC_FL_RunContent = 0;</script>
-    <script src="/webwork2_files/applets/AC_RunActiveContent.js" language="javascript">
-    </script>
+<script language="javascript">AC_FL_RunContent = 0;</script>
+<script src="/webwork2_files/applets/AC_RunActiveContent.js" language="javascript"></script>
 END_HEADER_TEXT
-
 };
 
 =head3  FlashApplet
 
-	Useage:    $applet = FlashApplet();
+    Useage:    $applet = FlashApplet(...);
 
 =cut
 
 sub FlashApplet {
 	return new FlashApplet(@_);
-
 }
 
 =head3  JavaApplet
 
-	Useage:    $applet = JavaApplet(
-	
-	
-	);
+    Useage:    $applet = JavaApplet(...);
 
 =cut
 
 sub JavaApplet {
 	return new JavaApplet(@_);
-
 }
 
 =head3  CanvasApplet
 
-	Useage:    $applet = CanvasApplet(
-	
-	
-	);
+    Useage:    $applet = CanvasApplet(...);
 
 =cut
 
@@ -87,10 +66,7 @@ sub CanvasApplet {
 
 =head3  GeogebraWebApplet
 
-	Useage:    $applet = GeogebraWebApplet(
-	
-	
-	);
+    Useage:    $applet = GeogebraWebApplet(...);
 
 =cut
 
@@ -100,347 +76,270 @@ sub GeogebraWebApplet {
 
 package Applet;
 
-
-
 =head1 Methods
 
 =cut
 
-## this method is defined in this file 
-## because the main subroutines HEADER_TEXT and MODES are 
-## not available to the module FlashApplet when that file
-## is compiled (at the time the apache child process is first initialized)
+# This method is defined in this file because the main subroutines HEADER_TEXT and MODES are not
+# available to the module FlashApplet when that file is compiled (at the time the apache child
+# process is first initialized).
 
 =head3  insertAll
 
-	Useage:   TEXT( $applet->insertAll() );
-	          \{ $applet->insertAll() \}     (used within BEGIN_TEXT/END_TEXT blocks)
+    Useage:  TEXT( $applet->insertAll() );
+             \{ $applet->insertAll() \}  (used within BEGIN_TEXT/END_TEXT blocks)
 
-=cut 
+=cut
 
-=pod 
+=pod
 
-Inserts applet at this point in the HTML code.  (In TeX mode a message "Applet" is written.)  This method
-also adds the applets header material into the header portion of the HTML page. It effectively inserts
-the outputs of both C<$applet-E<gt>insertHeader> and C<$applet-E<gt>insertObject> (defined in L<Applet.pm> ) 
-in the appropriate places. In addition it creates a hidden answer blank for storing the state of the applet
-and provides mechanisms for revealing the state while debugging the applet.
+Inserts applet at this point in the HTML code.  (In TeX mode a message "Applet" is written.)
+This method also adds the applets header material into the header portion of the HTML page. It
+effectively inserts the outputs of both C<$applet-E<gt>insertHeader> and
+C<$applet-E<gt>insertObject> (defined in L<Applet.pm> ) in the appropriate places. In addition
+it creates a hidden answer blank for storing the state of the applet and provides mechanisms for
+revealing the state while debugging the applet.
 
-Note: This method is defined here rather than in Applet.pl because it 
-      requires access to the RECORD_FORM_LABEL subroutine
-      and to the routine accessing the stored values of the answers.  These are defined in main::.
+Note: This method is defined here rather than in Applet.pl because it requires access to the
+      RECORD_FORM_LABEL subroutine and to the routine accessing the stored values of the
+      answers.  These are defined in main::.
       FIXME -- with the creation of the PGcore object this can now be rewritten
 
 =cut
 
-sub insertAll {  ## inserts both header text and object text
+# Inserts both header text and object text.
+sub insertAll {
 	my $self = shift;
 	my %options = @_;
-	
-	
-	##########################
-	# determine debug mode
+
+	# Determine debug mode
 	# debugMode can be turned on by setting it to 1 in either the applet definition or at insertAll time
-	##########################
-
-	my $debugMode = (defined($options{debug}) and $options{debug}>0) ? $options{debug} : 0;
-	my $includeAnswerBox = (defined($options{includeAnswerBox}) and $options{includeAnswerBox}==1) ? 1 : 0;
+	my $debugMode = (defined($options{debug}) && $options{debug} > 0) ? $options{debug} : 0;
+	my $includeAnswerBox = (defined($options{includeAnswerBox}) && $options{includeAnswerBox} == 1) ? 1 : 0;
 	$debugMode = $debugMode || $self->debugMode;
-    $self->debugMode( $debugMode);
+	$self->debugMode( $debugMode);
 
-	
 	my $reset_button = $options{reinitialize_button} || 0;
-	warn qq! please change  "reset_button=>1" to "reinitialize_button=>1" in the applet->installAll() command \n! if defined($options{reset_button});
+	warn qq! please change  "reset_button => 1" to "reinitialize_button => 1" in the applet->installAll() command \n!
+	if defined($options{reset_button});
 
-	##########################
-	# Get data to be interpolated into the HTML code defined in this subroutine
-	#
-    # This consists of the name of the applet and the names of the routines 
-    # to get and set State of the applet (which is done every time the question page is refreshed
-    # and to get and set Config  which is the initial configuration the applet is placed in 
-    # when the question is first viewed.  It is also the state which is returned to when the 
-    # reset button is pressed.
-	##########################
+	# Get data to be interpolated into the HTML code defined in this subroutine.
+	# This consists of the name of the applet and the names of the routines to get and set State
+	# of the applet (which is done every time the question page is refreshed and to get and set
+	# Config  which is the initial configuration the applet is placed in when the question is
+	# first viewed.  It is also the state which is returned to when the reset button is pressed.
 
-	# prepare html code for storing state 
-	my $appletName      = $self->appletName;
-	my $appletStateName = "${appletName}_state";   # the name of the hidden "answer" blank storing state FIXME -- use persistent data instead
-	my $getState        = $self->getStateAlias;    # names of routines for this applet
-	my $setState        = $self->setStateAlias;
-	my $getConfig       = $self->getConfigAlias;
-	my $setConfig       = $self->setConfigAlias;
+	# Prepare html code for storing state.
+	my $appletName = $self->appletName;
+	# The name of the hidden "answer" blank storing state.
+	my $appletStateName = "${appletName}_state";
 
-	my $base64_initialState     = encode_base64($self->initialState);
-	main::RECORD_FORM_LABEL($appletStateName);            #this insures that the state will be saved from one invocation to the next
-	                                                      # FIXME -- with PGcore the persistant data mechanism can be used instead
-    my $answer_value = '';
+	# Names of routines for this applet
+	my $getState = $self->getStateAlias;
+	my $setState = $self->setStateAlias;
+	my $getConfig = $self->getConfigAlias;
+	my $setConfig = $self->setConfigAlias;
 
-	##########################
-	# implement the sticky answer mechanism for maintaining the applet state when the question page is refreshed
-	# This is important for guest users for whom no permanent record of answers is recorded.
-	##########################
-	
-    if ( defined( ${$main::inputs_ref}{$appletStateName} ) and ${$main::inputs_ref}{$appletStateName} =~ /\S/ ) {   
+	my $base64_initialState = encode_base64($self->initialState);
+	# This insures that the state will be saved from one invocation to the next.
+	# FIXME -- with PGcore the persistant data mechanism can be used instead
+	main::RECORD_FORM_LABEL($appletStateName);
+	my $answer_value = '';
+
+	# Implement the sticky answer mechanism for maintaining the applet state when the question
+	# page is refreshed This is important for guest users for whom no permanent record of
+	# answers is recorded.
+	if (defined(${$main::inputs_ref}{$appletStateName}) && ${$main::inputs_ref}{$appletStateName} =~ /\S/) {
 		$answer_value = ${$main::inputs_ref}{$appletStateName};
-	} elsif ( defined( $main::rh_sticky_answers->{$appletStateName} )  ) {
-	    warn "type of sticky answers is ", ref( $main::rh_sticky_answers->{$appletStateName} );
-		$answer_value = shift( @{ $main::rh_sticky_answers->{$appletStateName} });
+	} elsif (defined($main::rh_sticky_answers->{$appletStateName})) {
+		warn "type of sticky answers is ", ref($main::rh_sticky_answers->{$appletStateName});
+		$answer_value = shift(@{$main::rh_sticky_answers->{$appletStateName}});
 	}
-	$answer_value =~ tr/\\$@`//d;   #`## make sure student answers can not be interpolated by e.g. EV3
-	$answer_value =~ s/\s+/ /g;     ## remove excessive whitespace from student answer
-	
-	##########################
-	# insert a hidden answer blank to hold the applet's state 
-	# (debug =>1 makes it visible for debugging and provides debugging buttons)
-	##########################
+	$answer_value =~ tr/\\$@`//d; # Make sure student answers can not be interpolated by e.g. EV3
+	$answer_value =~ s/\s+/ /g; # Remove excessive whitespace from student answer
 
+	# Insert a hidden answer blank to hold the applet's state.
+	# (debug => 1 makes it visible for debugging and provides debugging buttons)
 
-	##########################
-	# Regularize the applet's state -- which could be in either XML format or in XML format encoded by base64
-	# In rare cases it might be simple string -- protect against that by putting xml tags around the state
+	# Regularize the applet's state which could be in either XML format or in XML format encoded by base64.
+	# In rare cases it might be simple string.  Protect against that by putting xml tags around the state.
 	# The result:
 	# $base_64_encoded_answer_value -- a base64 encoded xml string
-	# $decoded_answer_value         -- and xml string
-	##########################
-    	
+	# $decoded_answer_value         -- an xml string
+
 	my $base_64_encoded_answer_value;
 	my $decoded_answer_value;
-	if ( $answer_value =~/<XML|<?xml/i) {
+	if ($answer_value =~ /<XML|<?xml/i) {
 		$base_64_encoded_answer_value = encode_base64($answer_value);
 		$decoded_answer_value = $answer_value;
 	} else {
 		$decoded_answer_value = decode_base64($answer_value);
-		if ( $decoded_answer_value =~/<XML|<?xml/i) {  # great, we've decoded the answer to obtain an xml string
+		if ($decoded_answer_value =~/<XML|<?xml/i) {
+			# Great, we've decoded the answer to obtain an xml string
 			$base_64_encoded_answer_value = $answer_value;
-		} else {    #WTF??  apparently we don't have XML tags
+		} else {
+			#WTF??  apparently we don't have XML tags
 			$answer_value = "<xml>$answer_value</xml>";
 			$base_64_encoded_answer_value = encode_base64($answer_value);
 			$decoded_answer_value = $answer_value;
 		}
-	}	
-	$base_64_encoded_answer_value =~ s/\r|\n//g;    # get rid of line returns
-
-	##########################
-    # Construct answer blank for storing state -- in both regular (answer blank hidden) 
-    # and debug (answer blank displayed) modes.
-	##########################
-	
-	##########################
-    # debug version of the applet state answerBox and controls (all displayed)
-    # stored in 
-    # $debug_input_element
-	##########################
-
-#     my $debug_input_element  = qq!\n<textarea  rows="4" cols="80" 
-# 	   name = "$appletStateName" id = "$appletStateName">$decoded_answer_value</textarea><br/>!;
-#  conversion to base64 is now being done in the setState module
-#  when submitting we want everything to be in the base64 mode for safety
-    my $debug_input_element  = qq!\n<textarea  rows="4" cols="80" 
-	   name = "$appletStateName" id = "$appletStateName">$answer_value</textarea><br/>!;
-
-	if ($getState=~/\S/) {   # if getStateAlias is not an empty string
-		$debug_input_element .= qq!
-	        <input type="button"  value="$getState" 
-	               onClick=" debugText=''; 
-	                         ww_applet_list['$appletName'].getState() ; 
-	                        if (debugText) {alert(debugText)};"
-	        />!;
 	}
-	if ($setState=~/\S/) {   # if setStateAlias is not an empty string
-		$debug_input_element .= qq!
-	        <input type="button"  value="$setState" 
-	               onClick="debugText='';
-	                        ww_applet_list['$appletName'].setState();
-	                        if (debugText) {alert(debugText)};"
-	        />!;
+	$base_64_encoded_answer_value =~ s/\r|\n//g; # Get rid of line returns
+
+	# Construct answer blank for storing state -- in both regular (answer blank hidden)
+	# and debug (answer blank displayed) modes.
+
+	# Debug version of the applet state answerBox and controls (all displayed) stored in
+	# $debug_input_element
+
+	# When submitting we want everything to be in the base64 mode for safety.
+	my $debug_input_element  = qq!\n<textarea  rows="4" cols="80"
+		name="$appletStateName" id="$appletStateName">$answer_value</textarea><br/>!;
+
+	if ($getState =~ /\S/) {
+		$debug_input_element .= qq!<input type="button"  value="$getState"
+			onClick="debugText=''; ww_applet_list['$appletName'].getState(); if (debugText) {alert(debugText)};"/>!;
 	}
-	if ($getConfig=~/\S/) {   # if getConfigAlias is not an empty string
-		$debug_input_element .= qq!
-	        <input type="button"  value="$getConfig" 
-	               onClick="debugText=''; 
-	                        ww_applet_list['$appletName'].getConfig();
-	                        if (debugText) {alert(debugText)};"
-	        />!;
+	if ($setState =~ /\S/) {
+		$debug_input_element .= qq!<input type="button"  value="$setState"
+			onClick="debugText=''; ww_applet_list['$appletName'].setState(); if (debugText) {alert(debugText)};"/>!;
 	}
-	if ($setConfig=~/\S/) {   # if setConfigAlias is not an empty string
-		$debug_input_element .= qq!
-		    <input type="button"  value="$setConfig" 
-	               onClick="debugText='';
-	                        ww_applet_list['$appletName'].setConfig();
-	                        if (debugText) {alert(debugText)};"
-            />!;
-    }
-    
-	##########################
-    # Construct answerblank for storing state
-    # using either the debug version (defined above) or the non-debug version
-    # where the state variable is hidden and the definition is very simple
-    # stored in 
-    # $state_input_element
-	##########################
-	        
+	if ($getConfig=~/\S/) {
+		$debug_input_element .= qq!<input type="button"  value="$getConfig"
+			onClick="debugText=''; ww_applet_list['$appletName'].getConfig(); if (debugText) {alert(debugText)};"/>!;
+	}
+	if ($setConfig=~/\S/) {
+		$debug_input_element .= qq!<input type="button"  value="$setConfig"
+			onClick="debugText=''; ww_applet_list['$appletName'].setConfig(); if (debugText) {alert(debugText)};"/>!;
+	}
+
+	# Construct answerblank for storing state using either the debug version (defined above) or
+	# the non-debug version where the state variable is hidden and the definition is very
+	# simple.
 	my $state_input_element = ($debugMode) ? $debug_input_element :
-	      qq!\n<input type="hidden" name = "$appletStateName" id = "$appletStateName"  value ="$base_64_encoded_answer_value">!;
-	      
-	##########################
-    # Construct the reset button string (this is blank if the button is not to be displayed
-    # $reset_button_str
-	##########################
+		qq!\n<input type="hidden" name="$appletStateName" id="$appletStateName"  value="$base_64_encoded_answer_value">!;
 
-    my $reset_button_str = ($reset_button) ?
-            qq!<input type='submit' name='previewAnswers' id ='previewAnswers' value='return this question to its initial state' 
-                 onClick="setHTMLAppletStateToRestart('$appletName')"><br/>!
-            : ''  ;
+	# Construct the reset button string (this is blank if the button is not to be displayed).
+	my $reset_button_str = ($reset_button) ?
+		qq!<input type='submit' name='previewAnswers' id='previewAnswers' value='return this question to its initial state'
+		onClick="setHTMLAppletStateToRestart('$appletName')"><br/>!
+		: '';
 
-	##########################
-	# Combine the state_input_button and the reset button into one string
-	# $state_storage_html_code
-	##########################
+	# Combine the state_input_button and the reset button into one string.
+	$state_storage_html_code = qq!<input type="hidden" name="previous_$appletStateName"
+		id="previous_$appletStateName" value = "$base_64_encoded_answer_value">!
+		. $state_input_element . $reset_button_str;
 
-
-    $state_storage_html_code = qq!<input type="hidden"  name="previous_$appletStateName" id = "previous_$appletStateName"  value = "$base_64_encoded_answer_value">!              
-                              . $state_input_element. $reset_button_str
-                             ;
-	##########################
-	# Construct the answerBox (if it is requested).  This is a default input box for interacting 
-	# with the applet.  It is separate from maintaining state but it often contains similar data.
-	# Additional answer boxes or buttons can be defined but they must be explicitly connected to 
-	# the applet with additional javaScript commands.
-	# Result: $answerBox_code
-	##########################
-
-    my $answerBox_code ='';
-    if ($includeAnswerBox) {
+	# Construct the answerBox (if it is requested).  This is a default input box for interacting
+	# with the applet.  It is separate from maintaining state but it often contains similar
+	# data.  Additional answer boxes or buttons can be defined but they must be explicitly
+	# connected to the applet with additional javaScript commands.
+	my $answerBox_code = '';
+	if ($includeAnswerBox) {
 		if ($debugMode) {
-		
-			$answerBox_code = $main::BR . main::NAMED_ANS_RULE('answerBox', 50 );
-			$answerBox_code .= qq!
-							 <br/><input type="button" value="get Answer from applet" onClick="eval(ww_applet_list['$appletName'].submitActionScript )"/>
-							 <br/>
-							!;
+			$answerBox_code = $main::BR . main::NAMED_ANS_RULE('answerBox', 50);
+			$answerBox_code .= qq!<br/><input type="button" value="get Answer from applet"
+				onClick="eval(ww_applet_list['$appletName'].submitActionScript )"/><br/>!;
 		} else {
-			$answerBox_code = main::NAMED_HIDDEN_ANS_RULE('answerBox', 50 );
+			$answerBox_code = main::NAMED_HIDDEN_ANS_RULE('answerBox', 50);
 		}
 	}
-	
-	##########################
-    # insert header material
-	##########################
+
+	# Insert header material
 	main::HEADER_TEXT($self->insertHeader());
-	# update the debug mode for this applet.
-    main::HEADER_TEXT(qq!<script language="javascript"> ww_applet_list["$appletName"].debugMode = $debugMode;\n</script>!);
-    
-	##########################
-    # Return HTML or TeX strings to be included in the body of the page
-	##########################
-        
-    return main::MODES(TeX=>' {\bf  applet } ', HTML=>$self->insertObject.$main::BR.$state_storage_html_code.$answerBox_code, PTX=>' applet ');
+	# Update the debug mode for this applet.
+	main::HEADER_TEXT(qq!<script language="javascript">ww_applet_list["$appletName"].debugMode = $debugMode;\n</script>!);
+
+	# Return HTML or TeX strings to be included in the body of the page
+	return main::MODES(
+		TeX =>' {\bf applet } ',
+		HTML => $self->insertObject.$main::BR.$state_storage_html_code.$answerBox_code,
+		PTX =>' applet '
+	);
 }
 
 =head3 Example problem
 
-
 =cut
-
-
 
 =pod
 
+    DOCUMENT();
 
-	DOCUMENT();
-	
-	# Load whatever macros you need for the problem
-	loadMacros("PG.pl",
-			   "PGbasicmacros.pl",
-			   "PGchoicemacros.pl",
-			   "PGanswermacros.pl",
-			   "AppletObjects.pl",
-			   "MathObjects.pl",
-			   "source.pl"
-			  );
-	 
-	## Do NOT show partial correct answers
-	$showPartialCorrectAnswers = 0;
-	
-	
-	
-	###################################
-	# Create  link to applet 
-	###################################
-	
-	$applet = FlashApplet();
-	my $appletName = "ExternalInterface";
-	$applet->codebase(findAppletCodebase("$appletName.swf"));
-	$applet->appletName($appletName);
-	$applet->appletId($appletName);
-	
-	# findAppletCodebase looks for the applet in a list
-	# of locations specified in global.conf
-	
-	###################################
-	# Add additional javaScript functions to header section of HTML to 
-	# communicate with the "ExternalInterface" applet.
-	###################################
-	
-	$applet->header(<<'END_HEADER');
-	<script language="javascript" src="https://devel.webwork.rochester.edu:8002/webwork2_files/js/BrowserSniffer.js">
-	</script>
-	
-	
-	<script language="JavaScript">
-		function getBrowser() {
-			  //alert("look for sniffer");
-		  var sniffer = new BrowserSniffer();
-		  //alert("found sniffer" +sniffer);
-		  return sniffer;
-		}
-	
-		function updateStatus(sMessage) {
-			  getQE("playbackStatus").value = sMessage;
-		}
-		
-		function newColor() {
+    # Load whatever macros you need for the problem
+    loadMacros(
+        "PG.pl",
+        "PGbasicmacros.pl",
+        "PGchoicemacros.pl",
+        "PGanswermacros.pl",
+        "AppletObjects.pl",
+        "MathObjects.pl",
+        "source.pl"
+    );
 
-		  getApplet("ExternalInterface").updateColor(Math.round(Math.random() * 0xFFFFFF));
-		}
-		
-	</script>
-	END_HEADER
-	
-	###################################
-	# Configure applet
-	###################################
-	
-	# not used here.  Allows for uploading an xml string for the applet
-	
-	
-	
-	
-	###################################
-	# write the text for the problem
-	###################################
-	
-	TEXT(beginproblem());
-	
-	
-	 
-	BEGIN_TEXT
-	\{ $applet->insertAll() \}
-	  $PAR
-	
-	  The Flash object operates above this line.  The box and button below this line are part of 
-	  the WeBWorK problem.  They communicate with the Flash object.
-	  $HR
-	  Status <input type="text" id="playbackStatus" value="started" /><br />
-	  Color <input type="button" value="new color" name="newColorButton" onClick="newColor()" />
-	   $PAR $HR
-	   This flash applet was created by Barbara Kaskosz. 
-	
-	END_TEXT
-	
-	ENDDOCUMENT();
+    # Do NOT show partial correct answers
+    $showPartialCorrectAnswers = 0;
 
+    ###################################
+    # Create link to applet
+    ###################################
 
+    $applet = FlashApplet();
+    my $appletName = "ExternalInterface";
+    $applet->codebase(findAppletCodebase("$appletName.swf"));
+    $applet->appletName($appletName);
+    $applet->appletId($appletName);
 
+    # findAppletCodebase looks for the applet in a list
+    # of locations specified in global.conf
+
+    ###################################
+    # Add additional javaScript functions to header section of HTML to
+    # communicate with the "ExternalInterface" applet.
+    ###################################
+
+    $applet->header(<<'END_HEADER');
+    <script language="javascript"
+            src="https://devel.webwork.rochester.edu:8002/webwork2_files/js/BrowserSniffer.js">
+    </script>
+
+    <script language="JavaScript">
+        function getBrowser() {
+            var sniffer = new BrowserSniffer();
+            return sniffer;
+        }
+
+        function updateStatus(sMessage) {
+            getQE("playbackStatus").value = sMessage;
+        }
+
+        function newColor() {
+            getApplet("ExternalInterface").updateColor(Math.round(Math.random() * 0xFFFFFF));
+        }
+    </script>
+    END_HEADER
+
+    ###################################
+    # Write the text for the problem
+    ###################################
+
+    TEXT(beginproblem());
+
+    BEGIN_TEXT
+    \{ $applet->insertAll() \}
+    $PAR
+
+    The Flash object operates above this line.  The box and button below this line are part of
+    the WeBWorK problem.  They communicate with the Flash object.
+    $HR
+    Status <input type="text" id="playbackStatus" value="started"><br>
+    Color <input type="button" value="new color" name="newColorButton" onClick="newColor()">
+    $PAR
+    $HR
+    This flash applet was created by Barbara Kaskosz.
+
+    END_TEXT
+
+    ENDDOCUMENT();
 
 =cut

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -197,12 +197,16 @@ sub SET_PROBLEM_TEXTDIRECTION {
 # Request that the problem HTML page also include additional CSS files
 # from the webwork2/htdocs/css/ directory.
 sub ADD_CSS_FILE {
-  my $file = shift ;
-  if ( !defined( $PG->{flags}{extra_css_files} ) ) {
-    $PG->{flags}{extra_css_files} = [ "$file" ];
-  } else {
-    push( @{$PG->{flags}{extra_css_files}}, $file );
-  }
+  my $file = shift;
+  push(@{$PG->{flags}{extra_css_files}}, $file);
+}
+
+# Request that the problem HTML page also include additional JS files.
+# If local is 1 the given file name will be prefixed with the webwork2/htdocs/js/ directory,
+# otherwise it is assumed the full url is provided.
+sub ADD_JS_FILE {
+	my ($file, $local) = @_;
+	push(@{$PG->{flags}{extra_js_files}}, { file => $file, local => $local });
 }
 
 sub AskSage {
@@ -223,10 +227,8 @@ sub sageReturnedFail {
 sub LABELED_ANS {
   my @in = @_;
   my @out = ();
-  #prepend labels with the quiz and section prefixes.
   while (@in ) {
   	my $label    = shift @in;
-  	$label       = join("", $PG->{QUIZ_PREFIX}, $PG->{SECTION_PREFIX}, $label);
   	$ans_eval = shift @in;
   	push @out, $label, $ans_eval;
   }


### PR DESCRIPTION
Make it possible for applet problems to work in gateway quizzes.  Existing problems (written as described at https://webwork.maa.org/wiki/GeoGebraWeb1) will need to be modified to work in gateway quizzes, but will continue to work in homework problems without modification.  The changes that are needed are shown in the updated example in the POD documentation for macros/AppletObjects.pl.

To make this work an ADD_JS_FILE method was needed.  This was needed in general for macros in any case.  The method can be called to add a javascript file to the header from a pg problem file or macro, and the corresponding code added on the webwork side ensures that this is done without repetition.

I have also made it so that when NAMED_ANS or LABELED_ANS are called, the answer name provided is not preprended with the QUIZ_PREFIX.  That wasn't working in any case, as it ends up making the label for the answer rule and the label for the evaluator not match up in every case.  For a problem to work correctly in a gateway quiz the answer rule needs to have the QUIZ_PREFIX, and the evaluator the same, so the QUIZ_PREFIX needs to be put onto the label earlier.  The best way to achieve this is to use NEW_ANS_NAME to get a label, and then use that for both the answer rule and the LABELED_ANS/NAMED_ANS methods.  I also removed the completely unused SECTION_PREFIX.  That can be added back if something is actually implemented to use it (albeit not in the LABELED_ANS method for the same reason as for the QUIZ_PREFIX).

Note that this is broken into two commits.  The first is general code clean up, and the second is the primary content of this pull request.

See https://github.com/openwebwork/webwork2/pull/1121 for the corresponding webwork2 changes.