### PR TITLE
Clean up the html help files and fix html validation and accessibility issues in them.

### DIFF
--- a/htdocs/helpFiles/Entering-Angles.html
+++ b/htdocs/helpFiles/Entering-Angles.html
@@ -1,41 +1,49 @@
+<h2 style="text-align: center">Entering Angles</h2>
 
-<center>
-<b><font size="+2">Entering Angles</font></b>
-</center>
-
-<ul type="square">
-
-<li><u>Angles in radians without units are the default:</u>
-<blockquote>
-For an angle of 60 degrees, enter it in radians as &nbsp; <tt>pi/3</tt> &nbsp; or &nbsp; <tt>1.04719...</tt>, but <b>not 60</b><br />
-By default, trig functions are evaluated in radians, so <tt>cos(pi/3) = 1/2</tt>, but <tt>cos(60) = -0.9524</tt> since it is radians.  You must convert degrees to radians before applying a trig function to an angle. 
-</blockquote>
-</li>
-
-<li><u>Occasionally, units are required on angles:</u>
-<blockquote>
-If asked for units on an angle, enter, for example, <br />
-<tt>pi/6 rad</tt> &nbsp; (including rad)<br />
-<tt>30 deg</tt> &nbsp; (including deg)
-</blockquote>
-</li>
-
-<li><u>Examples of constants available:</u>
-<blockquote><tt>pi</tt>, &nbsp; <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Sometimes decimals are not allowed:</u>
-<blockquote>Sometimes &nbsp; <tt>pi/6</tt> &nbsp; is allowed, but &nbsp; <tt>0.524</tt> &nbsp; is not</blockquote>
-</li>
-
-<li><u>Sometimes trig functions are not allowed:</u>
-<blockquote>
-Sometimes &nbsp; <tt>0.866025403784</tt> &nbsp; is allowed, but &nbsp; <tt>cos(pi/6)</tt> &nbsp; is not
-</blockquote>
-</li>
-
-<li><a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a></li>
-
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Angles in radians without units are the default:</u>
+		<blockquote>
+			<p style="margin-top: 0">
+				For an angle of 60 degrees, enter it in radians as <code style="color: black">pi/3</code> or
+				<code style="color: black">1.04719...</code>, but <b>not <code style="color: black">60</code></b>.
+			</p>
+			<p style="margin-top: 0.25rem">
+				By default, trig functions are evaluated in radians, so
+				<code style="color: black">cos(pi/3) = 1/2</code>, but
+				<code style="color: black">cos(60) = -0.9524</code> since it is radians.
+				You must convert degrees to radians before applying a trig function to an angle.
+			</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>Occasionally, units are required on angles:</u>
+		<blockquote>
+			If asked for units on an angle, enter, for example, <code style="color: black">pi/6 rad</code>
+			(including rad) or <code style="color: black">30 deg</code> (including deg).
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants available:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>Sometimes decimals are not allowed:</u>
+		<blockquote>
+			Sometimesg <code style="color: black">pi/6</code> is allowed, but <code style="color: black">0.524</code>
+			is not.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes trig functions are not allowed:</u>
+		<blockquote>
+			Sometimesg <code style="color: black">0.866025403784</code> is allowed, but
+			<code style="color: black">cos(pi/6)</code> is not.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>
-

--- a/htdocs/helpFiles/Entering-Decimals.html
+++ b/htdocs/helpFiles/Entering-Decimals.html
@@ -1,27 +1,41 @@
+<h2 style="text-align: center">Entering decimals</h2>
 
-<center>
-<b><font size="+2">Entering decimals</font></b>
-</center>
+<ul style="list-style-type: square">
+	<li>
+		<u>In general, give at least 5 decimal places.</u>
+		<blockquote>
+			Typically, if your answer is correct to 5 decimal places it will be marked correct, although the number of
+			decimal places required may vary from problem to problem. When in doubt, give more decimal places.
+		</blockquote>
+	</li>
 
-<ul type="square">
+	<li>
+		<u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
+		<blockquote>
+			For example, if your answers are <code style="color: black">-3/2, 4/3, 2pi, e^3, 5</code> enter them as
+			<code style="color: black">-1.5, 1.3333333, 6.2831853, 20.0855369, 5</code>.
+		</blockquote>
+	</li>
 
-<li><u>In general, give at least 5 decimal places.</u>
-<blockquote>Typically, if your answer is correct to 5 decimal places it will be marked correct, although the number of decimal places required may vary from problem to problem.  When in doubt, give more decimal places.</blockquote>
-</li>
+	<li>
+		<u>Sometimes, fractions and certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 
-<li><u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
-<blockquote>
-For example, if your answers are <nobr><tt>-3/2, 4/3, 2pi, e^3, 5</tt></nobr> enter them as
-<nobr><tt>-1.5, 1.3333333, 6.2831853, 20.0855369, 5</tt></nobr>
-</blockquote>
-
-<li><u>Sometimes, fractions and certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 </ul>
-

--- a/htdocs/helpFiles/Entering-Equations.html
+++ b/htdocs/helpFiles/Entering-Equations.html
@@ -1,40 +1,52 @@
-<center>
-<b><font size="+2">Entering Equations</font></b>
-</center>
+<h2 style="text-align: center">Entering Equations</h2>
 
-<ul type="square">
+<ul style="list-style-type: square">
+	<li>
+		<u>Equations must have an equals sign and use the correct variable names:</u>
+		<blockquote>
+			<code style="color: black">y = 5x+2</code> will be incorrect if the answer is
+			<code style="color: black">w = 5y+2</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of valid equations that are equivalent:</u>
+		<blockquote>
+			<p>
+				<code style="color: black">32 = 5*x + 2</code> is the same as <code style="color: black">30 = 5x</code>
+				or <code style="color: black">x = 6</code>
+			</p>
 
-<li><u>Equations must have an equals sign and use the correct variable names:</u>
-<blockquote>
-<tt>y = 5x+2</tt> &nbsp; will be incorrect if the answer is &nbsp; <tt>w = 5y+2</tt>
-</blockquote>
-</li>
-
-<li><u>Examples of valid equations that are equivalent:</u>
-<blockquote>
-<tt>32 = 5*x + 2</tt> &nbsp; is the same as &nbsp; <tt>30 = 5x</tt> &nbsp; or &nbsp; <tt>x = 6</tt></tt><br />
-<tt>y = (x-1)^2 + 3</tt> &nbsp; is the same as &nbsp; <tt>y - 3 = (x-1)^2</tt><br />
-<tt>x^2 + xy + y^2 = 13x</tt> &nbsp; is the same as &nbsp; <tt>y*(y+x) = 13x - x^2</tt><br />
-</blockquote>
-</li>
-
-<li><u>If there is no equation that solves the question:</u>
-<blockquote>
-Enter &nbsp; <tt>NONE</tt> &nbsp; or &nbsp; <tt>DNE</tt> &nbsp; (this may vary from problem to problem)
-</blockquote>
-</li>
-
-<li><u>Examples of constants used in equations:</u>
-<blockquote><tt>pi</tt>, <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Functions may be used in equations, but may not be applied across the equals sign:</u>
-<blockquote>
-<tt>sqrt(x) = sqrt(5)</tt> &nbsp; is valid, but &nbsp; <tt>sqrt(x=5)</tt> &nbsp; is not
-<br /> 
-<br />
-<a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a>
-</blockquote>
-</li>
-
+			<p>
+				<code style="color: black">y = (x-1)^2 + 3</code> is the same as
+				<code style="color: black">y - 3 = (x-1)^2</code>
+			</p>
+			<p>
+				<code style="color: black">x^2 + xy + y^2 = 13x</code> is the same as
+				<code style="color: black">y*(y+x) = 13x - x^2</code>
+			</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>If there is no equation that solves the question:</u>
+		<blockquote>
+			Enter <code style="color: black">NONE</code> or <code style="color: black">DNE</code> (this may vary from
+			problem to problem).
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants used in equations:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>Functions may be used in equations, but may not be applied across the equals sign:</u>
+		<blockquote>
+			<code style="color: black">sqrt(x) = sqrt(5)</code> is valid, but
+			<code style="color: black">sqrt(x=5)</code> is not
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Exponents.html
+++ b/htdocs/helpFiles/Entering-Exponents.html
@@ -1,26 +1,46 @@
-<center>
-<b><font size="+2">Entering exponents</font></b>
-</center>
+<h2 style="text-align: center">Entering Exponents</h2>
 
-<ul type="square">
+<ul style="list-style-type: square">
+	<li>
+		<u>Both ^ and ** are used for exponentiation.</u>
+		<blockquote>
+			For example, <code style="color: black">x^2</code> and <code style="color: black">x**2</code> are the same,
+			as are <code style="color: black">e^(-x/2)</code> and <code style="color: black">1/(e**(x/2))</code>.
+		</blockquote>
+	</li>
 
-<li><u>Both ^ and ** are used for exponentiation.</u>
-<blockquote>For example, <tt>x^2</tt> and <tt>x**2</tt> are the same, as are <tt>e^(-x/2)</tt> and <tt>1/(e**(x/2))</tt></blockquote>
-</li>
+	<li>
+		<u>
+			Square roots have a named function, but other roots do not and should be entered using fractional exponents.
+		</u>
+		<blockquote>
+			For example, the square root of 2 can be entered as <code style="color: black">sqrt(2)</code>,
+			<code style="color: black">2^(1/2)</code>, or <code style="color: black">2**(1/2)</code>, but the cube root
+			of 2 must be entered as <code style="color: black">2^(1/3)</code> or
+			<code style="color: black">2**(1/3)</code>. The parentheses in <code style="color: black">2^(1/3)</code> are
+			required, since <code style="color: black">2^1/3</code> will be interpreted as
+			<code style="color: black">(2^1)/3 = 2/3</code>.
+		</blockquote>
+	</li>
 
-<li><u>Square roots have a named function, but other roots do not and should be entered using fractional exponents.</u>
-<blockquote>
-For example, the square root of 2 can be entered as <tt>sqrt(2)</tt>, <tt>2^(1/2)</tt>, or <tt>2**(1/2)</tt>, but the cube root of 2 must be entered as <tt>2^(1/3)</tt> or <tt>2**(1/3)</tt>.  The parentheses in <tt>2^(1/3)</tt> are required, since <tt>2^1/3</tt> will be interpreted as <tt>(2^1)/3 = 2/3</tt>.
-</blockquote>
-</li>
+	<li>
+		<u>Sometimes, fractional exponents and certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>. When these operations are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 
-<li><u>Sometimes, fractional exponents and certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>.  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 </ul>
-

--- a/htdocs/helpFiles/Entering-Formulas.html
+++ b/htdocs/helpFiles/Entering-Formulas.html
@@ -1,68 +1,116 @@
+<h2 style="text-align: center">Entering Formulas</h2>
 
-<center>
-<b><font size="+2">Entering Formulas</font></b>
-</center>
-
-<ul type="square">
-
-<li><a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a><br /><br /></li>
-
-<li><u>Formulas must use the correct variable(s):</u>
-<blockquote>
-For example, a function of time &nbsp; <tt>t</tt> &nbsp; could be &nbsp; <tt>-16t^2 + 12</tt>, while &nbsp; <tt>-16x^2 + 12</tt> &nbsp; would be incorrect. 
-</blockquote>
-</li>
-
-<li><u>Examples of valid formulas:</u>
-<blockquote>
-<tt>5*sin((pi*x)/2)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>5 sin(pi x/2)</tt><br />
-<tt>e^(-x)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>e**(-x)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>1/(e^x)</tt><br />
-<tt>abs(5y)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>|5y|</tt><br />
-<tt>sqrt(9 - z^2)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>(9 - z^2)^(1/2)</tt><br />
-<tt>24</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4!</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 * 3 * 2 * 1</tt><br />
-<tt>pi</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 arctan(1)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 atan(1)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 tan^(-1)(1)</tt><br />
-</blockquote>
-</li>
-
-<li><u>Entering logarithms:</u>
-<blockquote>In this question, use <code>ln(x)</code> or <code>log(x)</code> 
-for natural log, 
-and <code>logten(x)</code> or <code>log10(x)</code> for 
-the base 10 logarithm.  Enter log base b as <code>ln(x)/ln(b)</code>.
-</blockquote>
-</li>
-
-<li><u>Examples of constants used in formulas:</u>
-<blockquote><tt>pi</tt>, <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Examples of operations used in formulas:</u>
-<blockquote>Addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, exponentiation <tt>^</tt> (or <tt>**</tt>), factorial <tt>!</tt>
-</blockquote>
-</li>
-
-<li><u>Examples of functions used in formulas:</u>
-<blockquote>
-<tt>sqrt(x) = x^(1/2)</tt>, <tt>abs(x) = | x |</tt><br />
-<tt>2^x, e^x, ln(x), log10(x)</tt> <br />
-<tt>sin(x), cos(x), tan(x), csc(x), sec(x), cot(x)</tt><br />
-<tt>arcsin(x) = asin(x) = sin^(-1)(x)</tt><br /> 
-<tt>arccos(x) = acos(x) = cos^(-1)(x)</tt><br />
-<tt>arctan(x) = atan(x) = tan^(-1)(x)</tt><br />
-</blockquote>
-
-<li><u>Sometimes formulas must be simplified:</u>
-<blockquote>
-For example, &nbsp; <tt>6x + 5 - 2x</tt> &nbsp; should be simplified to &nbsp; <tt>4x + 5</tt>
-</blockquote>
-</li>
-
-<li><u>Sometimes, certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Formulas must use the correct variable(s):</u>
+		<blockquote>
+			For example, a function of time <code style="color: black">t</code> could be
+			<code style="color: black">-16t^2 + 12</code>, while <code style="color: black">-16x^2 + 12</code> would be
+			incorrect.
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of valid formulas:</u>
+		<blockquote>
+			<ul style="list-style-type:disc">
+				<li>
+					<code style="color: black">5*sin((pi*x)/2)</code> or <code style="color: black">5 sin(pi x/2)</code>
+				</li>
+				<li>
+					<code style="color: black">e^(-x)</code> or <code style="color: black">e**(-x)</code> or
+					<code style="color: black">1/(e^x)</code>
+				</li>
+				<li>
+					<code style="color: black">abs(5y)</code> or <code style="color: black">|5y|</code>
+				</li>
+				<li>
+					<code style="color: black">sqrt(9 - z^2)</code> or <code style="color: black">(9 - z^2)^(1/2)</code>
+				</li>
+				<li>
+					<code style="color: black">24</code> or <code style="color: black">4!</code> or
+					<code style="color: black">4 * 3 * 2 * 1</code>
+				</li>
+				<li>
+					<code style="color: black">pi</code> or <code style="color: black">4 arctan(1)</code> or
+					<code style="color: black">4 atan(1)</code> or <code style="color: black">4 tan^(-1)(1)</code>
+				</li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Entering logarithms:</u>
+		<blockquote>
+			In this question, use <code style="color: black">ln(x)</code> or <code style="color: black">log(x)</code>
+			for natural log, and <code style="color: black">logten(x)</code> or
+			<code style="color: black">log10(x)</code> for the base 10 logarithm. Enter log base b as
+			<code style="color: black">ln(x)/ln(b)</code>.
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants used in formulas:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>Examples of operations used in formulas:</u>
+		<blockquote>
+			Addition <code style="color: black">+</code>, subtraction <code style="color: black">-</code>,
+			multiplication <code style="color: black">*</code>, division <code style="color: black">/</code>,
+			exponentiation <code style="color: black">^</code> (or <code style="color: black">**</code>),
+			factorial <code style="color: black">!</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of functions used in formulas:</u>
+		<blockquote>
+			<ul style="list-style-type:disc">
+				<li><code style="color: black">sqrt(x) = x^(1/2)</code></li>
+				<li><code style="color: black">abs(x) = |x|</code></li>
+				<li><code style="color: black">2^x</code></li>
+				<li><code style="color: black">e^x</code></li>
+				<li><code style="color: black">ln(x)</code></li>
+				<li><code style="color: black">log10(x)</code></li>
+				<li><code style="color: black">sin(x)</code></li>
+				<li><code style="color: black">cos(x)</code></li>
+				<li><code style="color: black">tan(x)</code></li>
+				<li><code style="color: black">csc(x)</code></li>
+				<li><code style="color: black">sec(x)</code></li>
+				<li><code style="color: black">cot(x)</code></li>
+				<li><code style="color: black">arcsin(x) = asin(x) = sin^(-1)(x)</code></li>
+				<li><code style="color: black">arccos(x) = acos(x) = cos^(-1)(x)</code></li>
+				<li><code style="color: black">arctan(x) = atan(x) = tan^(-1)(x)</code></li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes formulas must be simplified:</u>
+		<blockquote>
+			For example, <code style="color: black">6x + 5 - 2x</code> should be simplified to
+			<code style="color: black">4x + 5</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Formulas10.html
+++ b/htdocs/helpFiles/Entering-Formulas10.html
@@ -1,67 +1,116 @@
+<h2 style="text-align: center">Entering Formulas</h2>
 
