### PR TITLE
Make knowls wait until the page css has loaded before initializing.

### DIFF
--- a/htdocs/js/apps/Knowls/knowl.js
+++ b/htdocs/js/apps/Knowls/knowl.js
@@ -15,6 +15,11 @@
 	};
 
 	const initializeKnowl = (knowl) => {
+		if (getComputedStyle(knowl)?.display === '') {
+			setTimeout(() => initializeKnowl(knowl), 100);
+			return;
+		}
+
 		knowl.dataset.bsToggle = 'collapse';
 		if (!knowl.knowlContainer) {
 			knowl.knowlContainer = document.createElement('div');


### PR DESCRIPTION
This fixes issue [webwork2#1739](https://github.com/openwebwork/webwork2/issues/1739).

In the PG problem editor, the page in the iframe is not displayed until
after the page loads.  As such the javascript getComputedStyle method
fails.  The same things happens with the graphtool.  The same solution
is now implemented for knowls.