### PR TITLE
Fix apache2 error.log spamming caused by random_coprime

### DIFF
--- a/macros/PGauxiliaryFunctions.pl
+++ b/macros/PGauxiliaryFunctions.pl
@@ -215,7 +215,7 @@ sub random_coprime {
 					}
 				}
 			}
-			do {warn "Unable to find a coprime tuple from input"; return;} unless (@{$newcandidates[0]},@{$newcandidates[1]});
+			do {warn "Unable to find a coprime tuple from input"; return;} unless @{$newcandidates[0]};
 			return random_coprime([@newcandidates],@_);
 		} else {
 			my @coprime_tuples = @{$candidates[0]};


### PR DESCRIPTION
Fix an issue that causes a massive amount of messages to be sent to apache2's error.log.

The current code causes the message `Useless use of a variable in void context` to be added to the apache2 error.log for almost every pg problem that is loaded since PGauxiliaryFunctions.pl is loaded by PGstandard.pl, which in turn is loaded by almost every problem.

@Alex-Jordan:  Please check this to see if it is correct.  This is doing what it was doing before, but that may not be what was intended.