### PR TITLE
Fix the perltidy linter workflow.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,5 +28,6 @@ jobs:
       - name: Run perltidy
         shell: bash
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           shopt -s extglob globstar nullglob
           perltidy --pro=./.perltidyrc -b -bext='/' ./**/*.p[lm] ./**/*.t && git diff --exit-code


### PR DESCRIPTION
It seems there has been a change to either the version of `git` in the container image or to the `actions/checkout@v3` workflow.  This requires that the workspace be added as a safe directory in order for git commands to work.