### PR TITLE
Make sure matrix parentheses are transferred to student input for matrix ans_array (#627)

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -198,6 +198,8 @@ sub cmp_collect {
   $ans->{student_formula} = eval {$type->new($array)->with(ColumnVector=>$self->{ColumnVector})};
   if (!defined($ans->{student_formula}) || $self->context->{error}{flag})
     {Parser::reportEvalError($@); $self->cmp_error($ans); return 0}
+  $ans->{student_formula}{tree}{open} = $self->{open} if $self->{open};
+  $ans->{student_formula}{tree}{close} = $self->{close} if $self->{close};
   $ans->{student_value} = $ans->{student_formula};
   $ans->{preview_text_string} = $ans->{student_ans};
   $ans->{preview_latex_string} = $ans->{student_formula}->TeX;


### PR DESCRIPTION
This PR resolves the issue from #627 where the open/close delimiters that were set manually on a matrix (to show as determinant bars) are transferred to the student input generated from an `ans_array`.  See that issue for the test case.