### PR TITLE
Fix comparison between inequalities and plain sets and unions

### DIFF
--- a/macros/contextInequalities.pl
+++ b/macros/contextInequalities.pl
@@ -528,6 +528,12 @@ sub sub {(shift)->apply("sub",@_)}
 sub reduce {(shift)->apply("reduce",@_)}
 sub intersect {(shift)->apply("intersect",@_)}
 
+sub compare {
+  my $self = shift; my $other = shift; my $flag = shift;
+  my $context = $self->context;
+  return Value::_compare($self->demote,$self->demote($other),$flag);
+}
+
 #
 #  The name to use for error messages in answer checkers
 #


### PR DESCRIPTION
This PR fixes a problem where comparing an inequality to a plain Set or Union object (rather than an inequality version of those) can cause an error message.  See the ancient [bugzilla post](https://bugs.webwork.maa.org/show_bug.cgi?id=3691) about this for more.

For the usual Interval, Set, and Union, their precedences force the Set object to manage comparisons of Sets with Intervals, and the Union to manage comparisons between Unions and anything else, but the Inequality objects are higher precedence than the standard classes so that the results of combining inequalities with Intervals, Sets, or Unions will be an Inequality.  That means that when an Inequality::Interval compares to a Set, for example, the Inequality::Interval manages the comparison rather than the Set, which causes a problem because the Inequality::Interval uses the Interval comparison function, and that would not normally interact with a Set (since the Set would take precedence).

This fix overrides the `compare` method to force the Inequality to become a standard Interval, Set, or Union, and then calls the standard comparison on those (which will handle the precedences properly).  You can test the PR using

```
loadMacros("contextInequalities.pl");
Context("Inequalities");

sub TEST {
  my ($eq1,$eq2) = @_;
  my ($result, $error) = PG_restricted_eval("Compute('$eq1') == Compute('$eq2')");
  my $msg = ($error || ($result ? "True" : "False"));
  $msg =~ s/ at line .*|; see position .*//;
  TEXT("'$eq1' == '$eq2' ==> " . $msg, $BR);
}

TEST("{}", "x < 3");
TEST("(-inf,3) U [4,inf)", "x < 3");
TEST("x < 3", "{}");
TEST("x < 3", "(-inf,3) U [4,inf)");
```

The four tests will return errors without this patch, and should all return False with this PR applied.