### PR TITLE
Fix pointer focus for the center of a circle.

### DIFF
--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -664,6 +664,11 @@ window.graphTool = (containerId, options) => {
 			));
 			this.definingPts.push(center, point);
 			this.focusPoint = center;
+
+			// Redefine the circle's hasPoint method to return true if the center point has the given coordinates, so
+			// that a pointer over the center point will give focus to the object with the center point activated.
+			const circleHasPoint = this.baseObj.hasPoint.bind(this.baseObj);
+			this.baseObj.hasPoint = (x, y) => circleHasPoint(x, y) || center.hasPoint(x, y);
 		}
 
 		handleKeyEvent(e, el) {


### PR DESCRIPTION
Curently the center point of a circle can not be focused by clicking on it with the mouse.  This is because the jsxgraph circle hasPoint method only returns true if the circle itself contains the given point, but not if the center point contains the given point.  So redefine the hasPoint method for a circle to fix that.