### PR TITLE
singleResult should score even with messages

### DIFF
--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -291,7 +291,8 @@ sub single_check {
       push(@errors,'<TR VALIGN="TOP"><TD STYLE="text-align:right; border:0px" NOWRAP>' .
                    "<I>In answer $i</I>:&nbsp;</TD>".
                    '<TD STYLE="text-align:left; border:0px">'.$result->{ans_message}.'</TD></TR>');
-    } else {$score += $result->{score}}
+    }
+    $score += $result->{score};
   }
   $ans->score($score/$self->length);
   $ans->{ans_message} = $ans->{error_message} = "";


### PR DESCRIPTION
MultiAnswer objects with `singleResult=>1` do not properly compute score when `setMessage` is used.

To test:
```
DOCUMENT();
loadMacros(
  "PGstandard.pl",
  "PGML.pl",
  "parserMultiAnswer.pl",
);

TEXT(beginproblem());
$ShowPartialCorrectAnswers = 1;

Context("Numeric");

$answerA = MultiAnswer(Real(0), Real(0))->with(
    singleResult=>1,
    checker => sub {
        my ($cor, $stu, $self, $ansHash) = @_;
        $self->setMessage(1, 'message indicating half credit for answer 1 of part A');
        $self->setMessage(2, 'message indicating half credit for answer 2 of part A');
        return 0.75;
    });

$answerB = MultiAnswer(Real(0), Real(0))->with(
    singleResult=>1,
    checker => sub {
        my ($cor, $stu, $self, $ansHash) = @_;
        $self->setMessage(1, 'message indicating half credit for answer 1 of part A');
        return 0.75;
    });

$answerC = MultiAnswer(Real(0), Real(0))->with(
    singleResult=>1,
    checker => sub {
        my ($cor, $stu, $self, $ansHash) = @_;
        # no message about half credit for answer 1 of part C
        return 0.75;
    });

BEGIN_PGML

Single-result Multi-Answer objects are incorrectly scored when setMessage is used.

*Part A*  
Answer A _should_ receive 75% credit and a feedback message for each sub-part.  
1. [__________]{$answerA}  
1. [__________]{$answerA}  

*PartB*  
Answer B _should_ receive 75% credit and a feedback message for just one part.
1. [__________]{$answerB}  
1. [__________]{$answerB}  

*PartC*  
Answer C _should_ receive 75% credit and no feedback message.
1. [__________]{$answerC}  
1. [__________]{$answerC}  

END_PGML
ENDDOCUMENT();
```