### PR TITLE
Resolve problem with space after function to a power. (#598)

### DIFF
--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -266,7 +266,7 @@ sub pushBlankOperand {
 #    Otherwise, report the missing operand for this operator
 #
 sub Op {
-  my $self = shift; my $name = shift;
+  my $self = shift; my $name = shift; my $NAME = $name;
   my $ref = $self->{ref} = shift;
   my $context = $self->{context}; my $op;
   ($name,$op) = $context->operators->resolve($name);
@@ -283,10 +283,10 @@ sub Op {
           $self->pushOperand($self->Item("UOP")->new($self,$name,$top->{value},$ref));
         } else {
           my $def = $context->operators->resolveDef(' ');
-          $name = $def->{string} if defined($name) and ($name eq ' ' or $name eq $def->{space});
+          $name = $def->{string} if defined($NAME) and ($NAME eq ' ' or $NAME eq $def->{space});
           $self->pushOperator($name,$op->{precedence});
         }
-      } elsif (($ref && $name ne ' ') || $self->state ne 'fn') {$self->Op($name,$ref)}
+      } elsif (($ref && $NAME ne ' ') || $self->state ne 'fn') {$self->Op($NAME,$ref)}
     }
   } else {
     ($name,$op) = $context->operators->resolve('u'.$name)


### PR DESCRIPTION
This PR fixes an error introduced in 15ce46c that causes spaces after functions with powers to be misinterpreted.

You can test is via

```
TEXT(Compute("sin^2 (x)"))
```

which will throw an error in version 2.16 without the patch, and will produce `[sin(x)]^2` with the patch.

This resolves issue #598.