### PR TITLE
Correct typo in context property.  (#536)

### DIFF
--- a/macros/contextPiecewiseFunction.pl
+++ b/macros/contextPiecewiseFunction.pl
@@ -115,7 +115,7 @@ sub Init {
      },
 
      "in " => {
-        precedence => .35, asscoiativity => 'right', type => 'binary',
+        precedence => .35, associativity => 'right', type => 'binary',
         string => ' in ', TeX => '\in ', class => 'PiecewiseFunction::BOP::in',
      },
   );


### PR DESCRIPTION
This PR corrects a typo in the contextPiecewiseFunctions.pl file.  It would mean that the associativity of `in` is left rather than right, but since it is unlikely anyone would put two of these back to back anyway, it never really hurt anything.

Resolves issue #536.