### PR TITLE
direct use of WWPlot or TikZImage objects in image()

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2975,7 +2975,7 @@ sub image {
 	my @output_list = ();
 	while(@image_list) {
 		my $image_item = shift @image_list;
-		$image_item = main::insertGraph($image_item) if (ref($image_item) eq 'WWPlot' or ref($image_item) eq 'TikZImage');
+		$image_item = insertGraph($image_item) if (ref $image_item eq 'WWPlot' || ref $image_item eq 'TikZImage');
 		my $imageURL = alias($image_item)//'';
 		$imageURL = ($envir{use_site_prefix})? $envir{use_site_prefix}.$imageURL : $imageURL;
 		my $out = "";

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2911,9 +2911,9 @@ Usage:
 
     image($image, width => 100, height => 100, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
-where C<$image> can be a local file path or URL, C<width> and C<height> are
-pixel counts for HTML display, while C<tex_size> is per 1000 applied to
-linewidth (for example 800 leads to 0.8\linewidth)
+where C<$image> can be a local file path, URL, WWPlot object, or TikZImage object,
+C<width> and C<height> are pixel counts for HTML display, while C<tex_size> is
+per 1000 applied to linewidth (for example 800 leads to 0.8\linewidth)
 
     image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => ['alt text 1','alt text 2'], extra_html_tags => 'style="border:solid black 1pt"');
     image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => 'common alt text', extra_html_tags => 'style="border:solid black 1pt"');

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2924,7 +2924,8 @@ this produces an array in array context and joins the elements with C<' '> in sc
 
 #   More advanced macros
 sub image {
-	my $image_ref  = shift;
+	my $image_ref = shift;
+	$image_ref = main::insertGraph($image_ref) if (ref($image_ref) eq 'WWPlot' or ref($image_ref) eq 'TikZImage');
 	my @opt = @_;
 	unless (scalar(@opt) % 2 == 0 ) {
 		warn "ERROR in image macro.  A list of macros must be inclosed in square brackets.";

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2925,7 +2925,6 @@ this produces an array in array context and joins the elements with C<' '> in sc
 #   More advanced macros
 sub image {
 	my $image_ref = shift;
-	$image_ref = main::insertGraph($image_ref) if (ref($image_ref) eq 'WWPlot' or ref($image_ref) eq 'TikZImage');
 	my @opt = @_;
 	unless (scalar(@opt) % 2 == 0 ) {
 		warn "ERROR in image macro.  A list of macros must be inclosed in square brackets.";
@@ -2975,7 +2974,9 @@ sub image {
 
 	my @output_list = ();
 	while(@image_list) {
-		my $imageURL = alias(shift @image_list)//'';
+		my $image_item = shift @image_list;
+		$image_item = main::insertGraph($image_item) if (ref($image_item) eq 'WWPlot' or ref($image_item) eq 'TikZImage');
+		my $imageURL = alias($image_item)//'';
 		$imageURL = ($envir{use_site_prefix})? $envir{use_site_prefix}.$imageURL : $imageURL;
 		my $out = "";
 


### PR DESCRIPTION
This makes it so if `$gr` is either a WWPlot or TikZImage object, then you can just do:

``
image($gr,...)
``

instead of 

``
image(insertGraph($gr),...)
``

(This is related to #560.)