### PR TITLE
reduce extra digit checking in digits toltype

### DIFF
--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -62,7 +62,7 @@ like equality are "fuzzy", meaning that two items are equal when they are "close
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
     tolTruncation => 1,
-    tolExtraDigits => 3,
+    tolExtraDigits => 1,
     #
     #  For Formulas:
     #
@@ -117,7 +117,7 @@ $defaultContext = Value::Context->new(
     zeroLevel    => 1E-14,
     zeroLevelTol => 1E-12,
     tolTruncation => 1,
-    tolExtraDigits => 3,
+    tolExtraDigits => 1,
     #
     #  For Formulas:
     #


### PR DESCRIPTION
I think the default on this should be more loose, as close as it can be to the current relative tolerance defaults. This change means you must have the first three digits right (not counting trailing zeros which may always be omitted) and then if you give a 4th digit, it must be right. But now there will be no checking beyond that 4th digit. Assuming truncation or rounding are both set to be permitted, for π, these would now be correct:

3.14
3.141\d*
3.142

and these would now be incorrect:

3.15
3.14[^12]\d*
3.142\d+

A change is that, for example, 3.1417 is not correct by default before this change, but now it would be.

