### PR TITLE
Don't stringify as ijk if dimension is too large

### DIFF
--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -55,14 +55,16 @@ sub ijk {
 sub TeX {
   my $self = shift;
   return $self->ijk("TeX",@_)
-    if $self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk");
+    if (($self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk")) &&
+        scalar(@{$self->{coords}}) <= 3);
   return $self->SUPER::TeX;
 }
 
 sub string {
   my $self = shift;
   return $self->ijk("string",@_)
-    if $self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk");
+    if (($self->{ijk} || $self->{equation}{ijk} || $self->{equation}{context}->flag("ijk")) &&
+        scalar(@{$self->{coords}}) <= 3);
   return $self->SUPER::string;
 }
 


### PR DESCRIPTION
This PR fixes a problem with using `ijk` mode for vectors if a student enters a vector with too large a dimension.

See [the original resport](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=6641) for a test case.

In the past, stringification would fail when the vector has too large a dimension.  This PR changes the behavior to use ijk notation only when the dimension is small enough.  This had an effect in this line

https://github.com/openwebwork/pg/blob/1b0b5ecd2b6cbb06304e9be70cbfcf9903369845/lib/AnswerHash.pm#L269

when the `AnswerHash` values are converted to JSON.

With this PR, the stringification should always succeed.