### PR TITLE
Fix another regression caused by #609 (for develop).

### DIFF
--- a/macros/parserAssignment.pl
+++ b/macros/parserAssignment.pl
@@ -357,6 +357,7 @@ sub new {
 sub typeMatch {
   my $self = shift; my $other = shift; my $ans = shift;
   return 0 unless $self->type eq $other->type;
+  $other = $other->Package("Formula")->new($self->context,$other) unless $other->isFormula;
   my $typeMatch = $self->getTypicalValue($self)->{data}[1];
   $other = $self->getTypicalValue($other,1)->{data}[1];
   return 1 unless defined($other); # can't really tell, so don't report type mismatch


### PR DESCRIPTION
If a problem sets the answer to be a formula with an assigment, (something like `Formula("x = 5")` then all answers are counted
incorrect and a warning is displayed that the evaluated answer is not an answer hash.  This worked prior to #609.  The cause of this was the removal of a line that should not have been removed that converts the other answer being compared to to a Formula if it is not already.

Note that the original issue that was attempted to be fixed by #609 still is fixed with this change.

This fixes issue #644 that I just submitted about this.

This is #645 for develop.