### PR TITLE
This adds an empty group after the `\smallskip` in solutions and hints

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1226,7 +1226,7 @@ sub solution {
 	if ($printSolutionForInstructor) { # always print solutions for instructor types
 		$out = join('', $BITALIC, "(",
 			maketext("Instructor solution preview: show the student solution after due date."),
-			")", $EITALIC, $displayMode =~ /TeX/ ? "\\par\\smallskip" : $BR, @in);
+			")", $EITALIC, $displayMode =~ /TeX/ ? "\\par\\smallskip{}" : $BR, @in);
 	} elsif ($displaySolution) {
 		$out = join(' ', @in); # display solution
 	}
@@ -1276,7 +1276,7 @@ sub hint {
 		if ($printHintForInstructor) {
 			$out = join('', $BITALIC,
 				maketext("(Instructor hint preview: show the student hint after the following number of attempts:"),
-				" ", $showHint + 1, ")", $EITALIC, "\\par\\smallskip", @in);
+				" ", $showHint + 1, ")", $EITALIC, "\\par\\smallskip{}", @in);
 		} elsif ($displayHint and $afterAnswerDate) { # only display hints after the answer date.
 			$out = join(' ', @in);
 		}


### PR DESCRIPTION
Currently hardcopy fails for problems that use the old BEGIN_HINT/BEGIN_SOLUTION approaches, if
the next line begins with an aplha numeric character.

This fixes issue #664.  Note that the empty group is used instead of the space suggested there to prevent the potential of a space being injected in some cases.  Although, it probably still won't as TeX will probably gobble that space.