### PR TITLE
Fix student answer strings in hardcopy.

### DIFF
--- a/macros/answers/PGstringevaluators.pl
+++ b/macros/answers/PGstringevaluators.pl
@@ -601,10 +601,9 @@ sub STR_CMP {
 	});
 	$answer_evaluator->install_post_filter(sub {
 		my $rh_hash = shift;
-		my $c       = chr(128);    ## something that won't be typed
-		$rh_hash->{_filter_name}          = "clean up preview strings";
-		$rh_hash->{'preview_text_string'} = $rh_hash->{student_ans};
-		#		$rh_hash->{'preview_latex_string'} = "\\text{ ".$rh_hash->{student_ans}." }";
+		my $c       = MODES(HTML => chr(0x1F), TeX => chr(0xD), PTX => chr(0xD));    # something that won't be typed
+		$rh_hash->{_filter_name}           = "clean up preview strings";
+		$rh_hash->{'preview_text_string'}  = $rh_hash->{student_ans};
 		$rh_hash->{'preview_latex_string'} = "\\verb" . $c . $rh_hash->{student_ans} . $c;
 		$rh_hash;
 	});


### PR DESCRIPTION
Now that the preview_latex_string is used for hardcopy, the character used in the TeX verb for strings causes a problem (it was chr(128)). This switches to using the same character that used for the different display modes as is used in lib/String.pm.

You can use Library/MontanaState/FL/2.2B83Nested2.pg to test this.  Submit an answer, and generate a hardcopy with student answers.

I have had this sitting here for a while, but this just came up on the forums (see https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8197).