### PR TITLE
Fix vertical spacing around hints and solutions in html.

### DIFF
--- a/htdocs/js/apps/Knowls/knowl.css
+++ b/htdocs/js/apps/Knowls/knowl.css
@@ -9,6 +9,11 @@
 	padding: 0 2px;
 }
 
+.knowl-container {
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+
 .knowl:hover,
 .knowl.active {
 	border-bottom: 2px solid #aaf;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1186,7 +1186,8 @@ sub SOLUTION {
 	return "" if $solution_body eq "";
 
 	if ($displayMode =~ /HTML/) {
-		TEXT('<div>', knowlLink(SOLUTION_HEADING(), value => $solution_body, type => 'solution'), '</div>');
+		TEXT('<div class="knowl-container">',
+			knowlLink(SOLUTION_HEADING(), value => $solution_body, type => 'solution'), '</div>');
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN SOLUTION\n"
@@ -1211,7 +1212,7 @@ sub HINT {
 	my $hint_body = hint(@_);
 	return unless $hint_body;
 	if ($displayMode =~ /HTML/) {
-		TEXT('<div>', knowlLink(HINT_HEADING(), value => $hint_body, type => 'hint'), '</div>');
+		TEXT('<div class="knowl-container">', knowlLink(HINT_HEADING(), value => $hint_body, type => 'hint'), '</div>');
 	} elsif ($displayMode =~ /TeX/) {
 		TEXT(
 			"\n%%% BEGIN HINT\n"


### PR DESCRIPTION
After switching hints and solutions from being contained in `<p>...</p>` to being contained in `<div>...</div>` the vertical spacing above and below hints and solutions was removed.  This adds that spacing back.