### PR TITLE
Add new bypass_equivalence_test switch

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1721,6 +1721,7 @@ sub cmp_postfilter {
   $ans->{_filter_name} = "produce_equivalence_message";
   return $ans if $ans->{ans_message}; # don't overwrite other messages
   return $ans unless defined($ans->{prev_ans}); # if prefilters are erased, don't do this check
+  return $ans if ($ans->{bypass_equivalence_test});
   my $context = $self->context;
   Parser::Context->current(undef,$context);
   $ans->{prev_formula} = Parser::Formula($ans->{prev_ans});

--- a/macros/PGfunctionevaluators.pl
+++ b/macros/PGfunctionevaluators.pl
@@ -1037,10 +1037,11 @@ sub ORIGINAL_FUNCTION_CMP {
 			my $rh_ans = shift;	
 			#WARN_MESSAGE(pretty_print($inputs_ref));
 			my $isPreview = $inputs_ref->{previewAnswers}; # || ($inputs_ref->{action} =~ m/^Preview/);
+			return $rh_ans if ($rh_ans->{bypass_equivalence_test});
 			return $rh_ans unless !$isPreview # not preview mode
 				and $rh_ans->{ans_equals_prev_ans} # equivalent
 				and $rh_ans->{prev_ans} ne $rh_ans->{original_student_ans}; # not identical
-			
+
 			$rh_ans->{ans_message} = "This answer is equivalent to the one you just submitted.";
 			return $rh_ans;
 		}


### PR DESCRIPTION
Add bypass_equivalence_test switch to disable setting the message "This answer is equivalent to the one you just submitted" when it is not desired in a simple manner. This addresses the issue I reported in https://github.com/openwebwork/pg/issues/495 which I had originally not intended to work on right away.

It is primarily intended for use in problems whose graders do not "compare to" a fixed correct answer in the simple manner which the equivalence test code expects.

Can be tested by using the sample problem below by entering various equivalent answers one after the other with when the new setting is set to `1` to by bypass the message, to `0` to enable the message, or without being set (which leaves the message enabled).

```
DOCUMENT();
loadMacros(
  "PGstandard.pl",
  "MathObjects.pl",
);
Context("Numeric");
$aSoln = Compute("3x");
BEGIN_TEXT
\( x + 2x = \)
\{ $aSoln->ans_rule(8) \}
END_TEXT
ANS( $aSoln->cmp( bypass_equivalence_test => 1 ) );
ENDDOCUMENT();
```
