### PR TITLE
parserAssignment chokes when previous answer is undefined on the domain

### DIFF
--- a/macros/parserAssignment.pl
+++ b/macros/parserAssignment.pl
@@ -348,7 +348,18 @@ sub new {
   my $self = shift; $class = ref($self) || $self;
   my $f = $self->SUPER::new(@_);
   bless $f, $class if $f->type eq 'Assignment';
+  my $rhs = $f->getTypicalValue($f)->{data}[1];
+  Value->Error('Assignment of strings is not allowed.') if $rhs && $rhs->type eq 'String';
   return $f;
+}
+
+sub typeMatch {
+  my $self = shift; my $other = shift; my $ans = shift;
+  return 0 unless $self->type eq $other->type;
+  my $typeMatch = $self->getTypicalValue($self)->{data}[1];
+  $other = $self->getTypicalValue($other,1)->{data}[1];
+  return 1 unless defined($other); # can't really tell, so don't report type mismatch
+  $typeMatch->typeMatch($other,$ans);
 }
 
 sub cmp_class {

--- a/macros/parserAssignment.pl
+++ b/macros/parserAssignment.pl
@@ -351,18 +351,6 @@ sub new {
   return $f;
 }
 
-sub typeMatch {
-  my $self = shift; my $other = shift; my $ans = shift;
-  return 0 unless $self->type eq $other->type;
-  $other = $other->Package("Formula")->new($self->context,$other) unless $other->isFormula;
-  my $typeMatch = ($self->createRandomPoints(1))[1]->[0]{data}[1];
-  $main::__other__ = sub {($other->createRandomPoints(1))[1]->[0]{data}[1]};
-  $other = main::PG_restricted_eval('&$__other__()');
-  delete $main::{__other__};
-  return 1 unless defined($other); # can't really tell, so don't report type mismatch
-  $typeMatch->typeMatch($other,$ans);
-}
-
 sub cmp_class {
   my $self = shift; my $value;
   if ($self->{tree}{rop}{isConstant}) {


### PR DESCRIPTION
See #607 for details (incl. a MWE)

Submitting an answer whose domain is incompatible with the limits for the available variables causes an appropriate error message: `The domain of your function doesn't match that of the correct answer`

However, when followed up with an answer whose domain **is** compatible, you will get an error: `The evaluated answer is not an answer hash : ||. ` (This happens only based on domain, and is independent of whether or not the submitted answer is correct.)

The failure to complete the processing of the answer hash is due to the cmp_postfilter which compares the current and previous answers. 
_Note:_ So long as the submitted answer generates a feedback message, the comparison between the current and previous submissions is skipped.
Specifically, the `typeMatch` method call (which ensures that the current and previous responses are comparable objects _before_ actually comparing them) dies because the previous submission fails to generate valid points.

The solution is to simply remove `typeMatch` from `parser::Assignment::Formula`. It's not doing anything more than what (the superclass) `Value::Formula` is already doing. And `Value::Formula::typeMatch` is structured to handle situations where the generation of valid points fails. (Interesting to note: this looks like a bug that was fixed not long after parserAssignment was introduced -- but it was fixed for Value::Formula and the changes never made their way into parserAssignment... see 2e1ed6b41f8375d15b27c64490ff2e324f2826e9)

TL;DR -- parser::Assignment::Formula doesn't need to override `typeMatch`

postfilter: 🍻  to @dlglin for finding a teenaged bug!