### PR TITLE
PreTeXt: remove sidebyside

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2323,29 +2323,23 @@ sub PTX_cleanup {
 	# Wrap <p> tags where necessary, and other cleanup
 	# Nothing else should be creating p tags, so assume all p tags created here
 	# The only supported top-level elements within a statement, hint, or solution in a problem
-	# are p, blockquote, pre, sidebyside
+	# are p, blockquote, pre, tabular, image, video
 	if ($displayMode eq 'PTX') {
 		#encase entire string in <p>
 		#except not for certain "sub" structures that are also passed through EV3
 		$string = "<p>".$string."</p>" unless (($string =~ /^<fillin[^>]*\/>$/) or ($string =~ /^<var.*<\/var>$/s));
 
-		#a <sidebyside> may have been created within a <cell> of a <tabular> as a container of an <image>
-		#so here we clean that up
-		$string =~ s/(?s)(<cell>((?!<\/cell>).)*?)<sidebyside[^>]*>(.*?)<\/sidebyside>(.*?<\/cell>)/$1$3$4/g;
-
-		#inside a sidebyside, the only permissible children are p, image, video, and tabular
+		#inside a li, the only permissible children are p, image, video, and tabular
 		#insert opening and closing p, to be removed later if they enclose an image, video or tabular
-		$string =~ s/(<sidebyside[^>]*(?<!\/)>)/$1\n<p>/g;
-		$string =~ s/(<\/sidebyside>)/<\/p>\n$1/g;
-		#ditto for li, since we are not going to look to see if there is a nested list in there
+		#we are not going to look to see if there is a nested list in there
 		$string =~ s/(<li[^>]*(?<!\/)>)/$1\n<p>/g;
 		$string =~ s/(<\/li>)/<\/p>\n$1/g;
 
-		#close p right before any sidebyside, blockquote, or pre, image, video, or tabular
+		#close p right before any blockquote, pre, image, video, or tabular
 		#and open p immediately following. Later any potential side effects are cleaned up.
-		$string =~ s/(<(sidebyside|blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
-		$string =~ s/(<\/(sidebyside|blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
-		$string =~ s/(<(sidebyside|blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
+		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
+		$string =~ s/(<\/(blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
+		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
 
 		#within a <cell>, we may have an issue if there was an image that had '<\p>' and '<p>' wrapped around
 		#it from the above block. If the '</p>' has a preceding '<p>' within the cell, no problem. Otherwise,
@@ -2845,7 +2839,7 @@ sub begintable {
 		$out .= "\n\\par\\smallskip\\begin{center}\\begin{tabular}{"  .  "|c" x $number .  "|} \\hline\n";
 	}
 	elsif ($displayMode eq 'PTX') {
-		$out .= "\n".'<sidebyside><tabular top="medium" bottom="medium" left="medium" right="medium">'."\n";
+		$out .= "\n".'<tabular top="medium" bottom="medium" left="medium" right="medium">'."\n";
 	}
 	elsif ($displayMode eq 'Latex2HTML') {
 		$out .= "\n\\begin{rawhtml} <TABLE, BORDER=1>\n\\end{rawhtml}";
@@ -2872,7 +2866,7 @@ sub endtable {
 		$out .= "\n\\end {tabular}\\end{center}\\par\\smallskip\n";
 	}
 	elsif ($displayMode eq 'PTX') {
-		$out .= "\n".'</tabular></sidebyside>'."\n";
+		$out .= "\n".'</tabular>'."\n";
 	}
 	elsif ($displayMode eq 'Latex2HTML') {
 		$out .= "\n\\begin{rawhtml} </TABLE >\n\\end{rawhtml}";
@@ -3035,7 +3029,7 @@ sub image {
 			!
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = 100*$width/600;
-			$out = qq!<sidebyside widths="$ptxwidth%">\n<image source="$imageURL" />\n<\/sidebyside>!
+			$out = qq!<image width="$ptxwidth%" source="$imageURL" />!
 		} else {
 			$out = "Error: PGbasicmacros: image: Unknown displayMode: $displayMode.\n";
 		}
@@ -3055,7 +3049,7 @@ sub embedSVG {
 	return MODES( HTML => q!
 		<img src="! . alias($file_name).$str.q!">!,
 		TeX => "\\includegraphics[width=6in]{" . alias( $file_name ) . "}",
-		PTX => '<sidebyside><image source="' . alias($file_name) . '" /></sidebyside>',
+		PTX => '<image source="' . alias($file_name) . '" />',
 	);
 }
 
@@ -3069,7 +3063,7 @@ sub embedPDF {
 		width="100%"
 		height="100%"></object>!,
 		TeX => "\\includegraphics[width=6in]{" . alias( $file_name ) . "}",
-		PTX => '<sidebyside><image source="'.alias($file_name).'" /></sidebyside>',
+		PTX => '<image source="'.alias($file_name).'" />',
 	) ;
 }
 
@@ -3142,7 +3136,7 @@ sub video {
 			!
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = 100*$width/600;
-			$out = qq!<sidebyside><video source="$videoURL" width="$ptxwidth%" /></sidebyside>!
+			$out = qq!<video source="$videoURL" width="$ptxwidth%" />!
 		} else {
 			$out = "Error: PGbasicmacros: video: Unknown displayMode: $displayMode.\n";
 		}

--- a/macros/PGmatrixmacros.pl
+++ b/macros/PGmatrixmacros.pl
@@ -228,7 +228,7 @@ sub dm_begin_matrix {
                 $out .= qq!<TABLE class="matrix" BORDER="0" style="border-collapse: separate; border-spacing:10px 0px;">\n!;
         }
         elsif ( $main::displayMode eq 'PTX' ) {
-                $out .= qq!<sidebyside>\n<tabular>\n!;
+                $out .= qq!<tabular>\n!;
         }
         else {
                 $out = "Error: dm_begin_matrix: Unknown displayMode: $main::displayMode.\n";
@@ -384,7 +384,7 @@ sub dm_end_matrix {
                 $out .= "</TABLE>\n";
                 }
         elsif ( $main::displayMode eq 'PTX') {
-                $out .= qq!</tabular>\n</sidebyside>\n!;
+                $out .= qq!</tabular>\n!;
                 }
         else {
                 $out = "Error: PGmatrixmacros: dm_end_matrix: Unknown displayMode: $main::displayMode.\n";

--- a/macros/alignedChoice.pl
+++ b/macros/alignedChoice.pl
@@ -63,7 +63,7 @@ sub aligned_print_q {
     }
     $out .= "\\end{tabular}\n";
   } elsif ($main::displayMode eq "PTX") {
-    $out = "<sidebyside>\n<tabular>\n";
+    $out = "<tabular>\n";
     foreach $quest (@questions) {
       if (ref($quest) eq 'ARRAY') {($quest,$rest) = @{$quest}} else {$rest = ''}
       $out .= "<row>\n";
@@ -72,7 +72,7 @@ sub aligned_print_q {
       $out .= "<cell><m>=</m></cell>\n" if ($equals);
       $out .= "<cell>" . ans_rule($length) . $rest . "</cell>\n</row>\n";
     }
-    $out .= "</tabular>\n</sidebyside>\n";
+    $out .= "</tabular>\n";
   } else {
     $out = "Error: std_aligned_print_q: Unknown displayMode: ".
       $main::displayMode;

--- a/macros/niceTables.pl
+++ b/macros/niceTables.pl
@@ -507,7 +507,7 @@ sub DataTable {
   # build html and ptx strings for the table (which have structural similarities that distinguish them from tex)
   if ($options{LaYoUt} != 1) {
   $table = '<TABLE style = "'.$tablecss.'">';
-  $ptxtable = "<sidebyside" . (($center)?' margins="auto"':'') . ">\n<tabular" . (($midrules)?' top="minor" bottom="minor"':'') . ">\n";
+  $ptxtable = "<tabular" . (($midrules)?' top="minor" bottom="minor"':'') . ">\n";
   $table .= '<colgroup>';
   for my $i (0..$#{$columnscss})
     {$columnscss->[$i] = '' unless (defined($columnscss->[$i]));
@@ -549,7 +549,7 @@ sub DataTable {
       elsif ($bodystarted and ($i == $#{$dataref})) {$table .= '</TBODY>';};
     };
     $table .= "</TABLE>";
-    $ptxtable .= "</tabular>\n</sidebyside>";
+    $ptxtable .= "</tabular>";
    }# now if it is a Layout Table...
    else {
      $table = '<SECTION style = "display:table;'.$tablecss.'">';

--- a/macros/unionTables.pl
+++ b/macros/unionTables.pl
@@ -59,7 +59,7 @@ sub ColumnTable {
            '\medskip\hbox{\qquad\vtop{'.
            '\advance\hsize by -3em '.$col2.'}}\medskip',
     HTML => $HTMLtable,
-    PTX => qq!\n<sidebyside>\n<tabular valign="! . lc($valign) . qq!">\n<row>\n<cell>$col1</cell>\n<cell>$col2</cell>\n</row>\n</tabular>\n</sidebyside>\n!,
+    PTX => qq!\n<tabular valign="! . lc($valign) . qq!">\n<row>\n<cell>$col1</cell>\n<cell>$col2</cell>\n</row>\n</tabular>\n!,
 
   );
 }
@@ -121,7 +121,7 @@ sub BeginTable {
     TeX => '\par\medskip'.$tcenter.'{\kern '.$tbd.
            '\vbox{\halign{#\hfil&&\kern '.$tsp.' #\hfil',
     HTML => $table."\n",
-    PTX => qq!\n<sidebyside>\n<tabular top="$ptxborder" bottom="$ptxborder" left="$ptxborder" right="$ptxborder">\n!,
+    PTX => qq!\n<tabular top="$ptxborder" bottom="$ptxborder" left="$ptxborder" right="$ptxborder">\n!,
   );
 }
 
@@ -143,7 +143,7 @@ sub EndTable {
   MODES(
     TeX => '\cr}}\kern '.$tbd.'}\medskip'."\n",
     HTML => '</TABLE>'."\n",
-    PTX => "\n</tabular>\n</sidebyside>\n",
+    PTX => "\n</tabular>\n",
   );
 }
 


### PR DESCRIPTION
This is catching up with PreTeXt developments. Formerly, PTX did not allow `tabular`, `image` or `video` elements without certain wrappers like `figure`, `table`, and `sidebyside`. We never allowed the first two as WW output, and used `sidebyside` as the wrapper in all cases. Now this practice is not needed. PTX allows "naked" `tabular`, `image` and `video` elements. Clearing away all the `sidebyside` stuff simplifies this WW code, and also prevents PTX from issuing warnings that it detects a pointless `sidebyside`.

I'd like to include this in 2.16. I suspect no one else who is active would want to test PreTeXt stuff. If you would like to review this, I suggest just eyeing the code edits to see that I didn't leave a `<` somewhere where it should have been cut, and typos like that.