### PR TITLE
set pg version info in %ENV and PGcore obj+package

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -14,8 +14,17 @@
 # Artistic License for more details.
 ################################################################################
 package PGcore;
-
 use strict;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    my $dir = dirname(__FILE__);
+    do "${dir}/../VERSION";
+    warn "Error loading PG VERSION file: $!"    if $!;
+    warn "Error processing PG VERSION file: $@" if $@;
+    $ENV{PG_VERSION} = $PGcore::PG_VERSION || 'unknown';
+}
+
 our $internal_debug_messages = [];
 
 use PGanswergroup;
@@ -78,7 +87,7 @@ sub new {
 		vec_num                   => 0,     # for distinguishing matrices
 		QUIZ_PREFIX               => $envir->{QUIZ_PREFIX},
 		SECTION_PREFIX            => '',  # might be used for sequential (compound) questions?
-		
+		PG_VERSION                => $ENV{PG_VERSION},
 		PG_ACTIVE                 => 1,   # toggle to zero to stop processing
 		submittedAnswers          => 0,   # have any answers been submitted? is this the first time this session?
 		PG_session_persistence_hash =>{}, # stores data from one invoction of the session to the next.


### PR DESCRIPTION
replacement/improvement on #530 (@dpvc @drgrice1 thanks!)

with this PR, pg will now declare its version when PGcore.pm is loaded -- making the version available through:
* the ENV hash: `$ENV{PG_VERSION}` (available everywhere _outside_ of a problem's pg code)
* the PGcore object: `$PG->{PG_VERSION}` (in a problem's pg code)
* the PGcore package: `$PGcore::PG_VERSION` (also available in pg code)