### PR TITLE
Fix issue with contextFraction when checking for repeated formulas (#567)

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1731,6 +1731,7 @@ sub cmp_postfilter {
   return $ans if ($ans->{bypass_equivalence_test});
   my $context = $self->context;
   Parser::Context->current(undef,$context);
+  my $flags = Value::contextSet($context,$self->cmp_contextFlags($ans)); # save old context flags
   $ans->{prev_formula} = Parser::Formula($ans->{prev_ans});
   if (defined($ans->{prev_formula}) && defined($ans->{student_formula})) {
     my $prev = eval {$self->promote($ans->{prev_formula})->inherit($self)}; # inherit limits, etc.
@@ -1744,6 +1745,7 @@ sub cmp_postfilter {
 	and $ans->{prev_ans} ne $ans->{original_student_ans}) # but not identical
       {$ans->{ans_message} = "This answer is equivalent to the one you just submitted."}
   }
+  Value::contextSet($context,%{$flags});            # restore context values
   return $ans;
 }
 

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -195,7 +195,7 @@ sub atan2 {
 ##################################################
 
 sub string {
-  my $self = shift; my $equation = shift; my $prec = shift;
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my $n = $self->{data}[0];
   my $format = $self->getFlag("format",$equation->{format} ||
 			        ($equation->{context} || $self->context)->{format}{number});

--- a/lib/Value/Union.pm
+++ b/lib/Value/Union.pm
@@ -335,7 +335,7 @@ sub pdot {
 }
 
 sub string {
-  my $self = shift; my $equation = shift; shift; shift; my $prec = shift//0;
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my $op = ($equation->{context} || $self->context)->{operators}{'U'};
   my @intervals = ();
   foreach my $x (@{$self->data}) {
@@ -343,17 +343,17 @@ sub string {
     push(@intervals,$x->string($equation))
   }
   my $string = join($op->{string} || ' U ',@intervals);
-  $string = '('.$string.')' if $prec > ($op->{precedence} || 1.5);
+  $string = '('.$string.')' if defined($prec) && $prec > ($op->{precedence} || 1.5);
   return $string;
 }
 
 sub TeX {
-  my $self = shift; my $equation = shift; shift; shift; my $prec = shift//0; #FIXME find out about precedece
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my $op = ($equation->{context} || $self->context)->{operators}{'U'};
   my @intervals = ();
   foreach my $x (@{$self->data}) {push(@intervals,$x->TeX($equation))}
   my $TeX = join($op->{TeX} || $op->{string} || ' U ',@intervals);
-  $TeX = '\left('.$TeX.'\right)' if $prec > ($op->{precedence} || 1.5);
+  $TeX = '\left('.$TeX.'\right)' if defined($prec) && $prec > ($op->{precedence} || 1.5);
   return $TeX;
 }
 

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -892,7 +892,7 @@ sub isReduced {
 #
 
 sub string {
-  my $self = shift; my $equation = shift; my $prec = shift;
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my ($a,$b) = @{$self->{data}}; my $n = "";
   return "$a" if $b == 1;
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
@@ -903,7 +903,7 @@ sub string {
 }
 
 sub TeX {
-  my $self = shift; my $equation = shift; my $prec = shift;
+  my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my ($a,$b) = @{$self->{data}}; my $n = "";
   return "$a" if $b == 1;
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)


### PR DESCRIPTION
This PR fixes several problems that cause the issue described in #567 with the Fraction context.  The main problem was that the `string()` and `TeX()` methods were handling the parameters incorrectly (there are two that were missing, and `$prec` was getting the value from the first of them, which is what was causing the error).  The same issue also occurs for the Real class (which is probably why it made it into the Fraction class).

There is also a potential issue in the function-equivalence checking post-filter, which is that the context flags used there are not necessarily the same as the ones used in the main `cmp()` method.  So I've added the calls that set/reset the flags, which are duplicated from the main function.

Finally, I adjust the Union `string()` and `TeX()` to handle undefined `$prec` in the same way as in other MathObject classes (the current fix seems to assume that 0 is the lowest precedence, but there is no guarantee of that).