### PR TITLE
Fix problem with matrix type-checking in answer preview (#619)

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -201,6 +201,7 @@ sub cmp_collect {
   $ans->{student_value} = $ans->{student_formula};
   $ans->{preview_text_string} = $ans->{student_ans};
   $ans->{preview_latex_string} = $ans->{student_formula}->TeX;
+  return 0 if $ans->{typeError};
   if (Value::isFormula($ans->{student_formula}) && $ans->{student_formula}->isConstant) {
     $ans->{student_value} = Parser::Evaluate($ans->{student_formula});
     return 0 unless $ans->{student_value};
@@ -593,6 +594,7 @@ sub ans_collect {
       $ans->{typeError} = 0;
       my $result = $data->[$i][$j]->cmp(@ans_cmp_defaults)->evaluate($entry);
       $OK &= entryCheck($result,$blank);
+      $ans->{typeError} = 1 if $result->{typeError};
       push(@row,$result->{student_formula});
       entryMessage($result->{ans_message},$errors,$i,$j,$rows,$cols);
     }
@@ -624,8 +626,7 @@ sub entryMessage {
 
 sub entryCheck {
   my $ans = shift; my $blank = shift;
-  return 0 if $ans->{typeError};
-  return 1 if defined($ans->{student_value});
+  return 1 if defined($ans->{student_value}) || $ans->{typeError};
   if (!defined($ans->{student_formula})) {
     $ans->{student_formula} = $ans->{student_ans};
     $ans->{student_formula} = $blank unless $ans->{student_formula};

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -590,6 +590,7 @@ sub ans_collect {
 	$entry = $ans->{original_student_ans};
 	$ans->{student_formula} = $ans->{student_value} = undef unless $entry =~ m/\S/;
       }
+      $ans->{typeError} = 0;
       my $result = $data->[$i][$j]->cmp(@ans_cmp_defaults)->evaluate($entry);
       $OK &= entryCheck($result,$blank);
       push(@row,$result->{student_formula});
@@ -616,18 +617,20 @@ sub entryMessage {
   if ($rows == 1) {$title = "In entry $j"}
   elsif ($cols == 1) {$title = "In entry $i"}
   else {$title = "In entry ($i,$j)"}
-  push(@{$errors},"<TR VALIGN=\"TOP\"><TD NOWRAP STYLE=\"text-align:right; border:0px\"><I>$title</I>:&nbsp;</TD>".
-                  "<TD STYLE=\"text-align:left; border:0px\">$message</TD></TR>");
+  push(@{$errors},
+       "<TR><TD NOWRAP STYLE=\"vertical-align:top; background-color:transparent; text-align:right; border:0px\"><I>$title</I>:&nbsp;</TD>".
+       "<TD STYLE=\"background-color:transparent; text-align:left; border:0px\">$message</TD></TR>");
 }
 
 sub entryCheck {
   my $ans = shift; my $blank = shift;
+  return 0 if $ans->{typeError};
   return 1 if defined($ans->{student_value});
   if (!defined($ans->{student_formula})) {
     $ans->{student_formula} = $ans->{student_ans};
     $ans->{student_formula} = $blank unless $ans->{student_formula};
   }
-  return 0
+  return 0;
 }
 
 

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -582,7 +582,6 @@ sub ans_collect {
   my @array = (); my $data = [$self->value]; my $errors = []; my $OK = 1;
   if ($self->{ColumnVector}) {foreach my $x (@{$data}) {$x = [$x]}}
   $data = [$data] unless ref($data->[0]) eq 'ARRAY';
-  my $sawTypeError = 0;
   foreach my $i (0..$rows-1) {
     my @row = (); my $entry;
     foreach my $j (0..$cols-1) {
@@ -594,13 +593,12 @@ sub ans_collect {
       }
       my $result = $data->[$i][$j]->cmp(@ans_cmp_defaults)->evaluate($entry);
       $OK &= entryCheck($result,$blank);
-      $sawTypeError |= $result->{typeError};
+      $ans->{typeError} = 1 if $result->{typeError};
       push(@row,$result->{student_formula});
       entryMessage($result->{ans_message},$errors,$i,$j,$rows,$cols);
     }
     push(@array,[@row]);
   }
-  $ans->{typeError} = $sawTypeError;
   $ans->{student_formula} = [@array];
   $ans->{ans_message} = $ans->{error_message} = "";
   if (scalar(@{$errors})) {


### PR DESCRIPTION
This PR resolves the problem from #619 where a constant matrix where the student enters a formula produces bad messages when the student asks for an answer preview.  It adds a test for whether a typeMatch error is produced on one of the matrix entries, and the answer is marked incorrect silently in that case rather than going on with the check and crashing while trying to determine the matrix dimensions.

This also adds some CSS on the warning messages produced during answer checking so that the background is transparent (so you get the table cell background rather than that gray that is caused by changes in the theme CSS that occurred after the MathObjects code was written).

The test case is in #619.  Without the patch, you will get the warning message indicated there.  With the patch, you should get no pink messages, just the preview of the student answer.