### PR TITLE
Fix POD errors in the macros copied from the OPL.

### DIFF
--- a/lib/Matrix.pm
+++ b/lib/Matrix.pm
@@ -6,10 +6,10 @@ Matrix - Matrix of Reals
 Implements overrides for MatrixReal.pm for WeBWorK
 In general it is better to use MathObjects Matrices (Value::Matrix)
 in writing PG problem.  The answer checking is much superior with better
-error messages for syntax errors in student entries.  Some of the 
-subroutines in this file are still used behind the scenes 
+error messages for syntax errors in student entries.  Some of the
+subroutines in this file are still used behind the scenes
 by Value::Matrix to perform calculations,
-such as decompose_LR(). 
+such as decompose_LR().
 
 =head1 DESCRIPTION
 
@@ -38,9 +38,8 @@ use Carp;
 $Matrix::DEFAULT_FORMAT = '% #-19.12E ';
 # allows specification of the format
 
-=head4
+=head4 Method $matrix->_stringify()
 
-	Method $matrix->_stringify() 
 	-- overrides MatrixReal1 display mode
 
 =cut
@@ -77,17 +76,17 @@ sub _stringify {
 }
 
 =head3 Accessor functions
-	
+
 	(these are deprecated for direct use.  Use the covering Methods
 	 provided by MathObject Matrices instead.)
-	 
+
 	L($matrix) - return matrix L of the LR decomposition
 	R($matrix) - return matrix R of the LR decomposition
 	PL($matrix) - return permutation matrix
 	PR($matrix) - return permutation matrix
-	Original matrix is  PL * L * R *PR = M 
-	
-Obtain the Left Right matrices of the decomposition 
+	Original matrix is  PL * L * R *PR = M
+
+Obtain the Left Right matrices of the decomposition
 and the two pivot permutation matrices
 the original is M = PL*L*R*PR
 
@@ -143,9 +142,7 @@ sub PR {    # use this permuation on the right PL*L*R*PR =M
 
 }
 
-=head4
-
-	Method $matrix->rh_options
+=head4 Method $matrix->rh_options
 
 Meant for internal use when dealing with MatrixReal1
 
@@ -158,13 +155,11 @@ sub rh_options {
 	$self->[$MatrixReal1::OPTION_ENTRY];    # provides a reference to the options hash MEG
 }
 
-=head4
+=head4 Method $matrix->trace
 
-	Method $matrix->trace
-	
 	Returns: scalar which is the trace of the matrix.
-	
-	Used by MathObject Matrices for calculating the trace. 
+
+	Used by MathObject Matrices for calculating the trace.
 	Deprecated for direct use in PG questions.
 
 =cut
@@ -181,11 +176,9 @@ sub trace {
 	$sum;
 }
 
-=head4
+=head4 Method $new_matrix = $matrix->new_from_array_ref ([[a,b,c],[d,e,f]])
 
-	Method    $new_matrix = $matrix->new_from_array_ref ([[a,b,c],[d,e,f]])
-	
-	Deprecated in favor of using creation tools for MathObject Matrices 
+	Deprecated in favor of using creation tools for MathObject Matrices
 
 =cut
 
@@ -199,9 +192,7 @@ sub new_from_array_ref {    # this will build a matrix or a row vector from  [a,
 	$matrix;
 }
 
-=head4
-
-	Method $matrix->array_ref
+=head4 Method $matrix->array_ref
 
 Converts Matrix from an ARRAY to an ARRAY reference.
 
@@ -212,9 +203,7 @@ sub array_ref {
 	$this->[0];
 }
 
-=head4
-
-	Method $matrix->list
+=head4 Method $matrix->list
 
 Converts a Matrix column vector to an ARRAY (list).
 
@@ -231,10 +220,8 @@ sub list {    # this is used only for column vectors
 	@list;
 }
 
-=head4
+=head4 Method $matrix->new_row_matrix
 
-	Method $matrix->new_row_matrix
-	
 	Deprecated -- there are better tools for MathObject Matrices.
 
 Create a row 1 by n matrix from a list.  This subroutine appears to be broken
