### PR TITLE
Added new units to Units.pm

### DIFF
--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -129,7 +129,9 @@ our %known_units = (
 	},
 	# TIME
 	# s     -- seconds
-	# ms    -- miliseconds
+	# ms    -- milliseconds
+	# us    -- microseconds
+	# ns    -- nanoseconds
 	# min   -- minutes
 	# hr    -- hours
 	# day   -- days
@@ -150,6 +152,14 @@ our %known_units = (
 	},
 	'ms' => {
 		'factor' => 0.001,
+		's'      => 1
+	},
+	'us' => {
+		'factor' => 1E-6,
+		's'      => 1
+	},
+	'ns' => {
+		'factor' => 1E-9,
 		's'      => 1
 	},
 	'min' => {
@@ -214,6 +224,8 @@ our %known_units = (
 	# um   -- micrometer
 	# nm   -- nanometer
 	# A    -- Angstrom
+	# pm   -- picometer
+	# fm   -- femtometer
 	#
 	'km' => {
 		'factor' => 1000,
@@ -241,6 +253,14 @@ our %known_units = (
 	},
 	'A' => {
 		'factor' => 1E-10,
+		'm'      => 1
+	},
+	'pm' => {
+		'factor' => 1E-12,
+		'm'      => 1
+	},
+	'fm' => {
+		'factor' => 1E-15,
 		'm'      => 1
 	},
 	# ENGLISH LENGTHS
@@ -347,7 +367,7 @@ our %known_units = (
 		's'      => -1
 	},
 	# MASS
-	# mg   -- miligrams
+	# mg   -- milligrams
 	# g    -- grams
 	# kg   -- kilograms
 	# tonne -- metric ton
@@ -477,6 +497,7 @@ our %known_units = (
 	# keV    -- kilo electron volt
 	# MeV    -- mega electron volt
 	# GeV    -- giga electron volt
+	# TeV    -- tera electron volt
 	# kWh    -- kilo Watt hour
 	#
 	'J' => {
@@ -551,6 +572,12 @@ our %known_units = (
 		'kg'     => 1,
 		's'      => -2
 	},
+	'TeV' => {
+		'factor' => 1.6022E-7,
+		'm'      => 2,
+		'kg'     => 1,
+		's'      => -2
+	},
 	'kWh' => {
 		'factor' => 3.6E6,
 		'm'      => 2,
@@ -560,6 +587,8 @@ our %known_units = (
 	# POWER
 	# W      -- Watt
 	# kW     -- kilo Watt
+	# MW     -- mega Watt
+	# mW     -- milli Watt
 	# hp     -- horse power  746 W
 	#
 	'W' => {
@@ -570,6 +599,18 @@ our %known_units = (
 	},
 	'kW' => {
 		'factor' => 1000,
+		'm'      => 2,
+		'kg'     => 1,
+		's'      => -3
+	},
+	'MW' => {
+		'factor' => 1E6,
+		'm'      => 2,
+		'kg'     => 1,
+		's'      => -3
+	},
+	'mW' => {
+		'factor' => 0.001,
 		'm'      => 2,
 		'kg'     => 1,
 		's'      => -3
@@ -657,20 +698,40 @@ our %known_units = (
 	},
 	# ELECTRICAL UNITS
 	# C      -- Coulomb
+	# mC     -- milliCoulomb
+	# uC     -- microCoulomb
+	# nC     -- nanoCoulomb
 	# V      -- volt
-	# mV     -- milivolt
+	# mV     -- millivolt
 	# kV     -- kilovolt
 	# MV     -- megavolt
 	# F      -- Farad
-	# mF     -- miliFarad
+	# mF     -- milliFarad
 	# uF     -- microFarad
 	# ohm    -- ohm
 	# kohm   -- kilo-ohm
 	# Mohm	 -- mega-ohm
 	# S		 -- siemens
+	# mA     -- milli-ampere
+	# mamp   -- milli-ampere
 	#
 	'C' => {
 		'factor' => 1,
+		'amp'    => 1,
+		's'      => 1,
+	},
+	'mC' => {
+		'factor' => 0.001,
+		'amp'    => 1,
+		's'      => 1,
+	},
+	'uC' => {
+		'factor' => 1e-6,
+		'amp'    => 1,
+		's'      => 1,
+	},
+	'nC' => {
+		'factor' => 1e-9,
 		'amp'    => 1,
 		's'      => 1,
 	},
@@ -751,14 +812,29 @@ our %known_units = (
 		'amp'    => 2,
 		's'      => 3,
 	},
+	'mA' => {    # milliampere
+		'factor' => 0.001,
+		'amp'    => 1,
+	},
+	'mamp' => {
+		'factor' => 0.001,
+		'amp'    => 1,
+	},
 	# MAGNETIC UNITS
-	# T	 	 -- tesla
-	# G	 	 -- gauss
-	# Wb	 -- weber
-	# H	 	 -- henry
+	# T      -- tesla
+	# mT     -- millitesla
+	# G      -- gauss
+	# Wb     -- weber
+	# H      -- henry
 	#
 	'T' => {    # also kg/A s^2		N s/C m
 		'factor' => 1,
+		'kg'     => 1,
+		'amp'    => -1,
+		's'      => -2,
+	},
+	'mT' => {
+		'factor' => 0.001,
 		'kg'     => 1,
 		'amp'    => -1,
 		's'      => -2,
@@ -830,6 +906,7 @@ our %known_units = (
 	# Sv	-- sievert, dose equivalent radiation	http://xkcd.com/radiation
 	# mSv	-- millisievert				http://blog.xkcd.com/2011/03/19/radiation-chart
 	# uSv	-- microsievert				http://blog.xkcd.com/2011/04/26/radiation-chart-update
+	# Bq    -- becquerel, radioactivity             https://en.wikipedia.org/wiki/Becquerel
 	#
 	'Sv' => {
 		'factor' => 1,
@@ -845,6 +922,10 @@ our %known_units = (
 		'factor' => 0.000001,
 		'm'      => 2,
 		's'      => -2,
+	},
+	'Bq' => {
+		'factor' => 1,
+		's'      => -1,
 	},
 	# BIOLOGICAL & CHEMICAL UNITS
 	# mmol	-- milli mole

--- a/t/units/add_units.t
+++ b/t/units/add_units.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use Units;
+use Parser::Legacy::NumberWithUnits;
+
+loadMacros('parserNumberWithUnits.pl');
+
+my $Flops = { name => 'flops', conversion => { factor => 1, s => -1 } };
+my $bogomips;
+
+my $inv_sec = NumberWithUnits(4, 's^-1');
+
+subtest 'Unknown unit' => sub {
+	like
+		dies { $bogomips = NumberWithUnits(4, 'flops') },
+		qr/^Unrecognizable unit: \|flops\|/,
+		"Dies if it can't find the unit";
+};
+
+subtest 'Add a new unit' => sub {
+	my $todo = todo 'This will work when adding a new unit is fixed';
+	ok(
+		#lives { $bogomips = NumberWithUnits( 4, 'flops', {newUnit => $Flops}) },
+		lives { $bogomips = NumberWithUnits(4, 'flops', { newUnit => 'flops' }) },
+		"Can add a new unit in NumberWithUnits"
+	) or note($@);
+
+	ok(lives { check_score($bogomips, $inv_sec) }, 'This will work when adding a new unit is fixed');
+};
+
+subtest 'Overwrite an existing unit' => sub {
+	my $Hurts = { name => 'Hz', conversion => { factor => 1, s => -1 } };
+	my $donut = NumberWithUnits(4, 'Hz', { newUnit => $Hurts });
+	my $cps   = NumberWithUnits(4, 'cycles*s^-1');
+
+	my $todo = todo 'Will adding a newUnit overwrite the existing unit?';
+	is check_score($donut, $cps),     0, "We redefined the Hertz";
+	is check_score($donut, $inv_sec), 1, "Redefined as inverse seconds";
+};
+
+done_testing();

--- a/t/units/basic_parser.t
+++ b/t/units/basic_parser.t
@@ -23,7 +23,6 @@ methods are working.
 =cut
 
 use Test2::V0 '!E', { E => 'EXISTS' };
-use Scalar::Util qw(blessed);
 
 die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
 do "$ENV{PG_ROOT}/t/build_PG_envir.pl";

--- a/t/units/conversions.t
+++ b/t/units/conversions.t
@@ -119,7 +119,7 @@ subtest 'Check astronomical units' => sub {
 		'parsec conversion';
 };
 
-subtest 'Recently added electrical units' => sub {
+subtest 'Additional electrical units' => sub {
 	is multiply_by(1000, evaluate_units('eV')), { evaluate_units('keV') }, 'kilo-electron volt conversion';
 	is multiply_by(1E6,  evaluate_units('eV')), { evaluate_units('MeV') }, 'mega-electron volt conversion';
 	is multiply_by(1E9,  evaluate_units('eV')), { evaluate_units('GeV') }, 'giga-electron volt conversion';

--- a/t/units/conversions.t
+++ b/t/units/conversions.t
@@ -1,0 +1,143 @@
+#!/usr/bin/perl -w
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use lib "$ENV{PG_ROOT}/lib";
+use Units;
+
+subtest 'Check fundamental units' => sub {
+	is \%Units::fundamental_units,
+		{
+			factor => 1,
+			m      => 0,
+			kg     => 0,
+			s      => 0,
+			rad    => 0,
+			degC   => 0,
+			degF   => 0,
+			degK   => 0,
+			mol    => 0,
+			amp    => 0,
+			cd     => 0,
+		},
+		'Fundamental units correct'; # or bail_out('Evaluating units doomed to failure if fundamental_units is borked');
+
+	my @base_units = keys %Units::fundamental_units;
+	is \%Units::known_units, hash {
+		field m => { factor => 1, m => 1 };
+
+		all_keys match qr/^(?:[a-z02]+(?:-\w+)?|%)$/i;
+		all_vals hash {
+			field factor => !number(0);
+
+			all_keys in_set(@base_units);
+			all_vals match qr/\d/;    # all integers except for factor, which is a non-zero float
+			etc();
+		};
+
+		etc();
+	}, 'Known units have consistent structure';
+};
+
+subtest 'Check base units' => sub {
+	is { evaluate_units('kg') },  in_base_units(kg => 1, factor => 1), 'kilogram';
+	is { evaluate_units('N') },   in_base_units(kg => 1, m => 1, s => -2, factor => 1), 'Newton';
+	is { evaluate_units('C') },   in_base_units(amp => 1, s => 1, factor => 1), 'Coulomb';
+	is { evaluate_units('V') },   in_base_units(amp => -1, s => -3, kg => 1, m => 2, factor => 1), 'Volt';
+	is { evaluate_units('J*s') }, in_base_units(kg => 1, m => 2, s => -1, factor => 1), 'Joule-seconds';
+
+	is { evaluate_units('V/m') }, in_base_units(kg => 1, m => 1, s => -3, amp => -1, factor => 1),
+		'Volts per metre';
+	is { evaluate_units('N/C') }, in_base_units(kg => 1, m => 1, s => -3, amp => -1, factor => 1),
+		'Newtons per Coulomb';
+};
+
+subtest 'Check equivalent electrical units' => sub {
+	is { evaluate_units('N/C') }, { evaluate_units('V/m') },       'N/C = V/m';
+	is { evaluate_units('C/N') }, { evaluate_units('m/V') },       'C/N = m/V';
+	is { evaluate_units('N/C') }, { evaluate_units('J/amp*m*s') }, 'N/C = J/amp*m*s';
+	is { evaluate_units('V/m') }, { evaluate_units('N/C') },       'V/m = N/C';
+};
+
+subtest 'Check electrical units' => sub {
+	is multiply_by(1000, evaluate_units('mF')),  { evaluate_units('F') },    'millifarad conversion';
+	is multiply_by(1E6,  evaluate_units('uF')),  { evaluate_units('F') },    'microfarad conversion';
+	is multiply_by(1000, evaluate_units('ohm')), { evaluate_units('kohm') }, 'kilo-ohm conversion';
+	is multiply_by(1E6,  evaluate_units('ohm')), { evaluate_units('Mohm') }, 'kilo-ohm conversion';
+	is multiply_by(1000, evaluate_units('mV')),  { evaluate_units('V') },    'millivolt conversion';
+	is multiply_by(1000, evaluate_units('V')),   { evaluate_units('kV') },   'kilovolt conversion';
+};
+
+subtest 'Check magnetic units' => sub {
+	is multiply_by(1e4, evaluate_units('G')), { evaluate_units('T') }, 'magnetic field strength conversion';
+	is { evaluate_units('V/ohm') }, { evaluate_units('V*S') },     'conductivity definition';
+	is { evaluate_units('Wb') },    { evaluate_units('T*m^2') },   'Weber definition';
+	is { evaluate_units('H') },     { evaluate_units('V*s/amp') }, 'Henry definition';
+};
+
+subtest 'Check biological and chemical units' => sub {
+	is multiply_by(1000, evaluate_units('micromol/L')), { evaluate_units('mmol/L') }, 'concentration conversion';
+	is multiply_by(10,   evaluate_units('mg/L')),       { evaluate_units('mg/dL') },  'concentration conversion';
+	is multiply_by(1e9,  evaluate_units('nanomol')),    { evaluate_units('mol') },    'concentration conversion';
+};
+
+subtest 'Check radiation units' => sub {
+	is multiply_by(1000, evaluate_units('mSv')), { evaluate_units('Sv') }, 'milli-Sievert conversion';
+	is multiply_by(1e6,  evaluate_units('uSv')), { evaluate_units('Sv') }, 'micro-Sievert conversion';
+	is { evaluate_units('kat') }, { evaluate_units('mol/s') }, 'catalitic activity';
+};
+
+subtest 'Check a collection of units' => sub {
+	is multiply_by(1822.88854680448, evaluate_units('me')), { evaluate_units('amu') }, 'atomic mass conversion';
+
+	is { evaluate_units('lx') }, { evaluate_units('lm/m^2') }, 'lux = lumen per square metre';
+
+	is multiply_by(1e9,  evaluate_units('Pa')),  { evaluate_units('GPa') }, 'gigapascal conversion';
+	is multiply_by(1000, evaluate_units('kPa')), { evaluate_units('MPa') }, 'kilopascal conversion';
+
+	is multiply_by(2 * 1000 * $Units::PI, evaluate_units('rad/s')), { evaluate_units('kHz') },
+		'kilohertz conversion';
+
+	is multiply_by(0.01, %Units::fundamental_units), { evaluate_units('%') }, 'percent conversion';
+
+	my $todo = todo 'use within() to fudge factor in 9th decimal place';
+	is multiply_by((180 / $Units::PI)**2, evaluate_units('deg^2')), { evaluate_units('sr') },
+		'solid angle conversion';
+};
+
+subtest 'Check astronomical units' => sub {
+	my $second_arc = 0.0174532925 / 60 / 60;
+
+	is multiply_by(299792458, evaluate_units('m/s')), { evaluate_units('c') }, 'speed of light conversion';
+	is { evaluate_units('c*yr') }, { evaluate_units('light-year') }, 'light year';
+
+	my $todo = todo 'use within() to fudge factor in 9th decimal place';
+	is multiply_by(cos($second_arc) / sin($second_arc), evaluate_units('AU')), { evaluate_units('parsec') },
+		'parsec conversion';
+};
+
+subtest 'Recently added electrical units' => sub {
+	is multiply_by(1000, evaluate_units('eV')), { evaluate_units('keV') }, 'kilo-electron volt conversion';
+	is multiply_by(1E6,  evaluate_units('eV')), { evaluate_units('MeV') }, 'mega-electron volt conversion';
+	is multiply_by(1E9,  evaluate_units('eV')), { evaluate_units('GeV') }, 'giga-electron volt conversion';
+
+	is multiply_by(1000, evaluate_units('mC')), { evaluate_units('C') }, 'miliCoulomb conversion';
+	is multiply_by(1E6,  evaluate_units('uC')), { evaluate_units('C') }, 'microCoulomb conversion';
+};
+
+done_testing();
+
+sub in_base_units {
+	my %provided_units = @_;
+	return { %Units::fundamental_units, %provided_units };
+}
+
+sub multiply_by {
+	my ($conversion, %unit) = @_;
+	$unit{factor} *= $conversion;
+	return \%unit;
+}
+

--- a/t/units/electromagnetic.t
+++ b/t/units/electromagnetic.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use Units;
+use Parser::Legacy::NumberWithUnits;
+
+loadMacros('parserNumberWithUnits.pl');
+
+my $watt      = NumberWithUnits(1,    'W');
+my $milliwatt = NumberWithUnits(1E3,  'mW');
+my $megawatt  = NumberWithUnits(1E-6, 'MW');
+
+my $amp      = NumberWithUnits(1, 'amp');
+my $milliamp = NumberWithUnits(1, 'mamp');
+
+my $tesla      = NumberWithUnits(1,    'T');
+my $millitesla = NumberWithUnits(1000, 'mT');
+my $ten_gauss  = NumberWithUnits(10,   'G');
+my $one_mT     = NumberWithUnits(1,    'mT');
+
+my $coulomb      = NumberWithUnits(1,    'C');
+my $millicoulomb = NumberWithUnits(1000, 'mC');
+my $microcoulomb = NumberWithUnits(1E6,  'uC');
+my $nanocoulomb  = NumberWithUnits(1E9,  'nC');
+
+subtest 'Power units' => sub {
+	is check_score($milliwatt, $watt), 1, '1000 milliwatts is 1 watt';
+	is check_score($megawatt,  $watt), 1, '10^-6 megawatts is 1 watt';
+};
+
+subtest 'LaTeX output' => sub {
+	is $millicoulomb->TeX, '1000\ {\rm mC}', 'LaTeX output for a thousand coulombs';
+
+	my $todo = todo 'Display units with greek mu';
+	is $microcoulomb->TeX, '1\times 10^{6}\ {\rm \mu C}', 'LaTeX output for micrometers';
+};
+
+subtest 'Charge' => sub {
+	is check_score($millicoulomb, $coulomb), 1, '1000 millicoulombs is 1 coulomb';
+	is check_score($nanocoulomb,  $coulomb), 1, '10^9 nanocoulombs is 1 coulomb';
+};
+
+subtest 'Magnetic field' => sub {
+	is check_score($millitesla, $tesla),     1, '1000 milliTesla is 1 Tesla';
+	is check_score($one_mT,     $ten_gauss), 1, '1 milliTesla is 10 Gauss';
+};
+
+done_testing();

--- a/t/units/electron_volts.t
+++ b/t/units/electron_volts.t
@@ -15,14 +15,18 @@ my %electron_volt = evaluate_units('eV');
 my %kev           = evaluate_units('keV');
 my %mev           = evaluate_units('MeV');
 my %gev           = evaluate_units('GeV');
+my %tev           = evaluate_units('TeV');
 
 is \%electron_volt, by_factor(1.6022E-19, \%joule),         'eV and joules differ by a factor of 1.6022 x 10^19';
 is \%kev,           by_factor(1000,       \%electron_volt), 'kilo is factor 1000';
 is \%mev,           by_factor(10**6,      \%electron_volt), 'mega is factor 10^6';
 is \%gev,           by_factor(10**9,      \%electron_volt), 'giga is factor 10^9';
+is \%tev,           by_factor(10**12,     \%electron_volt), 'tera is factor 10^12';
 
-done_testing;
+done_testing();
 
+# this sub is useful when reusing units for testing
+# NumberWithUnits is mutable and test order dependant
 sub by_factor {
 	my ($value, $unit) = @_;
 	my $new_unit = {%$unit};    # shallow copy hash values

--- a/t/units/length.t
+++ b/t/units/length.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use Units;
+use Parser::Legacy::NumberWithUnits;
+
+loadMacros('parserNumberWithUnits.pl');
+
+my $micron     = NumberWithUnits(1,   'um');
+my $picometer  = NumberWithUnits(1E6, 'pm');
+my $femtometer = NumberWithUnits(1E9, 'fm');
+
+subtest 'LaTeX output' => sub {
+	is $picometer->TeX, '1\times 10^{6}\ {\rm pm}', 'LaTeX output for 1E6 picometers';
+
+	my $todo = todo 'Display units with greek mu';
+	is $micron->TeX, '1\ {\rm \mu m}', 'LaTeX output for micrometers';
+};
+
+subtest 'Equivalent to micrometer' => sub {
+	is check_score($picometer,  $micron), 1, '1 micrometer in picometers';
+	is check_score($femtometer, $micron), 1, '1 micrometer in femtometers';
+};
+
+done_testing();

--- a/t/units/radiation.t
+++ b/t/units/radiation.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use Units;
+use Parser::Legacy::NumberWithUnits;
+
+loadMacros('parserNumberWithUnits.pl');
+
+my $sievert     = NumberWithUnits(1,   'Sv');
+my $sievert_mSv = NumberWithUnits(1E3, 'mSv');
+my $sievert_uSv = NumberWithUnits(1E6, 'uSv');
+
+my $becquerel         = NumberWithUnits(1, 'Bq');
+my $reciprocal_second = NumberWithUnits(1, 's^-1');
+
+subtest 'LaTeX output' => sub {
+	is $sievert->TeX, '1\ {\rm Sv}', 'LaTeX output for 1 sievert';
+
+	my $todo = todo 'Display units with greek mu';
+	is $sievert_uSv->TeX, '1\times 10^{6}\ {\rm \mu Sv}', 'LaTeX output for microSieverts';
+};
+
+subtest 'Equivalent dose' => sub {
+	is check_score($sievert_mSv, $sievert), 1, '1 Sv in mSv';
+	is check_score($sievert_uSv, $sievert), 1, '1 Sv in uSv';
+};
+
+subtest 'Radioactivity' => sub {
+	is check_score($becquerel, $reciprocal_second), 1, 'a becquerel is a reciprocal second';
+};
+
+done_testing();

--- a/t/units/time.t
+++ b/t/units/time.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use Units;
+use Parser::Legacy::NumberWithUnits;
+
+loadMacros('parserNumberWithUnits.pl');
+
+my $second      = NumberWithUnits(1, 's');
+my $millisecond = NumberWithUnits(1, 'ms');
+my $microsecond = NumberWithUnits(1, 'us');
+my $nanosecond  = NumberWithUnits(1, 'ns');    # used in optics
+
+my $min  = NumberWithUnits(1, 'min');
+my $hour = NumberWithUnits(1, 'hour');
+my $day  = NumberWithUnits(1, 'day');
+my $year = NumberWithUnits(1, 'yr');
+
+subtest 'LaTeX output' => sub {
+	is $second->TeX, '1\ {\rm s}', 'LaTeX output for 1 second';
+
+	my $todo = todo 'Display units with greek mu';
+	is $microsecond->TeX, '1\ {\rm \mu s}', 'LaTeX output for 1 microsecond';
+};
+
+subtest 'Shorter times' => sub {
+	is check_score($millisecond * Real(1000), $second), 1, 'a thousand millis in a second';
+	is check_score($microsecond * Real(1E6),  $second), 1, 'a million micros in a second';
+	is check_score($nanosecond * Real(1E9),   $second), 1, 'a billion nanos in a second';
+};
+
+subtest 'Longer times' => sub {
+	is check_score($min / Real(60),                  $second), 1, '60 seconds in each minute run';
+	is check_score($hour / Real(3600),               $second), 1, '60 minutes in an hour';
+	is check_score($day / Real(24 * 3600),           $second), 1, '24 hours a day';
+	is check_score($year / Real(365.25 * 24 * 3600), $second), 1, 'an extra day every 4 years';
+};
+
+done_testing();


### PR DESCRIPTION
This PR adds the Becquerel, the measure of radioactivity, and extends the second, metre, electron-volt, Coulomb, ampere and tesla to mostly smaller prefixes for electric and magnetic units.  These are used in the areas of electromagnetism and nuclear physics with a couple for problems on optics and large power projects.  Tests have been added for the new units in **t/units/**.  It also corrects the spelling of **mili** to **milli** (double L).

When writing the test for adding new units with an optional hashref, the tests failed using syntax that I use in working problems.  I've wrapped them in exception handling blocks and marked them with TODOs so that they pass, but are available for examination.

One point that might warrant discussion is the milliampere.  I've added it as `mamp` which is consistent, but unappealing as it's not obvious what it is.  I've also added `mA` which is in line with SI convention.

Units added:
microsecond, nanosecond
picometre, femtometre
tera electron-volt
Megawatt, milliwatt
milliCoulomb, microCoulomb, nanoCoulomb
milli-ampere
milli-tesla
Becquerel