### PR TITLE
allow access to course environment PG_VERSION

### DIFF
--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -50,6 +50,7 @@ BEGIN {
                 fileFromPath
                 directoryFromPath
                 createDirectory
+				pgVersion
         );
 
 	our %SHARE = map { $_ => __PACKAGE__ } @SHARED_FUNCTIONS;
@@ -507,6 +508,10 @@ END
 		}
 	}
 	return $ret;
+}
+
+sub pgVersion {
+	return $CE->{PG_VERSION};
 }
 
 =back


### PR DESCRIPTION
this PR provides access to the pg version as read in from `pg/VERSION` by the CourseEnvironment.pm module from ww2

requested in issue: openwebwork/webwork2#1204

also tagging openwebwork/webwork2#1121