-<center>
-<b><font size="+2">Entering Formulas</font></b>
-</center>
-
-<ul type="square">
-
-<li><a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a><br /><br /></li>
-
-<li><u>Formulas must use the correct variable(s):</u>
-<blockquote>
-For example, a function of time &nbsp; <tt>t</tt> &nbsp; could be &nbsp; <tt>-16t^2 + 12</tt>, while &nbsp; <tt>-16x^2 + 12</tt> &nbsp; would be incorrect. 
-</blockquote>
-</li>
-
-<li><u>Examples of valid formulas:</u>
-<blockquote>
-<tt>5*sin((pi*x)/2)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>5 sin(pi x/2)</tt><br />
-<tt>e^(-x)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>e**(-x)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>1/(e^x)</tt><br />
-<tt>abs(5y)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>|5y|</tt><br />
-<tt>sqrt(9 - z^2)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>(9 - z^2)^(1/2)</tt><br />
-<tt>24</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4!</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 * 3 * 2 * 1</tt><br />
-<tt>pi</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 arctan(1)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 atan(1)</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>4 tan^(-1)(1)</tt><br />
-</blockquote>
-</li>
-
-<li><u>Entering logarithms:</u>
-<blockquote>In this question, use <code>ln(x)</code> for natural log, 
-and <code>log(x)</code>, <code>logten(x)</code> or <code>log10(x)</code> for 
-the base 10 logarithm.  Enter log base b as <code>ln(x)/ln(b)</code>.
-</blockquote>
-</li>
-
-<li><u>Examples of constants used in formulas:</u>
-<blockquote><tt>pi</tt>, <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Examples of operations used in formulas:</u>
-<blockquote>Addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, exponentiation <tt>^</tt> (or <tt>**</tt>), factorial <tt>!</tt>
-</blockquote>
-</li>
-
-<li><u>Examples of functions used in formulas:</u>
-<blockquote>
-<tt>sqrt(x) = x^(1/2)</tt>, <tt>abs(x) = | x |</tt><br />
-<tt>2^x, e^x, ln(x), log10(x)</tt> <br />
-<tt>sin(x), cos(x), tan(x), csc(x), sec(x), cot(x)</tt><br />
-<tt>arcsin(x) = asin(x) = sin^(-1)(x)</tt><br /> 
-<tt>arccos(x) = acos(x) = cos^(-1)(x)</tt><br />
-<tt>arctan(x) = atan(x) = tan^(-1)(x)</tt><br />
-</blockquote>
-
-<li><u>Sometimes formulas must be simplified:</u>
-<blockquote>
-For example, &nbsp; <tt>6x + 5 - 2x</tt> &nbsp; should be simplified to &nbsp; <tt>4x + 5</tt>
-</blockquote>
-</li>
-
-<li><u>Sometimes, certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Formulas must use the correct variable(s):</u>
+		<blockquote>
+			For example, a function of time <code style="color: black">t</code> could be
+			<code style="color: black">-16t^2 + 12</code>, while <code style="color: black">-16x^2 + 12</code> would be
+			incorrect.
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of valid formulas:</u>
+		<blockquote>
+			<ul style="list-style-type:disc">
+				<li>
+					<code style="color: black">5*sin((pi*x)/2)</code> or <code style="color: black">5 sin(pi x/2)</code>
+				</li>
+				<li>
+					<code style="color: black">e^(-x)</code> or <code style="color: black">e**(-x)</code> or
+					<code style="color: black">1/(e^x)</code>
+				</li>
+				<li>
+					<code style="color: black">abs(5y)</code> or <code style="color: black">|5y|</code>
+				</li>
+				<li>
+					<code style="color: black">sqrt(9 - z^2)</code> or <code style="color: black">(9 - z^2)^(1/2)</code>
+				</li>
+				<li>
+					<code style="color: black">24</code> or <code style="color: black">4!</code> or
+					<code style="color: black">4 * 3 * 2 * 1</code>
+				</li>
+				<li>
+					<code style="color: black">pi</code> or <code style="color: black">4 arctan(1)</code> or
+					<code style="color: black">4 atan(1)</code> or <code style="color: black">4 tan^(-1)(1)</code>
+				</li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Entering logarithms:</u>
+		<blockquote>
+			In this question, use <code style="color: black">ln(x)</code> for natural log, and
+			<code style="color: black">log(x)</code>, <code style="color: black">logten(x)</code> or
+			<code style="color: black">log10(x)</code> for the base 10 logarithm. Enter log base b as
+			<code style="color: black">ln(x)/ln(b)</code>.
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants used in formulas:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>Examples of operations used in formulas:</u>
+		<blockquote>
+			Addition <code style="color: black">+</code>, subtraction <code style="color: black">-</code>,
+			multiplication <code style="color: black">*</code>, division <code style="color: black">/</code>,
+			exponentiation <code style="color: black">^</code> (or <code style="color: black">**</code>),
+			factorial <code style="color: black">!</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of functions used in formulas:</u>
+		<blockquote>
+			<ul style="list-style-type:disc">
+				<li><code style="color: black">sqrt(x) = x^(1/2)</code></li>
+				<li><code style="color: black">abs(x) = |x|</code></li>
+				<li><code style="color: black">2^x</code></li>
+				<li><code style="color: black">e^x</code></li>
+				<li><code style="color: black">ln(x)</code></li>
+				<li><code style="color: black">log10(x)</code></li>
+				<li><code style="color: black">sin(x)</code></li>
+				<li><code style="color: black">cos(x)</code></li>
+				<li><code style="color: black">tan(x)</code></li>
+				<li><code style="color: black">csc(x)</code></li>
+				<li><code style="color: black">sec(x)</code></li>
+				<li><code style="color: black">cot(x)</code></li>
+				<li><code style="color: black">arcsin(x) = asin(x) = sin^(-1)(x)</code></li>
+				<li><code style="color: black">arccos(x) = acos(x) = cos^(-1)(x)</code></li>
+				<li><code style="color: black">arctan(x) = atan(x) = tan^(-1)(x)</code></li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes formulas must be simplified:</u>
+		<blockquote>
+			For example, <code style="color: black">6x + 5 - 2x</code> should be simplified to
+			<code style="color: black">4x + 5</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Fractions.html
+++ b/htdocs/helpFiles/Entering-Fractions.html
@@ -1,54 +1,73 @@
-<center>
-<b><font size="+2">Entering fractions</font></b>
-</center>
+<h2 style="text-align: center">Entering Fractions</h2>
 
-<ul type="square">
-
-<li><u>Examples of fractions, which are of the form a / b for non-decimal numbers a and b that have no common factors, include:</u>
-<blockquote>
-<tt>5/2, -1/3, pi/3, 4, sqrt(2)/2</tt>
-</blockquote>
-</li>
-
-<li><u>Examples of fractions that can be simplified include:</u>
-<blockquote>
-<tt>15/6, (3-4)/3, 2*pi/6, (16/2)/2</tt>
-</blockquote>
-</li>
-
-<li><u>Sometimes decimals are not allowed:</u>
-<blockquote>
-Allowed: &nbsp;&nbsp; <tt>5/2, -1/3, pi/3, 4, sqrt(2)/2, 2^(1/2)</tt><br />
-Not allowed: &nbsp;&nbsp; <tt>2.5, -0.33333, 3.14159/3, 0.707106/2, 2^(0.5)</tt>
-</blockquote>
-</li>
-
-<li><u>Sometimes a mixed fraction is required:</u>
-<blockquote>Enter <tt>1 2/3</tt> (for 1 and 2/3) with a space between the 1 and the 2 instead of <tt>5/3</tt></blockquote>
-</li>
-
-<li><u>Sometimes, you must make an integer into a fraction:</u>
-<blockquote>Enter <tt>4/1</tt> instead of <tt>4</tt></blockquote>
-</li>
-
-<li><u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
-<blockquote>
-For example, if your answers are <nobr><tt>-3/2, 4/3, 2pi, e^3, 5</tt></nobr> enter
-<nobr><tt>3/2, 4/3, 2*pi, e^3, 5</tt></nobr>
-</blockquote>
-
-<li><u>If there are no solutions:</u>
-<blockquote>
-Enter &nbsp; <tt>NONE</tt> &nbsp; or &nbsp; <tt>DNE</tt> &nbsp; (this may vary from problem to problem)
-</blockquote>
-</li>
-
-<li><u>Sometimes, certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>
+			Examples of fractions, which are of the form a / b for non-decimal numbers a and b that have no common
+			factors, include:
+		</u>
+		<blockquote>
+			<code style="color: black">5/2, -1/3, pi/3, 4, sqrt(2)/2</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of fractions that can be simplified include:</u>
+		<blockquote>
+			<code style="color: black">15/6, (3-4)/3, 2*pi/6, (16/2)/2</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes decimals are not allowed:</u>
+		<blockquote>
+			<p>Allowed:  <code style="color: black">5/2, -1/3, pi/3, 4, sqrt(2)/2, 2^(1/2)</code></p>
+			<p>Not allowed:  <code style="color: black">2.5, -0.33333, 3.14159/3, 0.707106/2, 2^(0.5)</code></p>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes a mixed fraction is required:</u>
+		<blockquote>
+			Enter <code style="color: black">1 2/3</code> (for 1 and 2/3) with a space between the 1 and the 2 instead of
+			<code style="color: black">5/3</code>.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, you must make an integer into a fraction:</u>
+		<blockquote>
+			Enter <code style="color: black">4/1</code> instead of <code style="color: black">4</code>.
+		</blockquote>
+	</li>
+	<li>
+		<u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
+		<blockquote>
+			For example, if your answers are <code style="color: black">-3/2, 4/3, 2pi, e^3, 5</code> enter
+			<code style="color: black">3/2, 4/3, 2*pi, e^3, 5</code>.
+		</blockquote>
+	</li>
+	<li>
+		<u>If there are no solutions:</u>
+		<blockquote>
+			Enter <code style="color: black">NONE</code> or <code style="color: black">DNE</code>
+			(this may vary from problem to problem).
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			and exponentiation <code style="color: black">^</code> (or <code style="color: black">**</code>). When these
+			operations are not allowed, it is usually because you are expected to be able to simplify your answer, often
+			without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Inequalities.html
+++ b/htdocs/helpFiles/Entering-Inequalities.html
@@ -1,65 +1,188 @@
-<center>
-<b><font size="+2">Entering inequalities</font></b>
-</center>
+<h2 style="text-align: center">Entering Inequalities</h2>
 
-<ul type="square">
-
-<li><u>Types of operators:</u>
-<blockquote>
-<table border="0" cellspacing="2">
-<tr><td><tt>&lt;</tt></td><td>&nbsp;&nbsp;&nbsp; less than</td></tr>
-<tr><td><tt>&lt;=</tt></td><td>&nbsp;&nbsp;&nbsp; less than or equal to (&nbsp; <tt>=&lt;</tt> &nbsp; might also work)</td></tr>
-<tr><td><tt>=</tt></td><td>&nbsp;&nbsp;&nbsp; equals</td></tr>
-<tr><td><tt>!=</tt></td><td>&nbsp;&nbsp;&nbsp; not equal to (uses exclamation point)</td></tr>
-<tr><td><tt>&gt;</tt></td><td>&nbsp;&nbsp;&nbsp; greater than</td></tr>
-<tr><td><tt>&gt;=</tt></td><td>&nbsp;&nbsp;&nbsp; greater than or equal to (&nbsp; <tt>=&gt;</tt> &nbsp; might also work)</td></tr>
-</table>
-</blockquote>
-</li>
-
-<li><u>Special symbols:</u>
-<blockquote>
-<tt>infinity</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>inf</tt> &nbsp;&nbsp;means positive infinity<br />
-<tt>-infinity</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>-inf</tt> &nbsp;&nbsp;means negative infinity<br />
-<tt>R</tt> &nbsp;&nbsp;means all real numbers<br />
-<tt>R</tt> &nbsp;&nbsp;is the same as&nbsp;&nbsp; <tt>-inf < x < inf</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>(-inf,inf)</tt><br />
-<tt>{2,4,5}</tt> &nbsp;&nbsp;using curly braces denotes a finite set<br /> 
-<tt>NONE</tt> &nbsp;&nbsp;or a pair of curly braces&nbsp;&nbsp; <tt>{}</tt> &nbsp;&nbsp;means the empty set<br />
-<tt>U</tt> &nbsp;&nbsp;denotes the union of intervals
-</blockquote>
-</li>
-
-<li><u>Entering answers using inequality or interval notation:</u>
-<blockquote>
-<table border="1" cellspacing="0" cellpadding="5">
-<tr><td>Inequality<br />Notation</td><td><font color="#FF0000">* </font>Interval<br />Notation</td><td>Remarks</td></tr>
-<tr><td><tt>x&LT;2</tt></td><td><tt>(-infinity,2)</tt></td>
-    <td>Use rounded parentheses <nobr><tt>(</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>)</tt></nobr> at infinite endpoints</td></tr>
-<tr><td><tt>x&GT;2</tt></td><td><tt>(2,infinity)</tt></td><td>&nbsp;</td></tr>
-<tr><td><tt>x&LT;=2</tt></td><td><tt>(-infinity,2]</tt></td><td>&nbsp;</td></tr>
-<tr><td><tt>x&GT;=2</tt></td><td><tt>[2,infinity)</tt></td><td>&nbsp;</td></tr>
-<tr><td><tt>0&LT;x&LT;=2</tt></td><td><tt>(0,2]</tt></td><td>&nbsp;</td></tr>
-<tr><td><nobr><tt>0&LT;x and x&LT;2</tt></nobr></td><td><tt>(0,2)</tt></td>
-    <td><tt>and</tt> &nbsp;&nbsp;is special</td></tr>
-<tr><td><nobr><tt>x&LT;0 or x&GT;2</tt></nobr></td><td><tt>(-inf,0)U(2,inf)</tt></td>
-    <td><tt>or</tt> &nbsp;&nbsp;is special<br /><tt>U</tt> &nbsp;&nbsp;denotes union</td></tr>
-<tr><td><nobr><tt>x=0 or x=2</tt></nobr></td><td><tt>{0,2}</tt></td>
-    <td>finite sets are allowed using curly braces&nbsp;&nbsp; <tt>{a,b,c}</tt></td></tr>
-<tr><td><nobr><tt>x<3 or x>3</tt></nobr></td><td><tt>(-inf,3)U(3,inf)</tt><br /><tt>x != 3</tt><br /><tt>R-{3}</tt></td><td>set differences are allowed</td></tr>
-</table>
-<br />
-<font color="#FF0000">* Some questions may not allow interval notation to be used</font>
-</blockquote>
-</li>
-
-<li><u>Tips for entering inequalities and intervals:</u>
-<blockquote>
-If an interval includes an endpoint, use square brackets: <nobr><tt>[</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>]</tt></nobr><br /><br />
-If an interval excludes an endpoint or an endpoint is infinite, use rounded parentheses: <nobr><tt>(</tt> &nbsp;&nbsp;or&nbsp;&nbsp; <tt>)</tt></nobr><br /><br />
-Use curly braces to enclose finite sets and commas to separate elements the set: <nobr><tt>{ -3, pi, 2/5, 0.75 }</tt></nobr><br /><br />
-All sets should be expressed in their simplest form in interval notation with no overlapping intervals.  For example,&nbsp;&nbsp; <tt>[2,4]U[3,5]</tt> &nbsp;&nbsp;is not equivalent to&nbsp;&nbsp; <tt>[2,5]</tt></br /><br />
-If you are asked to find the range of a function <tt>y = f(x)</tt>, your inequality should be in terms of the variable <tt>y</tt>
-</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Types of operators:</u>
+		<blockquote>
+			<ul style="list-style-type: disc">
+				<li><code style="color: black">&lt;</code> less than</li>
+				<li>
+					<code style="color: black">&lt;=</code> less than or equal to
+					(<code style="color: black">=&lt;</code> might also work)
+				</li>
+				<li><code style="color: black">=</code> equals</li>
+				<li><code style="color: black">!=</code> not equal to (uses exclamation point)</li>
+				<li><code style="color: black">&gt;</code> greater than</li>
+				<li>
+					<code style="color: black">&gt;=</code> greater than or equal to
+					(<code style="color: black">=&gt;</code> might also work)
+				</li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Special symbols:</u>
+		<blockquote>
+			<ul style="list-style-type: disc">
+				<li>
+					<code style="color: black">infinity</code> or <code style="color: black">inf</code>
+					means positive infinity
+				</li>
+				<li>
+					<code style="color: black">-infinity</code> or <code style="color: black">-inf</code>
+					means negative infinity
+				</li>
+				<li><code style="color: black">R</code> means all real numbers</li>
+				<li>
+					<code style="color: black">R</code> is the same as
+					<code style="color: black">-inf &lt; x &lt; inf</code> or
+					<code style="color: black">(-inf,inf)</code>
+				</li>
+				<li><code style="color: black">{2,4,5}</code> using curly braces denotes a finite set</li>
+				<li>
+					<code style="color: black">NONE</code> or a pair of curly braces
+					<code style="color: black">{}</code> means the empty set
+				</li>
+				<li><code style="color: black">U</code> denotes the union of intervals</li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Entering answers using inequality or interval notation:</u>
+		<blockquote>
+			<table style="margin-bottom: 0.5rem">
+				<tr>
+					<th style="border: 1px solid black; padding: 0.25rem">Inequality Notation</th>
+					<th style="border: 1px solid black; padding: 0.25rem">
+						Interval Notation<span style="color: #b00">*</span>
+					</th>
+					<th style="border: 1px solid black; padding: 0.25rem">Remarks</th>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x&LT;2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(-infinity,2)</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						Use rounded parentheses <code style="color: black">(</code> or
+						<code style="color: black">)</code> at infinite endpoints.
+					</td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x&GT;2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(2,infinity)</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem"></td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x&LT;=2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(-infinity,2]</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem"></td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x&GT;=2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">[2,infinity)</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem"></td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">0&LT;x&LT;=2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(0,2]</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem"></td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">0&LT;x and x&LT;2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(0,2)</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">and</code> is special
+					</td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x&LT;0 or x&GT;2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">(-inf,0)U(2,inf)</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">or</code> is special,
+						<code style="color: black">U</code> denotes union
+					</td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x=0 or x=2</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">{0,2}</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						finite sets are allowed using curly braces <code style="color: black">{a,b,c}</code>
+					</td>
+				</tr>
+				<tr>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<code style="color: black">x &lt; 3 or x &gt; 3</code>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">
+						<ul style="list-style: none; padding: 0; margin: 0">
+							<li><code style="color: black">(-inf,3)U(3,inf)</code></li>
+							<li><code style="color: black">x != 3</code></li>
+							<li><code style="color: black">R-{3}</code></li>
+						</ul>
+					</td>
+					<td style="border: 1px solid black; padding: 0.25rem">set differences are allowed</td>
+				</tr>
+			</table>
+			<span style="color: #b00">* Some questions may not allow interval notation to be used</span>
+		</blockquote>
+	</li>
+	<li>
+		<u>Tips for entering inequalities and intervals:</u>
+		<blockquote>
+			<ul style="list-style-type: disc">
+				<li>
+					If an interval includes an endpoint, use square brackets: <code style="color: black">[</code> or
+					<code style="color: black">]</code>
+				</li>
+				<li>
+					If an interval excludes an endpoint or an endpoint is infinite, use rounded parentheses:
+					<code style="color: black">(</code> or <code style="color: black">)</code>
+				</li>
+				<li>
+					Use curly braces to enclose finite sets and commas to separate elements the set:
+					<code style="color: black">{ -3, pi, 2/5, 0.75 }</code>
+				</li>
+				<li>
+					All sets should be expressed in their simplest form in interval notation with no overlapping
+					intervals. For example, <code style="color: black">[2,4]U[3,5]</code> is not equivalent to
+					<code style="color: black">[2,5]</code>
+				</li>
+				<li>
+					If you are asked to find the range of a function <code style="color: black">y = f(x)</code>, your
+					inequality should be in terms of the variable <code style="color: black">y</code>
+				</li>
+			</ul>
+		</blockquote>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Intervals.html
+++ b/htdocs/helpFiles/Entering-Intervals.html
@@ -1,60 +1,40 @@
-<h4 align="center">
-Using Interval Notation
-</h4>
+<h2 style="text-align: center">Using Interval Notation</h2>
 
