### PR TITLE
Remove a prefix from the answer rule insertion of  parserGraphTool.pl

### DIFF
--- a/macros/parserGraphTool.pl
+++ b/macros/parserGraphTool.pl
@@ -496,9 +496,8 @@ END_TIKZ
 	} else {
 		$self->constructJSXGraphOptions;
 		my $ans_name = $self->ANS_NAME;
-		my $prefix = ($main::setNumber =~ tr/./_/r) . "_" . $main::probNum;
-		$out .= "<div id='${prefix}_${ans_name}_graphbox' class='graphtool-container'></div>" .
-			"<script>graphTool('${prefix}_${ans_name}_graphbox', { " .
+		$out .= "<div id='${ans_name}_graphbox' class='graphtool-container'></div>" .
+			"<script>graphTool('${ans_name}_graphbox', { " .
 			"htmlInputId: '${ans_name}', " .
 			"staticObjects: '" . join(',', @{$self->{staticObjects}}) . "'," .
 			"snapSizeX: $self->{snapSizeX}," .


### PR DESCRIPTION
This was from my original implemenation, and was not supposed to make it here.
The setNumber and probNum may not be defined, and in that case this fails.