### PR TITLE
Patches to scaffold.pl so Preview does not modify which sections are open

### DIFF
--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -463,6 +463,10 @@ sub section_answers {
 			if $answers{$name} && (($answers{$name}{type} || "") eq "essay" || $answers{$name}{"scaffold_force"});
 		$evaluator->{rh_ans}{ans_message} = "";
 		delete $evaluator->{rh_ans}{error_message};
+		# In sections which are not yet open, make that known to answer
+		# evaluators. For MultiAnswer using a single result, this allows
+		# hiding the structure of the answer during a preview.
+		$PG_ANSWERS_HASH->{$name}{ans_eval}{rh_ans}{scaffold_past_open} = 1 if ($section_no > $prior_last_open);
 	}
 
 	my $myLastSet;    # we save the name of the last answer field whose score was set

--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -292,6 +292,10 @@ sub single_check {
 	$ans->{_filter_name} = "MultiAnswer Single Check";
 	my $inputs = $main::inputs_ref;
 	$self->{ans}[0] = $self->{cmp}[0]->evaluate($ans->{student_ans});
+	# Allow hiding the the structure of the answer for an
+	# answer in an unopened part of a scaffold problem.
+	my $hide_preview = 0;
+	$hide_preview = 1 if ($ans->{scaffold_past_open});
 	foreach my $i (1 .. $self->length - 1) {
 		$self->{ans}[$i] = $self->{cmp}[$i]->evaluate($inputs->{ $self->ANS_NAME($i) });
 	}
@@ -328,13 +332,18 @@ sub single_check {
 			. '</TABLE>';
 	}
 	if ($nonblank) {
-		$ans->{preview_latex_string} =
-			(
-				defined($self->{tex_format})
-				? sprintf($self->{tex_format}, @latex)
-				: join($self->{tex_separator}, @latex));
-		$ans->{preview_text_string} =
-			(defined($self->{format}) ? sprintf($self->{format}, @text) : join($self->{separator}, @text));
+		if ($hide_preview) {
+			$ans->{preview_latex_string} = "";
+			$ans->{preview_text_string}  = "";
+		} else {
+			$ans->{preview_latex_string} =
+				(
+					defined($self->{tex_format})
+					? sprintf($self->{tex_format}, @latex)
+					: join($self->{tex_separator}, @latex));
+			$ans->{preview_text_string} =
+				(defined($self->{format}) ? sprintf($self->{format}, @text) : join($self->{separator}, @text));
+		}
 		$ans->{student_ans} =
 			(defined($self->{format}) ? sprintf($self->{format}, @student) : join($self->{separator}, @student));
 	}


### PR DESCRIPTION
**Edited on 14-APR-2023 revised for current develop and with defaults set to retain prior behavior**

The updated version depends on:
  - https://github.com/openwebwork/pg/pull/809
  - https://github.com/openwebwork/webwork2/pull/1940
and should be merged only after those PRs.

---

This is at attempt to address the first issue from https://github.com/openwebwork/pg/issues/478 

Patches to:
  - prevent scaffold from opening additional section when Preview of the last open section determines it was all correct (**when the relevant setting is changed**), and 
  - prevent scaffold from closing open sections if an answer to a prior section became incorrect and Preview is being run (**when the relevant setting is changed**), and 
  - control switches were added to regulate these behaviors, with defaults to the preexisting behavior. (**updated to those defaults in response to the review comments**)

The revised code stores the state about the last open section in the database using the code added in https://github.com/openwebwork/pg/pull/809.

~~The current patch uses a hidden form field to provide the server with the "number" of the last scaffold section which was open. It does not have any mechanism to prevent a clever user from tampering with that value. As a result, the current implement can be abused to trick the system into opening additional sections if the value of the hidden field is modified to a large value.~~

~~My plan is to fix that by adding additional hidden fields including a (random) "nonce" and a "signature" that verifies (together with some server side state information which should remain constant for the user of a given problem) that these hidden fields were not tampered with. Such an approach may not be 100% secure, but should make it quite hard to abuse these changes.~~

~~However, the current draft code already provides the rough functionality I think we would like.~~

---

Testing - using the PG file in [scaffold-sample-01.zip](https://github.com/openwebwork/pg/files/5460947/scaffold-sample-01.zip) and the files in [scaffold-sample-new.zip](https://github.com/openwebwork/pg/files/6103029/scaffold-sample-new.zip)


**Before installing the patch:**
1. Open any of the sample problems, and enter answer 1,2 in part 1.
2. Click "Preview My Answers" .
3. Part 2 should open - even though the correct answer to part 1 was not submitted for grading. (No attempt was counted.)
4. Enter answer 1,2 in part 2.
5. Click "Preview My Answers" .
6. Part 3 should open - even though the correct answer to part 2 was not submitted for grading. (No attempt was counted.)
7. Make one of the answers in part 1 **and** one of the answers in part 2 incorrect.
8. Click "Preview My Answers" .
9. Parts 2 and 3 should close - even though only a "Preview" was requests.
10. Make the answer in part 1 correct, and click "Preview My Answers". (Part 2 should open.)
11. Make the answer in part 2 correct, and click "Preview My Answers". (Part 3 should open.)
12. Make the answer in part 2 **incorrect**, and click "Preview My Answers". (Part 3 should **close**.)
13. Make the answer in part 2 correct, and click "Preview My Answers". (Part 3 should open.)
14. Make the answer in part 1 **incorrect**, and click "Preview My Answers". (Part 3 should **close**, but part 1 will remain open as it is correct.)

- The ~~desired~~ newly supported alternate behavior requires using "Submit Answers" to get the additional sections to open, and would not close open sections on use of "Preview My Answers"  when the relevant settings are used.

---

**The defaults have been changed - so the testing instructions here are somewhat outdated. See below for revised testing instructions.**

**After installing the patch:**

  - Testing using `scaffold-sample-03.pg` should give exactly the same behavior as in the test before the patch, as it (explicitly) uses the settings to keep the behavior as it was.
  - Testing using `scaffold-sample-02.pg` should behave as follows (both settings are flipped):

1. Open the problem, and enter answer 1,2 in part 1.
2. Click "Preview My Answers" .
3. Part 2 should **not** open.
4. Click "Submit Answers".
5. Part 2 should now open (and an attempt was used up to get it to open).
6. Enter answer 1,2 in part 2.
7. Click "Submit Answers".
8. Part 3 should open (and an attempt was used up to get it to open).
9. Make one of the answers in part 1 **and** one of the answers in part 2 incorrect.
8. Click "Preview My Answers" .
9. Parts 2 and 3 should **remain open**.
10. Click "Submit Answers".
11. Parts 2 and 3 should now **close**.
12. Make the answer in part 1 correct, and click "Submit Answers". (Part 2 should open.)
13. Make the answer in part 2 correct, and click "Submit Answers". (Part 3 should open.)
14. Make the answer in part 2 **incorrect**, and click "Preview My Answers". (Part 3 should **remain open**.)
15. Click "Submit Answers". (Part 3 should **close**.)
13. Make the answer in part 2 correct the answer in part 1 **incorrect**, and click "Preview My Answers". (Part 2 should remain open).
14. Click "Submit Answers". (Part 2 should **close**.)

  - Testing using `scaffold-sample-01.pg` should behave as follows (only opening by preview is disabled, but closing remains enabled.):

1. Open the problem, and enter answer 1,2 in part 1.
2. Click "Preview My Answers" .
3. Part 2 should **not** open.
4. Click "Submit Answers".
5. Part 2 should now open (and an attempt was used up to get it to open).
6. Enter answer 1,2 in part 2.
7. Click "Submit Answers".
8. Part 3 should open (and an attempt was used up to get it to open).
9. Make one of the answers in part 1 **and** one of the answers in part 2 incorrect.
8. Click "Preview My Answers" .
9. Parts 2 and 3 should both **close**.