### PR TITLE
Update the url for the geogebra javascript used by the AppletObjects.pl macro

### DIFF
--- a/macros/AppletObjects.pl
+++ b/macros/AppletObjects.pl
@@ -70,7 +70,7 @@ sub CanvasApplet {
 =cut
 
 sub GeogebraWebApplet {
-	ADD_JS_FILE("//web.geogebra.org/4.4/web/web.nocache.js", 1);
+	ADD_JS_FILE("https://www.geogebra.org/apps/latest/web/web.nocache.js", 1);
 	return new GeogebraWebApplet(@_);
 }
 


### PR DESCRIPTION
The web.geogebra.org/4.4/web/web.nocache.js link is no longer valid.

www.geogebra.org/apps/latest/web/web.nocache.js is what will need to be used.