@@ -255,12 +242,11 @@ sub new_row_matrix {    # this builds a row vector from an array
 	$matrix;
 }
 
-=head4
+=head4 Method $matrix->proj
 
-	Method $matrix->proj
 	Provides behind the scenes calculations for MathObject Matrix->proj
 	Deprecated for direct use in favor of methods of MathObject matrix
-	
+
 =cut
 
 sub proj {
@@ -269,9 +255,8 @@ sub proj {
 	$self * $self->proj_coeff($vec);
 }
 
-=head4
+=head4 Method $matrix->proj_coeff
 
-	Method $matrix->proj_coeff
 	Provides behind the scenes calculations for MathObject Matrix->proj_coeff
 	Deprecated for direct use in favor of methods of MathObject matrix
 
@@ -292,12 +277,10 @@ sub proj_coeff {
 	$x_vector;
 }
 
-=head4
-
-	Method $matrix->new_column_matrix
+=head4 Method $matrix->new_column_matrix
 
 	Create column matrix from an ARRAY reference (list reference)
-	
+
 =cut
 
 sub new_column_matrix {
@@ -313,14 +296,12 @@ sub new_column_matrix {
 	$matrix;
 }
 
-=head4
+=head4 Method $matrix->new_from_col_vecs
 
 	This method takes an array of column vectors, or an array of arrays,
 	and converts them to a matrix where each column is one of the previous
 	vectors.
-	
-	Method $matrix->new_from_col_vecs
-	
+
 	Deprecated: The tools for creating MathObjects Matrices are simpler
 
 =cut
@@ -359,16 +340,14 @@ sub new_from_col_vecs {
 #  Modifications to MatrixReal.pm which allow use of complex entries
 ######################################################################
 
-=head3
+=head3 Overrides of MatrixReal which allow use of complex entries
 
-	Overrides of MatrixReal which allow use of complex entries
-	
 =cut
 
-=head4
+=head4 Function: cp()
 
-	Function: cp()
 	Provides ability to use complex numbers.
+
 =cut
 
 sub cp {    # MEG  makes new copies of complex number
@@ -377,9 +356,7 @@ sub cp {    # MEG  makes new copies of complex number
 	Complex1::cplx($z->Re, $z->Im);
 }
 
-=head4
-
-	Method $matrix->copy
+=head4 Method $matrix->copy
 
 =cut
 
@@ -418,9 +395,7 @@ sub copy {
 
 # MEG added 6/25/03 to accomodate complex entries
 
-=head4
-
-	Method $matrix->conj
+=head4 Method $matrix->conj
 
 =cut
 
@@ -430,9 +405,7 @@ sub conj {
 	$elem;
 }
 
-=head4
-
-	Method $matrix->transpose
+=head4 Method $matrix->transpose
 
 =cut
 
@@ -472,12 +445,11 @@ sub transpose {
 	$matrix1;
 }
 
-=head4
-
-	Method $matrix->decompose_LR
+=head4 Method $matrix->decompose_LR
 
 	Used by MathObjects Matrix for LR decomposition
-	Deprecated for direct use in PG problems. 
+	Deprecated for direct use in PG problems.
+
 =cut
 
 sub decompose_LR {

--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -22,9 +22,8 @@ use PGresource;
 
 our @ISA = qw ( PGcore  );    # look up features in PGcore -- in this case we want the environment.
 
-=head2
+=head2 new
 
-new
   Create one alias object per question (and per PGcore object since there is a unique PGcore per question.)
   Check that information is intact
   Construct unique id stub seeds -- the id stub seed is for this PGalias object which is

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -567,7 +567,7 @@ sub PG_restricted_eval {
 	WeBWorK::PG::Translator::PG_restricted_eval(@_);
 }
 
-=head2 base64 encoding and decoding
+=item base64 encoding and decoding
 
 	$str       = decode_base64($coded_str);
 	$coded_str = encode_base64($str);

--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -13,10 +13,6 @@
 # Artistic License for more details.
 ################################################################################
 
-=head2
-
-=cut
-
 =head2 loadMacros
 
 	loadMacros(@macroFiles)

--- a/macros/answers/ConditionalHint.pl
+++ b/macros/answers/ConditionalHint.pl
@@ -4,14 +4,13 @@ sub _ConditionalHint_init { };    # don't reload this file
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright � 2000-2007 The WeBWorK Project, http://openwebwork.sf.net/
-# $CVSHeader$
-# 
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of either: (a) the GNU General Public License as published by the
 # Free Software Foundation; either version 2, or (at your option) any later
 # version, or (b) the "Artistic License" which comes with this package.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
@@ -25,13 +24,13 @@ has entered an answer correctly.
 
 =head2 DESCRIPTION
 
-The subroutine ConditionalHint() allows a hint to be revealed 
-after a student has entered an answer correctly.  It is useful 
-for multi-part questions in which a hint for answering one part 
-should not be revealed until a previous part has been answered 
+The subroutine ConditionalHint() allows a hint to be revealed
+after a student has entered an answer correctly.  It is useful
+for multi-part questions in which a hint for answering one part
+should not be revealed until a previous part has been answered
 correctly.
 
-A subroutine IsAnswerCorrect() that returns 0 or 1 is also 
+A subroutine IsAnswerCorrect() that returns 0 or 1 is also
 provided.
 
 =head2 USAGE
@@ -48,7 +47,7 @@ Enter \( x^2 \) \{ ans_rule(20) \}
 ConditionalHint(
   ans_name=>$ans,
   ans_number=>1,
-  html_hint=>"$BR ${BBOLD}Hint:${EBOLD} 
+  html_hint=>"$BR ${BBOLD}Hint:${EBOLD}
   \( \displaystyle \int x^2 \, dx = \frac{x^3}{3} + C.\) $BR",
   tex_hint=>'',
 );

--- a/macros/contexts/contextInequalitiesAllowStrings.pl
+++ b/macros/contexts/contextInequalitiesAllowStrings.pl
@@ -5,12 +5,15 @@
     extra macros for Intermediate Algebra problems at CofI
 
 =head1 Synposis
+
     macros by R Cruz -- The College of Idaho
+
 =cut
 
 =head3 Allows string answers for the set of real numbers and the empty set
-       
+
 =pod
+
       Adds the string "All real numbers" to the Inequalities context
  NOT WORKING: Adds the string "No solution" to the Inequalities context
 

--- a/macros/graph/PGgraphgrid.pl
+++ b/macros/graph/PGgraphgrid.pl
@@ -8,7 +8,7 @@ PGgraphgrid.pl
 
 =head1 SYNOPSIS
 
-Provides subroutines plotting a parallelogram grid on a 
+Provides subroutines plotting a parallelogram grid on a
 graph object created by PGgraphmacros.pl.
 
 =head1 DESCRIPTION
@@ -19,11 +19,11 @@ Load the C<PGgraphgrid.pl> macro file.
 
 =item C<loadMacros("PGstandard.pl","MathObjects.pl","PGgraphmacros.pl","PGgraphgrid.pl");>
 
-= back
+=back
 
 The macro C<PGgraphgrid.pl> provides two different subroutines
 for graphing grids: the first one draws the grid using parallel lines
-and should be fast, and a second that draws each individual 
+and should be fast, and a second that draws each individual
 parallelogram and should be slow (but will suffer less from clipping):
 
 =over 12
@@ -34,14 +34,12 @@ parallelogram and should be slow (but will suffer less from clipping):
 
 =back
 
-Here C<$gr> is a graph object created by C<PGgraphmacros.pl>, 
-C<$B> is a two by two MathObjects matrix, the integers C<$hmin> and 
-C<$vmin> specify one corner of the grid, the integers C<$hmax> and 
+Here C<$gr> is a graph object created by C<PGgraphmacros.pl>,
+C<$B> is a two by two MathObjects matrix, the integers C<$hmin> and
+C<$vmin> specify one corner of the grid, the integers C<$hmax> and
 C<$vmax> specify the opposite corner of the grid, C<$color> is a string
 that specifies the drawing color, and C<$linewidth> is a positive integer
 for the line width.
-
-=over 12
 
 =head1 AUTHORS
 

--- a/macros/math/PGmorematrixmacros.pl
+++ b/macros/math/PGmorematrixmacros.pl
@@ -8,7 +8,7 @@ our $ArRaY = $main::PG->{ARRAY_PREFIX};
 =head2 NAME
 
 	macros/PGmorematrixmacros.pl
-	
+
 =cut
 
 sub _PGmorematrixmacros_init { }
@@ -67,12 +67,12 @@ sub random_diag_matrix {    ## Builds and returns a random diagonal \$n by \$n m
 	return $D;
 }
 
-=head4 swap_rows ($matrix, $row1, $row2) 
+=head4 swap_rows ($matrix, $row1, $row2)
 
 	(deprecated use MathObject Matrix instead)
 
-$matrix is assumed to be a RealMatrix1 object. 
-It is better to use MathObject Matrices and row swap mechanisms 
+$matrix is assumed to be a RealMatrix1 object.
+It is better to use MathObject Matrices and row swap mechanisms
 from MatrixReduce.pl instead.
 
 =cut
@@ -98,12 +98,12 @@ sub swap_rows {
 	return $B;
 }
 
-=head4  row_mult ($matrix, $scaler, $row) 
+=head4  row_mult ($matrix, $scaler, $row)
 
 	(deprecated use MathObject Matrix instead)
 
-$matrix is assumed to be a RealMatrix1 object. 
-It is better to use MathObject Matrices and row swap mechanisms 
+$matrix is assumed to be a RealMatrix1 object.
+It is better to use MathObject Matrices and row swap mechanisms
 from MatrixReduce.pl instead.
 
 =cut
@@ -129,7 +129,7 @@ sub row_mult {
 
 Adds a multiple of row1 to row2.
 
-$matrix is assumed to be a RealMatrix1 object. 
+$matrix is assumed to be a RealMatrix1 object.
 It is better to use MathObject Matrices and subroutines
 from MatrixReduce.pl instead.
 
@@ -153,9 +153,9 @@ sub linear_combo {
 	return $B;
 }
 
-=head2 
+=pod
 
-These should be compared to similar subroutines made later in 
+These should be compared to similar subroutines made later in
 MatrixCheckers.pl
 
 
@@ -191,7 +191,7 @@ ANS( basis_cmp( vectors_as_array_ref_in_array_ref, options_hash ) );
                             (This is only in unit mode)
                     'orthonormal' (Gives errors from orthogonal and orthonormal)
                             (This is only in orthonormal mode)
-                    'verbose' (Gives all the above answer messages)             
+                    'verbose' (Gives all the above answer messages)
 
     Returns an answer evaluator.
 
@@ -340,11 +340,11 @@ sub BASIS_CMP {
 
 =head4 compare_basis
 
-    compare_basis( $ans_hash, 
+    compare_basis( $ans_hash,
         %options
         ra_student_ans     # a reference to the array of students answer vectors
         rm_correct_ans,    # a reference to the correct answer matrix
-        %options               
+        %options
     )
 
 
@@ -373,8 +373,8 @@ sub compare_basis {
 		$vecs[$i] = $lin_space_tr * $vecs[$i];
 		($dim, $x_vector, $base_matrix) = $matrix_lr->solve_LR($vecs[$i]);
 		push(@ch_coord, $x_vector);
-		$errors = "A unique adapted answer could not be determined.  
-        Possibly the parameters have coefficient zero.<br>  dim = $dim base_matrix 
+		$errors = "A unique adapted answer could not be determined.
+        Possibly the parameters have coefficient zero.<br>  dim = $dim base_matrix
         is $base_matrix\n" if $dim;    # only print if the dim is not zero.
 	}
 
@@ -430,7 +430,7 @@ Most errors are handled well. Any error in an entry is caught by the PG_answer_e
 Right now the method basically ignores every thing outside the vectors. Also, an unmatched open parenthesis is caught,
 but a unmatched close parenthesis ends the vector, and since everything outside is ignored, no error is sent (other than the
 later when the length of the vectors is checked.
-In the end, the method returns an array of Matrix objects.   
+In the end, the method returns an array of Matrix objects.
 
 =cut
 
@@ -558,7 +558,7 @@ sub vec_list_string {
 
 	(this filter is not necessary when using MathObjects.  It may someday be useful
 	again if the AnswerEvaluator pipeline is used to its fullest extent. )
-	
+
     This filter was created to get, format, and evaluate each entry of the ans_array and ans_array_extension
     answer entry methods. Running this filter is necessary to get all the entries out of the answer
     hash. Each entry is evaluated and the resulting number is put in the display for student answer
@@ -675,11 +675,11 @@ sub ans_array_filter {
 
 }
 
-=head3 
+=pod
 
-The following subroutines, meant to be used with MatrixReal1 type matrices, are 
-deprecated.  In general you should use the MathObject Matrix type and the 
-checking methods in MatrixCheckers.pl 
+The following subroutines, meant to be used with MatrixReal1 type matrices, are
+deprecated.  In general you should use the MathObject Matrix type and the
+checking methods in MatrixCheckers.pl
 
 	are_orthogonal_vecs($vec_ref, %opts)
 	is_diagonal($matrix, %opts)
@@ -687,7 +687,7 @@ checking methods in MatrixCheckers.pl
 	display_correct_vecs($vec_ref, %opts)
 	vec_solution_cmp($vec,%opts)
 		filter: compare_vec_solution($rh_ans,%opts);
-	
+
 =cut
 
 sub are_orthogonal_vecs {

--- a/macros/math/PGnauGraphtheory.pl
+++ b/macros/math/PGnauGraphtheory.pl
@@ -697,6 +697,7 @@ sub GReulertrail_size {
 	my ($i, @deg, $pic, $comp, $diff, $temp, $graph, @index, @lowdeg);
 
 =pod
+
   for ($i = 0; $i < $size; $i++){
     push @lowdeg, 2;
   }
@@ -709,12 +710,13 @@ sub GReulertrail_size {
     }
     $graph = GRgraph_degrees(@deg);
     $comp = GRncomponents_graph($graph);
-    
+
     do {
       $diff = random (0, $size - 1, 1);
     } until ($lowdeg[$diff] < $size - 2);
     $lowdeg[$diff] += 2;
   }
+
 =cut
 
 	if ($size <= 4) {
@@ -755,6 +757,7 @@ sub GRnoneuler_size {
 	@ans = (1, '');
 
 =pod
+
   while ($graph eq 'DNE' || $ans == 1){
     @deg = ();
     for ($i = 0; $i < $size; $i++){
@@ -764,12 +767,13 @@ sub GRnoneuler_size {
     if ($graph ne 'DNE'){
       @ans = GRiseulertrail_graph($graph);
     }
-    
+
     do {
     $diff = random (0, $size - 1, 1);
     } until ($lowdeg[$diff] < $size - 1);
     $lowdeg[$diff]++;
   }
+
 =cut
 
 	do {

--- a/macros/math/VectorListCheckers.pl
+++ b/macros/math/VectorListCheckers.pl
@@ -8,7 +8,7 @@ VectorListCheckers.pl
 
 =head1 SYNOPSIS
 
-Provides subroutines for answer checking lists MathObjects 
+Provides subroutines for answer checking lists MathObjects
 vectors with real entries.
 
 =head1 DESCRIPTION
@@ -19,7 +19,7 @@ First, load the C<VectorListCheckers.pl> macro file.
 
 =item C<loadMacros("PGstandard.pl","MathObjects.pl","VectorListCheckers.pl");>
 
-= back
+=back
 
 For a MathObject list of MathObject vectors, the way to use the
 answer checkers is the same as using a custom answer checker
@@ -34,7 +34,7 @@ such as
 
 =back
 
-The "list of vectors" at the end of the checker name refers to the 
+The "list of vectors" at the end of the checker name refers to the
 fact that the student answer is a list of vectors.
 
 Here is an example of how to use these answer checkers.
@@ -49,7 +49,7 @@ loadMacros(
 "PGcourse.pl",
 );
 $showPartialCorrectAnswers = 1;
-TEXT(beginproblem()); 
+TEXT(beginproblem());
 
 Context('Vector');
 
@@ -59,13 +59,13 @@ $answer = List(ColumnVector(1,0,0),ColumnVector(0,1,0));
 
 Context()->texStrings;
 BEGIN_TEXT
-A basis for the column space of \( B = $B \) is 
+A basis for the column space of \( B = $B \) is
 $BR
 $BR
 \{ $answer->ans_rule(60) \}
 $BR
 $BR
-Enter your answer as a comma separated list of vectors, such as 
+Enter your answer as a comma separated list of vectors, such as
 \( \verb+<1,2,3>,<4,5,6>+ \).
 END_TEXT
 Context()->normalStrings;
@@ -88,10 +88,10 @@ ANS( $multians->cmp );
 
 The C<parametric_plane_checker_columns> should be used for
 solutions to non-homogeneous systems of linear equations for
-which the solution is essentially a point plus the span of 
+which the solution is essentially a point plus the span of
 several linearly independent vectors.  When using the parametric
 plane checker, the first vector input always serves as a point
-on the hyperplane (i.e., the first vector input is always a 
+on the hyperplane (i.e., the first vector input is always a
 particular solution), while the remaining vectors are a basis for
 the hyperplane (i.e., they span the homogeneous solution set).
 
@@ -180,10 +180,10 @@ sub basis_checker_list_of_vectors {
 $vector_list_column_syntax_angle_brackets = MODES(
 	TeX  => '',
 	HTML => "Enter a column vector such as
-\\( \\left\\lbrack \\begin{array}{r} 1 \\\\ 2 \\end{array} \\right\\rbrack \\) 
-using the syntax \\( \\verb+<1,2>+ \\). 
-If there is more than one vector in your answer, enter 
-your answer as a comma separated list of vectors, such as 
+\\( \\left\\lbrack \\begin{array}{r} 1 \\\\ 2 \\end{array} \\right\\rbrack \\)
+using the syntax \\( \\verb+<1,2>+ \\).
+If there is more than one vector in your answer, enter
+your answer as a comma separated list of vectors, such as
 \\( \\verb+<1,2>,<3,4>+ \\)."
 );
 
@@ -191,9 +191,9 @@ your answer as a comma separated list of vectors, such as
 
 $vector_list_row_syntax_angle_brackets = MODES(
 	TeX  => '',
-	HTML => "Enter a row vector using the syntax \\( \\verb+<1,2>+ \\). 
-If there is more than one vector in your answer, enter 
-your answer as a comma separated list of vectors, such as 
+	HTML => "Enter a row vector using the syntax \\( \\verb+<1,2>+ \\).
+If there is more than one vector in your answer, enter
+your answer as a comma separated list of vectors, such as
 \\( \\verb+<1,2>,<3,4>+ \\)."
 );
 


### PR DESCRIPTION
There was also a macro that had the bad copyright symbol.

You can use podchecker to check the syntax.  It is usually part of the base perl distribution.  I recommend using the -nowarnings flag if you do.  Even many of the macros that were in pg before have warnings.

You can also use the webwork2 script `bin/dev_scripts/generate-ww-pg-pod.pl` to generate all POD for webwork and pg.  If you have the WEBWORK_ROOT and PG_ROOT environment variables set as usual, then just run `/opt/webwork/webwork2/dev_scripts/generate-ww-pg-pod.pl -o ~/pod`.  Any errors for a file will be at the bottom of the generate POD for that file.

There were also some errors in some of the lib files.  So those are fixed to.