### PR TITLE
adjust newlines in PTX output

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1320,7 +1320,7 @@ sub statement {
 }
 
 sub STATEMENT {
-	if ($displayMode eq 'PTX') { TEXT('<statement>', "\n", statement(@_), "\n", '</statement>', "\n\n"); }
+	if ($displayMode eq 'PTX') { TEXT('<statement>', "\n", statement(@_), "\n", '</statement>', "\n"); }
 	else { TEXT(statement(@_)) };
 }
 

--- a/macros/scaffold.pl
+++ b/macros/scaffold.pl
@@ -625,7 +625,7 @@ sub add_container {
       '<div class="accordion-inner">'
     ],
     TeX => ["\\par{\\bf $number $title}\\addtolength{\\leftskip}{15pt}\\par "],
-    PTX => $name ? ["<task>\n", "<title>$name</title>"] : ["<task>\n"],
+    PTX => $name ? ["<task>\n", "<title>$name</title>\n"] : ["<task>\n"],
   )});
   push(@$PG_OUTPUT,main::MODES(
     HTML => '</div></div></div>',


### PR DESCRIPTION
This is a trivial adjustment of newlines in PTX output.

PTX output is XML. Someday I will change the `ptx` format to handle all formatting of the XML. For now, the XML is (sort of) pretty-printed using these manual newlines. It's not great. But this change is an improvement.