### PR TITLE
update the names of tmp folders for LaTeX images

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -175,7 +175,7 @@ sub footer {
 sub draw {
 	my $self = shift;
 
-	my $working_dir = WeBWorK::PG::ImageGenerator::makeTempDirectory(WeBWorK::PG::IO::ww_tmp_dir(), "tikz");
+	my $working_dir = WeBWorK::PG::ImageGenerator::makeTempDirectory(WeBWorK::PG::IO::ww_tmp_dir(), "latex");
 	my $data;
 
 	my $ext = $self->ext;


### PR DESCRIPTION
This is not important. But recent investigations had me seeing tmp folders with "tikz" in the name that had nothing to do with tikz. This changes that.