### PR TITLE
Fix calls to Parser::Value::TeX & too many (cooks)

### DIFF
--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -401,8 +401,8 @@ sub Close {
                     ($top->type eq 'Comma') ? $top->entryType : $top->typeRef,
                     ($type ne 'start') ? ($open,$paren->{close}) : () )};
         } else {
-	  $top->{value}{hadParens} = 1;
-	}
+          $top->{value}{hadParens} = 1 unless $open eq 'start';
+        }
         $self->pop; $self->push($top);
         $self->CloseFn() if ($paren->{function} && $self->prev->{type} eq 'fn');
       } elsif ($paren->{formInterval} eq $type && $self->top->{value}->length == 2) {

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -636,8 +636,9 @@ sub TeX {
   return $string unless $self->{value}->classMatch('Fraction');
   my $precedence = shift;
   my $frac = $self->context->operators->get('/')->{precedence};
+  my $noparens = shift;
   $string = '\left(' . $string . '\right)' if $self->{hadParens} ||
-    (defined $precedence && $precedence > $frac && $self->context->flag('showExtraParens') > 1);
+    (defined $precedence && $precedence > $frac && !$noparens);
   return $string;
 }
 

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -618,7 +618,7 @@ sub reduce {
 #
 sub string {
   my $self = shift;
-  my $string = $self->SUPER::string($self, @_);
+  my $string = $self->SUPER::string(@_);
   return $string unless $self->{value}->classMatch('Fraction');
   my $precedence = shift;
   my $frac = $self->context->operators->get('/')->{precedence};
@@ -627,15 +627,17 @@ sub string {
 }
 
 #
-#  Add parentheses if they are needed by precedence
+#  Add parentheses if they were there originally, or
+#  are needed by precedence and we asked for exxxtra parens
 #
 sub TeX {
   my $self = shift;
-  my $string = $self->SUPER::TeX($self, @_);
+  my $string = $self->SUPER::TeX(@_);
   return $string unless $self->{value}->classMatch('Fraction');
   my $precedence = shift;
   my $frac = $self->context->operators->get('/')->{precedence};
-  $string = '\left(' . $string . '\right)' if defined $precedence && $precedence > $frac;
+  $string = '\left(' . $string . '\right)' 
+    if defined $precedence && $precedence > $frac && $self->context->flag('showExtraParens') > 1;
   return $string;
 }
 
@@ -898,7 +900,6 @@ sub string {
   if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
     {$n = int($a/$b); $a = CORE::abs($a) % $b; $n .= " " unless $a == 0}
   $n .= "$a/$b" unless $a == 0 && $n ne '';
-  $n = "($n)" if defined $prec && $prec >= 1;
   return "$n";
 }
 
@@ -911,7 +912,6 @@ sub TeX {
   my $s = ""; ($a,$s) = (-$a,"-") if $a < 0;
   $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{\\textstyle\\frac{$a}{$b}}")
     unless $a == 0 && $n ne '';
-  $n = "\\left($n\\right)" if defined $prec && $prec >= 1;
   return "$n";
 }
 

--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -636,8 +636,8 @@ sub TeX {
   return $string unless $self->{value}->classMatch('Fraction');
   my $precedence = shift;
   my $frac = $self->context->operators->get('/')->{precedence};
-  $string = '\left(' . $string . '\right)' 
-    if defined $precedence && $precedence > $frac && $self->context->flag('showExtraParens') > 1;
+  $string = '\left(' . $string . '\right)' if $self->{hadParens} ||
+    (defined $precedence && $precedence > $frac && $self->context->flag('showExtraParens') > 1);
   return $string;
 }
 


### PR DESCRIPTION
In PR #512, contextFraction.pl inserted new methods into the `string` and `TeX` method call chains (originally routed directly to Parser::Value::TeX, now passing through context::Fraction::Value). These methods had the impact of adding necessary parens to the string (as precedence would require -- [see reference](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4981)).

However, strictly following precedence at the Fraction::Value layer causes [issues with unary negation](https://github.com/openwebwork/pg/pull/512#commitcomment-57951720) (as reported by @Alex-Jordan) -- because the precedence of `u-` is 6 (and precedence of `/` is 3). 

This issue is avoided in Fraction::BOP::divide::TeX via argument `$showparens eq 'nofractions'` via UOP::TeX (derived from `Parser::Context::Default::operations->{'u-'}{nofractionparens}`). This solution is not available at the Fraction::Value layer (and is already being handled on the BOP layer), so these additional parens will _now_ only be added when either:
- the parens are explicitly there in the original string definition, or
- precedence dictates AND we've explicitly set `showExtraParens => 2` in the context

Meanwhile the precedence parens remain a necessary addition for strings at the Fraction::Value layer because we cannot be assured that the original string contained them (see attached pg example of constructing a MathObject with precedence derived from perl operations [modified from code provided in #512]).

Furthermore, subsequent changes in #569 (stemming from issue #567) changed `context::Fraction::Fraction::TeX` to properly handle the incoming precedence. This had the effect of yet another layer trying to insert string and TeX parens based on precedence. This code was not previously being acted upon because the incoming precedence was not being handled properly (Fraction objects should never have ->{open} or ->{closed} defined as [noted](https://github.com/openwebwork/pg/pull/569/files#r626851711) by @taniwallach). This is definitely not the layer to be handling precedence issues and so that code has been removed.

See attached code: [check-parens.pg.txt](https://github.com/openwebwork/pg/files/7350814/check-parens.pg.txt)