### PR TITLE
Add options to add TeX libraries and add to the TeX preamble in the PGtikz.pl macro

### DIFF
--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -33,6 +33,8 @@ sub new {
 		tex           => '',
 		tikzOptions   => '',
 		tikzLibraries => '',
+		texPackages   => {},
+		addToPreamble => '',
 		ext           => 'png',
         imageName     => ''
 	};
@@ -76,6 +78,19 @@ sub tikzLibraries {
 	return &$self('tikzLibraries', @_);
 }
 
+# Set additional TeX packages to load.  This accepts a single hash parameter.
+sub texPackages {
+	my $self = shift;
+	return &$self('texPackages', $_[0]) if ref($_[0]) eq "HASH";
+	return &$self('texPackages');
+}
+
+# Additional TeX commands to add to the TeX preamble
+sub addToPreamble {
+	my $self = shift;
+	return &$self('addToPreamble', @_);
+}
+
 # Set the image type.  The valid types are 'png', 'gif', 'svg', and 'pdf'.
 # The 'pdf' option should be set for print.
 sub ext {
@@ -93,8 +108,13 @@ sub header {
 	my $self = shift;
 	my @output = ();
 	push(@output, "\\documentclass{standalone}\n");
+	push(@output, "\\usepackage[svgnames]{xcolor}\n");
 	push(@output, "\\usepackage{tikz}\n");
+	push(@output, map {
+			"\\usepackage" . ($self->texPackages->{$_} ne "" ? "[$self->texPackages->{$_}]" : "") . "{$_}\n"
+		} keys %{$self->texPackages});
 	push(@output, "\\usetikzlibrary{" . $self->tikzLibraries . "}") if ($self->tikzLibraries ne "");
+	push(@output, $self->addToPreamble);
 	push(@output, "\\begin{document}\n");
 	push(@output, "\\begin{tikzpicture}");
 	push(@output, "[" . $self->tikzOptions . "]") if ($self->tikzOptions ne "");

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -22,39 +22,58 @@ PGtikz.pl - Insert images into problems that are generated using LaTeX and TikZ.
 This is a convenience macro for utilizing the TikZImage object to insert TikZ
 images into problems.  Create a TikZ image as follows:
 
-	$image = createTikZImage();
-	$image->tex(<<END_TIKZ);
-	\draw (-2,0) -- (2,0);
-	\draw (0,-2) -- (0,2);
-	\draw (0,0) circle[radius=1.5];
-	END_TIKZ
+    $image = createTikZImage();
+    $image->tex(<<END_TIKZ);
+    \draw (-2,0) -- (2,0);
+    \draw (0,-2) -- (0,2);
+    \draw (0,0) circle[radius=1.5];
+    END_TIKZ
 
 Then insert the image into the problem with
 
-	image(insertGraph($image));
+    image(insertGraph($image));
 
 =head1 DETAILED USAGE
 
 There are several TikZImage parameters that may need to be set for the
 TikZImage object return by createTikZImage to generate the desired image.
 
-	$image->tex()              Add the tikz commands that define the image.
-							   This takes a single string parameter.  It is
-							   generally best to use single quotes around the
-							   string.  Escaping of special characters may be
+    $image->tex()              Add the tikz commands that define the image.
+                               This takes a single string parameter.  It is
+                               generally best to use single quotes around the
+                               string.  Escaping of special characters may be
                                needed in some cases.
 
-	$image->tikzOptions()      Add options that will be passed to
-							   \begin{tikzpicture}.  This takes a single
+    $image->tikzOptions()      Add options that will be passed to
+                               \begin{tikzpicture}.  This takes a single
                                string parameter.
+                               For example:
+                               $image->tikzOptions(
+                                   "x=.5cm,y=.5cm,declare function={f(\x)=sqrt(\x);}"
+                               );
 
-	$image->tikzLibraries()    Add additional tikz libraries to load.  This
+    $image->tikzLibraries()    Add additional tikz libraries to load.  This
                                takes a single string parameter.
+                               For example:
+                               $image->tikzLibraries("arrows.meta,calc");
 
-	$image->ext()              Set the file type to be used for the image.
-							   The valid image types are 'png', 'gif', 'svg',
-							   and 'pdf'.  The default is a 'png' image.  This
-							   macro sets this to 'pdf' when a hardcopy is
+    $image->texPackages()      Add tex packages to load.  This takes a hash for
+                               its parameter.  The keys of this hash are the
+                               package names, and the corresponding values a
+                               string consisting of options for the package.
+                               For example:
+                               $image->texPackages({
+                                   "pgfplots" => "",
+                                   "hf-tikz" => "customcolors"
+                               });
+
+    $image->addToPreamble()    Additional commands to add to the TeX preamble.
+                               This takes a single string parameter.
+
+    $image->ext()              Set the file type to be used for the image.
+                               The valid image types are 'png', 'gif', 'svg',
+                               and 'pdf'.  The default is a 'png' image.  This
+                               macro sets this to 'pdf' when a hardcopy is
                                generated.
 
 =cut


### PR DESCRIPTION
This makes that method more versatile.  For example, with this you can use the pgfplots package.

This was also something that was requested when the PGtikz.pl macro was originally introduced (see https://github.com/openwebwork/pg/pull/432#issuecomment-638989408).

You can test this with the attached pg file.
[tikz-package-test.zip](https://github.com/openwebwork/pg/files/6077223/tikz-package-test.zip)
