### PR TITLE
Add aliases to all context classes, and allow alternative tokens

### DIFF
--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -106,7 +106,9 @@ sub tokenize {
       foreach my $i (0..$#patternType) {
 	if (defined($match[$i])) {
 	  $p1 = pos($string) = pos($string) + length($match[$i]);
-	  push(@{$tokens},[($patternType[$i]||$tokenType->{$match[$i]}),$match[$i],$p0,$p1,$space]);
+	  my ($class, $id) = ($patternType[$i] || $tokenType->{$match[$i]}, $match[$i]);
+	  ($class,$id) = @$class if ref($class) eq 'ARRAY';
+	  push(@{$tokens},[$class,$id,$p0,$p1,$space]);
 	  last;
 	}
       }
@@ -536,7 +538,7 @@ sub CloseFn {
   my $top = $self->pop->{value}; my $fn = $self->pop;
   my $constant = $top->{isConstant};
   if ($top->{open} && $context->parens->resolveDef($top->{open})->{function} &&
-      $context->parens->resolveDef($top->{open})->{close} eq $top->{close} &&
+      $context->parens->match($top->{open},$top->{close}) &&
       !$context->functions->resolveDef($fn->{name})->{vectorInput})
          {$top = $top->coords} else {$top = [$top]}
   $self->pushOperand($self->Item("Function")->new($self,$fn->{name},$top,$constant,$fn->{ref}));

--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -98,6 +98,7 @@ sub tokenize {
   my $tokenPattern = $self->{context}{pattern}{token};
   my $tokenType = $self->{context}{pattern}{tokenType};
   my @patternType = @{$self->{context}{pattern}{type}};
+  $string =~ tr/\N{U+FF01}-\N{U+FF5E}/\x21-\x7E/ if $self->{context}->flag('convertFullWidthCharacters');
   @{$tokens} = (); $self->{error} = 0;
   $string =~ m/^\s*/gc; my $p0; my $p1;
   while (pos($string) < length($string)) {

--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -198,7 +198,7 @@ sub ImplicitMult {
   $iref->[2]--; $iref->[3] = $iref->[2]+1;
   $iref->[3]++ unless substr($self->{string},$iref->[2],1) eq ' ';
   $self->Error("Can't perform implied multiplication in this context",$iref)
-    unless $self->{context}{operators}{' '}{class};
+    unless $self->{context}->operators->resolveDef(' ')->{class};
   $self->Op(' ',$iref);
   $self->{ref} = $ref;
 }
@@ -265,8 +265,9 @@ sub pushBlankOperand {
 sub Op {
   my $self = shift; my $name = shift;
   my $ref = $self->{ref} = shift;
-  my $context = $self->{context}; my $op = $context->{operators}{$name};
-  $op = $context->{operators}{$op->{space}} if $self->{space} && defined($op->{space});
+  my $context = $self->{context}; my $op;
+  ($name,$op) = $context->operators->resolve($name);
+  ($name,$op) = $context->operators->resolve($op->{space}) if $self->{space} && defined($op->{space});
   if ($self->state eq 'operand') {
     if ($op->{type} eq 'unary' && $op->{associativity} eq 'left') {
       $self->ImplicitMult();
@@ -278,14 +279,14 @@ sub Op {
           my $top = $self->pop;
           $self->pushOperand($self->Item("UOP")->new($self,$name,$top->{value},$ref));
         } else {
-          $name = $context->{operators}{' '}{string}
-            if ($name//'') eq ' ' or ($name//'') eq $context->{operators}{' '}{space};
+          my $def = $context->operators->resolveDef(' ');
+          $name = $def->{string} if defined($name) and ($name eq ' ' or $name eq $def->{space});
           $self->pushOperator($name,$op->{precedence});
         }
       } elsif (($ref && $name ne ' ') || $self->state ne 'fn') {$self->Op($name,$ref)}
     }
   } else {
-    $name = 'u'.$name, $op = $context->{operators}{$name}
+    ($name,$op) = $context->operators->resolve('u'.$name)
       if ($op->{type} eq 'both' && defined $context->{operators}{'u'.$name});
     if ($op->{type} eq 'unary' && $op->{associativity} eq 'left') {
       $self->pushOperator($name,$op->{precedence});
@@ -319,12 +320,12 @@ sub Op {
 #
 sub Open {
   my $self = shift; my $type = shift;
-  my $paren = $self->{context}{parens}{$type};
   if ($self->state eq 'operand') {
-    if ($type eq $paren->{close}) {
+    my $parens = $self->{context}->parens;
+    if ($self->{context}->parens->match($type,$type)) {
       my $stack = $self->{stack}; my $i = scalar(@{$stack})-1;
       while ($i >= 0 && $stack->[$i]{type} ne "open") {$i--}
-      if ($i >= 0 && $stack->[$i]{value} eq $type) {
+      if ($i >= 0 && $parens->match($stack->[$i]{value},$type)) {
 	$self->Close($type,$self->{ref});
 	return;
       }
@@ -369,16 +370,17 @@ sub Open {
 sub Close {
   my $self = shift; my $type = shift;
   my $ref = $self->{ref} = shift;
-  my $parens = $self->{context}{parens};
+  my $parens = $self->{context}->parens;
 
   for ($self->state) {
     /open/ and do {
-      my $top = $self->pop; my $paren = $parens->{$top->{value}};
-      if ($paren->{emptyOK} && $paren->{close} eq $type) {
-        $self->pushOperand($self->Item("List")->new($self,[],1,$paren,undef,$top->{value},$paren->{close}))
+      my $top = $self->pop;
+      my ($open,$paren) = $parens->resolve($top->{value});
+      if ($paren->{emptyOK} && $parens->match($open,$type)) {
+        $self->pushOperand($self->Item("List")->new($self,[],1,$paren,undef,$open,$paren->{close}))
       }
       elsif ($type eq 'start') {$self->Error(["Missing close parenthesis for '%s'",$top->{value}],$top->{ref})}
-      elsif ($top->{value} eq 'start') {$self->Error(["Extra close parenthesis '%s'",$type],$ref)}
+      elsif ($open eq 'start') {$self->Error(["Extra close parenthesis '%s'",$type],$ref)}
       else {$top->{ref}[3]=$ref->[3]; $self->Error("Empty parentheses",$top->{ref})}
       last;
     };
@@ -386,29 +388,29 @@ sub Close {
     /operand/ and do {
       $self->Precedence(-1); return if ($self->{error});
       if ($self->state ne 'operand') {$self->Close($type,$ref); return}
-      my $paren = $parens->{$self->prev->{value}};
-      if ($paren->{close} eq $type) {
+      my ($open,$paren) = $parens->resolve($self->prev->{value});
+      if ($parens->match($open,$type)) {
         my $top = $self->pop;
         if (!$paren->{removable} || ($top->{value}->type eq "Comma")) {
           $top = $top->{value};
           $top = {type => 'operand', value =>
 	          $self->Item("List")->new($self,[$top->makeList],$top->{isConstant},$paren,
                     ($top->type eq 'Comma') ? $top->entryType : $top->typeRef,
-                    ($type ne 'start') ? ($self->top->{value},$type) : () )};
+                    ($type ne 'start') ? ($open,$paren->{close}) : () )};
         } else {
 	  $top->{value}{hadParens} = 1;
 	}
         $self->pop; $self->push($top);
         $self->CloseFn() if ($paren->{function} && $self->prev->{type} eq 'fn');
       } elsif ($paren->{formInterval} eq $type && $self->top->{value}->length == 2) {
-        my $top = $self->pop->{value}; my $open = $self->pop->{value};
+        my $top = $self->pop->{value}; $self->pop;
         $self->pushOperand(
            $self->Item("List")->new($self,[$top->makeList],$top->{isConstant},
-				     $paren,$top->entryType,$open,$type));
+				     $paren,$top->entryType,$open,$paren->{close}));
       } else {
         my $prev = $self->prev;
-        if ($type eq "start") {$self->Error(["Missing close parenthesis for '%s'",$prev->{value}],$prev->{ref})}
-        elsif ($prev->{value} eq "start") {$self->Error(["Extra close parenthesis '%s'",$type],$ref)}
+        if    ($type eq "start") {$self->Error(["Missing close parenthesis for '%s'",$prev->{value}],$prev->{ref})}
+        elsif ($open eq "start") {$self->Error(["Extra close parenthesis '%s'",$type],$ref)}
         else {$self->Error(["Mismatched parentheses: '%s' and '%s'",$prev->{value},$type],$ref)}
         return;
       }
@@ -482,16 +484,16 @@ sub Precedence {
     for ($prev->{type}) {
 
       /operator/ and do {
-        my $prev_prec = $context->{operators}{$prev->{name}}{rprecedence};
+        my $def = $context->operators->resolveDef($prev->{name});
+        my $prev_prec = $def->{rprecedence};
         $prev_prec = $prev->{precedence} unless $prev_prec;
         return if ($precedence > $prev_prec);
         if ($self->top(-2)->{type} eq 'operand' || $prev->{reverse}) {
-          return if ($precedence == $prev_prec &&
-              $context->{operators}{$prev->{name}}{associativity} eq 'right');
+          return if ($precedence == $prev_prec && $def->{associativity} eq 'right');
           if ($self->top(-2)->{type} eq 'fn') {
             my $top = $self->pop; my $op = $self->pop; my $fun = $self->pop;
             if (Parser::Function::checkInverse($self,$fun,$op,$top)) {
-              $fun->{name} = $context->{functions}{$fun->{name}}{inverse};
+              $fun->{name} = $context->functions->resolveDef($fun->{name})->{inverse};
               $self->push($fun);
             } else {$self->push($top,$op,$fun)}
           } else {
@@ -533,9 +535,9 @@ sub CloseFn {
   my $self = shift; my $context = $self->{context};
   my $top = $self->pop->{value}; my $fn = $self->pop;
   my $constant = $top->{isConstant};
-  if ($top->{open} && $context->{parens}{$top->{open}}{function} &&
-      $context->{parens}{$top->{open}}{close} eq $top->{close} &&
-      !$context->{functions}{$fn->{name}}{vectorInput})
+  if ($top->{open} && $context->parens->resolveDef($top->{open})->{function} &&
+      $context->parens->resolveDef($top->{open})->{close} eq $top->{close} &&
+      !$context->functions->resolveDef($fn->{name})->{vectorInput})
          {$top = $top->coords} else {$top = [$top]}
   $self->pushOperand($self->Item("Function")->new($self,$fn->{name},$top,$constant,$fn->{ref}));
 }
@@ -566,7 +568,7 @@ sub Num {
 #
 sub Const {
   my $self = shift; my $ref = $self->{ref}; my $name = shift;
-  my $const = $self->{context}{constants}{$name};
+  my $const = $self->{context}->constants->resolveDef($name);
   $self->ImplicitMult() if $self->state eq 'operand';
   if (defined($self->{context}{variables}{$name})) {
     $self->pushOperand($self->Item("Variable")->new($self,$name,$ref));

--- a/lib/Parser/BOP.pm
+++ b/lib/Parser/BOP.pm
@@ -18,8 +18,8 @@ $Parser::class->{BOP} = 'Parser::BOP';
 sub new {
   my $self = shift; my $class = ref($self) || $self;
   my $equation = shift; my $context = $equation->{context};
-  my ($bop,$lop,$rop,$ref) = @_;
-  my $def = $context->{operators}{$bop};
+  my ($bop,$lop,$rop,$ref) = @_; my $def;
+  ($bop, $def) = $context->operators->resolve($bop);
   if (!$def->{isComma}) {
     $lop = $self->Item("List",$context)->new($equation,[$lop->makeList],
        $lop->{isConstant},$context->{parens}{start}) if ($lop->type eq 'Comma');

--- a/lib/Parser/BOP/equality.pm
+++ b/lib/Parser/BOP/equality.pm
@@ -113,7 +113,7 @@ sub Allow {
   my $self = shift || "Value"; my $context = shift || $self->context;
   my $allow = shift; $allow = 1 unless defined($allow);
   if ($allow) {
-    my $prec = $context->{operators}{','}{precedence};
+    my $prec = $context->operators->resolveDef(',')->{precedence};
     $prec = 1 unless defined($prec);
     $context->operators->add(
       '=' => {

--- a/lib/Parser/Complex.pm
+++ b/lib/Parser/Complex.pm
@@ -65,7 +65,7 @@ $Parser::reduce->{'-a-bi'} = 1;
 #
 sub string {
   my $self = shift; my $precedence = shift; my $show = shift;
-  my $context = $self->context; my $plus = $context->{operators}{'+'}{precedence};
+  my $context = $self->context; my $plus = $context->operators->resolveDef('+')->{precedence};
   my $z = $self->Package("Complex")->make($context,@{$self->{value}})->string($self->{equation});
   $z = "(".$z.")" if defined($precedence) &&
     ($precedence > $plus || $precedence == $plus && $show eq "same") && $z =~ m/[-+]/;
@@ -74,7 +74,7 @@ sub string {
 
 sub TeX {
   my $self = shift; my $precedence = shift; my $show = shift;
-  my $context = $self->context; my $plus = $context->{operators}{'+'}{precedence};
+  my $context = $self->context; my $plus = $context->operators->resolveDef('+')->{precedence};
   my $z = $self->Package("Complex")->make($context,@{$self->{value}})->TeX($self->{equation});
   $z = '\left('.$z.'\right)' if defined($precedence) &&
     ($precedence > $plus || $precedence == $plus && $show eq "same") && $z =~ m/[-+]/;

--- a/lib/Parser/Constant.pm
+++ b/lib/Parser/Constant.pm
@@ -17,7 +17,7 @@ sub new {
   my $self = shift; my $class = ref($self) || $self;
   my $equation = shift;
   my ($name,$ref) = @_;
-  my $const = $equation->{context}{constants}{$name};
+  my $const = $equation->{context}->constants->resolveDef($name);
   my ($value,$type) = Value::getValueType($equation,$const->{value});
   my $c = bless {
     name => $name, type => $type, def => $const,

--- a/lib/Parser/Context.pm
+++ b/lib/Parser/Context.pm
@@ -47,6 +47,7 @@ sub new {
 #
 sub update {
   my $self = shift; return unless $self->{_initialized};
+  my $alternatives = $self->flag('parseAlternatives');
   my @patterns = ($self->numberPattern);
   my @tokens;
   foreach my $name (@{$self->{data}{objects}}) {
@@ -54,9 +55,16 @@ sub update {
     foreach my $pattern (keys %{$data->{patterns}}) {
       my $def = $data->{patterns}{$pattern};
       $def = [$def,$data->{tokenType}] unless ref($def) eq 'ARRAY';
-      push @patterns,[$pattern,@{$def}];
+      push @patterns,[$pattern,@{$def}] if $alternatives || ref($def->[1]) ne 'ARRAY';
     }
-    push @tokens,%{$data->{tokens}};
+    if ($alternatives) {
+      push @tokens,%{$data->{tokens}};
+    } else {
+      foreach my $token (keys %{$data->{tokens}}) {
+        my $value = $data->{tokens}{$token};
+        push @tokens,($token => $value) unless ref($value) eq 'ARRAY';
+      }
+    }
   }
   $self->{pattern}{type} = [];
   $self->{pattern}{tokenType} = {@tokens};
@@ -153,19 +161,16 @@ my $userContext;
 sub current {
   my $self = shift; my $contextTable = shift; my $context = shift;
   if ($contextTable) {$userContext = $contextTable} else {$contextTable = $userContext}
-  if (defined($context)) {
-    if (!ref($context)) {
-      my $name = $context;
-      $context = Parser::Context->getCopy($contextTable,$context);
-      Value::Error("Unknown context '%s'",$name) unless defined($context);
-    }
-    $contextTable->{current} = $context;
-    $Value::context = \$contextTable->{current};
-  } elsif (!defined($contextTable->{current})) {
-    $contextTable->{current} = $Parser::Context::Default::context{Numeric}->copy;
-    $Value::context = \$contextTable->{current};
+  $context = $contextTable->{current} unless defined($context);
+  $context = $Parser::Context::Default::context{Numeric}->copy unless defined($context);
+  if (!ref($context)) {
+    my $name = $context;
+    $context = Parser::Context->getCopy($contextTable,$context);
+    Value::Error("Unknown context '%s'",$name) unless defined($context);
   }
-  return $contextTable->{current};
+  $contextTable->{current} = $context;
+  $Value::context = \$contextTable->{current};
+  return $context;
 }
 
 #

--- a/lib/Parser/Context.pm
+++ b/lib/Parser/Context.pm
@@ -36,6 +36,7 @@ sub new {
   $context->{_reduction} = new Parser::Context::Reduction($context,%{$data{reduction}});
   $context->lists->set(%{$data{lists}});
   $context->flags->set(%{$data{flags}});
+  $context->{pattern}{numberPrecedence} = 5;
   $context->{_initialized} = 1;
   $context->update;
   return $context;
@@ -46,7 +47,7 @@ sub new {
 #
 sub update {
   my $self = shift; return unless $self->{_initialized};
-  my @patterns = ([$self->{pattern}{number},-10,'num']);
+  my @patterns = ($self->numberPattern);
   my @tokens;
   foreach my $name (@{$self->{data}{objects}}) {
     my $data = $self->{$name};
@@ -67,6 +68,11 @@ sub update {
   }
   my $pattern = '('.join(')|(',@patterns).')';
   $self->{pattern}{token} = qr/$pattern/;
+}
+
+sub numberPattern {
+  my $self = shift;
+  return [$self->{pattern}{number},$self->{pattern}{numberPrecedence},'num'];
 }
 
 #

--- a/lib/Parser/Context.pm
+++ b/lib/Parser/Context.pm
@@ -36,7 +36,7 @@ sub new {
   $context->{_reduction} = new Parser::Context::Reduction($context,%{$data{reduction}});
   $context->lists->set(%{$data{lists}});
   $context->flags->set(%{$data{flags}});
-  $context->{pattern}{numberPrecedence} = 5;
+  $context->{pattern}{numberPrecedence} = 5;  # comes after all specific tokens, and before generic variable pattern
   $context->{_initialized} = 1;
   $context->update;
   return $context;

--- a/lib/Parser/Context/Constants.pm
+++ b/lib/Parser/Context/Constants.pm
@@ -11,7 +11,7 @@ sub init {
   $self->{dataName} = 'constants';
   $self->{name} = 'constant';
   $self->{Name} = 'Constant';
-  $self->{namePattern} = qr/[a-zA-Z][a-zA-Z0-9]*|_blank_|_0/;
+  $self->{namePattern} = qr/\w+/;
   $self->{tokenType} = 'const';
 }
 

--- a/lib/Parser/Context/Constants.pm
+++ b/lib/Parser/Context/Constants.pm
@@ -31,7 +31,7 @@ sub uncreate {shift; (shift)->{value}}
 #
 sub value {
   my $self = shift; my $x = shift;
-  return $self->{context}{constants}{$x}{value};
+  return $self->{context}->constants->resolveDef($x)->{value};
 }
 
 #########################################################################

--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -44,17 +44,18 @@ $operators = {
            class => 'Parser::BOP::add'},
 
    '-' => {precedence => 1, associativity => 'left', type => 'both', string => '-',
-           class => 'Parser::BOP::subtract', rightparens => 'same'},
+           class => 'Parser::BOP::subtract', rightparens => 'same', alternatives => ["\x{2212}"]},
 
    'U' => {precedence => 1.5, associativity => 'left', type => 'bin', isUnion => 1,
-           string => ' U ', TeX => '\cup ', class => 'Parser::BOP::union'},
+           string => ' U ', TeX => '\cup ', class => 'Parser::BOP::union',
+           alternatives => ["\x{222A}","\x{22C3}"]},
 
    '><'=> {precedence => 2, associativity => 'left', type => 'bin',
            string => ' >< ', TeX => '\times ', perl => 'x', fullparens => 1,
-           class => 'Parser::BOP::cross'},
+           class => 'Parser::BOP::cross', alternatives => ["\x{00D7}"]},
 
    '.' => {precedence => 2, associativity => 'left', type => 'bin',
-           string => '.', TeX => '\cdot ', class => 'Parser::BOP::dot'},
+           string => '.', TeX => '\cdot ', class => 'Parser::BOP::dot', alternatives => ["\x{2219}", "\x{2022}"]},
 
    '*' => {precedence => 3, associativity => 'left', type => 'bin', space => ' *',
            string => '*', TeX => '', class => 'Parser::BOP::multiply'},
@@ -110,7 +111,9 @@ $parens = {
    '(' => {close => ')', type => 'Point', formMatrix => 1, formInterval => ']',
            formList => 1, removable => 1, emptyOK => 1, function => 1},
    '[' => {close => ']', type => 'Point', formMatrix => 1, formInterval => ')', removable => 1},
-   '<' => {close => '>', type => 'Vector'},
+   '<' => {close => '>', type => 'Vector',
+           alternatives => ["\x{2329}","\x{3008}","\x{27E8}"],
+           alternativeClose => ["\x{232A}","\x{3009}","\x{27E9}"]},
    '{' => {close => '}', type => 'Point', removable => 1},
    '|' => {close => '|', type => 'AbsoluteValue'},
    'start' => {close => 'start', type => 'List', formList => 1,
@@ -133,7 +136,7 @@ $lists = {
 
 $constants = {
    'e'  => exp(1),
-   'pi' => {value => 4*atan2(1,1), TeX => '\pi ', perl => "pi"},
+   'pi' => {value => 4*atan2(1,1), TeX => '\pi ', perl => "pi", alternatives => ["\x{03C0}","\x{1D70B}"]},
    'i'  => {value => Value::Complex->new(0,1), isConstant => 1,                        string => "i", perl => "i"},
    'j'  => {value => Value::Vector->new(0,1,0)->with(ijk=>1), TeX => '\boldsymbol{j}', string => "j", perl => "j"},
    'k'  => {value => Value::Vector->new(0,0,1)->with(ijk=>1), TeX => '\boldsymbol{k}', string => "k", perl => "k"},
@@ -183,7 +186,7 @@ $functions = {
    'log'   => {class => 'Parser::Function::numeric', TeX => '\log', simplePowers => 1},
    'log10' => {class => 'Parser::Function::numeric', nocomplex => 1, TeX => '\log_{10}'},
    'exp'   => {class => 'Parser::Function::numeric', inverse => 'log', TeX => '\exp'},
-   'sqrt'  => {class => 'Parser::Function::numeric', braceTeX => 1, TeX => '\sqrt'},
+   'sqrt'  => {class => 'Parser::Function::numeric', braceTeX => 1, TeX => '\sqrt', alternatives => ["\x{221A}"]},
    'abs'   => {class => 'Parser::Function::numeric'},
    'int'   => {class => 'Parser::Function::numeric'},
    'sgn'   => {class => 'Parser::Function::numeric', nocomplex => 1},
@@ -219,7 +222,7 @@ $functions = {
 };
 
 $strings = {
-   'infinity'  => {infinite => 1},
+   'infinity'  => {infinite => 1, alternatives => ["\x{221E}"]},
    'inf'  => {alias => 'infinity'},
    'NONE' => {},
    'DNE'  => {},
@@ -239,6 +242,8 @@ $flags = {
   allowBadOperands => 0,               # 1 is used by Typeset context (types need not match)
   allowBadFunctionInputs => 0,         # 1 is used by Typeset context (types need not match)
   allowWrongArgCount => 0,             # 1 = numbers need not be correct
+  parseAlternatives => 0,              # 1 = allow parsing of alternative tokens in the context
+  convertFullWidthCharacters => 0,     # 1 = convert Unicode full width characters to ASCII positions
 };
 
 ############################################################################
@@ -369,7 +374,7 @@ $context->{name} = "Complex";
 #
 $context = $context{"Complex-Vector"} = $context{Complex}->copy;
 $context->operators->redefine(['><','.'],from=>'Vector');
-$context->parens->add('<' => {close => '>', type => 'Vector'});
+$context->parens->redefine('<',from=>'Vector');
 $context->parens->set(
   '(' => {type => "Point", formMatrix => 0},
   '[' => {type => "Point", formMatrix => 0},

--- a/lib/Parser/Context/Functions.pm
+++ b/lib/Parser/Context/Functions.pm
@@ -11,7 +11,7 @@ sub init {
   $self->{dataName} = 'functions';
   $self->{name} = 'function';
   $self->{Name} = 'Function';
-  $self->{namePattern} = qr/[a-zA-Z][a-zA-Z0-9]*/;
+  $self->{namePattern} = qr/\w+|\x{221A}/;
   $self->{tokenType} = 'fn';
 }
 

--- a/lib/Parser/Context/Functions.pm
+++ b/lib/Parser/Context/Functions.pm
@@ -11,7 +11,7 @@ sub init {
   $self->{dataName} = 'functions';
   $self->{name} = 'function';
   $self->{Name} = 'Function';
-  $self->{namePattern} = qr/\w+|\x{221A}/;
+  $self->{namePattern} = qr/\w+|\x{221A}/;  # U+221A is the square root surd symbol
   $self->{tokenType} = 'fn';
 }
 

--- a/lib/Parser/Context/Parens.pm
+++ b/lib/Parser/Context/Parens.pm
@@ -12,6 +12,16 @@ sub init {
   $self->{name} = 'parenthesis';
   $self->{Name} = 'Parenthesis';
   $self->{namePattern} = qr/\S+/;
+  $self->{closes} = {};
+}
+
+#
+#  Determine if a close token matches with an open one.
+#
+sub match {
+  my $self = shift; my ($open,$close) = @_;
+  ($open) = $self->resolve($open);
+  return $self->{closes}{$open}{$close} || 0;
 }
 
 sub addToken {
@@ -19,15 +29,34 @@ sub addToken {
   my $data = $self->{context}{$self->{dataName}}{$token};
   unless ($data->{hidden}) {
     $self->{tokens}{$token} = "open";
-    $self->{tokens}{$data->{close}} = "close" unless $data->{close} eq $token;
+    my $close = $data->{close};
+    $self->{tokens}{$close} = "close" if defined($close) && $close ne $token;
   }
 }
 
 sub removeToken {
   my $self = shift; my $token = shift;
   my $data = $self->{context}{$self->{dataName}}{$token};
-  delete $self->{tokens}{$token};
-  delete $self->{tokens}{$data->{close}} unless $data->{hidden} || $data->{close} eq $token;
+  unless ($data->{hidden}) {
+    delete $self->{tokens}{$token};
+    my $close = $data->{close};
+    delete $self->{tokens}{$close} if defined($close) && $close ne $token;
+  }
+}
+
+#
+#  Create the {closes} hash
+#
+sub update {
+  my $self = shift;
+  $self->SUPER::update(@_);
+  $self->{closes} = {};
+  my $data = $self->{context}{$self->{dataName}};
+  foreach my $open (keys %{$data}) {
+    my $def = $data->{$open};
+    my ($base) = $self->resolve($open);
+    $self->{closes}{$base}{$def->{close}} = 1 if $def->{close};
+  }
 }
 
 #
@@ -37,6 +66,18 @@ sub clear {
   my $self = shift;
   $self->SUPER::clear();
   $self->redefine('start');
+}
+
+#
+#  Copy the {closes} hash
+#
+sub copy {
+  my $self = shift; my $orig = shift;
+  $self->SUPER::copy($orig);
+  $self->{closes} = {};
+  foreach my $open (keys %{$orig->{closes}}) {
+    $self->{closes}{$open} = {%{$orig->{closes}{$open}}};
+  }
 }
 
 #########################################################################

--- a/lib/Parser/Context/Reduction.pm
+++ b/lib/Parser/Context/Reduction.pm
@@ -12,6 +12,7 @@ sub init {
   $self->{name} = 'reduction';
   $self->{Name} = 'Reduction';
   $self->{namePattern} = qr/\S+/;
+  $self->{allowAlias} = 0;
 }
 
 sub update {} # no pattern or tokens needed

--- a/lib/Parser/Context/Strings.pm
+++ b/lib/Parser/Context/Strings.pm
@@ -15,14 +15,20 @@ sub init {
   $self->{tokenType} = 'str';
   $self->{precedence} = -5;
   $self->{caseInsensitive} = {};
+  $self->{ciAlternatives} = {};
 }
 
 sub update {
   my $self = shift;
   my @strings = keys %{$self->{caseInsensitive}};
+  $self->{patterns} = {};
   if (@strings) {
     my $pattern = '(?i)(?:'.Parser::Context::getPattern(@strings).')';
-    $self->{patterns} = {$pattern => [$self->{precedence},$self->{tokenType}]};
+    $self->{patterns}{$pattern} = [$self->{precedence},$self->{tokenType}];
+  }
+  foreach my $token (keys %{$self->{ciAlternatives}}) {
+    my $pattern = '(?i)(?:'.Parser::Context::getPattern(@{$self->{ciAlternatives}{$token}}).')';
+    $self->{patterns}{$pattern} = [$self->{precedence},[$self->{tokenType},$token]];
   }
   $self->SUPER::update;
 }
@@ -31,14 +37,46 @@ sub copy {
   my $self = shift; my $orig = shift;
   $self->SUPER::copy($orig);
   $self->{caseInsensitive} = {%{$orig->{caseInsensitive}}};
+  $self->{ciAlternatives} = {};
+  foreach my $token (keys %{$orig->{ciAlternatives}}) {
+    $self->{ciAlternatives}{$token} = [@{$orig->{ciAlternatives}{$token}}];
+  }
 }
 
+#
+#  Keep case insensitive strings separate so that they can be
+#    added as a separate pattern in the update method
+#
 sub addToken {
   my $self = shift; my $token = shift;
   my $data = $self->{context}{$self->{dataName}}{$token};
   return if $data->{hidden};
   my $field = (($data->{caseSensitive} || uc($token) eq lc($token)) ? "tokens" : "caseInsensitive");
   $self->{$field}{$token} = $self->{tokenType};
+  $self->addAlternatives($token,$data->{alternatives});
+}
+#
+#  Add case sensitive alternatives as normal, otherwise
+#    add them to the ciAlternative list
+#
+sub addAlternatives {
+  my $self = shift; my $token = shift; my $alternatives = shift || [];
+  my $data = $self->{context}{$self->{dataName}}{$token};
+  return if $data->{hidden} || !@$alternatives;
+  if ($data->{caseSensitive}) {
+    $self->SUPER::addAlternatives($token, $data->{alternatives});
+  } else {
+    my @strings = ();
+    foreach my $alt (@$alternatives) {
+      Value::Error("Illegal %s name '%s'",$self->{name},$alt) unless $alt =~ m/^$self->{namePattern}$/;
+      if (uc($alt) eq lc($alt)) {
+        $self->SUPER::addAlternatives($token, [$alt]);
+      } else {
+        push(@strings, $alt);
+      }
+    }
+    $self->{ciAlternatives}{$token} = [@strings] if @strings;
+  }
 }
 
 sub removeToken {
@@ -47,6 +85,11 @@ sub removeToken {
   return if $data->{hidden};
   my $field = (($data->{caseSensitive} || uc($token) eq lc($token)) ? "tokens" : "caseInsensitive");
   delete $self->{$field}{$token};
+  $self->removeAlternatives($token);
+}
+sub removeAlternatives {
+  my $self = shift; my $token = shift;
+  delete $self->{ciAlternatives}{$token};
 }
 
 

--- a/lib/Parser/Context/Variables.pm
+++ b/lib/Parser/Context/Variables.pm
@@ -64,7 +64,7 @@ sub uncreate {shift; (shift)->{type}};
 #
 sub type {
   my $self = shift; my $x = shift;
-  return $self->{context}{variables}{$x}{type};
+  return $self->{context}->variables->resolveDef($x)->{type};
 }
 
 #
@@ -72,7 +72,7 @@ sub type {
 #
 sub value {
   my $self = shift; my $x = shift;
-  return $self->{context}{variables}{$x}{value};
+  return $self->{context}->variables->resolveDef($x)->{value};
 }
 
 #
@@ -80,8 +80,10 @@ sub value {
 #
 sub variables {
   my $self = shift; my @names;
-  foreach my $x ($self->SUPER::names)
-    {push(@names,$x) unless $self->{context}{variables}{$x}{parameter}}
+  my $vars = $self->{context}{variables};
+  foreach my $x ($self->SUPER::names) {
+    push(@names,$x) unless $vars->{$x}{parameter} || $vars->{$x}{alias};
+  }
   return @names;
 }
 
@@ -90,8 +92,10 @@ sub variables {
 #
 sub parameters {
   my $self = shift; my @names;
-  foreach my $x ($self->SUPER::names)
-    {push(@names,$x) if $self->{context}{variables}{$x}{parameter}}
+  my $vars = $self->{context}{variables};
+  foreach my $x ($self->SUPER::names) {
+    push(@names,$x) if $vars->{$x}{parameter} && !$vars->{$x}{alias};
+  }
   return @names;
 }
 

--- a/lib/Parser/Context/Variables.pm
+++ b/lib/Parser/Context/Variables.pm
@@ -28,7 +28,7 @@ sub init {
   $self->{Name} = 'Variable';
   $self->{namePattern} = qr/\w+/;
   $self->{tokenType} = 'var';
-  $self->{precedence} = 10;
+  $self->{precedence} = 10;   # generic variable name pattern comes last (after specific names and after numbers)
   $self->{patterns}{$self->{namePattern}} = [$self->{precedence},$self->{tokenType}];
 }
 

--- a/lib/Parser/Context/Variables.pm
+++ b/lib/Parser/Context/Variables.pm
@@ -26,14 +26,11 @@ sub init {
   $self->{dataName} = 'variables';
   $self->{name} = 'variable';
   $self->{Name} = 'Variable';
-  $self->{namePattern} = qr/[a-zA-Z][a-zA-Z0-9]*/;
+  $self->{namePattern} = qr/\w+/;
   $self->{tokenType} = 'var';
-  $self->{precedence} = 5;
+  $self->{precedence} = 10;
   $self->{patterns}{$self->{namePattern}} = [$self->{precedence},$self->{tokenType}];
 }
-
-#sub addToken {}    # no tokens needed
-#sub removeToken {}
 
 #
 #  If the type is one of the named ones, use it's known type

--- a/lib/Parser/Function.pm
+++ b/lib/Parser/Function.pm
@@ -12,9 +12,8 @@ $Parser::class->{Function} = 'Parser::Function';
 sub new {
   my $self = shift; my $class = ref($self) || $self;
   my $equation = shift; my $context = $equation->{context};
-  my ($name,$params,$constant,$ref) = @_;
-  my $def = $context->{functions}{$name};
-  $name = $def->{alias}, $def = $context->{functions}{$name} if defined $def->{alias};
+  my ($name,$params,$constant,$ref) = @_; my $def;
+  ($name,$def) = $context->functions->resolve($name);
   my $fn = bless {
     name => $name, params => $params,
     def => $def, ref => $ref, equation => $equation,
@@ -106,7 +105,7 @@ sub copy {
 sub call {
   my $self = shift; my $name = shift;
   my $context = Parser::Context->current;
-  my $fn = $context->{functions}{$name};
+  my $fn = $context->functions->resolveDef($name);
   Value::Error("No definition for function '%s'",$name) unless defined($fn);
   my $isFormula = 0;
   foreach my $x (@_) {return $self->formula($name,@_) if Value::isFormula($x)}
@@ -227,8 +226,8 @@ sub checkMatrix {
 sub checkInverse {
   my $equation = shift;
   my $fn = shift; my $op = shift; my $rop = shift;
-  $op = $equation->{context}{operators}{$op->{name}};
-  $fn = $equation->{context}{functions}{$fn->{name}};
+  $op = $equation->{context}->operators->resolveDef($op->{name});
+  $fn = $equation->{context}->functions->resolveDef($fn->{name});
   return ($fn->{inverse} && $op->{isInverse} && $rop->{value}->string eq "-1");
 }
 

--- a/lib/Parser/String.pm
+++ b/lib/Parser/String.pm
@@ -21,7 +21,7 @@ sub new {
     $def = $strings->{uc($value)};
     $def = {} if $def->{caseSensitive} && $value ne uc($value);
   }
-  $value = $def->{alias}, $def = $strings->{$value} while defined($def->{alias});
+  ($value, $def) = $equation->{context}->strings->resolve($value);
   my $str = bless {
     value => $value, type => $Value::Type{string}, isConstant => 1,
     def => $def, ref => $ref, equation => $equation,

--- a/lib/Parser/UOP.pm
+++ b/lib/Parser/UOP.pm
@@ -11,8 +11,8 @@ $Parser::class->{UOP} = 'Parser::UOP';
 sub new {
   my $self = shift; my $class = ref($self) || $self;
   my $equation = shift; my $context = $equation->{context};
-  my ($uop,$op,$ref) = @_;
-  my $def = $context->{operators}{$uop};
+  my ($uop,$op,$ref) = @_; my $def;
+  ($uop,$def) = $context->operators->resolve($uop);
   my $UOP = bless {
     uop => $uop, op => $op,
     def => $def, ref => $ref, equation => $equation
@@ -151,7 +151,7 @@ sub Neg {
   my $self = shift;
   my $equation = $self->{equation};
   $self->Error("Can't reduce:  negation operator is not defined")
-    if (!defined($equation->{context}{operators}{'u-'}));
+    if (!defined($equation->{context}->operators->resolveDef('u-')));
   return ($self->Item("UOP")->new($equation,'u-',$self))->reduce;
 }
 

--- a/lib/Parser/Variable.pm
+++ b/lib/Parser/Variable.pm
@@ -14,9 +14,10 @@ $Parser::class->{Variable} = 'Parser::Variable';
 #
 sub new {
   my $self = shift; my $class = ref($self) || $self;
-  my $equation = shift; my $variables = $equation->{context}{variables};
-  my ($name,$ref) = @_;
-  unless ($variables->{$name}) {
+  my $equation = shift;
+  my ($name,$ref) = @_; my $def;
+  ($name,$def) = $equation->{context}->variables->resolve($name);
+  unless ($def) {
     my $string = substr($equation->{string},$ref->[2]);
     if ($string =~ m/^([a-z][a-z]+)/i) {
       $ref->[3] = $ref->[2]+length($1);
@@ -25,9 +26,8 @@ sub new {
     $equation->Error(["Variable '%s' is not defined in this context",$name],$ref);
   }
   $equation->Error(["Variable '%s' is not defined in this context",$name],$ref)
-    if $variables-> {$name}{parameter} && $equation->{context}{flags}{no_parameters};
+    if $def->{parameter} && $equation->{context}{flags}{no_parameters};
   $equation->{variables}{$name} = 1;
-  my $def = $variables->{$name};
   my $v = bless {
     name => $name, def => $def, type => $def->{type},
     ref => $ref, equation => $equation

--- a/lib/Value/Context/Diagnostics.pm
+++ b/lib/Value/Context/Diagnostics.pm
@@ -41,6 +41,7 @@ sub init {
   $self->{name} = 'diagnostics';
   $self->{Name} = 'Diagnostics';
   $self->{namePattern} = qr/[-\w_.]+/;
+  $self->{allowAlias} = 0;
 }
 
 sub update {} # no pattern or tokens needed

--- a/lib/Value/Context/Flags.pm
+++ b/lib/Value/Context/Flags.pm
@@ -12,6 +12,7 @@ sub init {
   $self->{name} = 'flag';
   $self->{Name} = 'Flag';
   $self->{namePattern} = qr/[-\w_.]+/;
+  $self->{allowAlias} = 0;
 }
 
 sub update {} # no pattern or tokens needed

--- a/lib/Value/Context/Lists.pm
+++ b/lib/Value/Context/Lists.pm
@@ -12,6 +12,7 @@ sub init {
   $self->{name} = 'list';
   $self->{Name} = 'List';
   $self->{namePattern} = qr/[^\s]+/;
+  $self->{allowAlias} = 0;
 }
 
 sub update {} # no pattern or tokens needed

--- a/lib/Value/Context/Lists.pm
+++ b/lib/Value/Context/Lists.pm
@@ -11,7 +11,7 @@ sub init {
   $self->{dataName} = 'lists';
   $self->{name} = 'list';
   $self->{Name} = 'List';
-  $self->{namePattern} = qr/[^\s]+/;
+  $self->{namePattern} = qr/\S+/;
   $self->{allowAlias} = 0;
 }
 

--- a/lib/Value/WeBWorK.pm
+++ b/lib/Value/WeBWorK.pm
@@ -92,6 +92,7 @@ my @wwEvalFields = qw(
   numZeroLevelTolDefault
   useBaseTenLog
   parseAlternatives
+  convertFullWidthCharacters
 );
 
 sub Parser::Context::copy {
@@ -105,13 +106,14 @@ sub Parser::Context::copy {
   return $context if $Value::_no_WeBWorK_; # hack for command-line debugging
   foreach my $x (@wwEvalFields) {$context->{WW}{$x} = $envir->{$x}}
   $context->flags->set(
-     tolerance         => $ww->{numRelPercentTolDefault} / 100,
-     zeroLevel         => $ww->{numZeroLevelDefault},
-     zeroLevelTol      => $ww->{numZeroLevelTolDefault},
-     num_points        => $ww->{functNumOfPoints} + 2,
-     max_adapt         => $ww->{functMaxConstantOfIntegration},
-     useBaseTenLog     => $ww->{useBaseTenLog},
-     parseAlternatives => $ww->{parseAlternatives},
+     tolerance                  => $ww->{numRelPercentTolDefault} / 100,
+     zeroLevel                  => $ww->{numZeroLevelDefault},
+     zeroLevelTol               => $ww->{numZeroLevelTolDefault},
+     num_points                 => $ww->{functNumOfPoints} + 2,
+     max_adapt                  => $ww->{functMaxConstantOfIntegration},
+     useBaseTenLog              => $ww->{useBaseTenLog},
+     parseAlternatives          => $ww->{parseAlternatives},
+     convertFullWidthCharacters => $ww->{convertFullWidthCharacters},
   );
   $context->{format}{number} = $ww->{numFormatDefault} if $ww->{numFormatDefault} ne '';
   $context->update if $context->flag('parseAlternatives',0) != $self->flag('parseAlternatives',0);

--- a/lib/Value/WeBWorK.pm
+++ b/lib/Value/WeBWorK.pm
@@ -91,6 +91,7 @@ my @wwEvalFields = qw(
   numZeroLevelDefault
   numZeroLevelTolDefault
   useBaseTenLog
+  parseAlternatives
 );
 
 sub Parser::Context::copy {
@@ -104,14 +105,16 @@ sub Parser::Context::copy {
   return $context if $Value::_no_WeBWorK_; # hack for command-line debugging
   foreach my $x (@wwEvalFields) {$context->{WW}{$x} = $envir->{$x}}
   $context->flags->set(
-     tolerance      => $ww->{numRelPercentTolDefault} / 100,
-     zeroLevel      => $ww->{numZeroLevelDefault},
-     zeroLevelTol   => $ww->{numZeroLevelTolDefault},
-     num_points     => $ww->{functNumOfPoints} + 2,
-     max_adapt      => $ww->{functMaxConstantOfIntegration},
-     useBaseTenLog  => $ww->{useBaseTenLog},
+     tolerance         => $ww->{numRelPercentTolDefault} / 100,
+     zeroLevel         => $ww->{numZeroLevelDefault},
+     zeroLevelTol      => $ww->{numZeroLevelTolDefault},
+     num_points        => $ww->{functNumOfPoints} + 2,
+     max_adapt         => $ww->{functMaxConstantOfIntegration},
+     useBaseTenLog     => $ww->{useBaseTenLog},
+     parseAlternatives => $ww->{parseAlternatives},
   );
   $context->{format}{number} = $ww->{numFormatDefault} if $ww->{numFormatDefault} ne '';
+  $context->update if $context->flag('parseAlternatives',0) != $self->flag('parseAlternatives',0);
   $context;
 }
 


### PR DESCRIPTION
This PR implements features in MathObjects to address the issues raised in #517.

The first is to support `alias` in more of the context classes, like operators, parens, variables, etc.  This makes handling aliases more uniform, and includes some error checking (e.g., that the object the alias points to actually exists).  This involves the most changes, especially in the parser.  In particular, one mush resolve the aliases in a number of locations in order to get the definition of the base object.  That involved adding `resolve()` and `resolveDef()` methods to the basic Context Data object, and using those methods in `Parser.pm` and other file whenever a token's data is needed.  I think I got all of the locations this needs to be done, but there might be some lurking out there.  These changes should not cause problems with existing usage, since there are no aliases in most of the cases where these are used (since it is a new feature), but since this does touch on fundamental areas of the parser, it needs some serious testing.  The existing aliases (for functions and strings) produce messages based on the resolved names rather than the originals (e.g., `arcsin` becomes `asin` automatically), so the resolved name is used in error messages.  That might be more confusing with aliased operators, etc.  (So if `**` where aliased to `^`, then `x**` would give a message about `^` needing a second argument.  This might want to ben revisited.)

I have made the changes for this feature in the first commit, so you may want to look at that in isolation in order to make the changes easier to understand.

The second feature is the addition of an `alternatives` property that provides alternative tokens for any given Context object.  For example

```
Context()->operators->set('-' => {alternatives => ["\x{2212}"]});
```

would add U+2212 (minus) to the list of tokens that act as the minus sign.  This is similar to aliasing U+2212 to the minus definition, except that (1) there is a configuration option to control whether alternatives are used or not (aliases are always used), and (2) if an object is removed, so are its alternatives (while aliases would have to be removed separately).  As part of this change, the name patterns for the various objects have been loosened up to allow Unicode characters in variable and function names, etc, and to make them less restrictive in other ways.  Also, the pattern for numbers has been moved so that strings and other objects can start with a number (an issue that has been raised in the past).  E.g., unicode Greek letters can be used for variables, as can `x_0`.

The second commit adds this functionality, and the third adds the configuration flag for it.

Third, there is now a feature where the full-width unicode characters at U+FF01 to U+FF5E can be converted to their ASCII equivalents automatically.  This should make using Chinese keyboards easier (and addresses awmorp's issue).

This is implemented in the fourth commit.

Finally, I have added a number of alternative Unicode versions to the default context definitions as an illustration of how this works.  If this PR is approved, then other of the contexts in PG/macros may want to be extended to include appropriate unicode values, or require other changes to avoid overriding these changes.  I have not looked at the problem library to see what problems might be adjusting the contexts in ways that might benefit from changes.

Finally, there is a corresponding pull request for webwork2 that needs to be used in order to set the `parseAlternatives` and `convertFullWidthCharacters` options on a course-wide basis.  Without that PR, you have to set these in the given context, and call the context's `update` method, as in

```
Context("Numeric")->flags->set(
  parseAlternatives => 1,
  convertFullWidthCharacters => 1
);
Context()->update;
```

in order to get the new features.