### PR TITLE
Fixed Gauss unit numerical factor

### DIFF
--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -744,7 +744,7 @@ our %known_units = ('m'  => {
                            's'         => -2,
                          },
                 'G' => {
-                           'factor'    => 1E-5,
+                           'factor'    => 1E-4,
                            'kg'        => 1,
                            'amp'       => -1,
                            's'         => -2,


### PR DESCRIPTION
I noticed that WeBWorK's definition of the unit Gauss has a numerical factor of 1E-5, but it looks like that should be 1E-4 according to [this](https://en.wikipedia.org/wiki/Gauss_(unit)) and [this](https://link.springer.com/content/pdf/bbm%3A978-3-540-74296-8%2F1.pdf).