### PR TITLE
replace romberg approximation with faster function

### DIFF
--- a/macros/PGstatisticsmacros.pl
+++ b/macros/PGstatisticsmacros.pl
@@ -31,41 +31,36 @@ sub normal_prob {
         warn 'You must also load PGnumericalmacros to use PGstatisticsmacros' unless defined(&_PGnumericalmacros_init);
 
 	my $a = shift;
-        my $b = shift;
+    my $b = shift;
  	my %options=@_;
 
-	my $mean = $options{'mean'} if defined ($options{'mean'});
-        $mean = 0 unless defined $mean;
-
-	my $deviation = $options{'deviation'} if defined ($options{'deviation'});
-        $deviation = 1 unless defined $deviation;
+	my $mean = $options{'mean'} // 0;
+	my $deviation = $options{'deviation'} // 1;
 
 	if ($deviation <= 0) {
 		warn 'Deviation must be a positive number.';
 		return;
-		}
+	}
 
-        my $z_score_of_a;
-	my $z_score_of_b;
-
+	my $prob;
 	if ( $a eq '-infty' ) {
-		$z_score_of_a = -6;
+		if ( $b eq 'infty' or '-infty') {
+			$prob = 1; # did you really need us to tell you that?
+		} else {
+			my $z_score_of_b = ($b - $mean)/$deviation;
+			$prob = 1 - uprob($z_score_of_b);
+		}
 	} else {
-		$z_score_of_a = ($a - $mean)/$deviation;
+		my $z_score_of_a = ($a - $mean)/$deviation;
+		if ( $b eq 'infty' or '-infty') {
+			$prob = uprob($z_score_of_a);
+		} else {
+            my $z_score_of_b = ( $b - $mean ) / $deviation;
+			$prob = uprob($z_score_of_a) - uprob($z_score_of_b);
+		}
 	}
 
-        if (($b eq 'infty') or ($b eq '+infty')) {
-		$z_score_of_b = 6;
-	} else {
-		$z_score_of_b = ($b - $mean)/$deviation;
-	}
-
-        my $function = sub { my $x=shift;
-                             $E**(-$x**2/2)/sqrt(2*$PI);
-                             };
-
-        my $prob = romberg($function, $z_score_of_a, $z_score_of_b, level => 8);
-        $prob;
+    return $prob;
 }
 
 =head3 "Inverse" of normal distribution
@@ -86,28 +81,26 @@ Load PGnumericalmacros.pl if you use this method.
 sub normal_distr {
 	warn 'You must also load PGnumericalmacros to use PGstatisticsmacros' unless defined(&_PGnumericalmacros_init);
 
-        my $prob = shift;
-        my %options=@_;
+	my $prob = shift;
+	my %options=@_;
 
-        my $mean = $options{'mean'} if defined ($options{'mean'});
-        $mean = 0 unless defined $mean;
+	my $mean      = $options{'mean'}      // 0;
+	my $deviation = $options{'deviation'} // 1;
 
-        my $deviation = $options{'deviation'} if defined ($options{'deviation'});
-        $deviation = 1 unless defined $deviation;
+	if ($deviation <= 0) {
+		warn 'Deviation must be a positive number.';
+		return;
+	}
+	if ($mean < 0 || $mean > 0.5) {
+		warn 'Probability must be between 0 and 0.5.';
+		return;
+	}
 
-        if ($deviation <= 0) {
-                warn 'Deviation must be a positive number.';
-                return;
-                }
+	$prob = 0.5 - $prob;
+	my $z_score_of_b = udistr($prob);
 
-        my $function = sub { my $x=shift;
-                             $E**(-$x**2/2)/sqrt(2*$PI);
-                             };
-
-        my $z_score_of_b = inv_romberg($function, 0, $prob);
-
-        my $b = $z_score_of_b * $deviation + $mean;
-        $b;
+	my $b = $z_score_of_b * $deviation + $mean;
+	$b;
 }
 
 


### PR DESCRIPTION
using `normal_prob` from PGstatisticsmacros.pl requires excessive CPU resources and slows down problem rendering to the tune of ~2 sec per instance of `normal_prob`. Replacing the romberg approximation with the `uprob` function (from Statistics::Distributions, already loaded in PGstatisticsmacros.pl) greatly reduces the CPU load for problems that require this calculation (and does not have any impact on the degree of accuracy for the calculated result). 