### PR TITLE
include the Bn string in a radio buttons answer hash

### DIFF
--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -403,6 +403,19 @@ sub cmp_preprocess {
   }
 }
 
+#
+#  Include the "Bn" string for the correct choice
+#  in the answer hash
+#
+sub cmp {
+  my $self = shift;
+  my $cmp = $self->SUPER::cmp(
+    correct_choice => $self->value,
+    @_
+  );
+  return $cmp;
+}
+
 ##################################################################
 #
 #  Handle old-style options (order, first, last, randomize)


### PR DESCRIPTION
An answer hash for radio buttons might currently look like:
```
         "AnSwEr0001" : {
            "_filter_name" : "dereference_array_ans",
            "ans_label" : "AnSwEr0001",
            "ans_message" : "",
            "ans_name" : "AnSwEr0001",
            "correct_ans" : "The Fundamental ... of Calculus",
            "correct_ans_latex_string" : "\\text{The Fundamental ... of Calculus}",
            "correct_value" : "The Fundamental ... of Calculus",
            "done" : "1",
            "error_flag" : "",
            "error_message" : "",
            "ignoreInfinity" : "1",
            "ignoreStrings" : "1",
            "original_student_ans" : "",
            "preview_latex_string" : "",
            "preview_text_string" : "",
            "score" : "0",
            "showEqualErrors" : "1",
            "showTypeWarnings" : "1",
            "showUnionReduceWarnings" : "1",
            "student_ans" : "",
            "studentsMustReduceUnions" : "1",
            "type" : "Value (parserRadioButtons)",
            "typeMatch" : "Value::Real"
         }
```

Nothing indicates the value attribute of the HTML button input corresponding to the correct choice. This edit adds to the hash like:

```
            "correct_choice" : "B1",
```