### PR TITLE
Fix parserMultiAnswer.pl issue when loaded twice

### DIFF
--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -2,7 +2,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: pg/macros/parserMultiAnswer.pl,v 1.11 2009/06/25 23:28:44 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1013,7 +1013,7 @@ sub Answer {
       }
       $rule = $ans->$method(@options);
       $rule = PGML::LaTeX($rule);
-      if (!(ref($ans) eq 'MultiAnswer' && $ans->{part} > 1)) {
+      if (!(ref($ans) eq 'parser::MultiAnswer' && $ans->{part} > 1)) {
         if (defined($item->{name})) {
           main::NAMED_ANS($item->{name} => $ans->cmp);
         } else {

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -1,7 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
 # Copyright &copy; 2000-2018 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader: pg/macros/parserMultiAnswer.pl,v 1.11 2009/06/25 23:28:44 gage Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the

--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -96,12 +96,12 @@ or
 loadMacros("MathObjects.pl");
 
 sub _parserMultiAnswer_init {
-  main::PG_restricted_eval('sub MultiAnswer {MultiAnswer->new(@_)}');
+  main::PG_restricted_eval('sub MultiAnswer {parser::MultiAnswer->new(@_)}');
 }
 
 ##################################################
 
-package MultiAnswer;
+package parser::MultiAnswer;
 our @ISA = qw(Value);
 
 our $answerPrefix = "MuLtIaNsWeR_";  # answer rule prefix

--- a/macros/parserMultiPart.pl
+++ b/macros/parserMultiPart.pl
@@ -31,7 +31,7 @@ sub _parserMultiPart_init {}
 loadMacros("parserMultiAnswer.pl");
 sub MultiPart {
   warn "The MultiPart object has been deprecated.${BR}You should use MultiAnswer object instead";
-  MultiAnswer->new(@_);
+  parser::MultiAnswer->new(@_);
 }
 
 


### PR DESCRIPTION
Fix parserMultiAnswer.pl to resolve issue which caused memory/CPU issues when it was loaded twice, for example by problem parts loaded using includePGproblem(). 

The issue was first reported in the forums at https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4875 where a sample set of simple files to trigger the bug is included. A copy of the posts follow, and the test files are also [here in sample.zip](https://github.com/openwebwork/pg/files/5119286/sample.zip).

The fix in this PR was provided by @dpvc in the forum thread, and resolves the issue.

---

**Copied from the forums:**

by Nathan Wallach - Sunday, 23 August 2020, 5:57 AM

Some locally developed problems are coded as "problem pieces" which are then loaded via a control PG file using includePGproblem(). The typical usage case is a set of several possible options for each part of a question, which are easy to maintain as single files (rather than inside one large file which selects each case from a long list).

This approach works well in some settings, but fails when multiple "problem pieces" need to use parserMultiAnswer.pl.

When 2 "problem pieces" both use MultiAnswer, trying to load the control file leads to Apache using huge amounts of CPU and RAM and failing to respond.

From this it seems that there is some problem using MultiAnswer in problems loaded via includePGproblem() from different files.

A set of sample file is attached which is just a trivial problem which uses MultiAnswer to grade 2 input boxes together, and given twice to trigger the error. When test2.pg is loaded after test1.pg by load_pair.pg the issue hits, and the server thrashes. Replacing test2.pg by test2b.pg which does not use MultiAnswer bypasses the problem, but fails to provide the intended behavior.

Hopefully there is some method to avoid the issue.

---

by Davide Cervone - Monday, 24 August 2020, 7:09 AM

It turns out that the loading of parserMultiAnswer.pl twice in a single problem is the source of the issue, and the problem occurs during the _parserMultiAnswer_init. This is where the MultiAnswer() function is defined, and it seems that there is a conflict with making that definition if the MultiAnswer package is already in place. So one solution is to rename the MultiAnswer package to parser::MultiAnswer This requires two lines to be changed in parserMultiAnswer.pl: the MultiAnswer->new() call in the _parserMultiAnswer_init() function, and the package MultiAnswer a few lines later. Once these are changed, the two problems load successfully for me.