### PR TITLE
Don't allow entryType change to modify original Value::Type entries

### DIFF
--- a/macros/contextInequalities.pl
+++ b/macros/contextInequalities.pl
@@ -380,7 +380,7 @@ sub _check {
     unless $self->{lop}{isInequality} && $self->{rop}{isInequality};
   $self->Error("Inequalities combined by '%s' must both use the same variable",$self->{bop})
     unless $self->{lop}{varName} eq $self->{rop}{varName};
-  $self->{type} = Value::Type("Interval",2);
+  $self->{type} = $Value::Type{interval};
   $self->{varName} = $self->{lop}{varName};
   $self->{isInequality} = 1;
 }
@@ -400,7 +400,7 @@ sub _check {
     unless $self->{lop}{isInequality} && $self->{rop}{isInequality};
   $self->Error("Inequalities combined by '%s' must both use the same variable",$self->{bop})
     unless $self->{lop}{varName} eq $self->{rop}{varName};
-  $self->{type} = Value::Type("Interval",2);
+  $self->{type} = $Value::Type{interval};
   $self->{varName} = $self->{lop}{varName};
   $self->{isInequality} = 1;
 }
@@ -840,7 +840,7 @@ our @ISA = ("Value::Interval");
 
 sub new {
   my $self = shift;
-  $self = $self->SUPER::new(@_);
+  $self = Value::Interval->new(@_);
   $self = $self->demote if $self->classMatch("Inequality");
   return $self;
 }
@@ -878,7 +878,7 @@ sub _check {
     my $entryType = $self->typeRef->{entryType};
     return unless $entryType->{name} =~ m/^(unknown|Interval|Set|Union)$/;
     foreach my $x (@{$self->{coords}}) {return unless $x->{isInequality}};
-    $entryType->{name} = "Inequality";
+    $self->typeRef->{entryType} = Value::Type("Inequality", $entryType->{length}, $entryType->{entryType});
   }
 }
 


### PR DESCRIPTION
This PR fixes a problem with the Inequalities context reported in the [forum](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=6562) where the use of a list of inequalities would cause an error when an answer is resubmitted.

The problem is due to the fact that the Inequalities context was changing a value that is part of `$Value::Types{interval}`, but `%Value::Type` is static code that is shared among all problems processed by a given https child process, so that change was propagating to problems processed subsequently by the same child.

The fix is to use `Value::Type()` to create a new `typeRef` object rather than modify the existing (shared) one.

This can be checked using the code in the original forum post.  With this patch, it should not cause an error when submitting the problem more than once.

This PR also fixes a second (unreported issue) in the Inequalities context, where direct calls to `Interval()` could produce incorrect results.  This can be tested with 

```
loadMacros("contextInequalitieis.pl");
Context("Inequalities");
TEXT(Interval('(', 1, 2, ')'));
```

which should produce the output `(1,2)`.  Without this patch, it produces just `)`.