### PR TITLE
Move cssnano from dependencies to devDependencies in the htdocs/package.json file.

### DIFF
--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -11,13 +11,13 @@
         "prepare": "npm run generate-assets"
     },
     "dependencies": {
-        "cssnano": "^5.1.4",
         "jsxgraph": "^1.4.2",
         "mathquill": "github:openwebwork/mathquill"
     },
     "devDependencies": {
         "autoprefixer": "^10.4.2",
         "chokidar": "^3.5.3",
+        "cssnano": "^5.1.7",
         "postcss": "^8.4.6",
         "rtlcss": "^3.5.0",
         "sass": "^1.49.0",


### PR DESCRIPTION
This was a minor mistake made when I added this dependency.  It certainly doesn't matter much, it is just where it should be.