### PR TITLE
Do a typecheck before comparing functions.  (bugzilla bug 4559)

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1734,7 +1734,7 @@ sub cmp_postfilter {
     next unless defined($prev);
     $context->{answerHash} = $ans; # values here can override context flags
     $ans->{prev_equals_current} = $prev->typeMatch($ans->{student_formula})
-      && Value::cmp_compare($prev,$ans->{student_formula},$ans);
+      && $prev->cmp_compare($ans->{student_formula},$ans);
     $context->{answerHash} = undef;
     if (   !$ans->{isPreview}                                 # not preview mode
 	and $ans->{prev_equals_current}                       # equivalent

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1733,7 +1733,8 @@ sub cmp_postfilter {
     my $prev = eval {$self->promote($ans->{prev_formula})->inherit($self)}; # inherit limits, etc.
     next unless defined($prev);
     $context->{answerHash} = $ans; # values here can override context flags
-    $ans->{prev_equals_current} = Value::cmp_compare($prev,$ans->{student_formula},$ans);
+    $ans->{prev_equals_current} = $prev->typeMatch($ans->{student_formula})
+      && Value::cmp_compare($prev,$ans->{student_formula},$ans);
     $context->{answerHash} = undef;
     if (   !$ans->{isPreview}                                 # not preview mode
 	and $ans->{prev_equals_current}                       # equivalent


### PR DESCRIPTION
This PR adjusts the function-equivalence check to call the correct-answer's `typeMatch()` method, which checks that the types of the return values are correct (the general comparison is less strict than that, as it allows promotion of types).

Resolve bugzilla [bug 4559](https://bugs.webwork.maa.org/show_bug.cgi?id=4559), where the bug is described, and a test-case is given.