### PR TITLE
Change mathQuillOpts a bit and disable MathQuill for parserWordCompletion.pl

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -122,6 +122,7 @@ BEGIN {
 package AnswerHash;
 use Exporter;
 use PGUtil qw(not_null pretty_print);
+use JSON;
 
 # initialization fields
 my %fields = (		'score'					=>	undef,
@@ -247,19 +248,25 @@ sub score {
 
 =head4  stringify_hash
 
-        Usage:      $rh_ans->stringify_hash;
+	Usage:      $rh_ans->stringify_hash;
 
-        Turns all values in the hash into strings (so they won't cause trouble outside
-        the safe compartment).
+	Turns all values in the hash into strings (so they won't cause trouble outside
+	the safe compartment).
+
+	A special case is made to convert the mathQuillOpts key (if defined)
+	into JSON so it can be used in javascript.
 
 =cut
 
 sub stringify_hash {
-  my $self = shift;
-  Parser::Context->current(undef,$self->{correct_value}->context) if $self->{correct_value};
-  foreach my $key (keys %$self) {
-    $self->{$key} = "$self->{$key}" if ref($self->{$key});
-  }
+	my $self = shift;
+	Parser::Context->current(undef,$self->{correct_value}->context) if $self->{correct_value};
+	if ($self->{mathQuillOpts} && ref($self->{mathQuillOpts}) eq "HASH") {
+		$self->{mathQuillOpts} = JSON->new->utf8->encode($self->{mathQuillOpts});
+	}
+	foreach my $key (keys %$self) {
+		$self->{$key} = "$self->{$key}" if ref($self->{$key});
+	}
 }
 
 # error methods

--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -253,19 +253,21 @@ sub score {
 	Turns all values in the hash into strings (so they won't cause trouble outside
 	the safe compartment).
 
-	A special case is made to convert the mathQuillOpts key (if defined)
-	into JSON so it can be used in javascript.
+	Hashes and arrays are converted into a JSON string.
 
 =cut
 
 sub stringify_hash {
 	my $self = shift;
 	Parser::Context->current(undef,$self->{correct_value}->context) if $self->{correct_value};
-	if ($self->{mathQuillOpts} && ref($self->{mathQuillOpts}) eq "HASH") {
-		$self->{mathQuillOpts} = JSON->new->utf8->encode($self->{mathQuillOpts});
-	}
 	foreach my $key (keys %$self) {
-		$self->{$key} = "$self->{$key}" if ref($self->{$key});
+		my $ref = ref($self->{$key});
+		next if !$ref;
+		if ($ref eq "HASH" or $ref eq "ARRAY") {
+			$self->{$key} = JSON->new->utf8->allow_unknown->allow_blessed->encode($self->{$key});
+		} else {
+			$self->{$key} = "$self->{$key}";
+		}
 	}
 }
 

--- a/macros/parserWordCompletion.pl
+++ b/macros/parserWordCompletion.pl
@@ -125,6 +125,11 @@ sub new {
   return $self;
 }
 
+sub cmp_defaults {(
+	shift->SUPER::cmp_defaults(@_),
+	mathQuillOpts => 'disabled'
+)}
+
 sub menu {
     my $self = shift;
     my $size = shift || 20;


### PR DESCRIPTION
The stringify_answers method of Translator.pm now JSON encodes the mathQuillOpts key of the answer hash if defined and a hash reference.  This allows the value of that key to be a hash.  This is easier to work with than manually creating JSON strings.  Furthermore, it can be directly passed to the mqedit.js javascript as a data attribute with an object value.

So this changes the way the mathQuillOpts answer hash key works.

Previously to disable the spaceBehavesLikeTabs option (i.e. to enable typing of spaces) and the disable rootsAreExponents you would need to do
      `$ans->cmp(mathQuillOpts => "spaceBehavesLikeTab: false, rootsAreExponents: false")`
Now you will do
      `$ans->cmp(mathQuillOpts => { spaceBehavesLikeTab => 0, rootsAreExponents => 0 })`

This changes the usage from before, but I doubt many were using these options yet.
    
Note that you can also use `$ans->cmp(mathQuillOpts => "disabled")` to disable MathQuill answers for an answer blank.  (This is done in the webwork2 code).
    
This also automatically disables MathQuill answer boxes when the answer is a parserWordCompletion.pl answer.

This is paired with the webwork2 pull request https://github.com/openwebwork/webwork2/pull/1288.
