### PR TITLE
Make pg request the loading of first party javascript and css.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -73,38 +73,11 @@ sub DOCUMENT {
 	#warn "problemSeed $problemSeed";
 	$inputs_ref->{problemSeed}='';   #this version of the problemSeed is tainted. It can be set by a student
 	$inputs_ref->{displayMode}='';   # not sure whether this should ever by used or not.
-	#use strict;
-	#FIXME
-	# load java script needed for displayModes
-	if ($envir{displayMode} eq 'HTML_jsMath') {
-		my $prefix = "";
-		if (!$envir{jsMath}{reportMissingFonts}) {
-			$prefix .= '<script>noFontMessage = 1</script>'."\n";
-		} elsif ($main::envir{jsMath}{missingFontMessage}) {
-			$prefix .= '<script>missingFontMessage = "'.$main::envir{jsMath}{missingFontMessage}.'"</script>'."\n";
-		}
-		$prefix .= '<script>processDoubleClicks = '.($main::envir{jsMath}{processDoubleClicks}?'1':'0')."</script>\n";
-		TEXT(
-		  $prefix,
-		  '<script src="'.$envir{jsMathURL}. '"></script>' . "\n" ,
-		  '<noscript><center><font color="#CC0000">' ,
-			  '<strong> Warning: the mathematics on this page requires JavaScript.',  ,$BR,
-					'If your browser supports it, be sure it is enabled.
-			  </strong>',
-		  '</font></center><p>
-		  </noscript>'
-		);
-		TEXT('<script>jsMath.Setup.Script("plugins/noImageFonts.js")</script>')
-		    if ($envir{jsMath}{noImageFonts});
-	} elsif ($envir{displayMode} eq 'HTML_asciimath') {
-		TEXT('<script src="'.$envir{asciimathURL}.'"></script>' . "\n" ,
-             '<script>mathcolor = "black"</script>' );
-  } elsif ($envir{displayMode} eq 'HTML_LaTeXMathML') {
-       TEXT('<script src="'.$envir{LaTeXMathMLURL}.'"></script>'."\n");
-  }
-  load_css();
-  load_js();
+
+	load_css();
+	load_js();
 }