-<ul>
-
-<li> If an endpoint is included, then use <tt>[</tt> or <tt>]</tt>.
-If not, then use <tt>(</tt> or <tt>)</tt>.  For example, the interval
-from -3 to 7 that includes 7 but not -3 is expressed <tt>(-3,7]</tt>.
-
-
-<br>
-<br>
-
-<li> For infinite intervals, use <tt>Inf</tt>
-for <font size="+2">&#8734;</font> (infinity) and/or
-<tt>-Inf</tt> for <font size="+2">-&#8734;</font> (-Infinity).  For
-example, the infinite interval containing all points greater than or
-equal to 6 is expressed <tt>[6,Inf)</tt>.
-
-
-<br>
-<br>
-
-<li> If the set includes more than one interval, they are joined using the union
-symbol U.  For example, the set consisting of all points in (-3,7] together with all points in [-8,-5) is expressed <code>[-8,-5)U(-3,7]</code>.
-
-<br>
-<br>
-
-<li> If the answer is the empty set, you can specify that by using
-     braces with nothing inside: <code> { } </code>
-
-<br>
-
-<br>
-
-<li> You can use <code>R</code> as a shorthand for all real numbers.
-  So, it is equivalent to entering <code>(-Inf, Inf)</code>.
-
-<br>
-<br>
-
-<li> You can use set difference notation.  So, for all real numbers
-  except 3, you can use <code>R-{3}</code> or
-  <code>(-Inf, 3)U(3,Inf)</code> (they are the same).  Similarly,
-  <code>[1,10)-{3,4}</code> is the same as <code>[1,3)U(3,4)U(4,10)</code>.
-
-
-<br>
-<br>
-
-
-<li> WeBWorK will <b>not</b> interpret <tt>[2,4]U[3,5]</tt> as equivalent
- to <tt>[2,5]</tt>, unless a problem tells you otherwise.  
-All sets should be expressed in their simplest interval notation form, with no 
-overlapping intervals.
-
+<ul style="list-style-type: square">
+	<li style="margin-bottom:0.5rem">
+		If an endpoint is included, then use <code style="color: black">[</code> or <code style="color: black">]</code>.
+		If not, then use <code style="color: black">(</code> or <code style="color: black">)</code>. For example, the
+		interval from -3 to 7 that includes 7 but not -3 is expressed <code style="color: black">(-3,7]</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		For infinite intervals, use <code style="color: black">Inf</code> for
+		<code style='color: black; font-size:1rem'>&#8734;</code> (infinity) and
+		<code style="color: black">-Inf</code> for <code style='color: black; font-size:1rem'>-&#8734;</code>
+		(-Infinity). For example, the infinite interval containing all points greater than or equal to 6 is expressed
+		<code style="color: black">[6,Inf)</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		If the set includes more than one interval, they are joined using the union symbol U. For example, the set
+		consisting of all points in (-3,7] together with all points in [-8,-5) is expressed
+		<code style="color: black">[-8,-5)U(-3,7]</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		If the answer is the empty set, you can specify that by using braces with nothing inside:
+		<code style="color: black"> { } </code>
+	</li>
+	<li style="margin-bottom:0.5rem">
+		You can use <code style="color: black">R</code> as a shorthand for all real numbers. So, it is equivalent to
+		entering <code style="color: black">(-Inf, Inf)</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		You can use set difference notation. So, for all real numbers except 3, you can use
+		<code style="color: black">R-{3}</code> or <code style="color: black">(-Inf, 3)U(3,Inf)</code> (they are the
+		same).  Similarly, <code style="color: black">[1,10)-{3,4}</code> is the same as
+		<code style="color: black">[1,3)U(3,4)U(4,10)</code>.
+	</li>
+	<li>
+		WeBWorK will <b>not</b> interpret <code style="color: black">[2,4]U[3,5]</code> as equivalent to
+		<code style="color: black">[2,5]</code>, unless a problem tells you otherwise. All sets should be expressed in
+		their simplest interval notation form, with no overlapping intervals.
+	</li>
 </ul>
-

--- a/htdocs/helpFiles/Entering-Limits.html
+++ b/htdocs/helpFiles/Entering-Limits.html
@@ -1,51 +1,67 @@
-<center>
-<b><font size="+2">Entering Limits</font></b>
-</center>
+<h2 style="text-align: center">Entering Limits</h2>
 
