### PR TITLE
Unexciting code cleanup stemming from memory leak effort

### DIFF
--- a/lib/PGresponsegroup.pm
+++ b/lib/PGresponsegroup.pm
@@ -19,7 +19,7 @@ use strict;
 use Exporter;
 use PGUtil  qw(not_null) ;
 use PGanswergroup;
-use Tie::IxHash;
+# use Tie::IxHash;
 
 #############################################
 # An object which contains the student response(s)

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1220,8 +1220,7 @@ sub process_answers{
  	#### @answer_entry_order was created from PG_ANSWERS_HASH which maintains the
  	#### order of its keys
 
-	our ($rf_fun, $temp_ans);
-	our($new_rf_fun, $new_temp_ans);
+	our ($new_rf_fun, $new_temp_ans);
  	foreach my $ans_name (keys %{ $PG->{PG_ANSWERS_HASH} }) {
  		my $local_debug = 0;  #enables reporting of each $ans_name evaluator and responses
  		$PG->debug_message("Executing answer evaluator $ans_name ") if $local_debug;
@@ -1250,7 +1249,7 @@ sub process_answers{
  	    # gather answers and answer evaluator (new method)
  	    ####################################
 
-		local($new_rf_fun,$new_temp_ans) = (undef,undef);
+		local ($new_rf_fun,$new_temp_ans);
 		my $answergrp = $PG->{PG_ANSWERS_HASH}->{$ans_name};  #this has all answer evaluators AND answer blanks (just to be sure ) 
  	    my $responsegrp = $answergrp->response_obj;
 #################
@@ -1265,7 +1264,7 @@ sub process_answers{
         	$skip_evaluation=1;
         } elsif (not ref($new_rf_fun) =~ /AnswerEvaluator/ ) {
 				$PG->warning_message( "Error in Translator.pm::process_answers: Answer $ans_name: 
-				                    Unrecognized evaluator type |". ref($rf_fun). "|");
+				                    Unrecognized evaluator type |". ref($new_rf_fun). "|");
 				$skip_evaluation=1;
 		}
 		if (not defined($new_temp_ans) ) {


### PR DESCRIPTION
This is mainly uncontroversial code-cleanup that happened during the process of chasing down leaks.

**Overview:**
- PGresponsegroup does not use `Tie::IxHash`
- fix a lingering typo in Translator from the update to "new_" `rf_fun` and `temp_ans`
- stop declaring `$answergroup` as a global in PG.pl (line 465)
- remove detritus from Translator 
- similar cleanup to PG.pl 

The change in PG.pl is the only substantive edit in this PR.

Globally scoping the PGanswergroup objects prevented its children (PGresponsegroup, AnswerHash) from being GC'ed. I imagine that this wasn't done purposefully, but because PG.pl is `reval`ed into the safe without any restrictions (no opcode masking, no strict) this oversight was easily missed.

These changes are not dependent on the leak cleanup PR openwebwork/webwork2#1226 in the ww2 codebase, but they should be implemented together for effective memory-leak prevention.