### PR TITLE
Fix the mathview button for essay answers (for develop).

### DIFF
--- a/htdocs/js/apps/MathView/mathview.js
+++ b/htdocs/js/apps/MathView/mathview.js
@@ -68,8 +68,12 @@ window.addEventListener('DOMContentLoaded', function () {
 		var input = this;
 
 		/* define the button and place it */
-		var button = $('<a>', {href: '#', class: 'btn', style: 'margin-left : 2ex; vertical-align : top'})
-			.html('<span class="icon icon-pencil" data-alt="Equation Editor"></span>')
+		var button = $('<a>', {
+			href: '#',
+			class: 'btn btn-sm btn-secondary codeshard-btn',
+			style: 'margin-left : 2ex; vertical-align : top'
+		})
+			.html('<i class="fa-solid fa-pencil" data-alt="Equation Editor"></i>')
 		$(input).after(button);
 		options = {
 			renderingMode: 'LATEX',


### PR DESCRIPTION
This did not get updated to the new versions of bootstrap and fontawesome.

This fixes the other part of https://github.com/openwebwork/webwork2/issues/1774.