### PR TITLE
Add typecheck to union answer checking

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1252,7 +1252,11 @@ sub cmp_equal {
   my $self = shift; my $ans = shift;
   my $error = $self->cmp_checkUnionReduce($ans->{student_value},$ans);
   if ($error) {$self->cmp_Error($ans,$error); return}
-  Value::List::cmp_equal($self,$ans);
+  if ($self->typeMatch($ans->{student_value})) {
+    Value::List::cmp_equal($self,$ans);
+  } else {
+    $self->SUPER::cmp_equal($ans);
+  }
 }
 
 #


### PR DESCRIPTION
This PR adds a type check to the Union answer checking so that if the student's answer is not of the correct type, the usual type-mismatch message will be produced.  This resolves an issue raised in the [WeBWorK forum](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4839) where a union would be marked correct when it was entered as a list with no braces.  This was due to the fact that the Union checker overrides the `cmp_equal` method that does the usual type checking, and calls the List answer checker, which uses `cmp_compare` to determine when individual sets in the union are matched.  The `cmp_compare` function does not do the type checking, and its comparison allows more type coercion than `cmp_equal` does, so that was allowing `{1,2,3}` to match `1,2,3` in the union.

This PR fixes that by adding a type check in the `cmp_equal` method for the Union.

You can check it by using the example in the link above, or by using

```
Context("Interval");
$U = Union(Set(1,2), Set(3,4));
$ans = $U->cmp->evaluate("1,2,3,4");
TEXT($ans->{score}, " ", $ans->{ans_message});
```

Without the patch, the score will be 1 and there is no answer message.  With the patch, the score will be 0, and there should be an error message about the answer being a list of numbers rather than a set, interval, or union.