### PR TITLE
Convert options

### DIFF
--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -30,14 +30,15 @@ package TikZImage;
 sub new {
 	my $class = shift;
 	my $data = {
-		tex           => '',
-		tikzOptions   => '',
-		tikzLibraries => '',
-		texPackages   => [],
-		addToPreamble => '',
-		ext           => 'svg',
-		svgMethod     => 'pdf2svg',
-        imageName     => ''
+		tex            => '',
+		tikzOptions    => '',
+		tikzLibraries  => '',
+		texPackages    => [],
+		addToPreamble  => '',
+		ext            => 'svg',
+		svgMethod      => 'pdf2svg',
+		convertOptions => [{},{}],
+		imageName      => ''
 	};
 	my $self = sub {
 		my $field = shift;

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -37,7 +37,7 @@ sub new {
 		addToPreamble  => '',
 		ext            => 'svg',
 		svgMethod      => 'pdf2svg',
-		convertOptions => [{},{}],
+		convertOptions => {input => {},output => {}},
 		imageName      => ''
 	};
 	my $self = sub {
@@ -185,9 +185,9 @@ sub draw {
 			}
 		} elsif ($ext ne 'pdf') {
 			system WeBWorK::PG::IO::externalCommand('convert') .
-				join('',map {" -$_ " . $self->convertOptions->[0]->{$_}} (keys %{$self->convertOptions->[0]})) .
+				join('',map {" -$_ " . $self->convertOptions->{input}->{$_}} (keys %{$self->convertOptions->{input}})) .
 				" $working_dir/image.pdf" .
-				join('',map {" -$_ " . $self->convertOptions->[1]->{$_}} (keys %{$self->convertOptions->[1]})) .
+				join('',map {" -$_ " . $self->convertOptions->{output}->{$_}} (keys %{$self->convertOptions->{output}})) .
 				" $working_dir/image.$ext > /dev/null 2>&1";
 		}
 

--- a/lib/TikZImage.pm
+++ b/lib/TikZImage.pm
@@ -108,6 +108,12 @@ sub svgMethod {
 	return &$self('svgMethod', @_);
 }
 
+# Set the options to be used by ImageMagick convert.
+sub convertOptions {
+	my $self = shift;
+	return &$self('convertOptions', @_);
+}
+
 # Set the file name.
 sub imageName {
 	my $self = shift;
@@ -178,7 +184,10 @@ sub draw {
 			}
 		} elsif ($ext ne 'pdf') {
 			system WeBWorK::PG::IO::externalCommand('convert') .
-				" $working_dir/image.pdf $working_dir/image.$ext > /dev/null 2>&1";
+				join('',map {" -$_ " . $self->convertOptions->[0]->{$_}} (keys %{$self->convertOptions->[0]})) .
+				" $working_dir/image.pdf" .
+				join('',map {" -$_ " . $self->convertOptions->[1]->{$_}} (keys %{$self->convertOptions->[1]})) .
+				" $working_dir/image.$ext > /dev/null 2>&1";
 		}
 
 		if (-r "$working_dir/image.$ext") {

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -84,6 +84,17 @@ TikZImage object return by createTikZImage to generate the desired image.
                                This macro sets the extension to 'pdf' when a
                                hardcopy is generated.
 
+    $image->convertOptions()   If ImageMagick's convert command is used to build
+                               the output image (presently only done for 'png'
+                               output) these input and output options will be
+                               used. For example:
+                               $image->convertOptions({
+                                   input => {density => 300},
+                                   output => {quality => 100, resize => "500x500"}
+                               });
+                               For a complete list of options, see:
+                               https://imagemagick.org/script/command-line-options.php
+
 =cut
 
 sub _PGtikz_init {

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -100,6 +100,7 @@ sub new {
 
 	my $image = $class->SUPER::new(@_);
 	$image->svgMethod($main::envir{tikzSVGMethod} // 'pdf2svg');
+	$image->convertOptions($main::envir{convertOptions} // [{},{}]);
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
 

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -100,7 +100,7 @@ sub new {
 
 	my $image = $class->SUPER::new(@_);
 	$image->svgMethod($main::envir{tikzSVGMethod} // 'pdf2svg');
-	$image->convertOptions($main::envir{convertOptions} // [{},{}]);
+	$image->convertOptions($main::envir{tikzConvertOptions} // {input => {},output => {}});
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
 


### PR DESCRIPTION
This branch follows #557 and should perhaps be rebased once #557 is resolved.

This PR has a counterpart in webwork2: https://github.com/openwebwork/webwork2/pull/1334

This allows the ImageMagick convert command to have options. The options I set for the default:
(1) increase the density that a PDF is carved up into before converting to another image
(2) increase the "quality" (decrease the compression) for building a PNG

The result is PNGs that look pretty good, and only take a little bit more space than the corresponding SVGs in my experiments.

Here is a test file, modified from the earlier PNG SVG comparison file. A line is commented out that sets options. It is commented out with the default options. I suggest seeing what happens when you revert to empty (`[{},{}]`).

```
DOCUMENT();

loadMacros("PGstandard.pl", "PGML.pl", "PGtikz.pl");

$a = random(-5, 5);

$tikz_code = <<END_TIKZ;
\tikzset{>={Stealth[scale=1.8]}}
\filldraw[draw=blue,fill=white,rounded corners=14pt,thick,use as bounding box] (-11,-11) rectangle (11,11);
\begin{scope}
	\clip[rounded corners=14pt] (-11,-11) rectangle (11,11);
	\draw[line width=0.2pt,color=lightgray,step=1] (-11,-11) grid (11,11);
\end{scope}
\huge
\draw[<->,thick] (-11,0) -- (11,0) node[above left,outer sep=2pt]{\(x\)};
\draw[<->,thick] (0,-11) -- (0,11) node[below right,outer sep=2pt]{\(y\)};
\foreach \x in {-10,-8,...,-2,2,4,...,10} \draw[thin] (\x,5pt) -- (\x,-5pt) node[below]{\(\x\)};
\foreach \y in {-10,-8,...,-2,2,4,...,10} \draw[thin] (5pt,\y) -- (-5pt,\y) node[left]{\(\y\)};
\draw[blue,line width=1.8pt,-{Stealth[scale=1.2]}] plot[domain=$a:11,samples=100,smooth]
(\x,{sqrt(\x-($a))});
\filldraw[red] ($a,0) circle[radius=4pt];
END_TIKZ

$graph_png = createTikZImage();
$graph_png->ext('png');
#$graph_png->convertOptions([{density => 300},{quality=>100}]);
$graph_png->tikzLibraries("arrows.meta");
$graph_png->tikzOptions("x=0.6cm,y=0.6cm");
$graph_png->tex($tikz_code);

$graph_svg = createTikZImage();
$graph_svg->tikzLibraries("arrows.meta");
$graph_svg->tikzOptions("x=0.6cm,y=0.6cm");
$graph_svg->tex($tikz_code);

BEGIN_PGML
[@ image(insertGraph($graph_png), width => 350, tex_size => 400) @]*
[@ image(insertGraph($graph_svg), width => 350, tex_size => 400) @]*
END_PGML

ENDDOCUMENT();

```


Note I am not wedded to the default options I set. These are just what PreTeXt settled on for a similar thing, so I started there.