### PR TITLE
Add a third optional argument to ADD_JS_FILE to add script tag attributes (defer, async, etc)

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -190,7 +190,7 @@ For example:
 =cut
 
 sub ADD_CSS_FILE {
-  my ($file, $external) = shift;
+  my ($file, $external) = @_;
   push(@{$PG->{flags}{extra_css_files}}, { file => $file, external => $external });
 }
 

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -203,16 +203,21 @@ from the webwork2/htdocs/ directory or from an external location.
 
 If external is 1, it is assumed the full url is provided.  If external is 0 or
 not given, then file name will be prefixed with the webwork2/htdocs/ directory.
+
+Addtional attributes can be passed as a hash reference in the optional third
+argument.  These attributes will be added as attributes to the script tag.
+
 For example:
 
 	ADD_JS_FILE("js/apps/Base64/Base64.js");
 	ADD_JS_FILE("//web.geogebra.org/4.4/web/web.nocache.js", 1);
+	ADD_JS_FILE("js/apps/GraphTool/graphtool.min.js", 0, { id => "gt_script", defer => undef });
 
 =cut
 
 sub ADD_JS_FILE {
-	my ($file, $external) = @_;
-	push(@{$PG->{flags}{extra_js_files}}, { file => $file, external => $external });
+	my ($file, $external, $attributes) = @_;
+	push(@{$PG->{flags}{extra_js_files}}, { file => $file, external => $external, attributes => $attributes });
 }
 
 sub AskSage {

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -204,7 +204,7 @@ from the webwork2/htdocs/ directory or from an external location.
 If external is 1, it is assumed the full url is provided.  If external is 0 or
 not given, then file name will be prefixed with the webwork2/htdocs/ directory.
 
-Addtional attributes can be passed as a hash reference in the optional third
+Additional attributes can be passed as a hash reference in the optional third
 argument.  These attributes will be added as attributes to the script tag.
 
 For example:


### PR DESCRIPTION
Add a third optional argument to ADD_JS_FILE.  This argument is a hash reference of attribute value pairs.  These attributes will be added to the script tag that is added to the page.  The code for adding these attributes to the html that is output is added in a corresponding pull request to webwork2 (see openwebwork/webwork2#1374).

The usage of this argument is documented in the POD for the method.  Its usage is also demonstrated in the paserGraphTool.pl macro.

Also, fix a bug that prevented the optional second argument of ADD_CSS_FILE from working.