### PR TITLE
tikz image package for PreTeXt output

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -254,19 +254,7 @@ sub make_alias {
 	
 	if ($ext eq 'html' 		    ) {
 	   $adr_output = $self->alias_for_html($aux_file_id,$ext)
-	} elsif (   $ext eq 'gif'  
-		     or $ext eq 'jpg' 
-		     or $ext eq 'png'
-		     or $ext eq 'svg'
-		    or $ext eq 'pdf'
-		    or $ext eq 'mp4'
-		    or $ext eq 'mpg'
-		    or $ext eq 'ogg'
-		    or $ext eq 'webm'
-		    or $ext eq 'css'
-		    or $ext eq 'js'
-		    or $ext eq 'nb'
-		    ) {
+	} elsif ($ext =~ /^(gif|jpg|png|svg|pdf|mp4|mpg|ogg|webm|css|js|nb|tgz)$/) {
 		if ($displayMode =~ /^HTML/ or $displayMode eq 'PTX') {
 			 $adr_output=$self->alias_for_html($aux_file_id, $ext);
 		} elsif ($displayMode eq 'TeX') {

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -113,6 +113,7 @@ sub new {
 	$image->svgMethod($main::envir{tikzSVGMethod} // 'pdf2svg');
 	$image->convertOptions($main::envir{tikzConvertOptions} // {input => {},output => {}});
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';
+	$image->SUPER::ext('tgz') if $main::displayMode eq 'PTX';
 	$image->imageName($main::PG->getUniqueName($image->ext));
 
 	return bless $image, $class;


### PR DESCRIPTION
This makes it such that for PTX display mode (used when producing PreTeXt output) the tikz "image" is actually a .tgz file with .tex, .pdf, .svg, and .png.

To test, check that earlier tikz examples still work. There are sample files in #557.

Next, check PreTeXt output is as described. To do that, you could use something like the following URL. You need to set:
* the server
* courseID should be a course ID 
* sourceFilePath should be a file path to some tikz example file accessible from that course
* userID and course_password should be a user in the course (login proctor or higher), and their password 

https://webwork.yoursite.edu/webwork2/html2xml?&amp;problemSeed=1&amp;answersSubmitted=0&amp;sourceFilePath=local/BEGINTIKZ.pg&amp;displayMode=PTX&amp;courseID=testing&amp;userID=anonymous&amp;course_password=anonymous&amp;outputformat=ptx

Ignore whatever your web browser displays and instead look at the page source. You should see something like:
```
<image source="/wwtmp/testing//images/4c09146e-8bc3-3ae3-aac3-ad011135bebb___ca219939-7303-3697-8505-574f0e733dc4.tgz" />
```
with that .tgz extension. Download that file (so, like from https://webwork.yoursite.edu/wwtmp/testing//images/4c09146e-8bc3-3ae3-aac3-ad011135bebb___ca219939-7303-3697-8505-574f0e733dc4.tgz) and see that it contains what it should contain.