+
 $main::displayMode = $PG->{displayMode};
 $main::PG = $PG;
 sub TEXT {
@@ -195,17 +168,18 @@ sub ADD_CSS_FILE {
   push(@{$PG->{flags}{extra_css_files}}, { file => $file, external => $external });
 }
 
+# This loads the basic css needed by pg.
+# It is expected that the requestor will also load the styles for Bootstrap.
+# Some problems use jquery-ui still, and so the requestor should also load the css for that if those problems are used,
+# although those problems should also be rewritten to not use jquery-ui.
 sub load_css() {
-	ADD_CSS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css", 1);
-	ADD_CSS_FILE("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css", 1);
-	ADD_CSS_FILE("js/vendor/bootstrap/css/bootstrap.min.css");
-	ADD_CSS_FILE("js/vendor/bootstrap/css/bootstrap-responsive.min.css");
-	ADD_CSS_FILE("css/bootstrap.sub.css");
-	ADD_CSS_FILE("themes/math4/math4.css");
-	ADD_CSS_FILE("css/knowlstyle.css");
-	ADD_CSS_FILE("js/apps/MathQuill/mathquill.css");
-	ADD_CSS_FILE("js/apps/MathQuill/mqeditor.css");
-	ADD_CSS_FILE("js/apps/ImageView/imageview.css");
+	ADD_CSS_FILE('js/apps/Problem/problem.css');
+	ADD_CSS_FILE('js/apps/Knowls/knowl.css');
+	ADD_CSS_FILE('js/apps/ImageView/imageview.css');
+	if ($envir{useMathQuill}) {
+		ADD_CSS_FILE('node_modules/mathquill/dist/mathquill.css');
+		ADD_CSS_FILE('js/apps/MathQuill/mqeditor.css');
+	}
 }
 
 =head4 ADD_JS_FILE
@@ -234,22 +208,19 @@ sub ADD_JS_FILE {
 	push(@{$PG->{flags}{extra_js_files}}, { file => $file, external => $external, attributes => $attributes });
 }
 
+# This loads the basic javascript needed by pg.
+# It is expected that the requestor will also load MathJax, Bootstrap, and jquery.
+# Some problems use jquery-ui still, and so the requestor should also load the js for that if those problems are used,
+# although those problems should also be rewritten to not use jquery-ui.
 sub load_js() {
-	ADD_JS_FILE("https://polyfill.io/v3/polyfill.min.js?features=es6", 1);
-	# ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js", 1);
-	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js", 1);
-	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js", 1);
-	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js", 1);
-	ADD_JS_FILE("js/apps/MathJaxConfig/mathjax-config.js");
-	ADD_JS_FILE("js/legacy/java_init.js");
-	ADD_JS_FILE("js/apps/InputColor/color.js");
-	ADD_JS_FILE("js/apps/Base64/Base64.js");
-	ADD_JS_FILE("js/legacy/vendor/knowl.js");
-	ADD_JS_FILE("js/apps/ImageView/imageview.js");
-	ADD_JS_FILE("themes/math4/math4.js");
-	ADD_JS_FILE("js/apps/MathQuill/mathquill.min.js");
-	ADD_JS_FILE("js/apps/MathQuill/mqeditor.js");
-	ADD_JS_FILE("js/submithelper.js");
+	ADD_JS_FILE('js/apps/InputColor/color.js',    0, { defer => undef });
+	ADD_JS_FILE('js/apps/Base64/Base64.js',       0, { defer => undef });
+	ADD_JS_FILE('js/apps/Knowls/knowl.js',        0, { defer => undef });
+	ADD_JS_FILE('js/apps/ImageView/imageview.js', 0, { defer => undef });
+	if ($envir{useMathQuill}) {
+		ADD_JS_FILE('node_modules/mathquill/dist/mathquill.js', 0, { defer => undef });
+		ADD_JS_FILE('js/apps/MathQuill/mqeditor.js',            0, { defer => undef });
+	}
 }
 
 sub AskSage {
@@ -439,15 +410,9 @@ sub EXTEND_RESPONSE { # for radio buttons and checkboxes
 }
 
 sub ENDDOCUMENT {
-	# Request MathQuill javascript and css, and insert MathQuill responses if MathQuill is enabled.
-	# Add responses to each answer's response group that store the latex form of the students'
-	# answers and add corresponding hidden input boxes to the page.
+	# Insert MathQuill responses if MathQuill is enabled.  Add responses to each answer's response group that store the
+	# latex form of the students' answers and add corresponding hidden input boxes to the page.
 	if ($envir{useMathQuill}) {
-		ADD_CSS_FILE("node_modules/mathquill/dist/mathquill.css");
-		ADD_CSS_FILE("js/apps/MathQuill/mqeditor.css");
-		ADD_JS_FILE("node_modules/mathquill/dist/mathquill.js", 0, { defer => undef });
-		ADD_JS_FILE("js/apps/MathQuill/mqeditor.js", 0, { defer => undef });
-
 		for my $answerLabel (keys %{$PG->{PG_ANSWERS_HASH}}) {
 			my $answerGroup = $PG->{PG_ANSWERS_HASH}{$answerLabel};
 			my $mq_opts = $answerGroup->{ans_eval}{rh_ans}{mathQuillOpts} // {};

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -102,7 +102,8 @@ sub DOCUMENT {
   } elsif ($envir{displayMode} eq 'HTML_LaTeXMathML') {
        TEXT('<script src="'.$envir{LaTeXMathMLURL}.'"></script>'."\n");
   }
-
+  load_css();
+  load_js();
 }
 $main::displayMode = $PG->{displayMode};
 $main::PG = $PG;
@@ -194,6 +195,19 @@ sub ADD_CSS_FILE {
   push(@{$PG->{flags}{extra_css_files}}, { file => $file, external => $external });
 }
 
+sub load_css() {
+	ADD_CSS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css", 1);
+	ADD_CSS_FILE("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css", 1);
+	ADD_CSS_FILE("js/vendor/bootstrap/css/bootstrap.min.css");
+	ADD_CSS_FILE("js/vendor/bootstrap/css/bootstrap-responsive.min.css");
+	ADD_CSS_FILE("css/bootstrap.sub.css");
+	ADD_CSS_FILE("themes/math4/math4.css");
+	ADD_CSS_FILE("css/knowlstyle.css");
+	ADD_CSS_FILE("js/apps/MathQuill/mathquill.css");
+	ADD_CSS_FILE("js/apps/MathQuill/mqeditor.css");
+	ADD_CSS_FILE("js/apps/ImageView/imageview.css");
+}
+
 =head4 ADD_JS_FILE
 
 Request that the problem HTML page also include additional JS files
@@ -218,6 +232,24 @@ For example:
 sub ADD_JS_FILE {
 	my ($file, $external, $attributes) = @_;
 	push(@{$PG->{flags}{extra_js_files}}, { file => $file, external => $external, attributes => $attributes });
+}
+
+sub load_js() {
+	ADD_JS_FILE("https://polyfill.io/v3/polyfill.min.js?features=es6", 1);
+	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js", 1);
+	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js", 1);
+	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js", 1);
+	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js", 1);
+	ADD_JS_FILE("js/apps/MathJaxConfig/mathjax-config.js");
+	ADD_JS_FILE("js/legacy/java_init.js");
+	ADD_JS_FILE("js/apps/InputColor/color.js");
+	ADD_JS_FILE("js/apps/Base64/Base64.js");
+	ADD_JS_FILE("js/legacy/vendor/knowl.js");
+	ADD_JS_FILE("js/apps/ImageView/imageview.js");
+	ADD_JS_FILE("themes/math4/math4.js");
+	ADD_JS_FILE("js/apps/MathQuill/mathquill.min.js");
+	ADD_JS_FILE("js/apps/MathQuill/mqeditor.js");
+	ADD_JS_FILE("js/submithelper.js");
 }
 
 sub AskSage {

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -236,7 +236,7 @@ sub ADD_JS_FILE {
 
 sub load_js() {
 	ADD_JS_FILE("https://polyfill.io/v3/polyfill.min.js?features=es6", 1);
-	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js", 1);
+	# ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js", 1);
 	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js", 1);
 	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js", 1);
 	ADD_JS_FILE("https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.min.js", 1);

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -176,9 +176,12 @@ sub load_css() {
 	ADD_CSS_FILE('js/apps/Problem/problem.css');
 	ADD_CSS_FILE('js/apps/Knowls/knowl.css');
 	ADD_CSS_FILE('js/apps/ImageView/imageview.css');
+
 	if ($envir{useMathQuill}) {
 		ADD_CSS_FILE('node_modules/mathquill/dist/mathquill.css');
 		ADD_CSS_FILE('js/apps/MathQuill/mqeditor.css');
+	} elsif ($envir{useMathView}) {
+		ADD_CSS_FILE('js/apps/MathView/mathview.css');
 	}
 }
 
@@ -217,9 +220,17 @@ sub load_js() {
 	ADD_JS_FILE('js/apps/Base64/Base64.js',       0, { defer => undef });
 	ADD_JS_FILE('js/apps/Knowls/knowl.js',        0, { defer => undef });
 	ADD_JS_FILE('js/apps/ImageView/imageview.js', 0, { defer => undef });
+
 	if ($envir{useMathQuill}) {
 		ADD_JS_FILE('node_modules/mathquill/dist/mathquill.js', 0, { defer => undef });
 		ADD_JS_FILE('js/apps/MathQuill/mqeditor.js',            0, { defer => undef });
+	} elsif ($envir{useMathView}) {
+		ADD_JS_FILE("js/apps/MathView/$envir{mathViewLocale}");
+		ADD_JS_FILE('js/apps/MathView/mathview.js');
+	} elsif ($envir{useWirisEditor}) {
+		ADD_JS_FILE('js/apps/WirisEditor/quizzes.js');
+		ADD_JS_FILE('js/apps/WirisEditor/wiriseditor.js');
+		ADD_JS_FILE('js/apps/WirisEditor/mathml2webwork.js');
 	}
 }
 


### PR DESCRIPTION
Rather than having the first party javascript and css (our code in pg/htdocs/js/apps) for problems loaded in numerous places in webwork2 (Problem.pm, GatewayQuiz.pm, system.template, gateway.template, all of the formats, ...), have PG request the needed files via ADD_JS_FILE and ADD_CSS_FILE.  This is done via the `load_js` and `load_css` methods in `PG.pl`.  The methods are called at the end of the `DOCUMENT` method, which in turn is called by all pg problems.

Note that it is assumed that the requestor (webwork2, standalone renderer, etc?) will also load the javascript and css for MathJax, Bootstrap, and jQuery that are needed for things in htdocs/js/apps (as well as jquery-ui need for some problems and macros).

Prior to this pull request, MathQuill was made so that it is enabled by PG via a setting passed in via the `envir`.  Now MathView and Wiris are also enabled in this way (although only one can be enabled at a time).

This change is made to make PG more self contained, but also because this will make rendering more uniform via other rendering approaches like the standalone renderer.

For webwork2 there is a paired pull request (openwebwork/webwork2#1581) that is needed to make this work.