### PR TITLE
In contextFraction only use \textstyle for mixed numbers.

### DIFF
--- a/macros/contextFraction.pl
+++ b/macros/contextFraction.pl
@@ -907,11 +907,16 @@ sub string {
 sub TeX {
   my $self = shift; my $equation = shift; shift; shift; my $prec = shift;
   my ($a,$b) = @{$self->{data}}; my $n = "";
+  my $textstyle = '';
   return "$a" if $b == 1;
-  if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b)
-    {$n = int($a/$b); $a = CORE::abs($a) % $b; $n .= " " unless $a == 0}
+  if ($self->getFlagWithAlias("showMixedNumbers","showProperFractions") && CORE::abs($a) > $b) {
+    $n = int($a/$b);
+    $a = CORE::abs($a) % $b;
+    $n .= ' ' unless $a == 0;
+    $textstyle = '\\textstyle';
+  }
   my $s = ""; ($a,$s) = (-$a,"-") if $a < 0;
-  $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{\\textstyle\\frac{$a}{$b}}")
+  $n .= ($self->{isHorizontal} ? "$s$a/$b" : "${s}{$textstyle\\frac{$a}{$b}}")
     unless $a == 0 && $n ne '';
   return "$n";
 }


### PR DESCRIPTION
  useTextstyle controls if the fraction's TeX output is displayed
  using \textstyle or not. By default this is turned on to
  match current behavior. It can now be turned off for users
  who want to display fractions without \textstyle.