### PR TITLE
Wrap solutions and hints in <div>...</div>.

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1186,7 +1186,7 @@ sub SOLUTION {
 	return "" if $solution_body eq "";
 
 	if ($displayMode =~ /HTML/) {
-		TEXT($PAR, knowlLink(SOLUTION_HEADING(), value => $solution_body, type => 'solution'));
+		TEXT('<div>', knowlLink(SOLUTION_HEADING(), value => $solution_body, type => 'solution'), '</div>');
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN SOLUTION\n"
@@ -1211,7 +1211,7 @@ sub HINT {
 	my $hint_body = hint(@_);
 	return unless $hint_body;
 	if ($displayMode =~ /HTML/) {
-		TEXT($PAR, knowlLink(HINT_HEADING(), value => $hint_body, type => 'hint'));
+		TEXT('<div>', knowlLink(HINT_HEADING(), value => $hint_body, type => 'hint'), '</div>');
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN HINT\n"


### PR DESCRIPTION
Don't just start a <p> tag, and never end it.  This removes the <p> tag and wraps solutions and hints in properly started and ended <div> tags.

In addition to making this output valid html, this ensures that knowl contents are placed immediately after a hint or solution.

This doesn't fix the bigger issue of the $PAR usage.  Problems in the OPL use this frequently.  The problem is that $PAR starts a <p> tag, but never ends it.  This results in invalid html.