### PR TITLE
hotfix   replace assemble_matrix with assemble_tableau

### DIFF
--- a/macros/tableau.pl
+++ b/macros/tableau.pl
@@ -515,7 +515,7 @@ sub initialize {
 	$self->{align} = ($self->{align})//$myAlignString;
  	$self->{S} = Value::Matrix->I($m);
  	$self->{basis_columns} = [($n+1)...($n+$m)] unless ref($self->{basis_columns})=~/ARRAY/;	
- 	my @rows = $self->assemble_matrix;
+ 	my @rows = $self->assemble_tableau;
  	$self->M( _Matrix([@rows]) ); #original matrix
  	$self->{data}= $self->M->data;	
 	my $new_obj_row = $self->objective_row;


### PR DESCRIPTION


[basis_change2.pg.txt](https://github.com/openwebwork/pg/files/6836688/basis_change2.pg.txt)
As result of a typo (while changing subroutine names) a call to assemble_matrix() remained, although the subroutine name had been changed to assemble_tableau.

To test:  This problem will give errors (usually-- it occasionally works ???) before the fix, claiming that assemble_matrix() is undefined.  After the fix it works properly. 