### PR TITLE
Properly add parentheses to Fraction::Value objects based on precedence.

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -613,6 +613,32 @@ sub reduce {
   return $self->SUPER::reduce;
 }
 
+#
+#  Add parentheses if they were there originally, or are needed by precedence
+#
+sub string {
+  my $self = shift;
+  my $string = $self->SUPER::string($self, @_);
+  return $string unless $self->{value}->classMatch('Fraction');
+  my $precedence = shift;
+  my $frac = $self->context->operators->get('/')->{precedence};
+  $string = '(' . $string . ')' if $self->{hadParens} || (defined $precedence && $precedence > $frac);
+  return $string;
+}
+
+#
+#  Add parentheses if they are needed by precedence
+#
+sub TeX {
+  my $self = shift;
+  my $string = $self->SUPER::TeX($self, @_);
+  return $string unless $self->{value}->classMatch('Fraction');
+  my $precedence = shift;
+  my $frac = $self->context->operators->get('/')->{precedence};
+  $string = '\left(' . $string . '\right)' if defined $precedence && $precedence > $frac;
+  return $string;
+}
+
 ###########################################################################
 
 package context::Fraction::Real;


### PR DESCRIPTION
Currently, Fraction MathObjects may lose necessary parentheses when stringified or texified.  For example `Compute("x^(2/7)")->string;` will produce `x^2/7`.  This means that

```
$f = Compute("x^(2/7)");
$g = Compute("$f");
```
would produce `$g` equivalent to `Compute("(x^2)/7")` rather than equivalent to `$f`.  (See this [Forum post](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4981) for more details.)

This PR resolves the issue by overriding the `string()` and `TeX()` methods to properly insert parentheses when needed.  These are added when the operator precedences require it, or (in `string()`) when the original had them (since the TeX version is a vertical fraction, they are are only added when precedence requires it).

To test, use

```
loadMacros("PGML.pl", "contextFraction.pl");

sub LaTeX {
  my $f = shift;
  return PGML::LaTeX('\(' . $f->TeX . '\)');
};

Context("Fraction");

$f1 = Compute("x^(2/7)");
$f2 = Compute("(2/7)*x");
$f3 = Compute("2/7 x");

TEXT($f1, " has parens", $BR);
TEXT(Compute("$f1"), " has parens", $BR);
TEXT($f2, " has parens", $BR);
TEXT(Compute("$f2"), " has parens", $BR);
TEXT($f3, " has no parens", $BR);
TEXT(Compute("$f3"), " has no parens", $BR);
TEXT($HR);

$x = Formula("x");
$f = Fraction(2,7);

$f4 = $x ** $f;
$f5 = $f * $x;

TEXT($f4, " has parens", $BR);
TEXT(Compute("$f4"), " has parens", $BR);
TEXT($f5, " has no parens", $BR);
TEXT(Compute("$f5"), " has no parens", $BR);

TEXT($HR, "No parens:", $BR);
TEXT(LaTeX($f1), $BR);
TEXT(LaTeX(Compute("$f1")), $BR);
TEXT(LaTeX($f2), $BR);
TEXT(LaTeX(Compute("$f2")), $BR);
TEXT(LaTeX($f3), $BR);
TEXT(LaTeX(Compute("$f3")), $BR);

TEXT($HR, "No parens:", $BR);
TEXT(LaTeX($f4), $BR);
TEXT(LaTeX(Compute("$f4")), $BR);
TEXT(LaTeX($f5), $BR);
TEXT(LaTeX(Compute("$f5")), $BR);
```
