### PR TITLE
Adjust the default class for [...] and {...}, and do type-matching in list comparisons.  (#535)

### DIFF
--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -110,11 +110,11 @@ $operators = {
 $parens = {
    '(' => {close => ')', type => 'Point', formMatrix => 1, formInterval => ']',
            formList => 1, removable => 1, emptyOK => 1, function => 1},
-   '[' => {close => ']', type => 'Point', formMatrix => 1, formInterval => ')', removable => 1},
+   '[' => {close => ']', type => 'List', formMatrix => 1, formInterval => ')', removable => 1},
    '<' => {close => '>', type => 'Vector',
            alternatives => ["\x{2329}","\x{3008}","\x{27E8}"],
            alternativeClose => ["\x{232A}","\x{3009}","\x{27E9}"]},
-   '{' => {close => '}', type => 'Point', removable => 1},
+   '{' => {close => '}', type => 'Set', removable => 1},
    '|' => {close => '|', type => 'AbsoluteValue'},
    'start' => {close => 'start', type => 'List', formList => 1,
                removable => 1, emptyOK => 1, hidden => 1},
@@ -284,8 +284,7 @@ $context->constants->remove('i','j','k');
 $context->parens->remove('<');
 $context->parens->set(
    '(' => {type => 'List', formMatrix => 0},
-   '[' => {type => 'List', formMatrix => 0},
-   '{' => {type => 'List'},
+   '[' => {formMatrix => 0}
 );
 $context->{name} = "Numeric";
 
@@ -356,8 +355,7 @@ $context->constants->remove('j','k');
 $context->parens->remove('<');
 $context->parens->set(
    '(' => {type => 'List', formMatrix => 0},
-   '[' => {type => 'List', formMatrix => 0},
-   '{' => {type => 'List'},
+   '[' => {formMatrix => 0}
 );
 $context->operators->set(
   '^'  => {class => 'Parser::Function::complex_power', negativeIsComplex => 1},
@@ -375,11 +373,7 @@ $context->{name} = "Complex";
 $context = $context{"Complex-Vector"} = $context{Complex}->copy;
 $context->operators->redefine(['><','.'],from=>'Vector');
 $context->parens->redefine('<',from=>'Vector');
-$context->parens->set(
-  '(' => {type => "Point", formMatrix => 0},
-  '[' => {type => "Point", formMatrix => 0},
-  '{' => {type => "Point"},
-);
+$context->parens->set('(' => {type => "Point"});
 $context->{name} = "Complex-Vector";
 
 #

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1521,7 +1521,10 @@ sub cmp_list_compare {
     #
     if ($ordered) {
       if (scalar(@correct)) {
-	if (shift(@correct)->cmp_compare($entry,$ans,$nth,$value)) {$score++; next ENTRY}
+	my $correct = shift(@correct);
+	if ($correct->typeMatch($entry) && $correct->cmp_compare($entry,$ans,$nth,$value)) {
+          $score++; next ENTRY;
+        }
       } else {
 	# do syntax check
 	if (ref($extra) eq 'CODE') {&$extra($entry,$ans,$nth,$value)}
@@ -1530,7 +1533,7 @@ sub cmp_list_compare {
       if ($error->{flag} == $CMP_ERROR) {$self->cmp_error($ans); return}
     } else {
       foreach my $k (0..$#correct) {
-	if ($correct[$k]->cmp_compare($entry,$ans,$nth,$value)) {
+	if ($correct[$k]->typeMatch($entry) && $correct[$k]->cmp_compare($entry,$ans,$nth,$value)) {
 	  splice(@correct,$k,1);
 	  $score++; next ENTRY;
 	}


### PR DESCRIPTION
This PR addresses the issues raised in #535.

1.  The default class for `[...]` and `{...}` when delimiting a list of numbers used to be `Point`, which causes the Point context to allow `{1,2}` to match `(1,2)` unexpectedly.  This PR changes `[...]` to produce a List instead and `{...}` to produce sets.  These two are still removable, however, so `[1]` is still just `1` and `{2}` is just `2`.  This is because these brackets and braces are supposed to be allowed as alternative parentheses (to make it easier to match them in a complex expression), and because MathObject strings use both `(...)` and `[...]` (again, to make matching them easier to see).  So while `{1,2}` will produce a set, `{1}` will not, unless `removable` is set to `0`, as it is in the Interval context.

2.  The default list checker did not call `typeMatch()` before comparing a correct entry to a student entry, and so `(1,2)` would match `{1,2}` as points.  This PR adds the `typeMatch()` call so that the comparison is made only between objects that should actually be compared.  Some people may have taken advantage of this deficiency, so some problems may break due to this change.  I don't know of any, but after 15 years of working this way, no doubt some problems will rely on this mis-feature.

This probably wants extensive testing before merging.

Resolves issue #535.