### PR TITLE
Make PTX multiple choice answers show their name.

### DIFF
--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -173,7 +173,7 @@ sub MENU {
     };
     $menu .= "</select>";
   } elsif ($main::displayMode eq 'PTX') {
-    $menu = '<var form="popup">' . "\n";
+    $menu = qq(<var form="popup" name="$name">) . "\n";
     foreach my $item (@list) {
       $menu .= '<li>';
       my $escaped_item = $item;

--- a/macros/parserRadioButtons.pl
+++ b/macros/parserRadioButtons.pl
@@ -592,7 +592,7 @@ sub BUTTONS {
     $radio[$#radio_buttons] .= "\n\\end{itemize}\n";
   }
   if ($main::displayMode eq 'PTX') {
-    $radio[0] = '<var form="buttons">' . "\n" . $radio[0];
+    $radio[0] = qq(<var form="buttons" name="$name">) . "\n" . $radio[0];
     $radio[$#radio_buttons] .= '</var>';
     #turn any math delimiters
     @radio = map {$_ =~ s/\\\(/<m>/g; $_} (@radio);


### PR DESCRIPTION
This makes PreTeXt static versions of popup and radio buttons answers have the answer name as an attribute of the element surrounding the choices. This is needed to associate the correct answer from the answer hash with the right element.