### PR TITLE
Fix an errant regex check that doubly base64 encoded Geogebra applet states.

### DIFF
--- a/macros/AppletObjects.pl
+++ b/macros/AppletObjects.pl
@@ -132,12 +132,12 @@ sub insertAll {
 
 	my $base_64_encoded_answer_value;
 	my $decoded_answer_value;
-	if ($answer_value =~ /<XML|<?xml/i) {
+	if ($answer_value =~ /<\??xml/i) {
 		$base_64_encoded_answer_value = $self->base64_encode($answer_value);
 		$decoded_answer_value         = $answer_value;
 	} else {
 		$decoded_answer_value = $self->base64_decode($answer_value);
-		if ($decoded_answer_value =~ /<XML|<?xml/i) {
+		if ($decoded_answer_value =~ /<\??xml/i) {
 			# Great, we've decoded the answer to obtain an xml string
 			$base_64_encoded_answer_value = $answer_value;
 		} else {


### PR DESCRIPTION
I disovered this thanks to an observation of @drdrew's while attempting to diagnose an issue with a Geogebra problem written by another author. It turns out that one part of the problem was the applet state being doubly base64 encoded.