### PR TITLE
Fix possibly undefined input in mqeditor.js.

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -12,7 +12,7 @@
 	const setupMQInput = (mq_input) => {
 		const answerLabel = mq_input.id.replace(/^MaThQuIlL_/, '');
 		const input = document.getElementById(answerLabel);
-		const inputType = input.type;
+		const inputType = input?.type;
 		if (typeof(inputType) != 'string'
 			|| inputType.toLowerCase() !== 'text'
 			|| !input.classList.contains('codeshard'))


### PR DESCRIPTION
This can happen if a problem is in a scaffold that can not be opened.  The hidden MathAuill latex input is still output on the page, and the mqeditor.js code then acts on it, but can't find the corresponding text input.