### PR TITLE
LaTeXImage.pm

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -101,11 +101,6 @@ sub tikzLibraries {
 # element the package options).
 sub texPackages {
 	my $self = shift;
-	# if tikzpicture is the environment, make sure tikz package is included
-	if ($self->environment->[0] eq 'tikzpicture') {
-		return &$self('texPackages', ['tikz',@$_[0]]) if ref($_[0]) eq "ARRAY";
-		return &$self('texPackages', ['tikz']);
-	}
 	return &$self('texPackages', $_[0]) if ref($_[0]) eq "ARRAY";
 	return &$self('texPackages');
 }
@@ -150,6 +145,9 @@ sub header {
 	my @xcolorOpts = grep { ref $_ eq "ARRAY" && $_->[0] eq "xcolor" && defined $_->[1] } @{$self->texPackages};
 	my $xcolorOpts = @xcolorOpts ? $xcolorOpts[0][1] : 'svgnames';
 	push(@output, "\\usepackage[$xcolorOpts]{xcolor}\n");
+	# Load tikz if environment is tikzpicture, but not if texPackages contains tikz already
+	my %istikzused = map {ref $_ eq "ARRAY" ? ($_->[0] => ($_->[0] eq 'tikz')) : ($_ => ($_ eq 'tikz'))} @{$self->texPackages};
+	push(@output, "\\usepackage{tikz}\n") if ($self->environment->[0] eq 'tikzpicture' && !$istikzused{'tikz'});
 	push(@output, map {
 			"\\usepackage" . (ref $_ eq "ARRAY" && @$_ > 1 && $_->[1] ne "" ? "[$_->[1]]" : "") . "{" . (ref $_ eq "ARRAY" ? $_->[0] : $_) . "}\n"
 		} grep { (ref $_ eq "ARRAY" && $_->[0] ne 'xcolor') || $_ ne 'xcolor' } @{$self->texPackages});

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -146,8 +146,9 @@ sub header {
 	my $xcolorOpts = @xcolorOpts ? $xcolorOpts[0][1] : 'svgnames';
 	push(@output, "\\usepackage[$xcolorOpts]{xcolor}\n");
 	# Load tikz if environment is tikzpicture, but not if texPackages contains tikz already
-	my %istikzused = map {ref $_ eq "ARRAY" ? ($_->[0] => ($_->[0] eq 'tikz')) : ($_ => ($_ eq 'tikz'))} @{$self->texPackages};
-	push(@output, "\\usepackage{tikz}\n") if ($self->environment->[0] eq 'tikzpicture' && !$istikzused{'tikz'});
+	push(@output, "\\usepackage{tikz}\n")
+	if ($self->environment->[0] eq 'tikzpicture' &&
+		!grep { (ref $_ eq "ARRAY" && $_->[0] eq 'tikz') || $_ eq 'tikz' } @{$self->texPackages});
 	push(@output, map {
 			"\\usepackage" . (ref $_ eq "ARRAY" && @$_ > 1 && $_->[1] ne "" ? "[$_->[1]]" : "") . "{" . (ref $_ eq "ARRAY" ? $_->[0] : $_) . "}\n"
 		} grep { (ref $_ eq "ARRAY" && $_->[0] ne 'xcolor') || $_ ne 'xcolor' } @{$self->texPackages});

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -24,7 +24,7 @@ use Carp;
 use WeBWorK::PG::IO;
 use WeBWorK::PG::ImageGenerator;
 
-package TikZImage;
+package LaTeXImage;
 
 # The constructor (it takes no parameters)
 sub new {

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -15,7 +15,7 @@
 ################################################################################
 
 # This is a Perl module which simplifies and automates the process of generating
-# simple images using TikZ, and converting them into a web-useable format.  Its
+# simple images using LaTeX, and converting them into a web-useable format.  Its
 # typical usage is via the macro PGtikz.pl and is documented there.
 
 use strict;
@@ -31,7 +31,9 @@ sub new {
 	my $class = shift;
 	my $data = {
 		tex            => '',
-		tikzOptions    => '',
+		environment    => '',
+		envirOptions   => '',
+		tikzOptions    => '',  # legacy
 		tikzLibraries  => '',
 		texPackages    => [],
 		addToPreamble  => '',
@@ -61,14 +63,27 @@ sub new {
 
 # Accessors
 
-# Set TikZ image code, not including begin and end tags, as a single
-# string parameter.  Works best single quoted.
+# Set LaTeX image code as a single string parameter.  Works best single quoted.
 sub tex {
 	my $self = shift;
 	return &$self('tex', @_);
 }
 
-# Set TikZ picture options as a single string parameter.
+# Set LaTeX environment as a single string parameter.
+sub environment {
+	my $self = shift;
+	return &$self('environment', @_);
+}
+
+# Set LaTeX environment options as a single string parameter.
+sub envirOptions {
+	my $self = shift;
+	# legacy support for tikzOptions
+	return $self->tikzOptions if ($self->tikzOptions ne '');
+	return &$self('envirOptions', @_);
+}
+
+# Legacy support for tikzOptions
 sub tikzOptions {
 	my $self = shift;
 	return &$self('tikzOptions', @_);
@@ -137,15 +152,16 @@ sub header {
 	push(@output, "\\usetikzlibrary{" . $self->tikzLibraries . "}") if ($self->tikzLibraries ne "");
 	push(@output, $self->addToPreamble);
 	push(@output, "\\begin{document}\n");
-	push(@output, "\\begin{tikzpicture}");
-	push(@output, "[" . $self->tikzOptions . "]") if ($self->tikzOptions ne "");
+	push(@output, "\\begin{" , $self->environment . "}") if $self->environment;
+	push(@output, "[" . $self->envirOptions . "]") if ($self->environment && $self->envirOptions ne "");
+	push(@output, "\n") if $self->environment;
 	@output;
 }
 
 sub footer {
 	my $self = shift;
 	my @output = ();
-	push(@output, "\\end{tikzpicture}\n");
+	push(@output, "\\end{" , $self->environment . "}\n") if $self->environment;
 	push(@output, "\\end{document}\n");
 	@output;
 }

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -32,7 +32,9 @@ sub new {
 	my $data = {
 		tex            => '',
 		environment    => '',
-		tikzOptions    => '',  # legacy
+		# if tikzOptions is nonempty, then environment
+		# will effectively be ['tikzpicture', tikzOptions]
+		tikzOptions    => '',
 		tikzLibraries  => '',
 		texPackages    => [],
 		addToPreamble  => '',
@@ -73,15 +75,15 @@ sub tex {
 # the environment. If there is a second element, it should be a string with options for
 # the environment. This could be extended to support environments with multiple option
 # fields that may use parentheses for delimiters.
+# If tikzOptions is nonempty, the input is ignored and output is ['tikzpicture',tikzOptions].
 sub environment {
 	my $self = shift;
-	# legacy support
 	return ['tikzpicture',$self->tikzOptions] if ($self->tikzOptions ne '');
 	return [&$self('environment', @_), ''] if (ref(&$self('environment', @_)) ne 'ARRAY');
 	return &$self('environment', @_);
 }
 
-# Legacy support for tikzOptions
+# Set TikZ picture options as a single string parameter.
 sub tikzOptions {
 	my $self = shift;
 	return &$self('tikzOptions', @_);
@@ -99,7 +101,7 @@ sub tikzLibraries {
 # element the package options).
 sub texPackages {
 	my $self = shift;
-	# Legacy: if tikzpicture is the environment, make sure tikz package is included
+	# if tikzpicture is the environment, make sure tikz package is included
 	if ($self->environment->[0] eq 'tikzpicture') {
 		return &$self('texPackages', ['tikz',@$_[0]]) if ref($_[0]) eq "ARRAY";
 		return &$self('texPackages', ['tikz']);

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1873,6 +1873,8 @@ sub default_preprocess_code {
 	$evalString =~ s/ENDDOCUMENT.*/ENDDOCUMENT();/s; # remove text after ENDDOCUMENT
 	$evalString =~ s/\n\h*(.*)\h*->\h*BEGIN_TIKZ[\h;]*\n/\n$1->tex\(<<END_TIKZ\);\n/g;
 	$evalString =~ s/\n\h*END_TIKZ[\h;]*\n/\nEND_TIKZ\n/g;
+	$evalString =~ s/\n\h*(.*)\h*->\h*BEGIN_LATEX_IMAGE[\h;]*\n/\n$1->tex\(<<END_LATEX_IMAGE\);\n/g;
+	$evalString =~ s/\n\h*END_LATEX_IMAGE[\h;]*\n/\nEND_LATEX_IMAGE\n/g;
 
 	$evalString =~ s/\\/\\\\/g;    # \ can't be used for escapes because of TeX conflict
 	$evalString =~ s/~~/\\/g;      # use ~~ as escape instead, use # for comments

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2914,7 +2914,7 @@ Usage:
 
     image($image, width => 100, height => 100, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
-where C<$image> can be a local file path, URL, WWPlot object, or TikZImage object,
+where C<$image> can be a local file path, URL, WWPlot object, or LaTeXImage object,
 C<width> and C<height> are pixel counts for HTML display, while C<tex_size> is
 per 1000 applied to linewidth (for example 800 leads to 0.8\linewidth)
 
@@ -2979,7 +2979,7 @@ sub image {
 	while(@image_list) {
 		my $image_item = shift @image_list;
 		$image_item = insertGraph($image_item)
-			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'TikZImage' || ref $image_item eq 'PGtikz');
+			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'LaTeXImage' || ref $image_item eq 'PGtikz');
 		my $imageURL = alias($image_item)//'';
 		$imageURL = ($envir{use_site_prefix})? $envir{use_site_prefix}.$imageURL : $imageURL;
 		my $out = "";

--- a/macros/PGlateximage.pl
+++ b/macros/PGlateximage.pl
@@ -34,7 +34,7 @@ with backslashes. In the above, \\\\ becomes \\, because a simple \\ would
 become \. But \x and \a do not require escaping the backslash. (It would be
 harmless to escape these too though.)
 
-If math content is wihtin the LaTeX code, delimit it with \(...\) instead of
+If math content is within the LaTeX code, delimit it with \(...\) instead of
 with dollar signs.
 
 Then insert the image into the problem with

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -44,11 +44,11 @@ LaTeXImage object return by createTikZImage to generate the desired image.
                                string.  Escaping of special characters may be
                                needed in some cases.
 
-    $image->tikzOptions()      Add options that will be passed to
+    $image->envirOptions()     Add options that will be passed to
                                \begin{tikzpicture}.  This takes a single
                                string parameter.
                                For example:
-                               $image->tikzOptions(
+                               $image->envirOptions(
                                    "x=.5cm,y=.5cm,declare function={f(\x)=sqrt(\x);}"
                                );
 
@@ -104,12 +104,14 @@ sub _PGtikz_init {
 package PGtikz;
 our @ISA = qw(LaTeXImage);
 
-# Not much needs to be done here.  The real work is done in LaTeXImage.pm.
+# Not much needs to be done here except flag this as needing the tikz environment wrapper.
+# The real work is done in LaTeXImage.pm.
 sub new {
 	my $self = shift;
 	my $class = ref($self) || $self;
 
 	my $image = $class->SUPER::new(@_);
+	$image->environment('tikzpicture');
 	$image->svgMethod($main::envir{tikzSVGMethod} // 'pdf2svg');
 	$image->convertOptions($main::envir{tikzConvertOptions} // {input => {},output => {}});
 	$image->SUPER::ext('pdf') if $main::displayMode eq 'TeX';

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -19,7 +19,7 @@ PGtikz.pl - Insert images into problems that are generated using LaTeX and TikZ.
 
 =head1 DESCRIPTION
 
-This is a convenience macro for utilizing the TikZImage object to insert TikZ
+This is a convenience macro for utilizing the LaTeXImage object to insert TikZ
 images into problems.  Create a TikZ image as follows:
 
     $image = createTikZImage();
@@ -35,8 +35,8 @@ Then insert the image into the problem with
 
 =head1 DETAILED USAGE
 
-There are several TikZImage parameters that may need to be set for the
-TikZImage object return by createTikZImage to generate the desired image.
+There are several LaTeXImage parameters that may need to be set for the
+LaTeXImage object return by createTikZImage to generate the desired image.
 
     $image->tex()              Add the tikz commands that define the image.
                                This takes a single string parameter.  It is
@@ -102,9 +102,9 @@ sub _PGtikz_init {
 }
 
 package PGtikz;
-our @ISA = qw(TikZImage);
+our @ISA = qw(LaTeXImage);
 
-# Not much needs to be done here.  The real work is done in TikZImage.pm.
+# Not much needs to be done here.  The real work is done in LaTeXImage.pm.
 sub new {
 	my $self = shift;
 	my $class = ref($self) || $self;

--- a/macros/PGtikz.pl
+++ b/macros/PGtikz.pl
@@ -56,6 +56,8 @@ LaTeXImage object return by createTikZImage to generate the desired image.
                                string parameter.
                                For example:
                                $image->tikzOptions(
+                                   "x=.5cm,y=.5cm,declare function={f(\x)=sqrt(\x);}"
+                               );
 
     $image->tikzLibraries()    Add additional tikz libraries to load.  This
                                takes a single string parameter.

--- a/t/latex_image_test/latex_image_test1.pg
+++ b/t/latex_image_test/latex_image_test1.pg
@@ -1,0 +1,41 @@
+##DESCRIPTION
+# TEST tikz from a pg problem
+##ENDDESCRIPTION
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",
+    "MathObjects.pl",
+    "PGlateximage.pl"
+);
+
+TEXT(beginproblem());
+
+##############################################################
+#  Setup
+##############################################################
+
+$drawing = createLaTeXImage();
+$drawing->texPackages([['xy','all']]);
+$drawing->BEGIN_LATEX_IMAGE
+\xymatrix{ A \ar[r] & B \ar[d] \\\\
+           D \ar[u] & C \ar[l] }
+END_LATEX_IMAGE
+
+$path = insertGraph($drawing);
+
+Context("Numeric");
+
+##############################################################
+#  Text
+##############################################################
+
+BEGIN_TEXT
+\{protect_underbar("path = $path")\};
+$BR alias = \{protect_underbar(alias($path))\}
+$PAR image = \{image($path, width => 228, height => 114, tex_size => 400)\}
+$PAR svg = \{embedSVG($path)\}
+END_TEXT
+
+ENDDOCUMENT();

--- a/t/latex_image_test/latex_image_test2.pg
+++ b/t/latex_image_test/latex_image_test2.pg
@@ -1,0 +1,44 @@
+##DESCRIPTION
+# TEST tikz from a pg problem
+##ENDDESCRIPTION
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",
+    "MathObjects.pl",
+    "PGlateximage.pl"
+);
+
+TEXT(beginproblem());
+
+##############################################################
+#  Setup
+##############################################################
+
+$drawing = createLaTeXImage();
+$drawing->texPackages(['circuitikz']);
+$drawing->environment(['circuitikz','scale=1.2, transform shape']);
+$drawing->BEGIN_LATEX_IMAGE
+\draw (60,1) to [battery2, v_=\(V_{cc}\), name=B] ++(0,2);
+\node[draw,red,circle,inner sep=4pt] at(B.left) {};
+\node[draw,red,circle,inner sep=4pt] at(B.right) {};
+END_LATEX_IMAGE
+
+$path = insertGraph($drawing);
+
+Context("Numeric");
+
+##############################################################
+#  Text
+##############################################################
+
+BEGIN_TEXT
+\{protect_underbar("path = $path")\};
+$BR alias = \{protect_underbar(alias($path))\}
+$PAR image = \{image($path, width => 228, height => 114, tex_size => 400)\}
+$PAR svg = \{embedSVG($path)\}
+END_TEXT
+
+ENDDOCUMENT();
+

--- a/t/tikz_test/tikz_test3.pg
+++ b/t/tikz_test/tikz_test3.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+# TEST tikz from a pgml problem
+##ENDDESCRIPTION
+
+DOCUMENT();
+
+loadMacros(
+    "PGstandard.pl",
+    "MathObjects.pl",
+    "PGML.pl",
+    "PGtikz.pl"
+);
+
+TEXT(beginproblem());
+
+##############################################################
+#  Setup
+##############################################################
+
+$a = random(1, 4);
+$b = random(3, 6);
+$c = random(5, 8);
+$d = random(7, 10);
+
+$tikz_code = <<END_TIKZ;
+\huge
+\begin{axis}
+	[
+		ybar=0pt,
+		bar width=2cm,
+		width=14cm,
+		height=12cm,
+		enlarge x limits=0.2,
+		ymajorgrids,
+		ymin=0,
+		ymax=11,        
+		ylabel={\textbf{Number of Books}},
+		xtick=data,
+		xticklabels={Philosophy, Math, Literature, History},
+		ytick={1,...,10},
+		major x tick style={opacity=0},
+	]
+	\addplot[fill=Blue!20] coordinates {(0, $a) (1, $b) (2, $c) (3, $d)};
+\end{axis}
+END_TIKZ
+
+$drawing = createTikZImage();
+$drawing->texPackages([["pgfplots"]]);
+$drawing->addToPreamble("\pgfplotsset{compat=1.15}");
+$drawing->tikzOptions("main_node/.style={circle,fill=blue!20,draw,minimum size=1em,inner sep=3pt}");
+$drawing->tex($tikz_code);
+
+
+$path = insertGraph($drawing);
+
+Context("Numeric");
+
+##############################################################
+#  Text
+##############################################################
+
+BEGIN_PGML
+path = [@ protect_underbar($path) @]
+[@ $BR @]*
+alias = [@ protect_underbar(alias($path)) @]*
+
+image = [@ image($path, width => 100, tex_size => 400) @]*
+
+svg = [@ embedSVG($path) @]*
+END_PGML
+
+ENDDOCUMENT();


### PR DESCRIPTION
This renames `TikZImage.pm` as `LaTeXImage.pm`, and makes it so other kinds of images (not necessarily tikz) can be used. It changes `PGtikz.pl` accordingly, and unless I made a mistake, any problem or macro that relies on `PGtikz.pl` should still work with no changes.

It adds `PGlateximage.pl` as the more general version of `PGtikz.pl`. There are two sample problems that use it in `t`. One makes an `xypic` image, one makes a `circuittikz` image.

There will be a `webwork2` PR to go along with this.