-<ul type="square">
-
-<li><u>Limits whose values are numbers:</u>
-<blockquote>
-For example, lim<sub>x &rarr; &infin;</sub> arctan(x) = &pi;/2, so you would enter &nbsp; <tt>pi/2</tt> 
-</blockquote>
-</li>
-
-<li><u>Limits whose values are infinite:</u>
-<blockquote>
-Enter &nbsp; <tt>infinity</tt>, &nbsp; <tt>inf</tt>, &nbsp; <tt>-infinity</tt>, &nbsp; <tt>-inf</tt>
-</blockquote>
-</li>
-
-<li><u>Limits that don't exist:</u>
-<blockquote>
-Enter &nbsp; <tt>DNE</tt> &nbsp; or &nbsp; <tt>NONE</tt> &nbsp; (this may vary from question to question)
-</blockquote>
-</li>
-
-<li><u>Limits whose value is a function:</u>
-<blockquote>
-Enter the function using appropriate syntax, for example:<br />
-<tt>sqrt(x) = x^(1/2)</tt>, <tt>abs(x) = | x |</tt><br />
-<tt>2^x, e^x, ln(x), log10(x)</tt> <br />
-<tt>sin(x), cos(x), tan(x), csc(x), sec(x), cot(x)</tt><br />
-<tt>arcsin(x) = asin(x) = sin^(-1)(x)</tt><br /> 
-<tt>arccos(x) = acos(x) = cos^(-1)(x)</tt><br />
-<tt>arctan(x) = atan(x) = tan^(-1)(x)</tt><br />
-</blockquote>
-</li>
-
-<li><u>Sometimes answers must be simplified:</u>
-<blockquote>
-For example, &nbsp; <tt>6x+5-2x+7</tt> &nbsp; should be simplified to &nbsp; <tt>4x+12</tt>
-</blockquote>
-</li>
-
-<li><u>Sometimes, certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Limits whose values are numbers:</u>
+		<blockquote>
+			For example, lim<sub>x &rarr; &infin;</sub> arctan(x) = &pi;/2, so you would enter
+			<code style="color: black">pi/2</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Limits whose values are infinite:</u>
+		<blockquote>
+			Enter <code style="color: black">infinity</code>, <code style="color: black">inf</code>,
+			<code style="color: black">-infinity</code>, <code style="color: black">-inf</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Limits that don't exist:</u>
+		<blockquote>
+			Enter <code style="color: black">DNE</code> or <code style="color: black">NONE</code>
+			(this may vary from question to question)
+		</blockquote>
+	</li>
+	<li>
+		<u>Limits whose value is a function:</u>
+		<blockquote>
+			Enter the function using appropriate syntax, for example:
+			<ul style="list-style-type: disc">
+				<li><code style="color: black">sqrt(x) = x^(1/2)</code></li>
+				<li><code style="color: black">abs(x) = |x|</code></li>
+				<li><code style="color: black">2^x, e^x, ln(x), log10(x)</code></li>
+				<li><code style="color: black">sin(x), cos(x), tan(x), csc(x), sec(x), cot(x)</code></li>
+				<li><code style="color: black">arcsin(x) = asin(x) = sin^(-1)(x)</code></li>
+				<li><code style="color: black">arccos(x) = acos(x) = cos^(-1)(x)</code></li>
+				<li><code style="color: black">arctan(x) = atan(x) = tan^(-1)(x)</code></li>
+			</ul>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes answers must be simplified:</u>
+		<blockquote>
+			For example, <code style="color: black">6x + 5 - 2x + 7</code> should be simplified to
+			<code style="color: black">4x + 12</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Logarithms.html
+++ b/htdocs/helpFiles/Entering-Logarithms.html
@@ -1,14 +1,61 @@
-<center>
-  <h2>Help Entering Logarithms</h2>
-</center>
-<ul>
-<li><font color='#222255'>Entering natural logarithm:</font> In this question, use <code>ln(x)</code> or <code>log(x)</code>.
-<br /><br /></li>
-<li><font color='#222255'>Entering base 10 logarithm:</font> In this question, use <code>log10(x)</code> or <code>logten(x)</code>.<br /><br /></li>
-<li><font color='#222255'>Entering logarithms base b:</font>  &nbsp; <code>ln(x)/ln(b)</code> &nbsp; or &nbsp; <code>log(x)/log(b)</code><blockquote>WeBWorK does not recognize logarithms to other bases, so you must use the change of base formula for logarithms to enter your answer.  For example, enter log base 2 of x as <br /><br /><code>ln(x)/ln(2)</code> &nbsp;&nbsp; or &nbsp;&nbsp; <code>log(x)/log(2)</code></blockquote></li>
-<li><font color='#222255'>Put parentheses around the arguments to logs:</font><blockquote><code>ln(2x+8)</code> &nbsp; and &nbsp; <code>ln2x+8 = ln(2)*x+8</code> &nbsp; are very different.</blockquote></li>
-<li><font color='#222255'>Sometimes logarithms must be simplified or expanded:</font><blockquote>For example, the required answer may be &nbsp; <code>ln(6) + ln(x)</code> &nbsp; or &nbsp; <code>ln(6x)</code></blockquote></li>
-<li><font color='#222255'>Sometimes, certain operations are not allowed.</font><blockquote>Usually, the operations that are not allowed include addition <code>+</code>, subtraction <code>-</code>, multiplication <code>*</code>, division <code>/</code>, and exponentiation <code>^</code> (or <code>**</code>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote></li>
-<li><font color='#222255'>Sometimes, certain functions are not allowed.</font>  <blockquote>Usually, the functions that are not allowed include square root <code>sqrt( )</code>, absolute value <code>| |</code> (or <code>abs( )</code>), as well as other named functions such as <code>sin( )</code>, <code>ln( )</code>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote></li>
-<li><a href='http://webwork.maa.org/wiki/Available_Functions' target='_new'>Link to a list of all available functions</a><br /><br /></li>
+<h2 style="text-align: center">Entering Logarithms</h2>
+
+<ul style="list-style-type: square">
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering natural logarithm:</span> In this question, use
+		<code style="color: black">ln(x)</code> or <code style="color: black">log(x)</code>.
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering base 10 logarithm:</span> In this question, use
+		<code style="color: black">log10(x)</code> or <code style="color: black">logten(x)</code>.
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering logarithms base b:</span>
+		<code style="color: black">ln(x)/ln(b)</code> or
+		<code style="color: black">log(x)/log(b)</code>
+		<blockquote>
+			WeBWorK does not recognize logarithms to other bases, so you must use the change of base formula for
+			logarithms to enter your answer. For example, enter log base 2 of x as
+			<code style="color: black">ln(x)/ln(2)</code> or <code style="color: black">log(x)/log(2)</code>.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Put parentheses around the arguments to logs:</span>
+		<blockquote>
+			<code style="color: black">ln(2x+8)</code> and <code style="color: black">ln2x+8 = ln(2)*x+8</code> are very
+			different.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes logarithms must be simplified or expanded:</span>
+		<blockquote>
+			For example, the required answer may be <code style="color: black">ln(6) + ln(x)</code> or
+			<code style="color: black">ln(6x)</code>.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes, certain operations are not allowed.</span>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes, certain functions are not allowed.</span>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Logarithms10.html
+++ b/htdocs/helpFiles/Entering-Logarithms10.html
@@ -1,13 +1,62 @@
-<center>
-  <h2>Help Entering Logarithms</h2>
-</center>
-<ul>
-<li><font color='#222255'>Entering natural logarithm:</font> In this question, use <code>ln(x)</code><br /><br /></li>
-<li><font color='#222255'>Entering base 10 logarithm:</font> In this question, use <code>log(x)</code>, <code>log10(x)</code>, or <code>logten(x)</code>.<br /><br /></li>
-<li><font color='#222255'>Entering logarithms base b:</font>  &nbsp; <code>ln(x)/ln(b)</code> &nbsp; or &nbsp; <code>log(x)/log(b)</code><blockquote>WeBWorK does not recognize logarithms to other bases, so you must use the change of base formula for logarithms to enter your answer.  For example, enter log base 2 of x as <br /><br /><code>ln(x)/ln(2)</code> &nbsp;&nbsp; or &nbsp;&nbsp; <code>log(x)/log(2)</code></blockquote></li>
-<li><font color='#222255'>Put parentheses around the arguments to logs:</font><blockquote><code>ln(2x+8)</code> &nbsp; and &nbsp; <code>ln2x+8 = ln(2)*x+8</code> &nbsp; are very different.</blockquote></li>
-<li><font color='#222255'>Sometimes logarithms must be simplified or expanded:</font><blockquote>For example, the required answer may be &nbsp; <code>ln(6) + ln(x)</code> &nbsp; or &nbsp; <code>ln(6x)</code></blockquote></li>
-<li><font color='#222255'>Sometimes, certain operations are not allowed.</font><blockquote>Usually, the operations that are not allowed include addition <code>+</code>, subtraction <code>-</code>, multiplication <code>*</code>, division <code>/</code>, and exponentiation <code>^</code> (or <code>**</code>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote></li>
-<li><font color='#222255'>Sometimes, certain functions are not allowed.</font>  <blockquote>Usually, the functions that are not allowed include square root <code>sqrt( )</code>, absolute value <code>| |</code> (or <code>abs( )</code>), as well as other named functions such as <code>sin( )</code>, <code>ln( )</code>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote></li>
-<li><a href='http://webwork.maa.org/wiki/Available_Functions' target='_new'>Link to a list of all available functions</a><br /><br /></li>
+<h2 style="text-align: center">Entering Logarithms</h2>
+
+<ul style="list-style-type: square">
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering natural logarithm:</span> In this question, use
+		<code style="color: black">ln(x)</code>.
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering base 10 logarithm:</span> In this question, use
+		<code style="color: black">log(x)</code>, <code style="color: black">log10(x)</code>, or
+		<code style="color: black">logten(x)</code>.
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Entering logarithms base b:</span>
+		<code style="color: black">ln(x)/ln(b)</code> or
+		<code style="color: black">log(x)/log(b)</code>
+		<blockquote>
+			WeBWorK does not recognize logarithms to other bases, so you must use the change of base formula for
+			logarithms to enter your answer. For example, enter log base 2 of x as
+			<code style="color: black">ln(x)/ln(2)</code> or <code style="color: black">log(x)/log(2)</code>.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Put parentheses around the arguments to logs:</span>
+		<blockquote>
+			<code style="color: black">ln(2x+8)</code> and <code style="color: black">ln2x+8 = ln(2)*x+8</code> are very
+			different.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes logarithms must be simplified or expanded:</span>
+		<blockquote>
+			For example, the required answer may be <code style="color: black">ln(6) + ln(x)</code> or
+			<code style="color: black">ln(6x)</code>.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes, certain operations are not allowed.</span>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li style="margin-bottom: 0.5rem">
+		<span style="color: #225">Sometimes, certain functions are not allowed.</span>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Numbers.html
+++ b/htdocs/helpFiles/Entering-Numbers.html
@@ -1,35 +1,56 @@
-<center>
-<b><font size="+2">Entering numbers</font></b>
-</center>
+<h2 style="text-align: center">Entering Angles</h2>
 
-<ul type="square">
-
-<li><u>Examples of (real) numbers include:</u>
-<blockquote><tt>4, 5/2, -1/3, pi/3, e^3, 3.1415926535, sqrt(2) = 2^(1/2), ln(2), sin(2pi/3)</tt></blockquote>
-</li>
-
-<li><u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
-<blockquote>
-For example, enter &nbsp; <nobr><tt>-1.5, 4/3, 2pi, e^3, 5</tt></nobr><br />
-Do not use commas in large numbers: enter &nbsp; <tt>4321</tt> &nbsp; (not &nbsp; <tt>4,321</tt>)
-</blockquote>
-
-<li><u>If there are no solutions:</u>
-<blockquote>
-Enter &nbsp; <tt>NONE</tt> &nbsp; or &nbsp; <tt>DNE</tt> &nbsp; (this may vary from problem to problem)
-</blockquote>
-</li>
-
-<li><u>If your answer is a decimal, give at least 5 decimal places.</u>
-<blockquote>Typically, if your answer is correct to 5 decimal places it will be marked correct, although the number of decimal places required may vary from problem to problem.  When in doubt, give more decimal places.</blockquote>
-</li>
-
-<li><u>Sometimes, fractions and certain operations are not allowed.</u>
-<blockquote>Usually, the operations that are not allowed include addition <tt>+</tt>, subtraction <tt>-</tt>, multiplication <tt>*</tt>, division <tt>/</tt>, and exponentiation <tt>^</tt> (or <tt>**</tt>).  When these operations are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
-<li><u>Sometimes, certain functions are not allowed.</u>  
-<blockquote>Usually, the functions that are not allowed include square root <tt>sqrt( )</tt>, absolute value <tt>| |</tt> (or <tt>abs( )</tt>), as well as other named functions such as <tt>sin( )</tt>, <tt>ln( )</tt>, etc.  When these functions are not allowed, it is usually because you are expected to be able to simplify your answer, often without using a calculator.</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>Examples of (real) numbers include:</u>
+		<blockquote>
+			<code style="color: black">
+				4, 5/2, -1/3, pi/3, e^3, 3.1415926535, sqrt(2) = 2^(1/2), ln(2), sin(2pi/3)
+			</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>If there is more than one correct answer, enter your answers as a comma separated list.</u>
+		<blockquote>
+			<p style="margin-top: 0">For example, enter <code style="color: black">-1.5, 4/3, 2pi, e^3, 5</code></p>
+			<p style="margin-top: 0">
+				Do not use commas in large numbers: enter <code style="color: black">4321</code> (not
+				<code style="color: black">4,321</code>)
+			</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>If there are no solutions:</u>
+		<blockquote>
+			Enter <code style="color: black">NONE</code> or <code style="color: black">DNE</code>
+			(this may vary from problem to problem)
+		</blockquote>
+	</li>
+	<li>
+		<u>If your answer is a decimal, give at least 5 decimal places.</u>
+		<blockquote>
+			Typically, if your answer is correct to 5 decimal places it will be marked correct, although the number of
+			decimal places required may vary from problem to problem. When in doubt, give more decimal places.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, fractions and certain operations are not allowed.</u>
+		<blockquote>
+			Usually, the operations that are not allowed include addition <code style="color: black">+</code>,
+			subtraction <code style="color: black">-</code>, multiplication <code style="color: black">*</code>,
+			division <code style="color: black">/</code>, and exponentiation <code style="color: black">^</code> (or
+			<code style="color: black">**</code>). When these operations are not allowed, it is usually because you are
+			expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
+	<li>
+		<u>Sometimes, certain functions are not allowed.</u>
+		<blockquote>
+			Usually, the functions that are not allowed include square root <code style="color: black">sqrt( )</code>,
+			absolute value <code style="color: black">| |</code> (or <code style="color: black">abs( )</code>), as well
+			as other named functions such as <code style="color: black">sin( )</code>,
+			<code style="color: black">ln( )</code>, etc. When these functions are not allowed, it is usually because
+			you are expected to be able to simplify your answer, often without using a calculator.
+		</blockquote>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Points.html
+++ b/htdocs/helpFiles/Entering-Points.html
@@ -1,40 +1,44 @@
-<center>
-<b><font size="+2">Entering Points</font></b>
-</center>
+<h2 style="text-align: center">Entering Angles</h2>
 
-<ul type="square">
-
-<li><u>A point must use parentheses and commas:</u>
-<blockquote>
-<tt>(4.5, 3/7)</tt> &nbsp; is a valid point in 2 dimensions<br />
-<tt>(pi,e,2)</tt> &nbsp; is a valid point in 3 dimensions 
-</blockquote>
-</li>
-
-<li><u>If the answer is more than one point:</u>
-<blockquote>
-Enter your answer as a comma-separated list of points, for example: &nbsp;&nbsp;
-<tt>(4,3), (5,10)</tt> 
-</blockquote>
-</li>
-
-<li><u>If there are no solutions:</u>
-<blockquote>
-Enter &nbsp; <tt>NONE</tt> &nbsp; or &nbsp; <tt>DNE</tt> &nbsp; (this may vary from problem to problem)
-</blockquote>
-</li>
-
-<li><u>Examples of constants used in points:</u>
-<blockquote><tt>pi</tt>, <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Functions may be used in each coordinate of a point, but may not be applied across the parentheses or commas:</u>
-<blockquote>
-<tt>(sqrt(2),sqrt(5))</tt> &nbsp; is valid, but &nbsp; <tt>(sqrt(2,5))</tt> &nbsp; is not
-<br /> 
-<br />
-<a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a>
-</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>A point must use parentheses and commas:</u>
+		<blockquote>
+			<p style="margin-top: 0"><code style="color: black">(4.5, 3/7)</code> is a valid point in 2 dimensions.</p>
+			<p style="margin-top: 0"><code style="color: black">(pi,e,2)</code> is a valid point in 3 dimensions.</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>If the answer is more than one point:</u>
+		<blockquote>
+			Enter your answer as a comma-separated list of points, for example:
+			<code style="color: black">(4,3), (5,10)</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>If there are no solutions:</u>
+		<blockquote>
+			Enter <code style="color: black">NONE</code> or <code style="color: black">DNE</code> (this may vary from
+			problem to problem)
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants used in points:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>
+			Functions may be used in each coordinate of a point, but may not be applied across the parentheses or
+			commas:
+		</u>
+		<blockquote>
+			<code style="color: black">(sqrt(2),sqrt(5))</code> is valid, but
+			<code style="color: black">(sqrt(2,5))</code> is not.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/Entering-Syntax.html
+++ b/htdocs/helpFiles/Entering-Syntax.html
@@ -1,4 +1,4 @@
-<h2>Syntax for entering answers to WeBWorK</h2>
+<h2 style="text-align: center">Syntax for entering answers to WeBWorK</h2>
 
 <h3 style="font-size: 1.25rem">Mathematical Symbols Available In WeBWorK</h3>
 <ul>

--- a/htdocs/helpFiles/Entering-Syntax.html
+++ b/htdocs/helpFiles/Entering-Syntax.html
@@ -1,137 +1,249 @@
-<h1 id="firstHeading">Syntax for entering answers to WeBWorK</h1>
+<h2>Syntax for entering answers to WeBWorK</h2>
 
+<h3 style="font-size: 1.25rem">Mathematical Symbols Available In WeBWorK</h3>
+<ul>
+	<li><code style="color: black">+</code> Addition.</li>
+	<li><code style="color: black">-</code> Subtraction.</li>
+	<li>
+		<code style="color: black">*</code> Multiplication. Multiplication can also be indicated by a space or
+		juxtaposition, e.g., <code style="color: black">2x</code>, <code style="color: black">2 x</code> or
+		<code style="color: black">2*x</code>, also <code style="color: black">2(3+4)</code>.
+	</li>
+	<li><code style="color: black">/</code> Division.</li>
+	<li>
+		<code style="color: black">^</code> or <code style="color: black">**</code> Exponent. You can use either
+		<code style="color: black">^</code> or <code style="color: black">** </code>for exponentiation, e.g.,
+		<code style="color: black">3^2</code> or <code style="color: black">3**2</code>.
+	</li>
+	<li>
+		<code style="color: black">( )</code> Parentheses. You can also use square brackets,
+		<code style="color: black">[ ]</code>, and braces, <code style="color: black">{ }</code>, for grouping, e.g.,
+		<code style="color: black">[1+2]/[3(4+5)]</code>
+	</li>
+</ul>
 
-<h4> <span class="mw-headline">Mathematical Symbols Available In WeBWorK</span></h4>
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Syntax for entering expressions</span></h3>
+<ul>
+	<li>Be careful entering expressions just as you would be careful entering expressions in a calculator.</li>
+	<li>
+		<b>Use the "Preview Button" to see exactly how your entry looks.</b>
+		E.g., to tell the difference between <code style="color: black">1+2/3*4</code> and
+		<code style="color: black">[1+2]/[3*4]</code> click the "Preview Button".
+	</li>
+	<li>
+		Sometimes using the <code style="color: black">*</code> symbol to indicate mutiplication makes things easier to
+		read. For example <code style="color: black">(1+2)*(3+4)</code> and <code style="color: black">(1+2)(3+4)</code>
+		are both valid. So are <code style="color: black">3*4</code> and <code style="color: black">3 4</code>
+		(<code style="color: black">3 space 4</code>, not <code style="color: black">34</code>) but using a
+		<code style="color: black">*</code> makes things clearer.
+	</li>
+	<li>
+		Use <code style="color: black">(</code>'s and <code style="color: black">)</code>'s to make your meaning clear.
+		You can also use <code style="color: black">[</code>'s and <code style="color: black">]</code>'s and
+		<code style="color: black">{</code>'s and <code style="color: black">}</code>'s.
+	</li>
+	<li>
+		Don't enter <code style="color: black">2/4+5</code> (which is <code style="color: black">5.5</code>) when you
+		really want <code style="color: black">2/(4+5)</code> (which is <code style="color: black">2/9</code>).
+	</li>
+	<li>
+		Don't enter <code style="color: black">2/3*4</code> (which is <code style="color: black">8/3</code>) when you
+		really want <code style="color: black">2/(3*4)</code> (which is <code style="color: black">2/12</code>).
+	</li>
+	<li>
+		Entering big quotients with square brackets, e.g. <code style="color: black">[1+2+3+4]/[5+6+7+8]</code>, is a
+		good practice.
+	</li>
+	<li>
+		Be careful when entering functions. It's always good practice to use parentheses when entering functions. Write
+		<code style="color: black">sin(t)</code> instead of <code style="color: black">sint</code> or
+		<code style="color: black">sin t</code> even though WeBWorK is smart enough to <b>usually</b> accept
+		<code style="color: black">sin t</code> or even <code style="color: black">sint</code>.  For example,
+		<code style="color: black">sin 2t</code> is interpreted as <code style="color: black">sin(2)t</code>, i.e.
+		<code style="color: black">(sin(2))*t</code> so be careful.
+	</li>
+	<li>
+		You can enter <code style="color: black">sin^2(t)</code> as a short cut although mathematically speaking
+		<code style="color: black">sin^2(t)</code> is shorthand for <code style="color: black">(sin(t))^2</code> (the
+		square of sin of t). (You can enter it as <code style="color: black">sin(t)^2</code> or even
+		<code style="color: black">sint^2</code>, but don't try such things unless you <b>really</b> understand the
+		precedence of operations. The "<code style="color: black">sin</code>" operation has highest precedence, so it is
+		performed first, using the next token (i.e. <code style="color: black">t</code>) as an argument. Then the result
+		is squared.) You can always use the Preview button to see a typeset version of what you entered and check
+		whether what you wrote was what you meant.
+	</li>
+	<li>
+		For example <code style="color: black">2+3sin^2(4x)</code> will work and is equivalent to
+		<code style="color: black">2+3(sin(4x))^2</code> or <code style="color: black">2+3sin(4x)^2</code>. Why does the
+		last expression work? Because things in parentheses are always done first
+		[ i.e. <code style="color: black">(4x)</code>], next all functions, such as sin, are evaluated
+		[giving <code style="color: black">sin(4x)</code>], next all exponents are taken
+		[giving <code style="color: black">sin(4x)^2</code>], next all multiplications and divisions are performed in
+		order from left to right [<code style="color: black">giving 3sin(4x)^2</code>], and finally all additions and
+		subtractions are performed [giving <code style="color: black">2+3sin(4x)^2</code>].
+	</li>
+	<li>
+		Is <code style="color: black">-5^2</code> positive or negative? It's negative. This is because the square
+		operation is done before the negative sign is applied. Use <code style="color: black">(-5)^2</code> if you want
+		to square negative 5.
+	</li>
+	<li>When in doubt use parentheses!!!</li>
+	<li>
+		The complete rules for the precedence of operations, in addition to the above, are
+		<ul>
+			<li>
+				Multiplications and divisions are performed left to right:
+				<code style="color: black">2/3*4 = (2/3)*4 = 8/3</code>.
+			</li>
+			<li>
+				Additions and subtractions are performed left to right:
+				<code style="color: black">1-2+3 = (1-2)+3 = 2.</code>
+			</li>
+			<li>
+				Exponents are taken right to left:
+				<code style="color: black">2^3^4 = 2^(3^4) = 2^81 =</code> a big number.
+			</li>
+		</ul>
+	</li>
+</ul>
 
-<ul><li> + Addition
-</li><li> - Subtraction
-</li><li> * Multiplication can also be indicated by a space or juxtaposition, e.g. 2x, 2 x or 2*x, also 2(3+4).
-</li><li> / Division
-</li><li> ^ or ** You can use either ^ or ** for exponentiation, e.g. 3^2 or 3**2
-</li><li> Parentheses: () - You can also use square brackets, [ ], and braces, { }, for grouping, e.g. [1+2]/[3(4+5)]
-</li></ul>
-<a name="Syntax_for_entering_expressions"></a><h4> <span class="mw-headline">Syntax for entering expressions</span></h4>
-<ul><li> Be careful entering expressions just as you would be careful entering expressions in a calculator.
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Mathematical Constants Available In WeBWorK</span></h3>
+<ul>
+	<li>
+		<code style="color: black">pi</code> This gives <code style="color: black">3.14159265358979</code>, e.g.
+		<code style="color: black">cos(pi)</code> is <code style="color: black">-1</code>
+	</li>
+	<li>
+		<code style="color: black">e</code> This gives <code style="color: black">2.71828182845905</code>, e.g.
+		<code style="color: black">ln(e*2)</code> is <code style="color: black">1 + ln(2)</code>
+	</li>
+</ul>
 
-</li><li> <b>Use the "Preview Button" to see exactly how your entry
-looks. E.g. to tell the difference between 1+2/3*4 and [1+2]/[3*4]
-click the "Preview Button".</b>
-</li><li> Sometimes using the * symbol to indicate mutiplication makes
-things easier to read. For example (1+2)*(3+4) and (1+2)(3+4) are both
-valid. So are 3*4 and 3&nbsp;4 (3 space 4, not 34) but using a * makes
-things clearer.
-</li><li> Use ('s and )'s to make your meaning clear. You can also use ['s and ]'s and {'s and }'s.
-</li><li> Don't enter 2/4+5 (which is 5.5) when you really want 2/(4+5) (which is 2/9).
-</li><li> Don't enter 2/3*4 (which is 8/3) when you really want 2/(3*4) (which is 2/12).
-</li><li> Entering big quotients with square brackets, e.g. [1+2+3+4]/[5+6+7+8], is a good practice.
-</li><li> Be careful when entering functions. It's always good practice
-to use parentheses when entering functions. Write sin(t) instead of
-sint or sin t even though WeBWorK is smart enough to <b>usually</b> accept sin t or even sint. For example, sin 2t is interpreted as sin(2)t, i.e. (sin(2))*t so be careful.
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Scientific Notation Available In WeBWorK</span></h3>
+<ul>
+	<li><code style="color: black">2.1E2</code> is the same as <code style="color: black">210</code></li>
+	<li><code style="color: black">2.1E-2</code> is the same as <code style="color: black">0.021</code></li>
+</ul>
 
-</li><li> You can enter sin^2(t) as a short cut although mathematically
-speaking sin^2(t) is shorthand for (sin(t))^2(the square of sin of t).
-(You can enter it as sin(t)^2 or even sint^2, but don't try such things
-unless you <b>really</b> understand the precedence of operations. The
-"sin" operation has highest precedence, so it is performed first, using
-the next token (i.e. t) as an argument. Then the result is squared.)
-You can always use the Preview button to see a typeset version of what
-you entered and check whether what you wrote was what you
-meant.&nbsp;:-)
-</li><li> For example 2+3sin^2(4x) will work and is equivalent to
-2+3(sin(4x))^2 or 2+3sin(4x)^2. Why does the last expression work?
-Because things in parentheses are always done first [ i.e. (4x)], next
-all functions, such as sin, are evaluated [giving sin(4x)], next all
-exponents are taken [giving sin(4x)^2], next all multiplications and
-divisions are performed in order from left to right [giving
-3sin(4x)^2], and finally all additions and subtractions are performed
-[giving 2+3sin(4x)^2].
-</li><li> Is -5^2 positive or negative? It's negative. This is because
-the square operation is done before the negative sign is applied. Use
-(-5)^2 if you want to square negative 5.
-</li><li> When in doubt use parentheses!!!&nbsp;:-)
-</li><li> The complete rules for the precedence of operations, in addition to the above, are
-<ul><li> Multiplications and divisions are performed left to right: 2/3*4 = (2/3)*4 = 8/3.
-
-</li><li> Additions and subtractions are performed left to right: 1-2+3 = (1-2)+3 = 2.
-</li><li> Exponents are taken right to left: 2^3^4 = 2^(3^4) = 2^81 = a big number.
-</li></ul>
-</li><li> <b>Use the "Preview Button" to see exactly how your entry
-looks. E.g. to tell the difference between 1+2/3*4 and [1+2]/[3*4]
-click the "Preview Button".</b>
-</li></ul>
-<a name="Mathematical_Constants_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Mathematical Constants Available In WeBWorK</span></h4>
-<ul><li> pi This gives 3.14159265358979, e.g. cos(pi) is -1
-</li><li> e This gives 2.71828182845905, e.g. ln(e*2) is 1 + ln(2)
-</li></ul>
-
-<a name="Scientific_Notation_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Scientific Notation Available In WeBWorK</span></h4>
-<ul><li> 2.1E2 is the same as  210
-</li><li> 2.1E-2 is the same as .021
-</li></ul>
-<a name="Mathematical_Functions_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Mathematical Functions Available In WeBWorK</span></h4>
-<p>Note that sometimes one or more of these functions is disabled for a WeBWorK problem because the 
-instructor wants you to calculate the answer by some means other than just using the function.
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Mathematical Functions Available In WeBWorK</span></h3>
+<p style="margin-bottom: 0.5rem">
+	Note that sometimes one or more of these functions is disabled for a WeBWorK problem because the instructor wants
+	you to calculate the answer by some means other than just using the function.
 </p>
-<ul><li> abs( ) The absolute value
-</li><li> cos( ) Note: cos( ) uses radian measure
+<ul>
+	<li><code style="color: black">abs( )</code> The absolute value</li>
+	<li><code style="color: black">cos( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">sin( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">tan( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">sec( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">cot( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">csc( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">exp( )</code> The same function as <code style="color: black">e^x</code>.</li>
+	<li>
+		<code style="color: black">log( )</code>
+		This is usually the natural log but your instructor may have redined this to be log base 10.
+	</li>
+	<li><code style="color: black">ln( )</code> The natural log.</li>
+	<li><code style="color: black">logten( )</code> The log to the base 10.</li>
+	<li><code style="color: black">arcsin( )</code></li>
+	<li>
+		<code style="color: black">asin( )</code> or <code style="color: black">sin^-1( )</code>
+		Another name for <code style="color: black">arcsin</code>.
+	</li>
+	<li><code style="color: black">arccos( )</code></li>
+	<li>
+		<code style="color: black">acos( )</code> or <code style="color: black">cos^-1( )</code>
+		Another name for <code style="color: black">arccos</code>.
+	</li>
+	<li><code style="color: black">arctan( )</code></li>
+	<li>
+		<code style="color: black">atan( )</code> or <code style="color: black">tan^-1( )</code>
+		Another name for <code style="color: black">arctan</code>.
+	</li>
+	<li><code style="color: black">arccot( )</code></li>
+	<li>
+		<code style="color: black">acot( )</code> or <code style="color: black">cot^-1( )</code>
+		Another name for <code style="color: black">arccot</code>.
+	</li>
+	<li><code style="color: black">arcsec( )</code></li>
+	<li>
+		<code style="color: black">asec( )</code> or <code style="color: black">sec^-1( )</code>
+		Another name for arcsec
+	</li>
+	<li><code style="color: black">arccsc( )</code></li>
+	<li>
+		<code style="color: black">acsc( )</code> or <code style="color: black">csc^-1( )</code>
+		Another name for <code style="color: black">arccsc</code>.
+	</li>
+	<li><code style="color: black">sinh( )</code></li>
+	<li><code style="color: black">cosh( )</code></li>
+	<li><code style="color: black">tanh( )</code></li>
+	<li><code style="color: black">sech( )</code></li>
+	<li><code style="color: black">csch( )</code></li>
+	<li><code style="color: black">coth( )</code></li>
+	<li><code style="color: black">arcsinh( )</code></li>
+	<li>
+		<code style="color: black">asinh( )</code> or <code style="color: black">sinh^-1( )</code>
+		Another name for <code style="color: black">arcsinh</code>.
+	</li>
+	<li><code style="color: black">arccosh( )</code></li>
+	<li>
+		<code style="color: black">acosh( )</code> or <code style="color: black">cosh^-1( )</code>
+		Another name for <code style="color: black">arccosh</code>.
+	</li>
+	<li><code style="color: black">arctanh( )</code></li>
+	<li>
+		<code style="color: black">atanh( )</code> or <code style="color: black">tanh^-1( )</code>
+		Another name for <code style="color: black">arctanh</code>.
+	</li>
+	<li><code style="color: black">arcsech( )</code></li>
+	<li>
+		<code style="color: black">asech( )</code> or <code style="color: black">sech^-1( )</code>
+		Another name for <code style="color: black">arcsech</code>.
+	</li>
+	<li><code style="color: black">arccsch( )</code></li>
+	<li>
+		<code style="color: black">acsch( )</code> or <code style="color: black">csch^-1( )</code>
+		Another name for <code style="color: black">arccsch</code>.
+	</li>
+	<li><code style="color: black">arccoth( )</code></li>
+	<li>
+		<code style="color: black">acoth( )</code> or <code style="color: black">coth^-1( )</code>
+		Another name for <code style="color: black">arccoth</code>.
+	</li>
+	<li><code style="color: black">sqrt( )</code></li>
+	<li>
+		<code style="color: black">n!</code> n factorial. This is defined for integers
+		<code style="color: black">n</code> such that <code style="color: black">n &ge; 0</code>.
+	</li>
+</ul>
 
-</li><li> sin( ) Note: sin( ) uses radian measure
-</li><li> tan( ) Note: tan( ) uses radian measure
-</li><li> sec( ) Note: sec( ) uses radian measure
-</li><li> cot( ) Note: cot( ) uses radian measure
-</li><li> csc( ) Note: csc( ) uses radian measure
-</li><li> exp( ) The same function as e^x
-</li><li> log( ) This is usually the natural log but your professor may have redined this as log to the base 10
-</li><li> ln( ) The natural log
-</li><li> logten( ) The log to the base 10
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Other Mathematical Functions</span></h3>
+<p style="margin-bottom: 0.5rem">These functions may not always be available for every problem.</p>
+<ul>
+	<li>
+		<code style="color: black">sgn( )</code> The sign function.  Its value is one of
+		<code style="color: black">-1</code>, <code style="color: black">0</code>, or
+		<code style="color: black">1</code>.
+	</li>
+	<li>
+		<code style="color: black">step( )</code> The step function. Its value is
+		<code style="color: black">0</code> if <code style="color: black">x &le; 0</code> and
+		<code style="color: black">1</code> if <code style="color: black">x &gt; 0</code>.
+	</li>
+	<li>
+		<code style="color: black">fact(n)</code>
+		The factorial function <code style="color: black">n!</code> (defined only for nonnegative integers)
+	</li>
+	<li>
+		<code style="color: black">P(n,k) = n*(n-1)*(n-2)...(n-k+1)</code>, the number of ordered sequences of
+		<code style="color: black">k</code> elements chosen from <code style="color: black">n</code> elements
+	</li>
+	<li>
+		<code style="color: black">C(n,k) = "n choose k"</code>, the number of unordered sequences of
+		<code style="color: black">k</code> elements chosen from <code style="color: black">n</code> elements
+	</li>
+</ul>
 
-</li><li> arcsin( )
-</li><li> asin( ) or sin^-1() Another name for arcsin
-</li><li> arccos( )
-</li><li> acos( ) or cos^-1() Another name for arccos
-</li><li> arctan( )
-</li><li> atan( ) or tan^-1() Another name for arctan
-</li><li> arccot( )
-</li><li> acot( ) or cot^-1() Another name for arccot
-</li><li> arcsec( )
-
-</li><li> asec( ) or sec^-1() Another name for arcsec
-</li><li> arccsc( )
-</li><li> acsc( ) or csc^-1() Another name for arccsc
-</li><li> sinh( )
-</li><li> cosh( )
-</li><li> tanh( )
-</li><li> sech( )
-</li><li> csch( )
-</li><li> coth( )
-
-</li><li> arcsinh( )
-</li><li> asinh( ) or sinh^-1() Another name for arcsinh
-</li><li> arccosh( )
-</li><li> acosh( ) or cosh^-1()Another name for arccosh
-</li><li> arctanh( )
-</li><li> atanh( ) or tanh^-1()Another name for arctanh
-</li><li> arcsech( )
-</li><li> asech( ) or sech^-1()Another name for arcsech
-</li><li> arccsch( )
-
-</li><li> acsch( ) or csch^-1() Another name for arccsch
-</li><li> arccoth( )
-</li><li> acoth( ) or coth^-1() Another name for arccoth
-</li><li> sqrt( )
-</li><li> n!  (n factorial -- defined for <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">n</span><span style="position: relative; margin-left: 0.277em;"><span class="cmsy10">Ã•</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.93em; vertical-align: 0.744em;"></span></span></nobr></span>
-</li><li> These functions may not always be available for every problem.
-<ul><li> sgn( ) The sign function, either -1, 0, or 1
-
-</li><li> step( ) The step function (0 if <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">x</span><span style="position: relative; margin-left: 0.277em;"><span class="cmmi10">&lt;</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.833em; vertical-align: 0.744em;"></span></span></nobr></span>, 1 if <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">x</span><span style="position: relative; margin-left: 0.277em;"><span class="cmsy10">Ã•</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.93em; vertical-align: 0.744em;"></span></span></nobr></span>)
-</li><li> fact(n) The factorial function n! (defined only for nonnegative integers)
-</li><li> P(n,k) = n*(n-1)*(n-2)...(n-k+1) the number of ordered sequences of k elements chosen from n elements
-</li><li> C(n,k) = "n choose k" the number of unordered sequences of k elements chosen from n elements
-</li></ul>
-</li></ul>
-
-For more information:
-
-<a href="http://webwork.maa.org/wiki/Available_Functions">http://webwork.maa.org/wiki/Available_Functions</a>
-
-
+For more information see the
+<a href="http://webwork.maa.org/wiki/Available_Functions">list of all available functions</a>.

--- a/htdocs/helpFiles/Entering-Units.html
+++ b/htdocs/helpFiles/Entering-Units.html
@@ -1,74 +1,203 @@
-
-<H4 align="center">Units Available in WeBWorK</H4><p><p>
+<h2 style="text-align: center">Units Available in WeBWorK</h2>
 <p>
-Some WeBWorK problems ask for answers with units.  Below is a list of basic units
-and how they need to be abbreviated in WeBWorK answers.  In some problems, you
-may need to combine units (e.g, velocity might be in <code>ft/s</code> for feet per
-second).
-<center>
-<table border="1" cellpadding="4">
-<tr> <th> Unit <th> Abbreviation
-<tr><td colspan="2" align="center"><b>Time</b>
-<tr><td> Seconds  <td align="center">  s
+	Some WeBWorK problems ask for answers with units. Below is a list of basic units and how they need to be abbreviated
+	in WeBWorK answers. In some problems, you may need to combine units (e.g, velocity might be in
+	<code style="color:black">ft/s</code> for feet per second).
+</p>
+<table style="margin: auto">
+	<tr>
+		<th style="padding: 0.5rem; border: 1px solid black">Unit</th>
+		<th style="padding: 0.5rem; border: 1px solid black">Abbreviation</th>
+	</tr>
 
-<tr><td> Minutes  <td align="center">  min
-<tr><td> Hours  <td align="center">  hr
-<tr><td> Days  <td align="center">  day
-<tr><td> Years  <td align="center">  yr
-<tr><td> Milliseconds  <td align="center">  ms
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Time</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Seconds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">s</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Minutes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">min</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Hours</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">hr</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Days</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">day</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Years</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">yr</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Milliseconds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ms</td>
+	</tr>
 
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Distance</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Feet</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ft</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Inches</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">in</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Miles</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mi</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Meters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">m</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Centimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cm</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Millimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mm</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Kilometers</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">km</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angstroms</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">A</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Light years</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">light-year</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Distance</b>
-<tr><td> Feet  <td align="center">  ft
-<tr><td> Inches  <td align="center">  in
-<tr><td> Miles  <td align="center">  mi
-<tr><td> Meters  <td align="center">  m
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Mass</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Grams</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">g</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Kilograms</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Slugs</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">slug</td>
+	</tr>
 
-<tr><td> Centimeters  <td align="center">  cm
-<tr><td> Millimeters  <td align="center">  mm
-<tr><td> Kilometers  <td align="center">  km
-<tr><td> Angstroms  <td align="center">  A
-<tr><td> Light years  <td align="center">  light-year
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Volume</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Liters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">L</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Cubic Centimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cc</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Milliliters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ml</td>
+	</tr>
 
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Force</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Newtons</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">N</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Dynes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">dyne</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Pounds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">lb</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Tons</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ton</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Mass</b>
-<tr><td> Grams  <td align="center">  g
-<tr><td> Kilograms  <td align="center">  kg
-<tr><td> Slugs  <td align="center">  slug
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Work/Energy</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Joules</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">J</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo Joule</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kJ</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">ergs</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">erg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">foot pounds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">lbf</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">calories</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cal</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo calories</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kcal</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">electron volts</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">eV</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo Watt hours</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kWh</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Volume</b>
-<tr><td> Liters  <td align="center">  L
-
-<tr><td> Cubic Centimeters  <td align="center">  cc
-<tr><td> Milliliters  <td align="center">  ml
-
-<tr><td colspan="2" align="center"><b>Force</b>
-<tr><td> Newtons  <td align="center">  N
-<tr><td> Dynes  <td align="center">  dyne
-
-<tr><td> Pounds  <td align="center">  lb
-<tr><td> Tons  <td align="center">  ton
-
-<tr><td colspan="2" align="center"><b>Work/Energy</b>
-<tr><td> Joules  <td align="center">  J
-<tr><td> kilo Joule  <td align="center">  kJ
-
-<tr><td> ergs  <td align="center">  erg
-<tr><td> foot pounds  <td align="center">  lbf
-<tr><td> calories  <td align="center">  cal
-<tr><td> kilo calories  <td align="center">  kcal
-<tr><td> electron volts  <td align="center">  eV
-
-<tr><td> kilo Watt hours  <td align="center">  kWh
-
-<tr><td colspan="2" align="center"><b>Misc</b>
-<tr><td> Amperes  <td align="center">  amp
-<tr><td> Moles  <td align="center">  mol
-<tr><td> Degrees Centrigrade  <td align="center">  degC
-
-<tr><td> Degrees Fahrenheit  <td align="center">  degF
-<tr><td> Degrees Kelvin  <td align="center">  degK
-<tr><td> Angle degrees <td align="center">  deg
-<tr><td> Angle radians <td align="center">  rad
-
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Misc</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Amperes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">amp</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Moles</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mol</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Centrigrade</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degC</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Fahrenheit</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degF</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Kelvin</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degK</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angle degrees</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">deg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angle radians</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">rad</td>
+	</tr>
 </table>
+<p style="text-align: center">
+	<a href="http://webwork.maa.org/wiki/Units" target="ww_help">More details on units in WeBWorK</a>
+</p>

--- a/htdocs/helpFiles/Entering-Vectors.html
+++ b/htdocs/helpFiles/Entering-Vectors.html
@@ -1,48 +1,71 @@
-<center>
-<b><font size="+2">Entering Vectors</font></b>
-</center>
+<h2 style="text-align: center">Entering Vectors</h2>
 
-<ul type="square">
-
-<li><u>Predefined vectors i, j, and k</u>
-<blockquote>
-<tt>i</tt> &nbsp; is the same as &nbsp; <tt>&lt;1,0,0&gt;</tt><br />
-<tt>j</tt> &nbsp; is the same as &nbsp; <tt>&lt;0,1,0&gt;</tt><br />
-<tt>k</tt> &nbsp; is the same as &nbsp; <tt>&lt;0,0,1&gt;</tt><br />
-</blockquote>
-</li>
-
-<li><u>A vector may be entered using angle brackets and commas, or adding multiples of i, j, and k:</u>
-<blockquote>
-<tt>&lt;4.5, 3/7&gt;</tt> &nbsp; and &nbsp; <tt>4.5i + 3/7j</tt> &nbsp; are valid vectors in 2 dimensions<br />
-<tt>&lt;pi,e,2&gt;</tt> &nbsp; and &nbsp; <tt>pi i + e j + 2 k</tt> &nbsp; are valid vectors in 3 dimensions 
-</blockquote>
-</li>
-
-<li><u>If the answer is more than one vector:</u>
-<blockquote>
-Enter your answer as a comma-separated list of vectors, for example: &nbsp;&nbsp;
-<tt>&lt;4,3&gt;, &lt;5,10&gt;</tt> 
-</blockquote>
-</li>
-
-<li><u>If there are no solutions:</u>
-<blockquote>
-Enter &nbsp; <tt>NONE</tt> &nbsp; or &nbsp; <tt>DNE</tt> &nbsp; (this may vary from problem to problem)
-</blockquote>
-</li>
-
-<li><u>Examples of constants used in vectors:</u>
-<blockquote><tt>pi</tt>, <tt>e = e^1</tt></blockquote>
-</li>
-
-<li><u>Functions may be used in each coordinate of a vector, but may not be applied across the parentheses or commas:</u>
-<blockquote>
-<tt>&lt;sqrt(2),sqrt(5)&gt;</tt> &nbsp; is valid, but &nbsp; <tt>&lt;sqrt(2,5)&gt;</tt> &nbsp; is not
-<br /> 
-<br />
-<a href="http://webwork.maa.org/wiki/Available_Functions" target="_new">Link to a list of all available functions</a>
-</blockquote>
-</li>
-
+<ul style="list-style-type: square">
+	<li>
+		<u>
+			Predefined vectors <code style="color: black">i</code>, <code style="color: black">j</code>, and
+			<code style="color: black">k</code>
+		</u>
+		<blockquote>
+			<p style="margin: 0">
+				<code style="color: black">i</code> is the same as <code style="color: black">&lt;1,0,0&gt;</code>
+			</p>
+			<p style="margin: 0">
+				<code style="color: black">j</code> is the same as <code style="color: black">&lt;0,1,0&gt;</code>
+			</p>
+			<p style="margin: 0">
+				<code style="color: black">k</code> is the same as <code style="color: black">&lt;0,0,1&gt;</code>
+			</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>
+			A vector may be entered using angle brackets and commas, or adding multiples of
+			<code style="color: black">i</code>, <code style="color: black">j</code>, and
+			<code style="color: black">k</code>:
+		</u>
+		<blockquote>
+			<p style="margin: 0">
+				<code style="color: black">&lt;4.5, 3/7&gt;</code> and <code style="color: black">4.5i + 3/7j</code>
+				are valid vectors in 2 dimensions.
+			</p>
+			<p style="margin: 0">
+				<code style="color: black">&lt;pi,e,2&gt;</code> and <code style="color: black">pi i + e j + 2 k</code>
+				are valid vectors in 3 dimensions.
+			</p>
+		</blockquote>
+	</li>
+	<li>
+		<u>If the answer is more than one vector:</u>
+		<blockquote>
+			Enter your answer as a comma-separated list of vectors, for example:
+			<code style="color: black">&lt;4,3&gt;, &lt;5,10&gt;</code>
+		</blockquote>
+	</li>
+	<li>
+		<u>If there are no solutions:</u>
+		<blockquote>
+			Enter <code style="color: black">NONE</code> or <code style="color: black">DNE</code>
+			(this may vary from problem to problem).
+		</blockquote>
+	</li>
+	<li>
+		<u>Examples of constants used in vectors:</u>
+		<blockquote><code style="color: black">pi</code>, <code style="color: black">e = e^1</code></blockquote>
+	</li>
+	<li>
+		<u>
+			Functions may be used in each coordinate of a vector, but may not be applied across the parentheses or
+			commas.
+		</u>
+		<blockquote>
+			<code style="color: black">&lt;sqrt(2),sqrt(5)&gt;</code> is valid, but
+			<code style="color: black">&lt;sqrt(2,5)&gt;</code> is not.
+		</blockquote>
+	</li>
+	<li>
+		<a href="http://webwork.maa.org/wiki/Available_Functions" target="ww_help">
+			Link to a list of all available functions
+		</a>
+	</li>
 </ul>

--- a/htdocs/helpFiles/IntervalNotation.html
+++ b/htdocs/helpFiles/IntervalNotation.html
@@ -1,57 +1,40 @@
+<h2 style="text-align: center">Using Interval Notation</h2>
 
-<h4 align="center">
-Using Interval Notation
-</h4>
-
-<ul>
-
-<li> If an endpoint is included, then use <tt>[</tt> or <tt>]</tt>.
-If not, then use <tt>(</tt> or <tt>)</tt>.  For example, the interval
-from -3 to 7 that includes 7 but not -3 is expressed <tt>(-3,7]</tt>.
-
-<br>
-<br>
-
-<li> For infinite intervals, use <tt>Inf</tt>
-for <font size="+2">&#8734;</font> (infinity) and/or
-<tt>-Inf</tt> for <font size="+2">-&#8734;</font> (-Infinity).  For
-example, the infinite interval containing all points greater than or
-equal to 6 is expressed <tt>[6,Inf)</tt>.
-
-<br>
-<br>
-
-<li> If the set includes more than one interval, they are joined using the union
-symbol U.  For example, the set consisting of all points in (-3,7] together with all points in [-8,-5) is expressed <code>[-8,-5)U(-3,7]</code>.
-
-<br>
-<br>
-
-<li> If the answer is the empty set, you can specify that by using
-     braces with nothing inside: <code> { } </code>
-
-<br>
-<br>
-
-<li> You can use <code>R</code> as a shorthand for all real numbers.
-  So, it is equivalent to entering <code>(-Inf, Inf)</code>.
-
-<br>
-<br>
-
-<li> You can use set difference notation.  So, for all real numbers
-  except 3, you can use <code>R-{3}</code> or
-  <code>(-Inf, 3)U(3,Inf)</code> (they are the same).  Similarly,
-  <code>[1,10)-{3,4}</code> is the same as <code>[1,3)U(3,4)U(4,10)</code>.
-
-<br>
-<br>
-
-
-<li> WeBWorK will <b>not</b> interpret <tt>[2,4]U[3,5]</tt> as equivalent
- to <tt>[2,5]</tt>, unless a problem tells you otherwise.  
-All sets should be expressed in their simplest interval notation form, with no 
-overlapping intervals.
-
+<ul style="list-style-type: square">
+	<li style="margin-bottom:0.5rem">
+		If an endpoint is included, then use <code style="color: black">[</code> or <code style="color: black">]</code>.
+		If not, then use <code style="color: black">(</code> or <code style="color: black">)</code>. For example, the
+		interval from -3 to 7 that includes 7 but not -3 is expressed <code style="color: black">(-3,7]</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		For infinite intervals, use <code style="color: black">Inf</code> for
+		<code style='color: black; font-size:1rem'>&#8734;</code> (infinity) and
+		<code style="color: black">-Inf</code> for <code style='color: black; font-size:1rem'>-&#8734;</code>
+		(-Infinity). For example, the infinite interval containing all points greater than or equal to 6 is expressed
+		<code style="color: black">[6,Inf)</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		If the set includes more than one interval, they are joined using the union symbol U. For example, the set
+		consisting of all points in (-3,7] together with all points in [-8,-5) is expressed
+		<code style="color: black">[-8,-5)U(-3,7]</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		If the answer is the empty set, you can specify that by using braces with nothing inside:
+		<code style="color: black"> { } </code>
+	</li>
+	<li style="margin-bottom:0.5rem">
+		You can use <code style="color: black">R</code> as a shorthand for all real numbers. So, it is equivalent to
+		entering <code style="color: black">(-Inf, Inf)</code>.
+	</li>
+	<li style="margin-bottom:0.5rem">
+		You can use set difference notation. So, for all real numbers except 3, you can use
+		<code style="color: black">R-{3}</code> or <code style="color: black">(-Inf, 3)U(3,Inf)</code> (they are the
+		same).  Similarly, <code style="color: black">[1,10)-{3,4}</code> is the same as
+		<code style="color: black">[1,3)U(3,4)U(4,10)</code>.
+	</li>
+	<li>
+		WeBWorK will <b>not</b> interpret <code style="color: black">[2,4]U[3,5]</code> as equivalent to
+		<code style="color: black">[2,5]</code>, unless a problem tells you otherwise. All sets should be expressed in
+		their simplest interval notation form, with no overlapping intervals.
+	</li>
 </ul>
-

--- a/htdocs/helpFiles/PDE-notation.html
+++ b/htdocs/helpFiles/PDE-notation.html
@@ -1,95 +1,107 @@
-<script type=text/javascript
-   src=http://cdn.mathjax.org/mathjax/latest/MathJax.js>
-</script>
+<h2 style="text-align: center">Entering Partial Derivatives</h2>
 
-<h4> Entering Partial Derivatives</h4>
-<br>
- 
-<table style=width:100%>
-  <tr>
-    <td>Partial Derivative</td>
-    <td>Enter into WeBWork</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial u}{\partial x}\)</td>
-    <td> ux</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial u}{\partial t}\)</td>
-    <td>ut</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial u}{\partial y}\)</td>
-    <td>uy</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial^2 u}{\partial x^2}\)</td>
-    <td>uxx</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial^2 u}{\partial t^2}\)</td>
-    <td>utt</td>
-  </tr>
-  <tr>
-    <td>\(\frac{\partial^2 u}{\partial y^2}\)</td>
-    <td>uyy</tdd>
-  </tr>
-</table
-<br>
-<br>
-To answer questions that require you to input a PDE you will also need to know the form
-of the PDE WeBWorK is expecting. In particular you will need to use the same letters
-for constants that WeBWorK is expecting. Below is a table of the PDE's 
-you may encounter.
-<br>
-<h4> Models </h4>
-<br>
-<table>
-  <tr>
-     <td>Model</td>
-     <td>PDE</td>
-  </tr>
-     <td>heat equation</td>
-     <td>\(k \frac{\partial^2 u}{\partial x^2} = \frac{\partial u}{\partial t}\)</td>
-  </tr>
-  <tr>
-     <td>heat equation with lateral heat transfer - \(u_m\) is the temperature of the surrounding medium and will be given, h is the constant from Newton's $
-     <td>\(k \frac{\partial^2 u}{\partial x^2}-h (u-um) = \frac{\partial u}{\partial t}\)</td>
-  </tr>
-  <tr>
-     <td>wave equation</td>
-     <td>\(a^2 \frac{\partial^2 u}{\partial x^2} = \frac{\partial^2 u}{\partial t^2}\))</td>
-  </tr>
-  <tr>
-     <td>wave equation with damping</td>
-     <td>\(a^2 \frac{\partial^2 u}{\partial x^2} = \frac{\partial^2 u}{\partial t^2}+c \frac{\partial u}{\partial t}\)</td>
-  </tr>
-  <tr>
-     <td>wave equation with an external force (f(x,t) will specified in the problem</td>
-     <td>\(a^2 \frac{\partial^2 u}{\partial x^2} + f(x,t) = \frac{\partial^2 u}{\partial t^2}\)</td>
-  </tr>
-  <tr>
-     <td>Laplace's equation</td>
-     <td>\(\frac{\partial^2 u}{\partial x^2}+\frac{\partial^2 u}{\partial y^2} = 0\)</td>
-  </tr>
+<table style="margin-left: auto; margin-right: auto; margin-bottom: 0.5rem">
+	<tr>
+		<th style="border: 1px solid black; padding: 0.25rem">Partial Derivative</th>
+		<th style="border: 1px solid black; padding: 0.25rem">Enter into WeBWork</th>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial u}{\partial x}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">ux</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial u}{\partial t}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">ut</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial u}{\partial y}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">uy</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial^2 u}{\partial x^2}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">uxx</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial^2 u}{\partial t^2}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">utt</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">\(\frac{\partial^2 u}{\partial y^2}\)</td>
+		<td style="border: 1px solid black; padding: 0.25rem">uyy</td>
+	</tr>
 </table>
