### PR TITLE
PG warnings cleanup and minor contextFraction issue

### DIFF
--- a/lib/PGresource.pm
+++ b/lib/PGresource.pm
@@ -17,6 +17,7 @@
 package PGresource;
 use strict;
 use Exporter;
+use Scalar::Util;
 use UUID::Tiny  ':std';
 use PGcore;
 our @ISA= qw( PGcore ) ;
@@ -60,6 +61,7 @@ sub new {
 		%options,
 	};
 	bless $self, $class;
+	Scalar::Util::weaken($self->{parent_alias});
 	$self->warning_message( "PGresource must be called with an  alias object") unless ref($parent_alias) =~ /PGalias/;
 	$self->warning_message(  "PGresource must be called with a name" ) unless $id;
 	$self->warning_message(  "PGresource must be called with a type") unless $type;

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -274,7 +274,7 @@ sub ForceBreak {
 
 sub Par {
   my $self = shift; my $token = shift;
-  $self->End("null", shift);
+  $self->End(undef, shift);
   $self->Item("par",$token,{noIndent => 1});
   $self->{atLineStart} = $self->{ignoreNL} = 1;
   $self->{indent} = $self->{actualIndent} = 0;

--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -274,7 +274,7 @@ sub ForceBreak {
 
 sub Par {
   my $self = shift; my $token = shift;
-  $self->End(null, shift);
+  $self->End("null", shift);
   $self->Item("par",$token,{noIndent => 1});
   $self->{atLineStart} = $self->{ignoreNL} = 1;
   $self->{indent} = $self->{actualIndent} = 0;
@@ -1092,7 +1092,7 @@ sub Align {
     "</div>\n";
 }
 
-my %bullet = (
+our %bullet = (
   bullet  => 'ul type="disc"',
   numeric => 'ol type="1"',
   alpha   => 'ol type="a"',
@@ -1366,7 +1366,7 @@ sub Align {
   return "<!-- PTX:WARNING: PGML wanted to " . $item->{align} . " align here. -->\n" . $self->string($item);
 }
 
-my %bullet = (
+our %bullet = (
   bullet  => 'ul',
   numeric => 'ol label="1."',
   alpha   => 'ol label="a."',

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1410,17 +1410,9 @@ a hard copy output.
               Latex2HTML => "output this in Latex2HTML mode",
              )
 
-    TEX     (tex_version, html_version) #obsolete
-
     M3      (tex_version, latex2html_version, html_version) #obsolete
 
 =cut
-
-
-#sub TEX {
-#	my ($tex, $html ) = @_;
-#	MODES(TeX => $tex, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
-#}
 
 
 #sub M3 {

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1416,15 +1416,17 @@ a hard copy output.
 
 =cut
 
-sub TEX {
-	my ($tex, $html ) = @_;
-	MODES(TeX => $tex, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
-}
 
-sub M3 {
-	my($tex, $l2h, $html) = @_;
-	MODES(TeX => $tex, Latex2HTML => $l2h, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
-}
+#sub TEX {
+#	my ($tex, $html ) = @_;
+#	MODES(TeX => $tex, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
+#}
+
+
+#sub M3 {
+#	my($tex,$l2h,$html) = @_;
+#	MODES(TeX => $tex, Latex2HTML => $l2h, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
+#}
 
 # MODES() is now table driven
 our %DISPLAY_MODE_FAILOVER = (

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1415,10 +1415,10 @@ a hard copy output.
 =cut
 
 
-#sub M3 {
-#	my($tex,$l2h,$html) = @_;
-#	MODES(TeX => $tex, Latex2HTML => $l2h, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
-#}
+sub M3 {
+	my($tex,$l2h,$html) = @_;
+	MODES(TeX => $tex, Latex2HTML => $l2h, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
+}
 
 # MODES() is now table driven
 our %DISPLAY_MODE_FAILOVER = (

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -894,12 +894,12 @@ sub isReduced {
 sub string {
   my $self = shift; my $equation = shift; my $prec = shift;
   my ($a,$b) = @{$self->{data}}; my $n = "";
-  return $a if $b == 1;
+  return "$a" if $b == 1;
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
     {$n = int($a/$b); $a = CORE::abs($a) % $b; $n .= " " unless $a == 0}
   $n .= "$a/$b" unless $a == 0 && $n ne '';
   $n = "($n)" if defined $prec && $prec >= 1;
-  return $n;
+  return "$n";
 }
 
 sub TeX {
@@ -912,7 +912,7 @@ sub TeX {
   $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{\\textstyle\\frac{$a}{$b}}")
     unless $a == 0 && $n ne '';
   $n = "\\left($n\\right)" if defined $prec && $prec >= 1;
-  return $n;
+  return "$n";
 }
 
 sub pdot {

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -905,7 +905,7 @@ sub string {
 sub TeX {
   my $self = shift; my $equation = shift; my $prec = shift;
   my ($a,$b) = @{$self->{data}}; my $n = "";
-  return $a if $b == 1;
+  return "$a" if $b == 1;
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
     {$n = int($a/$b); $a = CORE::abs($a) % $b; $n .= " " unless $a == 0}
   my $s = ""; ($a,$s) = (-$a,"-") if $a < 0;


### PR DESCRIPTION
This PR replaces #505 -- see link for previous comment thread
I've added one more significant change regarding a circular reference introduced by PGresource.pm

PR fix:
* fixed the tangled repo history from #505 

Fixed PGbasicmacros warning:
* Subroutine TEX redefined at...
* Fixed by removing the 'deprecated' TEX subroutine defined earlier in PGbasicmacros

Fixed PGML warnings:
* Unquoted string "null" may clash with future reserved word at... (in PGML)
* "my" variable %bullet masks earlier declaration in same scope at... (in PGML)

a minor change to contextFraction for consistency:
* method TeX called on a Fraction with denominator 1 will return a number, not a string
* this is an issue for homogenous responses from PG -- e.g. correct_answer_latex_string was not consistently a string

[NEW] Fix circular reference in PGresource:
* `parent_alias` causes a circular reference within the PG object, resulting in memory leakage
* Scalar::Util::weaken reduces the reference count so that garbage collection will not be prevented