### PR TITLE
Fix another regression caused by #609.

### DIFF
--- a/macros/parserAssignment.pl
+++ b/macros/parserAssignment.pl
@@ -357,6 +357,7 @@ sub new {
 sub typeMatch {
   my $self = shift; my $other = shift; my $ans = shift;
   return 0 unless $self->type eq $other->type;
+  $other = $other->Package("Formula")->new($self->context,$other) unless $other->isFormula;
   my $typeMatch = $self->getTypicalValue($self)->{data}[1];
   $other = $self->getTypicalValue($other,1)->{data}[1];
   return 1 unless defined($other); # can't really tell, so don't report type mismatch


### PR DESCRIPTION
If a problem sets the answer to be a formula with an assigment, (something like `Formula("x = 5")` then all answers are counted
incorrect and a warning is displayed that the evaluated answer is not an answer hash.  This worked prior to #609.  The cause of this was the removal of a line that should not have been removed that converts the other answer being compared to to a Formula if it is not already.

Note that the original issue that was attempted to be fixed by #609 still is fixed with this change.

This fixes issue #644 that I just submitted about this.

Attached are minimal working examples for the original issue as well as for this one.
[FormulaAssignment.pg.txt](https://github.com/openwebwork/pg/files/7962769/FormulaAssignment.pg.txt)
[ParserAssignmentMWE.pg.txt](https://github.com/openwebwork/pg/files/7962770/ParserAssignmentMWE.pg.txt)
See issue #607 for details on how to test ParserAssignmentMWE.pg, and issue #644 for details on testing FormulaAssignment.pg.

Note that this is definitely a hotfix.  This certainly brings in to question that #609 should have been a hotfix, considering that this is something that has been this way since 2008.