### PR TITLE
Fix graphing of the third point for the GraphTool cubictool. (hotfix)

### DIFF
--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -231,7 +231,7 @@
 					// Get a new x coordinate that is to the right, unless that is off the board.
 					// In that case go left instead.
 					let newX = this.point3.X() + gt.snapSizeX;
-					while ([this.point1, this.point2].some((other, i) => newX === other.X())) x += gt.snapSizeX;
+					while ([this.point1, this.point2].some((other, i) => newX === other.X())) newX += gt.snapSizeX;
 
 					// If the computed new x coordinate is off the board, then we need to move the point back instead.
 					const boundingBox = gt.board.getBoundingBox();


### PR DESCRIPTION
Currently if you graph three consecutive points where each point is one unit to the left of the previously graphed point, then when the third point is graphed there will be an error that causes the graph tool to become mostly unresponsive.  The problem was an undefined variable being used in phase3 of that tool.

This is #727 for main for hotfix consideration.