### PR TITLE
Wrap math content in `<script type="math/tex"></script>` tags for MathJax

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2112,7 +2112,7 @@ sub general_math_ev3 {
 
 	my $out;
 	if($displayMode eq "HTML_MathJax") {
-		$out = '<span>'.$in_delim.'</span>';
+		$out = '<span><script type="math/tex' . ($mode eq 'display' ? '; mode=display' : '') . '">' . $in . '</script></span>';
 	} elsif ($displayMode eq "HTML_dpng" ) {
 		# for jj's version of ImageGenerator
 		#$out = $envir->{'imagegen'}->add($in_delim);

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2112,7 +2112,7 @@ sub general_math_ev3 {
 
 	my $out;
 	if($displayMode eq "HTML_MathJax") {
-		$out = '<span><script type="math/tex' . ($mode eq 'display' ? '; mode=display' : '') . '">' . $in . '</script></span>';
+		$out = '<script type="math/tex' . ($mode eq 'display' ? '; mode=display' : '') . '">' . $in . '</script>';
 	} elsif ($displayMode eq "HTML_dpng" ) {
 		# for jj's version of ImageGenerator
 		#$out = $envir->{'imagegen'}->add($in_delim);


### PR DESCRIPTION
This is a replacement for @Alex-Jordan's previous attempt #563.

This is paired with openwebwork/webwork2#1322 and won't work without it.