### PR TITLE
alt option for image()

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2929,6 +2929,8 @@ sub image {
 		width    => 100,
 		height   => '',
 		tex_size => 800,
+		# default value for alt is undef, since an empty string is the explicit indicator of a decorative image
+		alt => undef,
 		extra_html_tags => '',
 	);
 	# handle options
@@ -2944,6 +2946,7 @@ sub image {
 	my $width       = $out_options{width};
 	my $height      = $out_options{height};
 	my $tex_size    = $out_options{tex_size};
+	my $alt         = $out_options{alt};
 	my $width_ratio = $tex_size*(.001);
 	my @image_list  = ();
 
@@ -2994,10 +2997,11 @@ sub image {
 			|| $displayMode eq 'HTML_asciimath'
 			|| $displayMode eq 'HTML_LaTeXMathML'
 			|| $displayMode eq 'HTML_img') {
-			$out = qq!<IMG SRC="$imageURL" class="image-view-elt" tabindex="0" role="button" WIDTH="$width" $height_attrib $out_options{extra_html_tags}>!
+			my $altattrib = (defined $alt) ? ('alt="' . ($alt =~ s/"/&quot;/gr) . '"') : '';
+			$out = qq!<IMG SRC="$imageURL" class="image-view-elt" tabindex="0" role="button" WIDTH="$width" $height_attrib $out_options{extra_html_tags} $altattrib>!
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = 100*$width/600;
-			$out = qq!<image width="$ptxwidth%" source="$imageURL" />!
+			$out = (defined $alt) ? qq!<image width="$ptxwidth%" source="$imageURL"><description>$alt</description></image>! : qq!<image width="$ptxwidth%" source="$imageURL" />!
 		} else {
 			$out = "Error: PGbasicmacros: image: Unknown displayMode: $displayMode.\n";
 		}

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2908,12 +2908,7 @@ sub row {
 =head2 Macros for displaying static images
 
     Usage:
-    $string = image($image, width => 100, height => 100, tex_size => 800)
-    $string = image($image, width => 100, height => 100, extra_html_tags => 'align="middle"', tex_size => 800)
-    $string = image([$image1, $image2], width => 100, height => 100, tex_size => 800)
-    $string = caption($string);
-    $string = imageRow([$image1, $image2 ], [$caption1, $caption2]);
-             # produces a complete table with rows of pictures.
+    $string = image($image, width => 100, height => 100, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
 =cut
 
@@ -2955,6 +2950,7 @@ sub image {
 	my $height_attrib = '';
 	$height_attrib = qq{height = "$height"} if ($height);
 
+	# if image() is being called to support the legacy imageRow(), its argument may be an array reference
 	if (ref($image_ref) =~ /ARRAY/ ) {
 		@image_list = @{$image_ref};
 	} else {
@@ -3012,6 +3008,7 @@ sub image {
 		}
 		push(@output_list, $out);
 	}
+	# if image() is being called to support the legacy imageRow(), wantarray is true
 	return wantarray ? @output_list : $output_list[0];
 }
 

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2997,11 +2997,16 @@ sub image {
 			|| $displayMode eq 'HTML_asciimath'
 			|| $displayMode eq 'HTML_LaTeXMathML'
 			|| $displayMode eq 'HTML_img') {
-			my $altattrib = (defined $alt) ? ('alt="' . ($alt =~ s/"/&quot;/gr) . '"') : '';
+			my $altattrib = '';
+			if (defined $alt) {$altattrib = 'alt="' . encode_pg_and_html($alt) . '"'};
 			$out = qq!<IMG SRC="$imageURL" class="image-view-elt" tabindex="0" role="button" WIDTH="$width" $height_attrib $out_options{extra_html_tags} $altattrib>!
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = 100*$width/600;
-			$out = (defined $alt) ? qq!<image width="$ptxwidth%" source="$imageURL"><description>$alt</description></image>! : qq!<image width="$ptxwidth%" source="$imageURL" />!
+			if (defined $alt) {
+				$out = qq!<image width="$ptxwidth%" source="$imageURL"><description>$alt</description></image>!
+			} else {
+				$out = qq!<image width="$ptxwidth%" source="$imageURL" />!
+			}
 		} else {
 			$out = "Error: PGbasicmacros: image: Unknown displayMode: $displayMode.\n";
 		}


### PR DESCRIPTION
Currently to get alt text in an HTML image, you must awkwardly use `extra_html_tags`. This adds `alt` as an option, which is not only less awkward, but also allows PreTeXt to do its natural thing with an alt text description.