### PR TITLE
PR #490 but for develop

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -372,8 +372,8 @@ sub query_sage_server {
 	 	my $header_block = shift(@lines);
 	 	warn "checking for header:  $header_block" if $debug;
 	 	next unless $header_block=~/\S/; #skip empty lines;
-	 	next if $header_block=~/HTTP/ and $header_block=~/100/; # skip continue line
-	 	if ($header_block=~/200/) { # 200 return is ok
+	 	next if ($header_block =~ m!HTTP[ 12/.]+100!); # skip continue line
+	 	if ($header_block=~ m!HTTP[ 12/.]+200!) { # 200 return is ok
 	 		$header_ok=1;
 	 		last;
 	 	}


### PR DESCRIPTION
I have been running into sporadic issues with AskSage problems. They seemed to randomly fail when trying to connect to the Sage Cell Server.

It turns out the response header gives plenty of opportunity to match "100":

```http
checking for header:  HTTP/2 200 
date: Fri, 17 Jul 2020 16:51:30 GMT
content-type: application/json; charset=UTF-8
content-length: 437
set-cookie: __cfduid=dc7f19b456d5fb97ea5fbf50f3f71c4fa1595004689; expires=Sun, 16-Aug-20 16:51:29 GMT; path=/; domain=.sagemath.org; HttpOnly; SameSite=Lax
vary: Accept-Encoding
cf-cache-status: DYNAMIC
cf-request-id: 03ff493591000074018d33d200000001
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
server: cloudflare
cf-ray: 5b4577cf49197401-IAD at /Users/drdrew42/mojo/renderv2/lib/RenderApp/Controller/../../PG/lib/WeBWorK/PG/IO.pm line 327
```

So, I've tightened up the regex matching for the header to more accurately identify HTTP 100 and HTTP 200 responses.