### PR TITLE
Implement a better method for generating svg images with TikZImage.pm.

### DIFF
--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -142,7 +142,7 @@ sub draw {
 		or warn "Can't open $working_dir/image.tex for writing.";
 	chmod(0777, "$working_dir/image.tex");
 	print $fh $self->header;
-	print $fh $self->tex . "\n";
+	print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
 	print $fh $self->footer;
 	close $fh;
 

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -162,6 +162,7 @@ sub draw {
 	system "cd " . $working_dir . " && $latex_binary image.tex > pdflatex.stdout 2> /dev/null";
 
 	if (-r "$working_dir/image.$tex_ext") {
+		chmod(0777, "$working_dir/image.$tex_ext");
 		# Convert the file to the appropriate type of image file
 		if ($ext eq 'svg') {
 			if ($self->svgMethod eq 'dvisvgm') {

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -35,7 +35,7 @@ sub new {
 		tikzLibraries => '',
 		texPackages   => {},
 		addToPreamble => '',
-		ext           => 'png',
+		ext           => 'svg',
         imageName     => ''
 	};
 	my $self = sub {
@@ -46,7 +46,7 @@ sub new {
 			if ($field eq 'ext') {
 				my $ext = shift;
 				$data->{ext} = $ext
-				if ($ext eq 'png' || $ext eq 'gif' || $ext eq 'svg' || $ext eq 'pdf');
+				if ($ext && ($ext eq 'png' || $ext eq 'gif' || $ext eq 'svg' || $ext eq 'pdf'));
 			}
 			else {
 				$data->{$field} = shift;

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -115,12 +115,13 @@ sub header {
 	my $self = shift;
 	my @output = ();
 	push(@output, "\\documentclass{standalone}\n");
-	push(@output, "\\usepackage[svgnames]{xcolor}\n");
 	push(@output, "\\def\\pgfsysdriver{pgfsys-dvisvgm.def}\n") if $self->ext eq 'svg' && $self->svgMethod eq 'dvisvgm';
+	my $xcolorOpts = $self->texPackages->{xcolor} ? $self->texPackages->{xcolor} : 'svgnames';
+	push(@output, "\\usepackage[$xcolorOpts]{xcolor}\n");
 	push(@output, "\\usepackage{tikz}\n");
 	push(@output, map {
 			"\\usepackage" . ($self->texPackages->{$_} ne "" ? "[$self->texPackages->{$_}]" : "") . "{$_}\n"
-		} keys %{$self->texPackages});
+		} grep { $_ ne 'xcolor' } keys %{$self->texPackages});
 	push(@output, "\\usetikzlibrary{" . $self->tikzLibraries . "}") if ($self->tikzLibraries ne "");
 	push(@output, $self->addToPreamble);
 	push(@output, "\\begin{document}\n");

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -287,26 +287,6 @@ sub curlCommand {
 	return $CE->{externalPrograms}{curl};
 }
 
-=item convertCommand
-
-	convert -- path to convert defined in site.conf
-
-=cut
-
-sub convertCommand {
-	return $CE->{externalPrograms}{convert};
-}
-
-=item pdflatexCommand
-
-	pdflatex -- path to pdflatex defined in site.conf
-
-=cut
-
-sub pdflatexCommand {
-	return $CE->{externalPrograms}{pdflatex};
-}
-
 =item copyCommand
 
 	copyCommand -- path to cp defined in site.conf
@@ -317,6 +297,15 @@ sub copyCommand {
 	return $CE->{externalPrograms}{cp};
 }
 
+=item externalCommand
+
+	returns the path to a requested external command that is defined in site.conf
+
+=cut
+
+sub externalCommand {
+	return $CE->{externalPrograms}{$_[0]};
+}
 
 #
 # isolate the call to the sage server in case we have to jazz it up

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1871,6 +1871,8 @@ sub default_preprocess_code {
 	$evalString =~ s/\n\h*BEGIN_SOLUTION[\h;]*\n/\nSOLUTION\(EV3P\(<<'END_SOLUTION'\)\);\n/g;
 	$evalString =~ s/\n\h*BEGIN_HINT[\h;]*\n/\nHINT\(EV3P\(<<'END_HINT'\)\);\n/g;
 	$evalString =~ s/ENDDOCUMENT.*/ENDDOCUMENT();/s; # remove text after ENDDOCUMENT
+	$evalString =~ s/\n\h*(.*)\h*->\h*BEGIN_TIKZ[\h;]*\n/\n$1->tex\(<<END_TIKZ\);\n/g;
+	$evalString =~ s/\n\h*END_TIKZ[\h;]*\n/\nEND_TIKZ\n/g;
 
 	$evalString =~ s/\\/\\\\/g;    # \ can't be used for escapes because of TeX conflict
 	$evalString =~ s/~~/\\/g;      # use ~~ as escape instead, use # for comments

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2975,7 +2975,8 @@ sub image {
 	my @output_list = ();
 	while(@image_list) {
 		my $image_item = shift @image_list;
-		$image_item = insertGraph($image_item) if (ref $image_item eq 'WWPlot' || ref $image_item eq 'TikZImage');
+		$image_item = insertGraph($image_item)
+			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'TikZImage' || ref $image_item eq 'PGtikz');
 		my $imageURL = alias($image_item)//'';
 		$imageURL = ($envir{use_site_prefix})? $envir{use_site_prefix}.$imageURL : $imageURL;
 		my $out = "";

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -96,7 +96,7 @@ sub new {
 	my $class = ref($self) || $self;
 
 	my $image = $class->SUPER::new(@_);
-	$image->ext($main::envir{tikzImageExtension} // 'png');
+	$image->svgMethod($main::envir{tikzSVGMethod} // 'pdf2svg');
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
 

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -96,6 +96,7 @@ sub new {
 	my $class = ref($self) || $self;
 
 	my $image = $class->SUPER::new(@_);
+	$image->ext($main::envir{tikzImageExtension} // 'png');
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
 

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -23,7 +23,7 @@ This is a convenience macro for utilizing the TikZImage object to insert TikZ
 images into problems.  Create a TikZ image as follows:
 
     $image = createTikZImage();
-    $image->tex(<<END_TIKZ);
+    $image->BEGIN_TIKZ
     \draw (-2,0) -- (2,0);
     \draw (0,-2) -- (0,2);
     \draw (0,0) circle[radius=1.5];

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -57,15 +57,18 @@ TikZImage object return by createTikZImage to generate the desired image.
                                For example:
                                $image->tikzLibraries("arrows.meta,calc");
 
-    $image->texPackages()      Add tex packages to load.  This takes a hash for
-                               its parameter.  The keys of this hash are the
-                               package names, and the corresponding values a
-                               string consisting of options for the package.
+    $image->texPackages()      Add tex packages to load.  This takes an array for
+                               its parameter.  Each element of this array should
+                               either be the package name as a string, or an
+                               array with two elements, the first of which is the
+                               package name as a string and the second of which
+                               is a string containing the options for the package.
                                For example:
-                               $image->texPackages({
-                                   "pgfplots" => "",
-                                   "hf-tikz" => "customcolors"
-                               });
+                               $image->texPackages([
+                                   "pgfplots",
+                                   ["hf-tikz", "customcolors"],
+                                   ["xcolor", "cmyk,table"]
+                               ]);
 
     $image->addToPreamble()    Additional commands to add to the TeX preamble.
                                This takes a single string parameter.

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -72,21 +72,41 @@ TikZImage object return by createTikZImage to generate the desired image.
 
     $image->ext()              Set the file type to be used for the image.
                                The valid image types are 'png', 'gif', 'svg',
-                               and 'pdf'.  The default is a 'png' image.  This
-                               macro sets this to 'pdf' when a hardcopy is
-                               generated.
+                               and 'pdf'.  The default is an 'svg' image.  You
+                               should determine if an 'svg' image works well with
+                               the TikZ code that you utilize.  If not, then use
+                               this method to change the exension to 'png' or
+                               'gif'.
+
+                               This macro sets the extension to 'pdf' when a
+                               hardcopy is generated.
 
 =cut
 
-sub _PGtikz_init {}
+sub _PGtikz_init {
+	main::PG_restricted_eval('sub createTikZImage { PGtikz->new(@_); }');
+}
+
+package PGtikz;
+our @ISA = qw(TikZImage);
 
 # Not much needs to be done here.  The real work is done in TikZImage.pm.
-sub createTikZImage
-{
-	my $image = new TikZImage;
-	$image->ext('pdf') if $main::displayMode eq 'TeX';
+sub new {
+	my $self = shift;
+	my $class = ref($self) || $self;
+
+	my $image = $class->SUPER::new(@_);
+	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
-	return $image;
+
+	return bless $image, $class;
+}
+
+sub ext {
+	my $self = shift;
+	my $ext = shift;
+	return $self->SUPER::ext($ext) if $ext && $main::displayMode ne 'TeX';
+	return $self->SUPER::ext;
 }
 
 1;


### PR DESCRIPTION
The current implementation generates a pdf using pdflatex, and then converts the pdf to svg using imagemagick's convert utility.

This changes it so that it uses latex to generate a dvi with the pgfsysdriver redefined to pgfsys-dvisvgm.def, and then converts the dvi to svg using dvisvgm.  This is the best way that I have found of creating svg images from tikz/tex.

This does require another external program (dvisvgm).  That is added in a corresponding pull request to webwork2.

I have attached a couple of examples to compare the png image generation to the svg image generation.
[examples.zip](https://github.com/openwebwork/pg/files/6254945/examples.zip)

To test this, make sure to set the dvisvgm external command in site.conf.  See https://github.com/openwebwork/webwork2/pull/1308.
