### PR TITLE
Remove noParens marker from operand (if any) when reducing double negatives. #634

### DIFF
--- a/lib/Parser/UOP/minus.pm
+++ b/lib/Parser/UOP/minus.pm
@@ -29,7 +29,10 @@ sub _eval {-($_[1])}
 sub _reduce {
   my $self = shift; my $op = $self->{op};
   my $reduce = $self->{equation}{context}{reduction};
-  return $op->{op} if $op->isNeg && $reduce->{'-(-x)'};
+  if ($op->isNeg && $reduce->{'-(-x)'}) {
+    delete $op->{op}{noParens};
+    return $op->{op};
+  }
   return $op if $op->{isZero} && $reduce->{'-0'};
   return $self;
 }


### PR DESCRIPTION
This PR resolves a problem with missing parentheses after reducing a double negative involving a multiplication.  This was due to an interaction between the rules for `(-x)*y` and `-(-x)`.  The first rule technically produces `-(x*y)`, but marks the multiplication as not needing parentheses, and the second just returns `x`, so when used to reduce `-(-4*x^2)`, the inner `-4*x^2` (which is `(-4)*x^2)`) becomes `-(4*x^2)` with the multiplication marked for no parentheses, and then `-(-(4*x^2))` becomes just `4*x^2` market as needing no parentheses.  This is why `e^(-(-4*x^2))` produced `e^4*x^2` as its string output (though it was still structurally correct internally).

The easiest fix is to remove the `noParens` marker in the `-(-x)` reduction rule, as is done here.

Resolves issue #634.