### PR TITLE
Fix styles for tables output by begintable/endtable in PGbasicmacros.pl.

### DIFF
--- a/htdocs/js/apps/Problem/problem.scss
+++ b/htdocs/js/apps/Problem/problem.scss
@@ -100,9 +100,11 @@
 		}
 	}
 
-	table {
+	.pg-table {
+		text-align: center;
 		thead, tbody, tfoot, tr, td, th {
-			border: revert;
+			padding: 0.25rem;
+			border: 1px solid black;
 		}
 	}
 }

--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -2756,7 +2756,7 @@ sub begintable {
 		|| $displayMode eq 'HTML_asciimath'
 		|| $displayMode eq 'HTML_LaTeXMathML'
 		|| $displayMode eq 'HTML_img') {
-		$out .= "<TABLE BORDER='1' STYLE='text-align:center;'>\n"
+		$out .= '<table class="pg-table">';
 	}
 	else {
 		$out = "Error: PGbasicmacros: begintable: Unknown displayMode: $displayMode.\n";
@@ -2783,7 +2783,7 @@ sub endtable {
 		|| $displayMode eq 'HTML_asciimath'
 		|| $displayMode eq 'HTML_LaTeXMathML'
 		|| $displayMode eq 'HTML_img') {
-		$out .= "</TABLE>\n";
+		$out .= '</table>';
 	}
 	else {
 		$out = "Error: PGbasicmacros: endtable: Unknown displayMode: $displayMode.\n";


### PR DESCRIPTION
When the begintable method is called, instead of using the deprecated border attribute, instead add the `pg-table` css class.  The css for that class is defined in htdocs/js/apps/Problem/problem.scss`.

This is a small change for this particular table.  Much more like this needs to be done in general to make PG generate valid html without deprecated attributes.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8128#p19764 for a discussion on this particular issue.