### PR TITLE
Follow alias chain, not just first alias.  (#518)

### DIFF
--- a/lib/Parser/String.pm
+++ b/lib/Parser/String.pm
@@ -18,7 +18,7 @@ sub new {
   my ($value, $ref) = @_;
   my $def = $strings->{$value};
   my $VALUE = uc($value); my $DEF = $strings->{$VALUE};
-  ($value, $def) = ($VALUE, $DEF)  if !$def && $DEF && (!$DEF->{caseSensitive} || $value eq $VALUE);
+  ($value, $def) = ($VALUE, $DEF) if !$def && $DEF && !$DEF->{caseSensitive};
   ($value, $def) = $equation->{context}->strings->resolve($value);
   my $str = bless {
     value => $value, type => $Value::Type{string}, isConstant => 1,

--- a/lib/Parser/String.pm
+++ b/lib/Parser/String.pm
@@ -17,12 +17,9 @@ sub new {
   my $equation = shift; my $strings = $equation->{context}{strings};
   my ($value, $ref) = @_;
   my $def = $strings->{$value};
-  my $VALUE = uc($value);
-  unless ($def) {
-    $def = $strings->{$VALUE};
-    $def = {}, $VALUE = $value if $def->{caseSensitive} && $value ne $VALUE;
-  }
-  ($value, $def) = $equation->{context}->strings->resolve($VALUE);
+  my $VALUE = uc($value); my $DEF = $strings->{$VALUE};
+  ($value, $def) = ($VALUE, $DEF)  if !$def && $DEF && (!$DEF->{caseSensitive} || $value eq $VALUE);
+  ($value, $def) = $equation->{context}->strings->resolve($value);
   my $str = bless {
     value => $value, type => $Value::Type{string}, isConstant => 1,
     def => $def, ref => $ref, equation => $equation,

--- a/lib/Parser/String.pm
+++ b/lib/Parser/String.pm
@@ -17,11 +17,12 @@ sub new {
   my $equation = shift; my $strings = $equation->{context}{strings};
   my ($value, $ref) = @_;
   my $def = $strings->{$value};
+  my $VALUE = uc($value);
   unless ($def) {
-    $def = $strings->{uc($value)};
-    $def = {} if $def->{caseSensitive} && $value ne uc($value);
+    $def = $strings->{$VALUE};
+    $def = {}, $VALUE = $value if $def->{caseSensitive} && $value ne $VALUE;
   }
-  ($value, $def) = $equation->{context}->strings->resolve($value);
+  ($value, $def) = $equation->{context}->strings->resolve($VALUE);
   my $str = bless {
     value => $value, type => $Value::Type{string}, isConstant => 1,
     def => $def, ref => $ref, equation => $equation,

--- a/lib/Value/Context/Data.pm
+++ b/lib/Value/Context/Data.pm
@@ -256,7 +256,7 @@ sub resolve {
   my $self = shift; my $name = shift;
   my $data = $self->{context}{$self->{dataName}};
   my $def = $data->{$name};
-  $name = $def->{alias}, $def = $data->{$name} if defined($def) && $def->{alias};
+  $name = $def->{alias}, $def = $data->{$name} while defined($def) && $def->{alias};
   return ($name, $def);
 }
 


### PR DESCRIPTION
[Alex's issue](https://github.com/openwebwork/pg/pull/518#issuecomment-785426797) turns out to be due to the `resolve()` method only following one alias, instead of following an alias chain.  This PR causes `resolve()` to follow aliases until the end.  MathObjects try to prevent there from being an alias loop (one alias pointing to an alias that points back to the first), but it is possible to make them if you try hard, so this could potentially loop infinitely if a page author worked hard to make that true.  One could introduce a counter and a maximum depth for alias links to avoid that.