### PR TITLE
Modification to parserPopUp and PGbasic macros for Moodle opaque

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -514,6 +514,8 @@ sub NAMED_ANS_RADIO {
 	my $extend = shift;
 	my %options = @_;
 
+        my $moodle_prefix = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%":'';
+
 	my $checked = '';
 	if ($value =~/^\%/) {
 		$value =~ s/^\%//;
@@ -534,7 +536,7 @@ sub NAMED_ANS_RADIO {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=RADIO NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+		HTML => qq!<label><INPUT TYPE=RADIO NAME="$moodle_prefix$name" id="$moodle_prefix$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
 		PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
@@ -549,6 +551,8 @@ sub NAMED_ANS_RADIO_EXTENSION {
 	my $value = shift;
 	my $tag = shift;
 	my %options = @_;
+
+        my $moodle_prefix = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%":'';
 
 	my $checked = '';
 	if ($value =~/^\%/) {
@@ -574,7 +578,7 @@ sub NAMED_ANS_RADIO_EXTENSION {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=RADIO NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=RADIO NAME="$name" id="${name}_$value" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+		HTML => qq!<label><INPUT TYPE=RADIO NAME="$moodle_prefix$name" id="$moodle_prefix${name}_$value" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
 		PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
@@ -711,6 +715,8 @@ sub NAMED_ANS_CHECKBOX {
 	my $value = shift;
 	my $tag =shift;
 
+        my $moodle_prefix = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%":'';
+
 	my $checked = '';
 	if ($value =~/^\%/) {
 		$value =~ s/^\%//;
@@ -733,7 +739,7 @@ sub NAMED_ANS_CHECKBOX {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=CHECKBOX NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$moodle_prefix$name" id="$moodle_prefix$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
 		PTX => '<li>'."$tag".'</li>'."\n",
 	);
 
@@ -744,6 +750,8 @@ sub NAMED_ANS_CHECKBOX_OPTION {
 	my $value = shift;
 	my $tag =shift;
 	my %options = @_;
+
+        my $moodle_prefix = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%":'';
 
 	my $checked = '';
 	if ($value =~/^\%/) {
@@ -771,7 +779,7 @@ sub NAMED_ANS_CHECKBOX_OPTION {
 	MODES(
 		TeX => qq!\\item{$tag}\n!,
 		Latex2HTML => qq!\\begin{rawhtml}\n<INPUT TYPE=CHECKBOX NAME="$name" id="$name" VALUE="$value" $checked>\\end{rawhtml}$tag!,
-		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$name" id="$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
+		HTML => qq!<label><INPUT TYPE=CHECKBOX NAME="$moodle_prefix$name" id="$moodle_prefix$name" aria-label="$label" VALUE="$value" $checked>$tag</label>!,
 		PTX => '<li>'."$tag".'</li>'."\n",
 	);
 

--- a/macros/parserPopUp.pl
+++ b/macros/parserPopUp.pl
@@ -164,8 +164,9 @@ sub MENU {
   $name = main::NEW_ANS_NAME() unless $name;
   my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
   my $label = main::generate_aria_label($name);
+  my $moodle_prefix = ($main::envir{use_opaque_prefix}) ? "%%IDPREFIX%%":'';
   if ($main::displayMode =~ m/^HTML/) {
-    $menu = qq!<select class="pg-select" name="$name" id="$name" aria-label="$label" size="1">\n!;
+    $menu = qq!<select class="pg-select" name="$moodle_prefix$name" id="$moodle_prefix$name" aria-label="$label" size="1">\n!;
     foreach my $item (@list) {
       my $selected = ($item eq $answer_value) ? " selected" : "";
       my $option = $self->quoteHTML($item,1);


### PR DESCRIPTION
Modification to PGbasicmacros so that radio button and checkbox can be use in Moodle with opaque server. Note that the checkbox still has issues (only the last checked box is saved).

Modification to parserPopUp so that the PopUp command can be use in Moodle with opaque server.