-<br>
-For problems with proportional quantities the constant of proportionality is c.
-<br>
-<br>
-<h4>  Entering Boundary and Initial Conditions </h4>
-<br>
+
+<p style="margin-bottom: 0.5rem">
+	To answer questions that require you to input a PDE you will also need to know the form of the PDE WeBWorK is
+	expecting. In particular you will need to use the same letters for constants that WeBWorK is expecting. Below is a
+	table of the PDE's you may encounter.
+</p>
+
+<h3>Models</h3>
+<table>
+	<tr>
+		<th style="border: 1px solid black; padding: 0.25rem">Model</th>
+		<th style="border: 1px solid black; padding: 0.25rem">PDE</th>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">heat equation</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(k \frac{\partial^2 u}{\partial x^2} = \frac{\partial u}{\partial t}\)
+		</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			heat equation with lateral heat transfer - \(u_m\) is the temperature of the surrounding medium and will be
+			given, and h is the constant from Newton's $
+		</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(k \frac{\partial^2 u}{\partial x^2}-h (u-u_m) = \frac{\partial u}{\partial t}\)
+		</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">wave equation</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(a^2 \frac{\partial^2 u}{\partial x^2} = \frac{\partial^2 u}{\partial t^2}\)
+		</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">wave equation with damping</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(a^2 \frac{\partial^2 u}{\partial x^2} =
+			\frac{\partial^2 u}{\partial t^2}+c \frac{\partial u}{\partial t}\)
+		</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			wave equation with an external force (f(x,t) will specified in the problem
+		</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(a^2 \frac{\partial^2 u}{\partial x^2} + f(x,t) = \frac{\partial^2 u}{\partial t^2}\)
+		</td>
+	</tr>
+	<tr>
+		<td style="border: 1px solid black; padding: 0.25rem">Laplace's equation</td>
+		<td style="border: 1px solid black; padding: 0.25rem">
+			\(\frac{\partial^2 u}{\partial x^2}+\frac{\partial^2 u}{\partial y^2} = 0\)
+		</td>
+	</tr>
+</table>
+
+<p style="margin-bottom: 0.5rem">For problems with proportional quantities the constant of proportionality is c.</p>
+
+<h4>Entering Boundary and Initial Conditions</h4>
+
 There are three types of boundary conditions we will consider:
-<br>
-1. Ends held at a constant temperature \(u_0\) (Dirichlet condition): \(u(L,t) = u_0\)
-<br>
-2. Ends insulated (Neumann condition): \(\frac{\partial u}{\partial x}\big\vert_{x=L} = 0\)
-<br>
-3. Heat transfer through the ends into a medium held at constant temperature \(u_m\)
-<br>
-<br>
 
-Suppose that we want to enter the boundary condition \(\frac{\partial u}{\partial x}\big\vert_{x=0}=0\).
-You will be given two answer blanks: the first is to input the partial derivative and the point, ux(0,t),
-and the second will be for the right hand side. In WeBWorK notation the boundary condition would be given as <code>ux(0,t) = 0</code>.
+<ol>
+	<li>Ends held at a constant temperature \(u_0\) (Dirichlet condition): \(u(L,t) = u_0\)</li>
+	<li>Ends insulated (Neumann condition): \(\frac{\partial u}{\partial x}\big\vert_{x=L} = 0\)</li>
+	<li>Heat transfer through the ends into a medium held at constant temperature \(u_m\)</li>
+</ol>
 
+<p>
+	Suppose that we want to enter the boundary condition \(\frac{\partial u}{\partial x}\big\vert_{x=0}=0\). You will be
+	given two answer blanks: the first is to input the partial derivative and the point, \(ux(0,t)\), and the second
+	will be for the right hand side. In WeBWorK notation the boundary condition would be given as
+	\(ux(0,t) = 0\).
+</p>

--- a/htdocs/helpFiles/Syntax.html
+++ b/htdocs/helpFiles/Syntax.html
@@ -1,124 +1,249 @@
-<h1 id="firstHeading">Syntax for entering answers to WeBWorK</h1>
+<h2>Syntax for entering answers to WeBWorK</h2>
 
+<h3 style="font-size: 1.25rem">Mathematical Symbols Available In WeBWorK</h3>
+<ul>
+	<li><code style="color: black">+</code> Addition.</li>
+	<li><code style="color: black">-</code> Subtraction.</li>
+	<li>
+		<code style="color: black">*</code> Multiplication. Multiplication can also be indicated by a space or
+		juxtaposition, e.g., <code style="color: black">2x</code>, <code style="color: black">2 x</code> or
+		<code style="color: black">2*x</code>, also <code style="color: black">2(3+4)</code>.
+	</li>
+	<li><code style="color: black">/</code> Division.</li>
+	<li>
+		<code style="color: black">^</code> or <code style="color: black">**</code> Exponent. You can use either
+		<code style="color: black">^</code> or <code style="color: black">** </code>for exponentiation, e.g.,
+		<code style="color: black">3^2</code> or <code style="color: black">3**2</code>.
+	</li>
+	<li>
+		<code style="color: black">( )</code> Parentheses. You can also use square brackets,
+		<code style="color: black">[ ]</code>, and braces, <code style="color: black">{ }</code>, for grouping, e.g.,
+		<code style="color: black">[1+2]/[3(4+5)]</code>
+	</li>
+</ul>
 
-<h4> <span class="mw-headline">Mathematical Symbols Available In WeBWorK</span></h4>
-<ul><li> + Addition
-</li><li> - Subtraction
-</li><li> * Multiplication can also be indicated by a space or juxtaposition, e.g. 2x, 2 x or 2*x, also 2(3+4).
-</li><li> / Division
-</li><li> ^ or ** You can use either ^ or ** for exponentiation, e.g. 3^2 or 3**2
-</li><li> Parentheses: () - You can also use square brackets, [ ], and braces, { }, for grouping, e.g. [1+2]/[3(4+5)]
-</li></ul>
-<a name="Syntax_for_entering_expressions"></a><h4> <span class="mw-headline">Syntax for entering expressions</span></h4>
-<ul><li> Be careful entering expressions just as you would be careful entering expressions in a calculator.
-</li><li> <b>Use the "Preview Button" to see exactly how your entry
-looks. E.g. to tell the difference between 1+2/3*4 and [1+2]/[3*4]
-click the "Preview Button".</b>
-</li><li> Sometimes using the * symbol to indicate mutiplication makes
-things easier to read. For example (1+2)*(3+4) and (1+2)(3+4) are both
-valid. So are 3*4 and 3&nbsp;4 (3 space 4, not 34) but using a * makes
-things clearer.
-</li><li> Use ('s and )'s to make your meaning clear. You can also use ['s and ]'s and {'s and }'s.
-</li><li> Don't enter 2/4+5 (which is 5.5) when you really want 2/(4+5) (which is 2/9).
-</li><li> Don't enter 2/3*4 (which is 8/3) when you really want 2/(3*4) (which is 2/12).
-</li><li> Entering big quotients with square brackets, e.g. [1+2+3+4]/[5+6+7+8], is a good practice.
-</li><li> Be careful when entering functions. It's always good practice
-to use parentheses when entering functions. Write sin(t) instead of
-sint or sin t even though WeBWorK is smart enough to <b>usually</b> accept sin t or even sint. For example, sin 2t is interpreted as sin(2)t, i.e. (sin(2))*t so be careful.
-</li><li> You can enter sin^2(t) as a short cut although mathematically
-speaking sin^2(t) is shorthand for (sin(t))^2(the square of sin of t).
-(You can enter it as sin(t)^2 or even sint^2, but don't try such things
-unless you <b>really</b> understand the precedence of operations. The
-"sin" operation has highest precedence, so it is performed first, using
-the next token (i.e. t) as an argument. Then the result is squared.)
-You can always use the Preview button to see a typeset version of what
-you entered and check whether what you wrote was what you
-meant.&nbsp;:-)
-</li><li> For example 2+3sin^2(4x) will work and is equivalent to
-2+3(sin(4x))^2 or 2+3sin(4x)^2. Why does the last expression work?
-Because things in parentheses are always done first [ i.e. (4x)], next
-all functions, such as sin, are evaluated [giving sin(4x)], next all
-exponents are taken [giving sin(4x)^2], next all multiplications and
-divisions are performed in order from left to right [giving
-3sin(4x)^2], and finally all additions and subtractions are performed
-[giving 2+3sin(4x)^2].
-</li><li> Is -5^2 positive or negative? It's negative. This is because
-the square operation is done before the negative sign is applied. Use
-(-5)^2 if you want to square negative 5.
-</li><li> When in doubt use parentheses!!!&nbsp;:-)
-</li><li> The complete rules for the precedence of operations, in addition to the above, are
-<ul><li> Multiplications and divisions are performed left to right: 2/3*4 = (2/3)*4 = 8/3.
-</li><li> Additions and subtractions are performed left to right: 1-2+3 = (1-2)+3 = 2.
-</li><li> Exponents are taken right to left: 2^3^4 = 2^(3^4) = 2^81 = a big number.
-</li></ul>
-</li><li> <b>Use the "Preview Button" to see exactly how your entry
-looks. E.g. to tell the difference between 1+2/3*4 and [1+2]/[3*4]
-click the "Preview Button".</b>
-</li></ul>
-<a name="Mathematical_Constants_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Mathematical Constants Available In WeBWorK</span></h4>
-<ul><li> pi This gives 3.14159265358979, e.g. cos(pi) is -1
-</li><li> e This gives 2.71828182845905, e.g. ln(e*2) is 1 + ln(2)
-</li></ul>
-<a name="Scientific_Notation_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Scientific Notation Available In WeBWorK</span></h4>
-<ul><li> 2.1E2 is the same as  210
-</li><li> 2.1E-2 is the same as .021
-</li></ul>
-<a name="Mathematical_Functions_Available_In_WeBWorK"></a><h4> <span class="mw-headline">Mathematical Functions Available In WeBWorK</span></h4>
-<p>Note that sometimes one or more of these functions is disabled for a WeBWorK problem because the 
-instructor wants you to calculate the answer by some means other than just using the function.
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Syntax for entering expressions</span></h3>
+<ul>
+	<li>Be careful entering expressions just as you would be careful entering expressions in a calculator.</li>
+	<li>
+		<b>Use the "Preview Button" to see exactly how your entry looks.</b>
+		E.g., to tell the difference between <code style="color: black">1+2/3*4</code> and
+		<code style="color: black">[1+2]/[3*4]</code> click the "Preview Button".
+	</li>
+	<li>
+		Sometimes using the <code style="color: black">*</code> symbol to indicate mutiplication makes things easier to
+		read. For example <code style="color: black">(1+2)*(3+4)</code> and <code style="color: black">(1+2)(3+4)</code>
+		are both valid. So are <code style="color: black">3*4</code> and <code style="color: black">3 4</code>
+		(<code style="color: black">3 space 4</code>, not <code style="color: black">34</code>) but using a
+		<code style="color: black">*</code> makes things clearer.
+	</li>
+	<li>
+		Use <code style="color: black">(</code>'s and <code style="color: black">)</code>'s to make your meaning clear.
+		You can also use <code style="color: black">[</code>'s and <code style="color: black">]</code>'s and
+		<code style="color: black">{</code>'s and <code style="color: black">}</code>'s.
+	</li>
+	<li>
+		Don't enter <code style="color: black">2/4+5</code> (which is <code style="color: black">5.5</code>) when you
+		really want <code style="color: black">2/(4+5)</code> (which is <code style="color: black">2/9</code>).
+	</li>
+	<li>
+		Don't enter <code style="color: black">2/3*4</code> (which is <code style="color: black">8/3</code>) when you
+		really want <code style="color: black">2/(3*4)</code> (which is <code style="color: black">2/12</code>).
+	</li>
+	<li>
+		Entering big quotients with square brackets, e.g. <code style="color: black">[1+2+3+4]/[5+6+7+8]</code>, is a
+		good practice.
+	</li>
+	<li>
+		Be careful when entering functions. It's always good practice to use parentheses when entering functions. Write
+		<code style="color: black">sin(t)</code> instead of <code style="color: black">sint</code> or
+		<code style="color: black">sin t</code> even though WeBWorK is smart enough to <b>usually</b> accept
+		<code style="color: black">sin t</code> or even <code style="color: black">sint</code>.  For example,
+		<code style="color: black">sin 2t</code> is interpreted as <code style="color: black">sin(2)t</code>, i.e.
+		<code style="color: black">(sin(2))*t</code> so be careful.
+	</li>
+	<li>
+		You can enter <code style="color: black">sin^2(t)</code> as a short cut although mathematically speaking
+		<code style="color: black">sin^2(t)</code> is shorthand for <code style="color: black">(sin(t))^2</code> (the
+		square of sin of t). (You can enter it as <code style="color: black">sin(t)^2</code> or even
+		<code style="color: black">sint^2</code>, but don't try such things unless you <b>really</b> understand the
+		precedence of operations. The "<code style="color: black">sin</code>" operation has highest precedence, so it is
+		performed first, using the next token (i.e. <code style="color: black">t</code>) as an argument. Then the result
+		is squared.) You can always use the Preview button to see a typeset version of what you entered and check
+		whether what you wrote was what you meant.
+	</li>
+	<li>
+		For example <code style="color: black">2+3sin^2(4x)</code> will work and is equivalent to
+		<code style="color: black">2+3(sin(4x))^2</code> or <code style="color: black">2+3sin(4x)^2</code>. Why does the
+		last expression work? Because things in parentheses are always done first
+		[ i.e. <code style="color: black">(4x)</code>], next all functions, such as sin, are evaluated
+		[giving <code style="color: black">sin(4x)</code>], next all exponents are taken
+		[giving <code style="color: black">sin(4x)^2</code>], next all multiplications and divisions are performed in
+		order from left to right [<code style="color: black">giving 3sin(4x)^2</code>], and finally all additions and
+		subtractions are performed [giving <code style="color: black">2+3sin(4x)^2</code>].
+	</li>
+	<li>
+		Is <code style="color: black">-5^2</code> positive or negative? It's negative. This is because the square
+		operation is done before the negative sign is applied. Use <code style="color: black">(-5)^2</code> if you want
+		to square negative 5.
+	</li>
+	<li>When in doubt use parentheses!!!</li>
+	<li>
+		The complete rules for the precedence of operations, in addition to the above, are
+		<ul>
+			<li>
+				Multiplications and divisions are performed left to right:
+				<code style="color: black">2/3*4 = (2/3)*4 = 8/3</code>.
+			</li>
+			<li>
+				Additions and subtractions are performed left to right:
+				<code style="color: black">1-2+3 = (1-2)+3 = 2.</code>
+			</li>
+			<li>
+				Exponents are taken right to left:
+				<code style="color: black">2^3^4 = 2^(3^4) = 2^81 =</code> a big number.
+			</li>
+		</ul>
+	</li>
+</ul>
+
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Mathematical Constants Available In WeBWorK</span></h3>
+<ul>
+	<li>
+		<code style="color: black">pi</code> This gives <code style="color: black">3.14159265358979</code>, e.g.
+		<code style="color: black">cos(pi)</code> is <code style="color: black">-1</code>
+	</li>
+	<li>
+		<code style="color: black">e</code> This gives <code style="color: black">2.71828182845905</code>, e.g.
+		<code style="color: black">ln(e*2)</code> is <code style="color: black">1 + ln(2)</code>
+	</li>
+</ul>
+
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Scientific Notation Available In WeBWorK</span></h3>
+<ul>
+	<li><code style="color: black">2.1E2</code> is the same as <code style="color: black">210</code></li>
+	<li><code style="color: black">2.1E-2</code> is the same as <code style="color: black">0.021</code></li>
+</ul>
+
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Mathematical Functions Available In WeBWorK</span></h3>
+<p style="margin-bottom: 0.5rem">
+	Note that sometimes one or more of these functions is disabled for a WeBWorK problem because the instructor wants
+	you to calculate the answer by some means other than just using the function.
 </p>
-<ul><li> abs( ) The absolute value
-</li><li> cos( ) Note: cos( ) uses radian measure
-</li><li> sin( ) Note: sin( ) uses radian measure
-</li><li> tan( ) Note: tan( ) uses radian measure
-</li><li> sec( ) Note: sec( ) uses radian measure
-</li><li> cot( ) Note: cot( ) uses radian measure
-</li><li> csc( ) Note: csc( ) uses radian measure
-</li><li> exp( ) The same function as e^x
-</li><li> log( ) This is usually the natural log but your professor may have redined this as log to the base 10
-</li><li> ln( ) The natural log
-</li><li> logten( ) The log to the base 10
-</li><li> arcsin( )
-</li><li> asin( ) or sin^-1() Another name for arcsin
-</li><li> arccos( )
-</li><li> acos( ) or cos^-1() Another name for arccos
-</li><li> arctan( )
-</li><li> atan( ) or tan^-1() Another name for arctan
-</li><li> arccot( )
-</li><li> acot( ) or cot^-1() Another name for arccot
-</li><li> arcsec( )
-</li><li> asec( ) or sec^-1() Another name for arcsec
-</li><li> arccsc( )
-</li><li> acsc( ) or csc^-1() Another name for arccsc
-</li><li> sinh( )
-</li><li> cosh( )
-</li><li> tanh( )
-</li><li> sech( )
-</li><li> csch( )
-</li><li> coth( )
-</li><li> arcsinh( )
-</li><li> asinh( ) or sinh^-1() Another name for arcsinh
-</li><li> arccosh( )
-</li><li> acosh( ) or cosh^-1()Another name for arccosh
-</li><li> arctanh( )
-</li><li> atanh( ) or tanh^-1()Another name for arctanh
-</li><li> arcsech( )
-</li><li> asech( ) or sech^-1()Another name for arcsech
-</li><li> arccsch( )
-</li><li> acsch( ) or csch^-1() Another name for arccsch
-</li><li> arccoth( )
-</li><li> acoth( ) or coth^-1() Another name for arccoth
-</li><li> sqrt( )
-</li><li> n!  (n factorial -- defined for <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">n</span><span style="position: relative; margin-left: 0.277em;"><span class="cmsy10">Õ</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.93em; vertical-align: 0.744em;"></span></span></nobr></span>
-</li><li> These functions may not always be available for every problem.
-<ul><li> sgn( ) The sign function, either -1, 0, or 1
-</li><li> step( ) The step function (0 if <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">x</span><span style="position: relative; margin-left: 0.277em;"><span class="cmmi10">&lt;</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.833em; vertical-align: 0.744em;"></span></span></nobr></span>, 1 if <span class="typeset"><nobr><span class="scale"><span style="position: relative;"><span style="position: absolute; top: -0.131em; left: 0em;"><span class="cmmi10">x</span><span style="position: relative; margin-left: 0.277em;"><span class="cmsy10">Õ</span></span><span style="position: relative; margin-left: 0.277em;"><span class="cmr10">0</span></span>&nbsp;</span><span class="blank" style="width: 2.429em; height: 0.722em; vertical-align: 0.722em;"></span></span><span class="blank" style="height: 0.93em; vertical-align: 0.744em;"></span></span></nobr></span>)
-</li><li> fact(n) The factorial function n! (defined only for nonnegative integers)
-</li><li> P(n,k) = n*(n-1)*(n-2)...(n-k+1) the number of ordered sequences of k elements chosen from n elements
-</li><li> C(n,k) = "n choose k" the number of unordered sequences of k elements chosen from n elements
-</li></ul>
-</li></ul>
+<ul>
+	<li><code style="color: black">abs( )</code> The absolute value</li>
+	<li><code style="color: black">cos( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">sin( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">tan( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">sec( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">cot( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">csc( )</code> Note: Uses radian measure.</li>
+	<li><code style="color: black">exp( )</code> The same function as <code style="color: black">e^x</code>.</li>
+	<li>
+		<code style="color: black">log( )</code>
+		This is usually the natural log but your instructor may have redined this to be log base 10.
+	</li>
+	<li><code style="color: black">ln( )</code> The natural log.</li>
+	<li><code style="color: black">logten( )</code> The log to the base 10.</li>
+	<li><code style="color: black">arcsin( )</code></li>
+	<li>
+		<code style="color: black">asin( )</code> or <code style="color: black">sin^-1( )</code>
+		Another name for <code style="color: black">arcsin</code>.
+	</li>
+	<li><code style="color: black">arccos( )</code></li>
+	<li>
+		<code style="color: black">acos( )</code> or <code style="color: black">cos^-1( )</code>
+		Another name for <code style="color: black">arccos</code>.
+	</li>
+	<li><code style="color: black">arctan( )</code></li>
+	<li>
+		<code style="color: black">atan( )</code> or <code style="color: black">tan^-1( )</code>
+		Another name for <code style="color: black">arctan</code>.
+	</li>
+	<li><code style="color: black">arccot( )</code></li>
+	<li>
+		<code style="color: black">acot( )</code> or <code style="color: black">cot^-1( )</code>
+		Another name for <code style="color: black">arccot</code>.
+	</li>
+	<li><code style="color: black">arcsec( )</code></li>
+	<li>
+		<code style="color: black">asec( )</code> or <code style="color: black">sec^-1( )</code>
+		Another name for arcsec
+	</li>
+	<li><code style="color: black">arccsc( )</code></li>
+	<li>
+		<code style="color: black">acsc( )</code> or <code style="color: black">csc^-1( )</code>
+		Another name for <code style="color: black">arccsc</code>.
+	</li>
+	<li><code style="color: black">sinh( )</code></li>
+	<li><code style="color: black">cosh( )</code></li>
+	<li><code style="color: black">tanh( )</code></li>
+	<li><code style="color: black">sech( )</code></li>
+	<li><code style="color: black">csch( )</code></li>
+	<li><code style="color: black">coth( )</code></li>
+	<li><code style="color: black">arcsinh( )</code></li>
+	<li>
+		<code style="color: black">asinh( )</code> or <code style="color: black">sinh^-1( )</code>
+		Another name for <code style="color: black">arcsinh</code>.
+	</li>
+	<li><code style="color: black">arccosh( )</code></li>
+	<li>
+		<code style="color: black">acosh( )</code> or <code style="color: black">cosh^-1( )</code>
+		Another name for <code style="color: black">arccosh</code>.
+	</li>
+	<li><code style="color: black">arctanh( )</code></li>
+	<li>
+		<code style="color: black">atanh( )</code> or <code style="color: black">tanh^-1( )</code>
+		Another name for <code style="color: black">arctanh</code>.
+	</li>
+	<li><code style="color: black">arcsech( )</code></li>
+	<li>
+		<code style="color: black">asech( )</code> or <code style="color: black">sech^-1( )</code>
+		Another name for <code style="color: black">arcsech</code>.
+	</li>
+	<li><code style="color: black">arccsch( )</code></li>
+	<li>
+		<code style="color: black">acsch( )</code> or <code style="color: black">csch^-1( )</code>
+		Another name for <code style="color: black">arccsch</code>.
+	</li>
+	<li><code style="color: black">arccoth( )</code></li>
+	<li>
+		<code style="color: black">acoth( )</code> or <code style="color: black">coth^-1( )</code>
+		Another name for <code style="color: black">arccoth</code>.
+	</li>
+	<li><code style="color: black">sqrt( )</code></li>
+	<li>
+		<code style="color: black">n!</code> n factorial. This is defined for integers
+		<code style="color: black">n</code> such that <code style="color: black">n &ge; 0</code>.
+	</li>
+</ul>
 
-For more information:
+<h3 style="font-size: 1.25rem"><span class="mw-headline">Other Mathematical Functions</span></h3>
+<p style="margin-bottom: 0.5rem">These functions may not always be available for every problem.</p>
+<ul>
+	<li>
+		<code style="color: black">sgn( )</code> The sign function.  Its value is one of
+		<code style="color: black">-1</code>, <code style="color: black">0</code>, or
+		<code style="color: black">1</code>.
+	</li>
+	<li>
+		<code style="color: black">step( )</code> The step function. Its value is
+		<code style="color: black">0</code> if <code style="color: black">x &le; 0</code> and
+		<code style="color: black">1</code> if <code style="color: black">x &gt; 0</code>.
+	</li>
+	<li>
+		<code style="color: black">fact(n)</code>
+		The factorial function <code style="color: black">n!</code> (defined only for nonnegative integers)
+	</li>
+	<li>
+		<code style="color: black">P(n,k) = n*(n-1)*(n-2)...(n-k+1)</code>, the number of ordered sequences of
+		<code style="color: black">k</code> elements chosen from <code style="color: black">n</code> elements
+	</li>
+	<li>
+		<code style="color: black">C(n,k) = "n choose k"</code>, the number of unordered sequences of
+		<code style="color: black">k</code> elements chosen from <code style="color: black">n</code> elements
+	</li>
+</ul>
 
-<a href="http://webwork.maa.org/wiki/Available_Functions">http://webwork.maa.org/wiki/Available_Functions</a>
+For more information see the
+<a href="http://webwork.maa.org/wiki/Available_Functions">list of all available functions</a>.

--- a/htdocs/helpFiles/Syntax.html
+++ b/htdocs/helpFiles/Syntax.html
@@ -1,4 +1,4 @@
-<h2>Syntax for entering answers to WeBWorK</h2>
+<h2 style="text-align: center">Syntax for entering answers to WeBWorK</h2>
 
 <h3 style="font-size: 1.25rem">Mathematical Symbols Available In WeBWorK</h3>
 <ul>

--- a/htdocs/helpFiles/Units.html
+++ b/htdocs/helpFiles/Units.html
@@ -1,69 +1,203 @@
-      
-<H4 align="center">Units Available in WeBWorK</H4><p><p>
+<h2 style="text-align: center">Units Available in WeBWorK</h2>
 <p>
-Some WeBWorK problems ask for answers with units.  Below is a list of basic units
-and how they need to be abbreviated in WeBWorK answers.  In some problems, you
-may need to combine units (e.g, velocity might be in <code>ft/s</code> for feet per
-second).
-<center>
-<table border="1" cellpadding="4">
-<tr> <th> Unit <th> Abbreviation
-<tr><td colspan="2" align="center"><b>Time</b>
-<tr><td> Seconds  <td align="center">  s
-<tr><td> Minutes  <td align="center">  min
-<tr><td> Hours  <td align="center">  hr
-<tr><td> Days  <td align="center">  day
-<tr><td> Years  <td align="center">  yr
-<tr><td> Milliseconds  <td align="center">  ms
+	Some WeBWorK problems ask for answers with units. Below is a list of basic units and how they need to be abbreviated
+	in WeBWorK answers. In some problems, you may need to combine units (e.g, velocity might be in
+	<code style="color:black">ft/s</code> for feet per second).
+</p>
+<table style="margin: auto">
+	<tr>
+		<th style="padding: 0.5rem; border: 1px solid black">Unit</th>
+		<th style="padding: 0.5rem; border: 1px solid black">Abbreviation</th>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Distance</b>
-<tr><td> Feet  <td align="center">  ft
-<tr><td> Inches  <td align="center">  in
-<tr><td> Miles  <td align="center">  mi
-<tr><td> Meters  <td align="center">  m
-<tr><td> Centimeters  <td align="center">  cm
-<tr><td> Millimeters  <td align="center">  mm
-<tr><td> Kilometers  <td align="center">  km
-<tr><td> Angstroms  <td align="center">  A
-<tr><td> Light years  <td align="center">  light-year
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Time</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Seconds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">s</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Minutes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">min</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Hours</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">hr</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Days</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">day</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Years</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">yr</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Milliseconds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ms</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Mass</b>
-<tr><td> Grams  <td align="center">  g
-<tr><td> Kilograms  <td align="center">  kg
-<tr><td> Slugs  <td align="center">  slug
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Distance</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Feet</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ft</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Inches</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">in</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Miles</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mi</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Meters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">m</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Centimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cm</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Millimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mm</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Kilometers</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">km</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angstroms</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">A</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Light years</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">light-year</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Volume</b>
-<tr><td> Liters  <td align="center">  L
-<tr><td> Cubic Centimeters  <td align="center">  cc
-<tr><td> Milliliters  <td align="center">  ml
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Mass</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Grams</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">g</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Kilograms</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Slugs</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">slug</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Force</b>
-<tr><td> Newtons  <td align="center">  N
-<tr><td> Dynes  <td align="center">  dyne
-<tr><td> Pounds  <td align="center">  lb
-<tr><td> Tons  <td align="center">  ton
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Volume</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Liters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">L</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Cubic Centimeters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cc</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Milliliters</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ml</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Work/Energy</b>
-<tr><td> Joules  <td align="center">  J
-<tr><td> kilo Joule  <td align="center">  kJ
-<tr><td> ergs  <td align="center">  erg
-<tr><td> foot pounds  <td align="center">  lbf
-<tr><td> calories  <td align="center">  cal
-<tr><td> kilo calories  <td align="center">  kcal
-<tr><td> electron volts  <td align="center">  eV
-<tr><td> kilo Watt hours  <td align="center">  kWh
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Force</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Newtons</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">N</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Dynes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">dyne</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Pounds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">lb</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Tons</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">ton</td>
+	</tr>
 
-<tr><td colspan="2" align="center"><b>Misc</b>
-<tr><td> Amperes  <td align="center">  amp
-<tr><td> Moles  <td align="center">  mol
-<tr><td> Degrees Centrigrade  <td align="center">  degC
-<tr><td> Degrees Fahrenheit  <td align="center">  degF
-<tr><td> Degrees Kelvin  <td align="center">  degK
-<tr><td> Angle degrees <td align="center">  deg
-<tr><td> Angle radians <td align="center">  rad
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Work/Energy</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Joules</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">J</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo Joule</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kJ</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">ergs</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">erg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">foot pounds</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">lbf</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">calories</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">cal</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo calories</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kcal</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">electron volts</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">eV</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">kilo Watt hours</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">kWh</td>
+	</tr>
 
+	<tr>
+		<td colspan="2" style="padding: 0.5rem; border: 1px solid black; text-align: center"><b>Misc</b></td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Amperes</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">amp</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Moles</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mol</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Centrigrade</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degC</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Fahrenheit</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degF</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Kelvin</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degK</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angle degrees</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">deg</td>
+	</tr>
+	<tr>
+		<td style="padding: 0.5rem; border: 1px solid black">Angle radians</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">rad</td>
+	</tr>
 </table>
-
-More Units at <a href="http://webwork.maa.org/wiki/Units">http://webwork.maa.org/wiki/Units</a>
-
-</center>
+<p style="text-align: center">
+	<a href="http://webwork.maa.org/wiki/Units" target="ww_help">More details on units in WeBWorK</a>
+</p>

--- a/htdocs/js/apps/Knowls/knowl.js
+++ b/htdocs/js/apps/Knowls/knowl.js
@@ -55,7 +55,10 @@
 			} else {
 				insertElt = knowl.closest('li');
 				if (insertElt) {
-					insertElt.after(knowl.knowlContainer);
+					const newLi = document.createElement('li');
+					newLi.style.listStyle = 'none';
+					newLi.append(knowl.knowlContainer);
+					insertElt.after(newLi);
 				} else {
 					let append = false;
 					insertElt = knowl;


### PR DESCRIPTION
This was brought to my attention by a communication with someone working on accessibility issues for WeBWorK problems embedded in LibreTexts.

One issue is that of headings not being at the correct level.  This is actually a somewhat complicated issue for these help files.  For now I started the headings with `h2`s.  Generally that will work for in webwork and most other places.  It assumes there is an `h1` somewhere before.  However, the complication is if the help file is already inside a deeper level, or if the the problem itself is already in a deeper level.  Then the headings in the help file will not be at the correct level, and could mess up the heading structure of the page containing it.  So another option that may need to be considered is not having headings at all in the help files.