### PR TITLE
Fix and deprecate unionInclude.pl

### DIFF
--- a/macros/deprecated/unionInclude.pl
+++ b/macros/deprecated/unionInclude.pl
@@ -17,21 +17,17 @@ sub _unionInclude_init { };    # don't reload this file
 #
 sub includePGfile {
 	my $name   = shift;
-	my $PGfile = $main::envir{'fileName'};
+	my $PGfile = $main::envir{'probFileName'};
 	$PGfile =~ s![^/]+$!!;
 	$PGfile .= $name;
 	while ($PGfile =~ s![^/]*/../!!) { }
 	$PGfile =~ s!^tmpEdit/!!;
-	#  warn("file is $PGfile, directory is $main::templateDirectory");
 	my $problem = read_whole_problem_file($main::templateDirectory . $PGfile);
 
-	my ($oldpname, $oldname) =
-		($main::envir{'probFileName'}, $main::envir{'fileName'});
+	my $oldname = $main::envir{'probFileName'};
 	$main::envir{'probFileName'} = $PGfile;
-	$main::envir{'fileName'}     = $PGfile;
 	includePGtext($problem, %main::envir);
-	($main::envir{'probFileName'}, $main::envir{'fileName'}) =
-		($oldpname, $oldname);
+	$main::envir{'probFileName'} = $oldname;
 }
 
 ######################################################################

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -532,7 +532,7 @@ sub DataTable {
 							${ $dataref->[$i][$j] }{cellcss} =
 								"border-left:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
 						}
-						if ($alignmentcolumns[$m] != 0) {
+						if (defined $alignmentcolumns[$m] && $alignmentcolumns[$m] != 0) {
 							${ $dataref->[$i][$j] }{cellcss} =
 								"border-right:solid 1px; " . ${ $dataref->[$i][$j] }{cellcss};
 						}


### PR DESCRIPTION
Make the unionInclude.pl macro work again.  `fileName` is no longer in the environment.  Instead of having `fileName` and `probFileName` in the environment that were both always the same thing, there is now only `probFileName`.

However, this macro should not be used anymore, so it is also moved to deprecated.

There is also a minor fix for a warning in niceTables.pl that I keep seeing.  This was included in #709 and accidentally reverted in #724.