### PR TITLE
Fix some issues with the sage.pl macro.

### DIFF
--- a/macros/sage.pl
+++ b/macros/sage.pl
@@ -73,7 +73,7 @@ sub new {
 
      
 # handle legacy case where AnswerReturn was used
-   unless ($options{ShowAnswerBlank} =~ \S){
+   unless ($options{ShowAnswerBlank} =~ /\S/){
    		if ($options{AnswerReturn} == 0) {
    			$options{ShowAnswerBlank} = 'none';
    		} else {
@@ -126,7 +126,7 @@ sub new {
     if ($recordAnswerBlank eq 'none') {
 		$sage::recordAnswerString = <<EndOfString;
 def record_answer(ansVals):
-    print '';
+    print('');
 EndOfString
 	} else {
 		$sage::recordAnswerString = <<EndOfString;
@@ -186,10 +186,10 @@ SAGE_CODE
 sub sagePrint{ 
   my $self = shift;
   main::TEXT(main::MODES(TeX=>"", HTML=><<"SAGE_PRINT"));
-    <script src="$self->{CellServer}/static/jquery.min.js"></script>
+    <script>var jqSave = \$.noConflict(true);</script>
     <script src="$self->{CellServer}/embedded_sagecell.js"> </script>
     <script>
-      \$(function () {
+      jqSave(function () {
         sagecell.makeSagecell({
            inputLocation:     '#sagecell',
            template:              sagecell.templates.minimal,
@@ -198,6 +198,7 @@ sub sagePrint{
            evalButtonText:    '$self->{ButtonText}'
          });
        });
+       \$ = jQuery = jqSave;
     </script>
 SAGE_PRINT
 }
@@ -244,14 +245,15 @@ package main;
 sub sageCalculatorHeader {
 $CellServer = 'https://sagecell.sagemath.org';
 main::HEADER_TEXT(main::MODES(TeX=>"", HTML=><<"END_OF_FILE"));
-<script src="$CellServer/static/jquery.min.js"></script>
+    <script>var jqSave = \$.noConflict(true);</script>
     <script src="$CellServer/static/embedded_sagecell.js"></script>
-    <script>\$(function () {
+    <script>jqSave(function () {
     // Make *any* div with class 'sage-compute' a Sage cell
     sagecell.makeSagecell({inputLocation: 'div.sage-compute',
                            autoeval: 1,
                            hide: ["permalink"],
                            evalButtonText: 'Evaluate'});
+    \$ = jQuery = jqSave;
     });
     </script>
 END_OF_FILE


### PR DESCRIPTION
First, there was an obvious typo that made the macro's ShowAnswerBlank option fail.

Next, sage uses python3 which requires that the print function have its arguments parenthesized.  This causes the record_answer method in the ShowAnswerBlank eq 'none' case to fail.

Next, '<script src="$CellServer/static/jquery.min.js"></script>' was recently added to this macro before the loading of the sagecell
javascript.  The sagecell javascript internally loads its own jQuery instance, and so there is no need for that.  Furthermore, that version of jQuery conflicts with the version currently in use by WeBWorK.

Finally, the sagecell server does not correctly deal with jQuery.  They recently added the usage of the noConflict method, but it was not done so correctly.  This conflicts with our jQuery usage.  So our version of jQuery is cached and restored after the sagecell javascript is loaded and executed.  This is not the perfect solution, as it is theoretically possible for something else (another ready or window load function) to be executed during the time that the sagecell server code is loading.  The only perfect solution is for the sagecell code to be fixed.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=5011 for some of my discussion on this.