### PR TITLE
Fix the prevention of creating degenerate objects with keyboard contols.

### DIFF
--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -38,6 +38,7 @@
 					}
 
 					el.setPosition(JXG.COORDS_BY_USER, [x, el.Y()]);
+					gt.board.update();
 				}
 			},
 

--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -452,6 +452,7 @@ window.graphTool = (containerId, options) => {
 		else if (y > boundingBox[1]) y = boundingBox[1] - gt.snapSizeY;
 
 		point1.setPosition(JXG.COORDS_BY_USER, [x, y]);
+		gt.board.update();
 	};
 
 	// Prevent paired points from being moved into the same position by a drag.  This

--- a/htdocs/js/apps/GraphTool/quadratictool.js
+++ b/htdocs/js/apps/GraphTool/quadratictool.js
@@ -38,6 +38,7 @@
 					}
 
 					el.setPosition(JXG.COORDS_BY_USER, [x, el.Y()]);
+					gt.board.update();
 				}
 			},
 


### PR DESCRIPTION
When graphing a parabola (via any of the tools that do so) or a cubic it is possible to create degenerate objects.  The code that is supposed to prevent that wasn't quite working right.  The jsxgraph board object needs to be updated after setting the position of a point programatically.

To test this graph any of those objects and then move one of the defining points of the object around with the keyboard.  For example, graph a three point quadratic and try to move one point onto the same vertical line as another point.  That should not be possible.