### PR TITLE
Fix the drag and drop macro for bootstrap 5 and some other improvements and issue fixes

### DIFF
--- a/htdocs/js/apps/DragNDrop/dragndrop.css
+++ b/htdocs/js/apps/DragNDrop/dragndrop.css
@@ -1,8 +1,17 @@
+.dd-bucket-pool {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: space-evenly;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
 .dd-container {
+	display: flex;
+	flex-direction: column;
 	width: 350px;
-	float: left;
-	margin: 10px !important;
-	padding: 0;
+	padding: 0.5rem;
 	color: #000000;
 	border: 1px solid #388E8E !important;
 	border-radius: 5px;
@@ -10,26 +19,39 @@
 }
 
 .nestable-label {
-	margin: 10px 0 10px 0;
+	margin: 0 0 10px 0;
 }
 
-.dd, .dd-list, .dd-item {
-	display: block;
-	position: relative;
+.dd-list {
+	display: flex !important;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.dd {
+	flex-grow: 1;
+}
+
+.dd-list, .dd-item {
 	list-style: none;
 	margin: 0;
 	padding: 0;
 	min-height: 30px;
 }
 
+.dd-hidden {
+	display: none;
+}
+
 .dd-empty, .dd-handle, .dd-placeholder {
-	display: block;
-	position: relative;
-	margin: 0 10px 10px 10px !important;
-	padding: 4px !important;
-	min-height: 30px;
+	margin: 0 !important;
+	min-height: 30px !important;
 	box-sizing: border-box;
 	border-radius: 5px;
+}
+
+.dd-empty {
+	height: 100%;
 }
 
 .dd-handle {
@@ -61,7 +83,16 @@
 }
 
 .dd-dragel .dd-handle {
-	-webkit-box-shadow: 2px 4px 6px 0 rgba(0,0,0,.1);
 	box-shadow: 2px 4px 6px 0 rgba(0,0,0,.1);
 	opacity: 0.8;
+}
+
+.dd-remove-bucket {
+	margin-top: 0.5rem;
+	align-self: center;
+}
+
+.dd-buttons {
+	display: flex;
+	gap: 0.25rem;
 }

--- a/htdocs/js/apps/DragNDrop/dragndrop.js
+++ b/htdocs/js/apps/DragNDrop/dragndrop.js
@@ -5,14 +5,14 @@
 			this.bucketId = pgData['bucketId'];
 			this.label = pgData['label'] || '';
 			this.removable = pgData['removable'];
-			this.bucketPool = $('.bucket_pool[data-ans="' + this.answerInputId + '"]').first()[0];
+			this.bucketPool = $('.dd-bucket-pool[data-ans="' + this.answerInputId + '"]').first()[0];
 
 			const $bucketPool = $(this.bucketPool);
 			const $newBucket = this._newBucket(
 				this.bucketId,
 				this.label,
 				this.removable,
-				$bucketPool.find('.hidden.past_answers.bucket[data-bucket-id="' + this.bucketId + '"]')
+				$bucketPool.find('.dd-hidden.dd-past-answers.dd-bucket[data-bucket-id="' + this.bucketId + '"]')
 			);
 
 			$bucketPool.append($newBucket);
@@ -37,13 +37,13 @@
 			$newBucket.append($('<div class="dd" data-bucket-id="' + bucketId + '"></div>'));
 
 			if (removable != 0) {
-				$newBucket.append($('<a class="btn remove_bucket">Remove</a>'));
+				$newBucket.append($('<button type="button" class="btn btn-secondary dd-remove-bucket">Remove</button>'));
 			}
 
-			if ($bucketHtmlElement.find('ol.answer li').length) {
+			if ($bucketHtmlElement.find('ol.dd-answer li').length) {
 				const $ddList = $('<ol class="dd-list"></ol>');
 
-				$bucketHtmlElement.find('ol.answer li').each(function() {
+				$bucketHtmlElement.find('ol.dd-answer li').each(function() {
 					const $item = $('<li><div class="dd-handle">' + $(this).html() + '</div></li>');
 
 					$item.addClass('dd-item').attr('data-shuffled-index', $(this).attr('data-shuffled-index'));
@@ -76,12 +76,12 @@
 
 		_ddUpdate() {
 			const answerInputId = this.answerInputId;
-			const $bucketPool = $('.bucket_pool[data-ans="' + answerInputId + '"]').first();
+			const $bucketPool = $('.dd-bucket-pool[data-ans="' + answerInputId + '"]').first();
 			const el = this;
 
 			$(function() {
-				$bucketPool.parent().find('.add_bucket').off();
-				$bucketPool.parent().find('.add_bucket').on('click', function() {
+				$bucketPool.parent().find('.dd-add-bucket').off();
+				$bucketPool.parent().find('.dd-add-bucket').on('click', function() {
 					new DragNDropBucket({
 						answerInputId: $(this).attr('data-ans'),
 						bucketId: +($('.dd').length) + 1,
@@ -89,8 +89,8 @@
 						label:'',
 					});
 				});
-				$bucketPool.find('.remove_bucket').off();
-				$bucketPool.find('.remove_bucket').on('click', function() {
+				$bucketPool.find('.dd-remove-bucket').off();
+				$bucketPool.find('.dd-remove-bucket').on('click', function() {
 					if ($bucketPool.find('.dd ol').length == 1) {
 						return 0;
 					}
@@ -100,16 +100,16 @@
 					$container.remove();
 					el._nestableUpdate();
 				});
-				$bucketPool.parent().find('.reset_buckets').off();
-				$bucketPool.parent().find('.reset_buckets').on('click', function() {
+				$bucketPool.parent().find('.dd-reset-buckets').off();
+				$bucketPool.parent().find('.dd-reset-buckets').on('click', function() {
 					$bucketPool.find('.dd-container').remove();
-					$bucketPool.find('div.hidden.default.bucket').each(function() {
+					$bucketPool.find('div.dd-hidden.dd-default.dd-bucket').each(function() {
 						const bucketId = $(this).attr('data-bucket-id');
 						const $bucket = el._newBucket(
 							$(this).attr('data-bucket-id'),
-							$(this).find('.label').first().html(),
+							$(this).find('.dd-label').first().html(),
 							$(this).attr('data-removable'),
-							$bucketPool.find('.hidden.default.bucket[data-bucket-id="' + bucketId + '"]')
+							$bucketPool.find('.dd-hidden.dd-default.dd-bucket[data-bucket-id="' + bucketId + '"]')
 						);
 
 						$bucketPool.append($bucket);
@@ -128,15 +128,15 @@
 
 	}
 
-	$('div.bucket_pool').each(function() {
+	$('div.dd-bucket-pool').each(function() {
 		const answerInputId = $(this).attr('data-ans');
 
-		if ($(this).find('div.bucket.past_answers.hidden').length) {
-			$(this).find('div.bucket.past_answers.hidden').each(function() {
+		if ($(this).find('div.dd-bucket.dd-past-answers.dd-hidden').length) {
+			$(this).find('div.dd-bucket.dd-past-answers.dd-hidden').each(function() {
 				new DragNDropBucket({
 					answerInputId : answerInputId,
 					bucketId : $(this).attr('data-bucket-id'),
-					label : $(this).find('.label').html(),
+					label : $(this).find('.dd-label').html(),
 					removable : $(this).attr('data-removable'),
 				});
 			});

--- a/lib/DragNDrop.pm
+++ b/lib/DragNDrop.pm
@@ -162,14 +162,15 @@ sub HTML {
 	my $self = shift;
 
 	my $out = '';
-	$out .= "<div class='bucket_pool' data-ans='$self->{answerInputId}'>";
+	$out .= "<div class='dd-bucket-pool' data-ans='$self->{answerInputId}'>";
 
 	# buckets from instructor-defined default settings
 	for (my $i = 0; $i < @{ $self->{defaultBuckets} }; $i++) {
 		my $defaultBucket = $self->{defaultBuckets}->[$i];
-		$out .= "<div class='hidden default bucket' data-bucket-id='$i' data-removable='$defaultBucket->{removable}'>";
-		$out .= "<div class='label'>$defaultBucket->{label}</div>";
-		$out .= "<ol class='answer'>";
+		$defaultBucket->{removable} //= 0;
+		$out .= "<div class='dd-hidden dd-default dd-bucket' data-bucket-id='$i' data-removable='$defaultBucket->{removable}'>";
+		$out .= "<div class='dd-label'>$defaultBucket->{label}</div>";
+		$out .= "<ol class='dd-answer'>";
 		for my $j (@{ $defaultBucket->{indices} }) {
 			$out .= "<li data-shuffled-index='$j'>$self->{aggregateList}->[$j]</li>";
 		}
@@ -178,10 +179,10 @@ sub HTML {
 
 	# buckets from past answers
 	for my $bucket (@{ $self->{bucketList} }) {
-		$out .= "<div class='hidden past_answers bucket' data-bucket-id='$bucket->{bucket_id}' ";
+		$out .= "<div class='dd-hidden dd-past-answers dd-bucket' data-bucket-id='$bucket->{bucket_id}' ";
 		$out .= "data-removable='$bucket->{removable}'>";
-		$out .= "<div class='label'>$bucket->{label}</div>";
-		$out .= "<ol class='answer'>";
+		$out .= "<div class='dd-label'>$bucket->{label}</div>";
+		$out .= "<ol class='dd-answer'>";
 
 		for my $index (@{ $bucket->{indices} }) {
 			$out .= "<li data-shuffled-index='$index'>$self->{aggregateList}->[$index]</li>";
@@ -190,9 +191,9 @@ sub HTML {
 		$out .= "</div>";
 	}
 	$out .= '</div>';
-	$out .= "<br clear='all'><div><a class='btn btn-secondary reset_buckets'>reset</a>";
+	$out .= "<div class='dd-buttons'><button type='button' class='btn btn-secondary dd-reset-buckets'>reset</button>";
 	if ($self->{AllowNewBuckets} == 1) {
-		$out .= "<a class='btn btn-secondary add_bucket' data-ans='$self->{answerInputId}'>add bucket</a>";
+		$out .= "<button type='button' class='btn btn-secondary dd-add-bucket' data-ans='$self->{answerInputId}'>add bucket</button>";
 	}
 	$out .= "</div>";
 

--- a/macros/draggableProof.pl
+++ b/macros/draggableProof.pl
@@ -207,13 +207,13 @@ sub new {
 		);
 	}
 
-	my $proof =
+	$proof =
 		$options{NumBuckets} == 2
 		? main::List(main::List(@unorder[ $numNeeded .. $numProvided - 1 ]),
 		main::List(@unorder[ 0 .. $numNeeded - 1 ]))
 		: main::List('(' . join(',', @unorder[ 0 .. $numNeeded - 1 ]) . ')');
 
-	my $extra = main::Set(@unorder[ $numNeeded .. $numProvided - 1 ]);
+	$extra = main::Set(@unorder[ $numNeeded .. $numProvided - 1 ]);
 
 	my $InferenceMatrix = $options{InferenceMatrix};
 
@@ -245,12 +245,12 @@ sub new {
 	} else {
 		my @matches = ($previous =~ /(\([^\(\)]*\)|-?\d+)/g);
 		if ($self->{NumBuckets} == 2) {
-			my $indices1 = [ split(',', @matches[0] =~ s/\(|\)//gr) ];
+			my $indices1 = [ split(',', $matches[0] =~ s/\(|\)//gr) ];
 			$dnd->addBucket($indices1->[0] != -1 ? $indices1 : [], label => $options{'SourceLabel'});
-			my $indices2 = [ split(',', @matches[1] =~ s/\(|\)//gr) ];
+			my $indices2 = [ split(',', $matches[1] =~ s/\(|\)//gr) ];
 			$dnd->addBucket($indices2->[0] != -1 ? $indices2 : [], label => $options{'TargetLabel'});
 		} else {
-			my $indices1 = [ split(',', @matches[0] =~ s/\(|\)//gr) ];
+			my $indices1 = [ split(',', $matches[0] =~ s/\(|\)//gr) ];
 			$dnd->addBucket($indices1->[0] != -1 ? $indices1 : [], label => $options{'TargetLabel'});
 		}
 	}
@@ -309,7 +309,7 @@ sub DamerauLevenshtein {
 	my $db;
 	for my $i (2 .. @ar1 + 1) {
 		$db = 0;
-		my $k, $l, $cost;
+		my ($k, $l, $cost);
 		for my $j (2 .. @ar2 + 1) {
 			$k = $da[ $ar2[ $j - 2 ] ];
 			$l = $db;
@@ -340,8 +340,7 @@ sub Print {
 
 		# HTML mode
 		return
-			join("\n", '<div style="min-width:750px;">', $ans_rule, $self->{dnd}->HTML,
-			'<br clear="all" />', '</div>',);
+			join('', '<div class="dd-wrapper">', $ans_rule, $self->{dnd}->HTML, '</div>',);
 	} else {
 		# TeX mode
 		return $self->{dnd}->TeX;

--- a/macros/draggableSubsets.pl
+++ b/macros/draggableSubsets.pl
@@ -207,7 +207,7 @@ sub new {
 	} else {
 		my @matches = ($previous =~ /(\([^\(\)]*\)|-?\d+)+/g);
 		for (my $i = 0; $i < @matches; $i++) {
-			my $match     = @matches[$i] =~ s/\(|\)//gr;
+			my $match     = $matches[$i] =~ s/\(|\)//gr;
 			my $indices   = [ split(',', $match) ];
 			my $label     = $i < @$defaultShuffledBuckets ? $defaultShuffledBuckets->[$i]->{label}     : '';
 			my $removable = $i < @$defaultShuffledBuckets ? $defaultShuffledBuckets->[$i]->{removable} : 1;
@@ -252,8 +252,7 @@ sub Print {
 
 		# HTML mode
 		return
-			join("\n", '<div style="min-width:750px;">', $ans_rule, $self->{dnd}->HTML,
-			'<br clear="all" />', '</div>',);
+			join('', '<div class="dd-wrapper">', $ans_rule, $self->{dnd}->HTML, '</div>',);
 	} else {
 		# TeX mode
 		return $self->{dnd}->TeX;
@@ -296,7 +295,7 @@ sub filter {
 
 	my @order   = @{ $self->{order} };
 	my @student = ($anshash->{original_student_ans} =~ /(\([^\(\)]*\)|-?\d+)/g);
-	my @correct = ($anshash->{correct_ans}          =~ /({[^{}]*}|-?\d+)/g);
+	my @correct = ($anshash->{correct_ans}          =~ /(\{[^{}]*\}|-?\d+)/g);
 
 	$anshash->{correct_ans_latex_string} = join(
 		",",
@@ -319,4 +318,5 @@ sub filter {
 
 	return $anshash;
 }
+
 1;


### PR DESCRIPTION
Add a prefix to the css classes used by the javascript and css used for the DragNDrop macros.  The existing classes were very likely to clash with other classes and cause problems.  Note that the bootstrap 2 `hidden` class was used, and that class no longer exists for bootstrap 5.  I could have used the bootstrap 5 equivalent `d-none`, but decided to go with something that doesn't depend on an external library (although `btn` and `bnt-secondary` classes are used -- so the dependency is really still there).

Switch the `a` elements used for buttons to `button` elements as they should be in modern html markup.

The style is improved to be responsive to the screen width.

Finally, fix some warnings that were appearing in the error log.  See lines 210 and 299 of draggableSubsets.pl, and lines 210, 216, 248, 250, 253, and 312 of draggableProof.pl.