### PR TITLE
new message_for_blank_answer setting

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -879,6 +879,9 @@ sub blank_postfilter  {
     return($rh_ans) unless defined($rh_ans->{error_flag}) and $rh_ans->{error_flag} eq 'BLANK';
     $rh_ans->{error_flag} = undef;
     $rh_ans->{error_message} = '';
+    if ( defined($rh_ans->{message_for_blank_answer} ) ) {
+        $rh_ans->{ans_message} = $rh_ans->{message_for_blank_answer};
+    }
     $rh_ans->{done} =1;    # no further checking is needed.
     $rh_ans;
 };


### PR DESCRIPTION
I was asked to trigger a answer feedback message on blank input boxes is some cases (ex. where `DNE` is needed, but a student may leave the box blank). I could not get that to work using `AnswerHints` as the `blank_postfilter` runs before `AnswerHints`.

A workaround was to remove all post filters and the install a modified version of the `blank_postfilter` which sets a message.

I am proposing adding a new setting `message_for_blank_answer` which can be used to provide a specific message for a blank (empty or all white-space) input box, which is a much simpler approach and easily reused.

After this PR the `cmp()` call can include `message_for_blank_answer => "Do not leave this box empty"` to set one possible message.