### PR TITLE
Fix tab order for the three point quadratic and four point cubic tools.

### DIFF
--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -1174,7 +1174,8 @@ window.graphTool = (containerId, options) => {
 							if (e.key !== 'Tab' ||
 								(index === 0 && e.shiftKey) ||
 								(index === gt.graphedObjs.length - 1 && !e.shiftKey) ||
-								(a.length > 1 && ((pIndex === 0 && !e.shiftKey) || (pIndex === 1 && e.shiftKey)))
+								(a.length > 1 &&
+									((pIndex === 0 && !e.shiftKey) || (pIndex === a.length - 1 && e.shiftKey)))
 							)
 								return;
 
@@ -1194,8 +1195,8 @@ window.graphTool = (containerId, options) => {
 
 							obj.blur();
 						};
+						point.rendNode.addEventListener('keydown', point.focusOutHandler);
 					}
-					point.rendNode.addEventListener('keydown', point.focusOutHandler);
 
 					// Attach a focusin handler to all points to update the coordinates display.
 					point.focusInHandler = (e) => gt.setTextCoords(point.X(), point.Y());


### PR DESCRIPTION
There was an indexing error in the logic of the tab focus handler of the selection tool that results in the last defining point of an object that has three or more defining points not working correctly.

To see the issue, graph any object and then graph a quadratic or cubic after that.  Immediately after completing the graph of the quadratic or cubic hit shift-tab.  With the code in the release candidate branch the focus will jump back to the last point on first object that was graphed.  With this pull request the focus will go to the next to last point on the quadratic or cubic as it should.

You can use the attached problem to test this.
[Demo.pg.txt](https://github.com/openwebwork/pg/files/8544732/Demo.pg.txt)
