### PR TITLE
MathQuill fix for RTL languages

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/htdocs/js/apps/MathQuill/mqeditor.css
@@ -15,6 +15,7 @@ span[id^="mq-answer"].incorrect {
 }
 
 span[id^="mq-answer"] {
+	/*rtl:ignore*/
 	direction: ltr;
 	padding: 4px 5px 2px 5px;
 	border-radius: 4px !important;
@@ -31,6 +32,7 @@ input[type="text"].codeshard.mq-edit {
 	max-height: 95vh;
 	position: fixed;
 	font-size: .75em;
+	/*rtl:ignore*/
 	direction: ltr;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
MathQuill when used in an RTL language should still create the input boxes as LTR and the menu should internally be in LTR so the symbols will appear properly.

To test, open a problem (the `blankProblem.pg` is good enough).
Change the course language to `he-il` (you can add `$language = 'he-il';` to the `simple.conf` file of the course, and then comment/uncomment that line when testing).

Before the patch:
  1. The MathQuill toolbar (when in Hebrew) will be garbled:
     - the icons for roots and exponents are displayed wrong (sort of partially mirrored right-to-left).
  2. Using those buttons or typing `4^5` or `sqrt` will get a messed up display inside the formatted input box.
  3. Also `5!` will get the factorial displayed on the left side of the `5`.
  4. Typing `sin(5x)` puts the argument on the left of the `sin`.

The patch tells `rtlcss` not to mirror the `direction` settings which were intended to prevent such problems.

After installing the patch you need to run `npm install` in `/opt/webwork/pg/htdocs` before checking that the fix works.