### PR TITLE
Make PGML work for hardcopy if used in a set header file

### DIFF
--- a/macros/PGML.pl
+++ b/macros/PGML.pl
@@ -1488,7 +1488,7 @@ sub Format {
   my $parser = PGML::Parse->new(shift);
   my $format;
   if ($main::displayMode eq 'TeX') {
-    $format = "{\\pgmlSetup\n".PGML::Format::tex->new($parser)->format."\\par}%\n";
+    $format = "\n{\\pgmlSetup\n" . PGML::Format::tex->new($parser)->format . "\\par}%\n";
   } elsif ($main::displayMode eq 'PTX') {
     $format = PGML::Format::ptx->new($parser)->format."\n";
     $format = main::PTX_cleanup($format);
@@ -1518,95 +1518,6 @@ sub LaTeX {
 }
 
 ######################################################################
-#
-#  TeX code needed for PGML in hardcopy
-#
-
-our $preamble = <<'END_PREAMBLE';
-\ifdim\lastskip=\pgmlMarker
-  \let\pgmlPar=\relax
- \else
-  \let\pgmlPar=\par
-  \vadjust{\kern3pt}%
-\fi
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-%    definitions for PGML
-%
-
-\ifx\pgmlCount\undefined  % do not redefine if multiple files load PGML.pl
-  \newcount\pgmlCount
-  \newdimen\pgmlPercent
-  \newdimen\pgmlPixels  \pgmlPixels=.5pt
-\fi
-\pgmlPercent=.01\hsize
-
-\def\pgmlSetup{%
-  \parskip=0pt \parindent=0pt
-%  \ifdim\lastskip=\pgmlMarker\else\par\fi
-  \pgmlPar
-}%
-
-\def\pgmlIndent{\par\advance\leftskip by 2em \advance\pgmlPercent by .02em \pgmlCount=0}%
-\def\pgmlbulletItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
-\def\pgmldiscItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
-\def\pgmlcircleItem{\par\indent\llap{$\circ$ }\ignorespaces}%
-\def\pgmlsquareItem{\par\indent\llap{\vrule height 1ex width .75ex depth -.25ex\ }\ignorespaces}%
-\def\pgmlnumericItem{\par\indent\advance\pgmlCount by 1 \llap{\the\pgmlCount. }\ignorespaces}%
-\def\pgmlalphaItem{\par\indent{\advance\pgmlCount by `\a \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%
-\def\pgmlAlphaItem{\par\indent{\advance\pgmlCount by `\A \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%
-\def\pgmlromanItem{\par\indent\advance\pgmlCount by 1 \llap{\romannumeral\pgmlCount. }\ignorespaces}%
-\def\pgmlRomanItem{\par\indent\advance\pgmlCount by 1 \llap{\uppercase\expandafter{\romannumeral\pgmlCount}. }\ignorespaces}%
-
-\def\pgmlCenter{%
-  \par \parfillskip=0pt
-  \advance\leftskip by 0pt plus .5\hsize
-  \advance\rightskip by 0pt plus .5\hsize
-  \def\pgmlBreak{\break}%
-}%
-\def\pgmlRight{%
-  \par \parfillskip=0pt
-  \advance\leftskip by 0pt plus \hsize
-  \def\pgmlBreak{\break}%
-}%
-
-\def\pgmlBreak{\\}%
-
-\def\pgmlHeading#1{%
-  \par\bfseries
-  \ifcase#1 \or\huge \or\LARGE \or\large \or\normalsize \or\footnotesize \or\scriptsize \fi
-}%
-
-\def\pgmlRule#1#2{%
-  \par\noindent
-  \hbox{%
-    \strut%
-    \dimen1=\ht\strutbox%
-    \advance\dimen1 by -#2%
-    \divide\dimen1 by 2%
-    \advance\dimen2 by -\dp\strutbox%
-    \raise\dimen1\hbox{\vrule width #1 height #2 depth 0pt}%
-  }%
-  \par
-}%
-
-\def\pgmlIC#1{\futurelet\pgmlNext\pgmlCheckIC}%
-\def\pgmlCheckIC{\ifx\pgmlNext\pgmlSpace \/\fi}%
-{\def\getSpace#1{\global\let\pgmlSpace= }\getSpace{} }%
-
-{\catcode`\ =12\global\let\pgmlSpaceChar= }%
-{\obeylines\gdef\pgmlPreformatted{\par\small\ttfamily\hsize=10\hsize\obeyspaces\obeylines\let^^M=\pgmlNL\pgmlNL}}%
-\def\pgmlNL{\par\bgroup\catcode`\ =12\pgmlTestSpace}%
-\def\pgmlTestSpace{\futurelet\next\pgmlTestChar}%
-\def\pgmlTestChar{\ifx\next\pgmlSpaceChar\ \pgmlTestNext\fi\egroup}%
-\def\pgmlTestNext\fi\egroup#1{\fi\pgmlTestSpace}%
-
-\def^^M{\ifmmode\else\space\fi\ignorespaces}%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-END_PREAMBLE
-
-######################################################################
 
 package main;
 
@@ -1616,19 +1527,6 @@ sub _PGML_init {
   my $context = Context(); # prevent Typeset context from becoming active
   loadMacros("contextTypeset.pl");
   Context($context);
-  $problemPreamble->{TeX} .= $PGML::preamble unless $problemPreamble->{TeX} =~ m/definitions for PGML/;
-  ## Avoid bad spacing at the top of the problem (need to modify hardcopyPreamble.tex)
-  TEXT(MODES(HTML=>'', TeX=>'
-    \ifx\pgmlMarker\undefined
-      \newdimen\pgmlMarker \pgmlMarker=0.00314159pt  % hack to tell if \newline was used
-    \fi
-    \ifx\oldnewline\undefined \let\oldnewline=\newline \fi
-    \def\newline{\oldnewline\hskip-\pgmlMarker\hskip\pgmlMarker\relax}%
-    \parindent=0pt
-    \catcode`\^^M=\active
-    \def^^M{\ifmmode\else\fi\ignorespaces}%  skip paragraph breaks in the preamble
-    \def\par{\ifmmode\else\endgraf\fi\ignorespaces}%
-  '));
 }
 
 ######################################################################

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1224,7 +1224,7 @@ sub solution {
 	if ($printSolutionForInstructor) { # always print solutions for instructor types
 		$out = join('', $BITALIC, "(",
 			maketext("Instructor solution preview: show the student solution after due date."),
-			")", $EITALIC, $displayMode =~ /TeX/ ? "\\par\\medskip" : $BR, @in);
+			")", $EITALIC, $displayMode =~ /TeX/ ? "\\par\\smallskip" : $BR, @in);
 	} elsif ($displaySolution) {
 		$out = join(' ', @in); # display solution
 	}
@@ -1241,7 +1241,7 @@ sub SOLUTION {
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN SOLUTION\n", #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
-			$PAR, "\\medskip", SOLUTION_HEADING(), $solution_body, $PAR,
+			"\\par\\smallskip", SOLUTION_HEADING(), $solution_body, "\\par\\medskip",
 			"\n%%% END SOLUTION\n"    #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
 		);
 	} elsif ($displayMode =~ /HTML/) {
@@ -1275,7 +1275,7 @@ sub hint {
 		if ($printHintForInstructor) {
 			$out = join('', $BITALIC,
 				maketext("(Instructor hint preview: show the student hint after the following number of attempts:"),
-				" ", $showHint + 1, ")\\par\\medskip", $EITALIC, @in);
+				" ", $showHint + 1, ")", $EITALIC, "\\par\\smallskip", @in);
 		} elsif ($displayHint and $afterAnswerDate) { # only display hints after the answer date.
 			$out = join(' ', @in);
 		}
@@ -1303,7 +1303,7 @@ sub HINT {
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN HINT\n", #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
-			"\\par\\medskip", HINT_HEADING(), hint(@_) . $PAR,
+			"\\par\\smallskip", HINT_HEADING(), hint(@_), "\\par\\medskip",
 			"\n%%% END HINT\n"    #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
 		) if hint(@_) ;
 	} elsif ($displayMode =~ /PTX/) {
@@ -1529,7 +1529,7 @@ sub ALPHABET  {
 # Some constants which are different in tex and in HTML
 # The order of arguments is TeX, Latex2HTML, HTML
 # Adopted Davide Cervone's improvements to PAR, LTS, GTS, LTE, GTE, LBRACE, RBRACE, LB, RB. 7-14-03 AKP
-sub PAR { MODES( TeX => '\\par ', Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}', HTML => '<P>', PTX => "\n\n"); };
+sub PAR { MODES( TeX => '\\vskip\\baselineskip ', Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}', HTML => '<P>', PTX => "\n\n"); };
 #sub BR { MODES( TeX => '\\par\\noindent ', Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}', HTML => '<BR>'); };
 # Alternate definition of BR which is slightly more flexible and gives more white space in printed output
 # which looks better but kills more trees.

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1545,11 +1545,10 @@ sub LTS { MODES(TeX => '<', Latex2HTML => '\\lt ', HTML => '&lt;', HTML_tth => '
 sub GTS { MODES(TeX => '>', Latex2HTML => '\\gt ', HTML => '&gt;', HTML_tth => '>', PTX => '\gt' ); };  #only for use in math mode
 sub LTE { MODES(TeX => '\\le ', Latex2HTML => '\\le ', HTML => '<U>&lt;</U>', HTML_tth => '\\le ', PTX => '\leq' ); };  #only for use in math mode
 sub GTE { MODES(TeX => '\\ge ', Latex2HTML => '\\ge ', HTML => '<U>&gt;</U>', HTML_tth => '\\ge ', PTX => '\geq' ); };  #only for use in math mode
-sub BEGIN_ONE_COLUMN { MODES(TeX => "\\ifdefined\\nocolumns\\else \\end{multicols}\\fi\n",  Latex2HTML => " ", HTML =>   " "); };
+sub BEGIN_ONE_COLUMN { MODES(TeX => "\\ifdefined\\nocolumns\\else\\end{multicols}\\fi\n",  Latex2HTML => " ", HTML =>   " "); };
 sub END_ONE_COLUMN { MODES(TeX =>
-		" \\ifdefined\\nocolumns\\else \\begin{multicols}{2}\n\\columnwidth=\\linewidth \\fi\n",
+		"\\ifdefined\\nocolumns\\else\\begin{multicols}{2}\n\\columnwidth=\\linewidth\\fi\n",
 		Latex2HTML => ' ', HTML => ' ');
-
 };
 sub SOLUTION_HEADING { MODES( TeX => '{\\bf '.maketext('Solution: ').' }',
 		Latex2HTML => '\\par {\\bf '.maketext('Solution:').' }',
@@ -2470,39 +2469,10 @@ A wide variety of google widgets, youtube videos, and other online resources can
 
 sub beginproblem {
 	my $out = "";
-	my $problemValue = $envir->{problemValue} || 0;
-	my $fileName     = $envir->{probFileName};
-	my $probNum      = $envir->{probNum};
-	my $l2hFileName  = protect_underbar($envir->{probFileName});
-	my %inlist;
-	my $permissionLevel = $envir->{permissionLevel};
-	my $points = maketext('points');
-
-	$points = maketext('point') if $problemValue == 1;
-	## Prepare header for the problem
-	grep($inlist{$_}++, @{$envir->{'PRINT_FILE_NAMES_FOR'}});
-	my $effectivePermissionLevel = $envir->{effectivePermissionLevel}; # permission level of user assigned to question
-	my $PRINT_FILE_NAMES_PERMISSION_LEVEL = $envir->{'PRINT_FILE_NAMES_PERMISSION_LEVEL'};
-	my $studentLogin = $envir->{studentLogin};
-	my $print_path_name_flag = (defined($effectivePermissionLevel) &&
-		defined($PRINT_FILE_NAMES_PERMISSION_LEVEL) &&
-		$effectivePermissionLevel >= $PRINT_FILE_NAMES_PERMISSION_LEVEL)
-		|| (defined($inlist{$studentLogin}) and ($inlist{$studentLogin} > 0)) ? 1 : 0;
 	$out .= MODES(
 		TeX  => "\n%%% BEGIN PROBLEM PREAMBLE\n", #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
-		HTML => '<P style="margin: 0">'
+		HTML => ""
 	);
-	if ($print_path_name_flag) {
-		$out .= &M3("{\\bf\\footnotesize ($problemValue $points) \\path|$fileName|}\\smallskip\n",
-			" \\begin{rawhtml} ($problemValue $points) <B>$l2hFileName</B><BR>\\end{rawhtml}",
-			"($problemValue $points) <B>$fileName</B><BR>"
-		) if ($problemValue >= 0 and ($envir->{setNumber} =~ /\S/) and ($envir->{setNumber} ne 'Undefined_Set') and ($envir->{setNumber} ne 'not defined'));
-	} else {
-		$out .= &M3("($problemValue $points)\\smallskip\n",
-			"($problemValue $points) ",
-			"($problemValue $points) "
-		) if ($problemValue >= 0 and ($envir->{setNumber} =~ /\S/) and ($envir->{setNumber} ne 'Undefined_Set') and ($envir->{setNumber} ne 'not defined'));
-	}
 	$out .= MODES(%{main::PG_restricted_eval(q!$main::problemPreamble!)});
 	$out .= MODES(
 		TeX  => "\n%%% END PROBLEM PREAMBLE\n", #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying


### PR DESCRIPTION
Move the PGML `preamble` from the `problemPreamble` environment variable into the TeX `hardcopyPreamble.tex` template files and restructure things a bit so that PGML will work in a header file.

To make this work the following things needed to be done:

The PGML detect previous newline hack had to be removed.  Instead nicer spacing was implemented that applies to both PGML and PG problems.

The catcode changes for PGML problems that ignores carriage returns needed to be scoped (and was moved into the pgmlSetup definition). This was actually a problem in general when PG and PGML problems were used in the same homework set.  Any PG problem after the first PGML problem ended up not being displayed correctly as a result.

Now PGML no longer uses the problemPreamble environment variable (in fact nothing does).

One (perhaps controversial) change is that `parindent=0pt` is set globally.  Previously this was set only for PGML problems.  The reason for this is that even PG problems need this.  This makes the hardcopy output for PG problems more like the output that is shown on screen when the problem is worked online.

Note that this is paired with the webwork2 pull request https://github.com/openwebwork/webwork2/pull/1239 where the `hardcopyPreamble.tex` files are changed.

This fixes issue https://github.com/openwebwork/webwork2/issues/1066.