### PR TITLE
correct 'LaTeXImage' to 'PGlateximage'

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2842,9 +2842,9 @@ Usage:
 
     image($image, width => 100, height => 100, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
-where C<$image> can be a local file path, URL, WWPlot object, or LaTeXImage object,
-C<width> and C<height> are pixel counts for HTML display, while C<tex_size> is
-per 1000 applied to linewidth (for example 800 leads to 0.8\linewidth)
+where C<$image> can be a local file path, URL, WWPlot object, PGlateximage object,
+or PGtikz object, C<width> and C<height> are pixel counts for HTML display,
+while C<tex_size> is per 1000 applied to linewidth (for example 800 leads to 0.8\linewidth)
 
     image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => ['alt text 1','alt text 2'], extra_html_tags => 'style="border:solid black 1pt"');
     image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => 'common alt text', extra_html_tags => 'style="border:solid black 1pt"');
@@ -2907,7 +2907,7 @@ sub image {
 	while(@image_list) {
 		my $image_item = shift @image_list;
 		$image_item = insertGraph($image_item)
-			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'LaTeXImage' || ref $image_item eq 'PGtikz');
+			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'PGlateximage' || ref $image_item eq 'PGtikz');
 		my $imageURL = alias($image_item)//'';
 		$imageURL = ($envir{use_site_prefix})? $envir{use_site_prefix}.$imageURL : $imageURL;
 		my $out = "";


### PR DESCRIPTION
I think this one is worthy of a hotfix. If you have a PGlateximage object, you currently cannot pass it directly to `image()` as you can with a `PGtikz` object or a `WWplot` object. You still have to use `image(insertGraph())`. I think this is just an oversight we made when changing the name of `LaTeXImage.pl` to `PGlateximage.pl`. I'd like to be able to tell people (and documentation) you do not need `insertGraph()`.

If you agree with this as a hotfix, what is the right way to put this into `develop` as well?