### PR TITLE
Fix problem with decimals with no leading 0 (#525)

### DIFF
--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -54,7 +54,7 @@ $operators = {
            string => ' >< ', TeX => '\times ', perl => 'x', fullparens => 1,
            class => 'Parser::BOP::cross', alternatives => ["\x{00D7}"]},
 
-   '.' => {precedence => 2, associativity => 'left', type => 'bin',
+   '.' => {precedence => 2, associativity => 'left', type => 'bin', patternPrecedence => 8, # after number patter
            string => '.', TeX => '\cdot ', class => 'Parser::BOP::dot', alternatives => ["\x{2219}", "\x{2022}"]},
 
    '*' => {precedence => 3, associativity => 'left', type => 'bin', space => ' *',

--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -54,7 +54,7 @@ $operators = {
            string => ' >< ', TeX => '\times ', perl => 'x', fullparens => 1,
            class => 'Parser::BOP::cross', alternatives => ["\x{00D7}"]},
 
-   '.' => {precedence => 2, associativity => 'left', type => 'bin', patternPrecedence => 8, # after number patter
+   '.' => {precedence => 2, associativity => 'left', type => 'bin', patternPrecedence => 8, # after number pattern
            string => '.', TeX => '\cdot ', class => 'Parser::BOP::dot', alternatives => ["\x{2219}", "\x{2022}"]},
 
    '*' => {precedence => 3, associativity => 'left', type => 'bin', space => ' *',


### PR DESCRIPTION
This PR adds a `patternPrecedence` property to context items that allows individual tokens to be prioritized in the pattern list.  It then uses that to put the `.` operator pattern after the number pattern, so that decimal numbers with no leading zero will be identified first, and then if `.` is not used as a decimal, it will be recognized as a dot product.

Without the patch, `Compute(".123")` produces an error about a missing operand for `.` but with the patch, it should produce .123 as expected.   Also

```
Context("Vector");
TEXT(Compute("<1,2> . <3,4>"));
```

should produce an output of 11.

Resolves issue #525.