### PR TITLE
Switch from opening a new window to opening a dialog when an image is clicked

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -3034,12 +3034,7 @@ sub image {
 			|| $displayMode eq 'HTML_asciimath'
 			|| $displayMode eq 'HTML_LaTeXMathML'
 			|| $displayMode eq 'HTML_img') {
-			my $wid = ($envir->{onTheFlyImageSize} || 0) +30;
-			$out = qq!<A HREF="$imageURL" TARGET="_blank"
-			onclick="window.open(this.href, this.target, 'width=$wid, height=$wid, scrollbars=yes, resizable=on'); return false;">
-			<IMG SRC="$imageURL" WIDTH="$width" $height_attrib $out_options{extra_html_tags}>
-			</A>
-			!
+			$out = qq!<IMG SRC="$imageURL" class="image-view-elt" tabindex="0" role="button" WIDTH="$width" $height_attrib $out_options{extra_html_tags}>!
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = 100*$width/600;
 			$out = qq!<sidebyside widths="$ptxwidth%">\n<image source="$imageURL" />\n<\/sidebyside>!


### PR DESCRIPTION
The current method of having a new browser window or tab open when an image in a PG problem is clicked is intrusive.  Furthermore the behavior that occurs is different depending on which browser is in use.

This changes to opening a bootstrap modal dialog  when an image is clicked instead.  That dialog can be moved around and the image in the dialog can be resized using the zoom in and zoom out buttons in the dialog.  The image can also be resized using the +/- keys or the mouse wheel.

This is the pg part that creates the DOM element.

The javascript for this is in https://github.com/openwebwork/webwork2/pull/1207