### PR TITLE
Use the correct close string (resolves issues reported by Alex)

### DIFF
--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -409,7 +409,7 @@ sub Close {
         my $top = $self->pop->{value}; $self->pop;
         $self->pushOperand(
            $self->Item("List")->new($self,[$top->makeList],$top->{isConstant},
-				     $paren,$top->entryType,$open,$paren->{close}));
+				     $paren,$top->entryType,$open,$type));
       } else {
         my $prev = $self->prev;
         if    ($type eq "start") {$self->Error(["Missing close parenthesis for '%s'",$prev->{value}],$prev->{ref})}


### PR DESCRIPTION
This fixes the problem reported by [Alex](https://github.com/openwebwork/pg/pull/518#issuecomment-770272968).  It was due to using a hale-open, half-close interval (where the close delimiter isn't the usual one for the open delimiter).  This puts back the original action on this line that was incorrectly changed in the original PR.