### PR TITLE
Make the student answer not javascript if the display mode is TeX for the parserGraphTool.pl macro

### DIFF
--- a/macros/parserGraphTool.pl
+++ b/macros/parserGraphTool.pl
@@ -521,7 +521,7 @@ END_SCRIPT
 # The raw list form of the answer is displayed in the "Entered" box.
 sub cmp_preprocess {
 	my $self = shift; my $ans = shift;
-	if (defined($ans->{student_value})) {
+	if ($main::displayMode ne 'TeX' && defined($ans->{student_value})) {
 		my $ans_name = $self->ANS_NAME;
 		$self->constructJSXGraphOptions;
 		my $graphObjs = @{$self->{staticObjects}} ?


### PR DESCRIPTION
This is needed to make a useful form of student answers show up in hardcopy.  Prior to openwebwork/webwork2#1541 this didn't matter.  Now it is.  I mentioned that this would need to be done if that pull request was merged.  See https://github.com/openwebwork/webwork2/pull/1541#issuecomment-1013805229.