### PR TITLE
Make sure negative numbers are handled as a negated number in Value items (#658)

### DIFF
--- a/lib/Parser/Value.pm
+++ b/lib/Parser/Value.pm
@@ -25,7 +25,10 @@ sub new {
   return $value->{tree}->copy($equation) if ($type eq 'Formula');
   return $self->Item("String",$context)->new($equation,$value,$ref) if ($type eq 'String');
   return $self->Item("String",$context)->newInfinity($equation,$value,$ref) if ($type eq 'Infinity');
-  return $self->Item("Number",$context)->new($equation,$value,$ref) if ($type eq 'Number');
+  if ($type eq 'Number') {
+    my $number = $self->Item("Number",$context)->new($equation,CORE::abs($value),$ref);
+    return ($value < 0 ? $self->Item("UOP",$context)->new($equation,'u-',$number) : $number);
+  }
   return $self->Item("Number",$context)->new($equation,$value->{data},$ref)
     if ($type eq 'value' && $value->class eq 'Complex');
   $equation->Error(["Can't convert %s to a constant",Value::showClass($value)],$ref)


### PR DESCRIPTION
This PR fixes the problem where substituting a negative constant into a formula might not get the needed parentheses.  It does so by providing a proper tree structure (negation together with a number) so that the parentheses are inserted when needed.

You can test using

```
Context()->variables->add(y => 'Real');
TEXT(Formula('x^y')->substitute(x => -3));
```

which should produce `(-3)^y` rather than `-3^y`, while

```
TEXT(Formula('x+y')->substitue(x => -3));
```

should produce `-3+y` (not `(-3)+y`).

Similarly, 

```
TEXT(Formula('x^y')->substitue(x => 3));
```

should produce `3^y`, as expected.

Resolves issue #658.