### PR TITLE
Make sure MultiAnswer uses the correct context (#632)

### DIFF
--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -386,7 +386,7 @@ sub perform_check {
 
   Parser::Context->current(undef,$context);    # change to multi-answser's context
   my $flags = Value::contextSet($context,$self->cmp_contextFlags($ans)); # save old context flags
-  $context->{answerHash} = $rf_ans;            # attach the answerHash
+  $context->{answerHash} = $rh_ans;            # attach the answerHash
   my @result = Value::cmp_compare([@correct],[@student],$self,$rh_ans);
   Value::contextSet($context,%{$flags});       # restore context values
   $context->{answerHash} = undef;              # remove answerHash

--- a/macros/parserMultiAnswer.pl
+++ b/macros/parserMultiAnswer.pl
@@ -370,7 +370,8 @@ sub entry_check {
 #
 sub perform_check {
   my $self = shift; my $rh_ans = shift;
-  $self->context->clearError;
+  my $context = $self->context;
+  $context->clearError;
   my @correct; my @student;
   foreach my $ans (@{$self->{ans}}) {
     push(@correct,$ans->{correct_value});
@@ -382,8 +383,15 @@ sub perform_check {
   my $inputs = $main::inputs_ref;
   $rh_ans->{isPreview} = $inputs->{previewAnswers} ||
                          ($inputs_{action} && $inputs->{action} =~ m/^Preview/);
+
+  Parser::Context->current(undef,$context);    # change to multi-answser's context
+  my $flags = Value::contextSet($context,$self->cmp_contextFlags($ans)); # save old context flags
+  $context->{answerHash} = $rf_ans;            # attach the answerHash
   my @result = Value::cmp_compare([@correct],[@student],$self,$rh_ans);
-  if (!@result && $self->context->{error}{flag}) {$self->cmp_error($self->{ans}[0]); return 1}
+  Value::contextSet($context,%{$flags});       # restore context values
+  $context->{answerHash} = undef;              # remove answerHash
+  if (!@result && $context->{error}{flag}) {$self->cmp_error($self->{ans}[0]); return 1}
+
   my $result = (scalar(@result) > 1 ? [@result] : $result[0] || 0);
   if (ref($result) eq 'ARRAY') {
     die "Checker subroutine returned the wrong number of results"


### PR DESCRIPTION
This PR resolves the issue raised in #632, where error messages sometimes aren't reported.  The problem was that the wrong context was being checked.  The errors are stored in the context object, and with MultiAnswer, where the answers can use different contexts, the error message needs to be set in the proper one.  The test case from #632 uses a PopUp, and that has its own context (to store the string values of the pop-up), and that context was being left as the active one.  The solution is to set the context to that of the MultiAnswer (just as is usually done in the standard MathObject `cmp_parse` method, which is not used by the MultiAnswer object, which has its own `single_cmp` and `entry_cmp` methods).