### PR TITLE
Fix some HTML validation issues

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -629,9 +629,8 @@ inside the PGcore object would report.
 =cut
 
 sub debug_message {
-	my $self = shift;
-	my @str  = @_;
-	push @{ $self->{DEBUG_messages} }, "<br/>\n", @str;
+	my ($self, @str) = @_;
+	push @{ $self->{DEBUG_messages} }, @str;
 }
 
 sub get_debug_messages {
@@ -640,10 +639,9 @@ sub get_debug_messages {
 }
 
 sub warning_message {
-	my $self = shift;
-	my @str  = @_;
-	unshift @str, "<br/>------";    # mark start of each message
-	push @{ $self->{WARNING_messages} }, @str;
+	my ($self, @str) = @_;
+	# Mark the start of each message.
+	push @{ $self->{WARNING_messages} }, '------', @str;
 }
 
 sub get_warning_messages {
@@ -652,9 +650,8 @@ sub get_warning_messages {
 }
 
 sub internal_debug_message {
-	my $self = shift;
-	my @str  = @_;
-	push @{$internal_debug_messages}, @str;
+	my ($self, @str) = @_;
+	push @$internal_debug_messages, @str;
 }
 
 sub get_internal_debug_messages {

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -321,7 +321,7 @@ sub NAMED_ANS_RULE {
 
 		# Note: codeshard is used in the css to identify input elements that come from pg
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
-			. qq!dir="auto" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" !
+			. qq!dir="auto" autocomplete="off" autocapitalize="off" spellcheck="false" !
 			. qq!value="$answer_value">!
 			. qq!<input type=hidden name="$previous_name" value="$answer_value">!,
 		PTX => qq!<fillin name="$name" characters="$col" />!
@@ -417,7 +417,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
-			. qq!dir="auto" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" !
+			. qq!dir="auto" autocomplete="off" autocapitalize="off" spellcheck="false" !
 			. qq!value="$answer_value">!
 			. qq!<input type=hidden  name="previous_$name" id="previous_$name" value="$answer_value">!,
 		PTX => qq!<fillin name="$name" characters="$col" />!,
@@ -966,11 +966,11 @@ sub NAMED_POP_UP_LIST {
 		|| $displayMode eq 'HTML_LaTeXMathML'
 		|| $displayMode eq 'HTML_img')
 	{
-		$out = qq!<SELECT class="pg-select" NAME = "$moodle_prefix$name" id="$moodle_prefix$name" SIZE=1> \n!;
+		$out = qq!<SELECT class="pg-select" NAME="$moodle_prefix$name" id="$moodle_prefix$name" SIZE=1>\n!;
 		my $i;
 		foreach ($i = 0; $i < @list; $i = $i + 2) {
 			my $select_flag = ($list[$i] eq $answer_value) ? "SELECTED" : "";
-			$out .= qq!<OPTION $select_flag VALUE ="$list[$i]" > $list[$i+1]  </OPTION>\n!;
+			$out .= qq!<OPTION $select_flag VALUE="$list[$i]">$list[$i+1]</OPTION>\n!;
 		}
 		$out .= " </SELECT>\n";
 	} elsif ($displayMode eq "Latex2HTML") {
@@ -1094,7 +1094,7 @@ sub NAMED_ANS_ARRAY_EXTENSION {
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text size=$col name="$name" id="$name" class="codeshard" aria-label="$label" !
-			. qq!autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" value="$answer_value">!,
+			. qq!autocomplete="off" autocapitalize="off" spellcheck="false" value="$answer_value">!,
 		PTX => qq!<fillin name="$name" characters="$col" />!,
 	);
 }
@@ -1464,7 +1464,7 @@ sub BR {
 	MODES(
 		TeX        => '\\leavevmode\\\\\\relax ',
 		Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}',
-		HTML       => '<BR/>',
+		HTML       => '<BR>',
 		PTX        => "\n\n"
 	);
 }

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -361,9 +361,9 @@ sub NAMED_HIDDEN_ANS_RULE {
 
 	MODES(
 		TeX        => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
-		Latex2HTML => qq!\\begin{rawhtml}<input type=text size=$col name="$name" value="">\\end{rawhtml}!,
-		HTML       => qq!<input type=hidden size=$col name="$name" id ="$name" value="$answer_value">!
-			. qq!<input type=hidden  name="previous_$name" id = "previous_$name" value="$answer_value">!,
+		Latex2HTML => qq!\\begin{rawhtml}<input type=text name="$name" value="">\\end{rawhtml}!,
+		HTML       => qq!<input type=hidden name="$name" id="$name" value="$answer_value">!
+			. qq!<input type=hidden name="previous_$name" id="previous_$name" value="$answer_value">!,
 		PTX => '',
 	);
 }

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -453,10 +453,10 @@ sub NAMED_ANS_BOX {
 	$answer_value = encode_pg_and_html($answer_value);
 	my $out = MODES(
 		TeX        => qq!\\vskip $height in \\hrulefill\\quad !,
-		Latex2HTML =>
-			qq!\\begin{rawhtml}<TEXTAREA NAME="$name" id="$name" aria-label="$label" ROWS="$row" COLS="$col"
+		Latex2HTML => qq!\\begin{rawhtml}<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col"
 				>$answer_value</TEXTAREA>\\end{rawhtml}!,
-		HTML => qq!<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col">$answer_value</TEXTAREA>!
+		HTML => qq!<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col" aria-label="$label">!
+			. qq!$answer_value</TEXTAREA>!
 			. qq!<INPUT TYPE=HIDDEN NAME="previous_$name" VALUE="$answer_value">!,
 		PTX => '<var name="' . "$name" . '" height="' . "$row" . '" width="' . "$col" . '" />',
 	);

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -455,11 +455,9 @@ sub NAMED_ANS_BOX {
 		TeX        => qq!\\vskip $height in \\hrulefill\\quad !,
 		Latex2HTML =>
 			qq!\\begin{rawhtml}<TEXTAREA NAME="$name" id="$name" aria-label="$label" ROWS="$row" COLS="$col"
-		              WRAP="VIRTUAL">$answer_value</TEXTAREA>\\end{rawhtml}!,
-		HTML => qq!<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col"
-		        WRAP="VIRTUAL">$answer_value</TEXTAREA>
-		        <INPUT TYPE=HIDDEN  NAME="previous_$name" VALUE = "$answer_value">
-		        !,
+				>$answer_value</TEXTAREA>\\end{rawhtml}!,
+		HTML => qq!<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col">$answer_value</TEXTAREA>!
+			. qq!<INPUT TYPE=HIDDEN NAME="previous_$name" VALUE="$answer_value">!,
 		PTX => '<var name="' . "$name" . '" height="' . "$row" . '" width="' . "$col" . '" />',
 	);
 	$out;

--- a/macros/core/PGessaymacros.pl
+++ b/macros/core/PGessaymacros.pl
@@ -24,10 +24,10 @@ PGessaymacros.pl - Macros for building answer evaluators.
 
 Answer Evaluators:
 
-	essay_cmp()   - 
+	essay_cmp()   -
 
 Answer Boxes
-    
+
         essay_box()
 
     To use essay answers just put an essay_box() into your problem file wherever you want the input box to go and then use essay_cmp() for the corresponding checker.  You will then need grade the problem manually.  The grader can be found in the "Detail Set List".
@@ -115,7 +115,7 @@ sub NAMED_ESSAY_BOX {
 			qq!\\begin{rawhtml}<TEXTAREA NAME="$name" id="$name" ROWS="$row" COLS="$col" >$answer_value</TEXTAREA>\\end{rawhtml}!,
 		HTML => qq!
          <TEXTAREA NAME="$name" id="$name" aria-label="$label" ROWS="$row" COLS="$col" class="latexentryfield"
-               WRAP="VIRTUAL" title="Enclose math expressions with backticks or use LaTeX.">$answer_value</TEXTAREA>
+               title="Enclose math expressions with backticks or use LaTeX.">$answer_value</TEXTAREA>
            <INPUT TYPE=HIDDEN  NAME="previous_$name" VALUE = "$answer_value">
             !,
 		PTX => '<var form="essay" width="' . $col . '" height="' . $row . '" />',
@@ -130,12 +130,12 @@ sub essay_help {
 		TeX        => '',
 		Latex2HTML => '',
 		HTML       => qq!
-            <P>  This is an essay answer text box.  You can type your answer in here and, after you hit submit, 
-                 it will be saved so that your instructor can grade it at a later date.  If your instructor makes 
-                 any comments on your answer those comments will appear on this page after the question has been 
-                 graded.  You can use LaTeX to make your math equations look pretty.   
-                 LaTeX expressions should be enclosed using the parenthesis notation and not dollar signs. 
-            </P> 
+            <P>  This is an essay answer text box.  You can type your answer in here and, after you hit submit,
+                 it will be saved so that your instructor can grade it at a later date.  If your instructor makes
+                 any comments on your answer those comments will appear on this page after the question has been
+                 graded.  You can use LaTeX to make your math equations look pretty.
+                 LaTeX expressions should be enclosed using the parenthesis notation and not dollar signs.
+            </P>
            !,
 		PTX => '',
 	);

--- a/macros/core/compoundProblem2.pl
+++ b/macros/core/compoundProblem2.pl
@@ -4,7 +4,7 @@ sub _compoundProblem2_init { };    # don't reload this file
 $width = 700;                      #457
 HEADER_TEXT(<<'END_HEADER_TEXT');
 
-<style type="text/css">
+<style>
 
 * {margin:0; padding:0; font:12px Verdana,Arial}
 code {font-family:"Courier New",Courier}

--- a/macros/core/compoundProblem5.pl
+++ b/macros/core/compoundProblem5.pl
@@ -36,34 +36,34 @@ C<PROCESS_SECTIONS()> to finalize all the sections.
 Here is a sample:
 
 	loadMacros("compoundProblem5.pl");
-	
+
 	$scaffold = Scaffold();   # create the scaffold
 	Context("Numeric");
-	
+
 	##########################################
 	#  Section 1
 	##########################################
-	
+
 	$f = Compute("x^2-1");
-	
+
 	Context()->texStrings;
 	DISPLAY_SECTION("Section 1: The equation",<<'END_SECTION');
 	  Enter the function \($f\): \{ SECTION_ANS($f->cmp); $f->ans_rule(10) \}
 	END_SECTION
 	Context()->normalStrings;
-	
+
 	##########################################
 	#  Section 2
 	##########################################
-	
+
 	$x = Compute("sqrt(3)/2");
-	
+
 	DISPLAY_SECTION("Section 2: The number",<<'END_SECTION');
 	  What is \(\sin(\pi/3)\)? \{ SECTION_ANS($x->cmp); $x->ans_rule \}
 	END_SECTION
-	
+
 	##########################################
-	
+
 	PROCESS_SCAFFOLD();
 
 The C<DISPLAY_SECTION()> and C<DISPLAY_PGML_SECTION()> macros can
@@ -162,7 +162,7 @@ C<SECTION_PGML_SOLUTION()> to create it.  E.g.,
     DISPLAY_SECTION("Part 1",<<'END_SECTION');
     \(1 + 1\) = \{ANS($r->cmp); $r->ans_rule(5)\}
     END_SECTION
-    
+
     SECTION_SOLUTION(<<'END_SOLUTION');
     When you add 1 to 1 you get 2.
     END_SOLUTION
@@ -176,16 +176,16 @@ attach to:
     DISPLAY_SECTION("Part 1",<<'END_SECTION');
     \(1 + 1\) = \{ANS($r1->cmp); $r1->ans_rule(5)\}
     END_SECTION
-    
+
     $r2 = Real(4);
     DISPLAY_SECTION("Part 1",<<'END_SECTION');
     \(2\times 2\) = \{ANS($r2->cmp); $r2->ans_rule(5)\}
     END_SECTION
-    
+
     SECTION_SOLUTION({section => 1},<<'END_SOLUTION')
     When you add 1 to 1 you get 2.
     END_SOLUTION
-    
+
     SECTION_SOLUTION({section => 2},<<'END_SOLUTION')
     When you multiply 2 by 2 you get 4.
     END_SOLUTION
@@ -205,7 +205,7 @@ sub _compoundProblem5_init { };    # don't reload this file
 #
 HEADER_TEXT(<<'END_HEADER_TEXT');
 
-<style type="text/css">
+<style>
 
 .section-li {list-style: none}          /* don't show bullets */
 .section-li > div {padding:0 .5em;}     /* move the contents away from the edges */
@@ -588,7 +588,7 @@ sub HIDE_OTHER_RESULTS {
 	#  Add styles that dim the hidden rows
 	#
 	my @styles = (map {".attemptResults > tbody > tr:nth-child($_) {opacity:.5}"} @hide);
-	main::HEADER_TEXT("<style type=\"text/css\">\n" . join("\n", @styles) . "\n</style>\n");
+	main::HEADER_TEXT('<style>' . join('', @styles) . '</style>');
 }
 
 #

--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -479,7 +479,7 @@ sub hide_other_results {
 	#
 	if (@hide) {
 		my @styles = (map {".attemptResults > tbody > tr:nth-child($_) {opacity:.5}"} @hide);
-		main::HEADER_TEXT("<style type=\"text/css\">\n" . join("\n", @styles) . "\n</style>\n");
+		main::HEADER_TEXT('<style>' . join('', @styles) . '</style>');
 	}
 }
 

--- a/macros/ui/quickMatrixEntry.pl
+++ b/macros/ui/quickMatrixEntry.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w 
+#!/usr/bin/perl -w
 
 ###################################
 # quick matrix entry package
@@ -30,16 +30,16 @@ sub MATRIX_ENTRY_BUTTON {
 	# warn("answer number $answer_name rows $rows columns $columns");
 	return qq!
 	$PAR
-		<input class="opener" type='button' name="$answer_name" value="Quick Entry" 
+		<input class="opener" type='button' name="$answer_name" value="Quick Entry"
 		rows="$rows" columns="$columns">
 	$PAR!;
 }
 
 our $quick_entry_javascript = <<'END_JS';
-<script type="text/javascript">
-$(function() {        
+<script>
+$(function() {
         $( "#quick_entry_form" ).dialog({
-            autoOpen: false,  
+            autoOpen: false,
             });
         //console.log('startup');
         var name = $("#quick_entry_form").attr("name");
@@ -58,7 +58,7 @@ $(function() {
 				pos= "#"+name;
 			}  //MaTrIx_AnSwEr0007_0_3
 			//console.log($(pos).val());
-			return $(pos).val() ; 
+			return $(pos).val() ;
 		}
     $( ".opener" ).click(function() {
          //console.log(this.name );
@@ -77,13 +77,13 @@ $(function() {
          //console.log("entry " + entry); # prefill the entry area
          $("textarea#matrix_input").val(entry);
          $( "#quick_entry_form" ).dialog( "open" );
-      
+
     });
     $( "#closer" ).click(function() {
         //var name="AnSwEr0007";
         var entry1 = $("textarea#matrix_input").val().replace(/^\s*/,'');
         //remove initial white space
-        var entry2=entry1; 
+        var entry2=entry1;
         // replace commas with a space
         // replace ] with a return
         // replace [ with nothing
@@ -100,7 +100,7 @@ $(function() {
         for (i=0; i<mat3.length; i++) {
             for(j=0; j<mat3[i].length; j++){
                 insert_value(name,i,j,mat3[i][j]);
-            }		
+            }
         }
         $( "#quick_entry_form" ).dialog( "close" );
       });
@@ -110,7 +110,7 @@ END_JS
 
 our $quick_entry_form = <<'END_TEXT';
 <div id="quick_entry_form" name="quick entry" title="Enter matrix">
-  <textarea id="matrix_input" rows="5" columns = "10"> 
+  <textarea id="matrix_input" rows="5" columns = "10">
   </textarea>
   <button id="closer">enter</button>
 </div>

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -24,7 +24,7 @@ is(
 		. qq{Enter a value for <script type="math/tex">\\pi</script>.\n}
 		. qq{<div style="margin-top:1em"></div>\n}
 		. qq{<input type=text class="codeshard" size=5 name="AnSwEr0001" id="AnSwEr0001" aria-label="answer 1 " }
-		. qq{dir="auto" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" value="3.14159">}
+		. qq{dir="auto" autocomplete="off" autocapitalize="off" spellcheck="false" value="3.14159">}
 		. qq{<input type=hidden name="previous_AnSwEr0001" value="3.14159">\n}
 		. qq{</div>\n}
 		. qq{<input type=hidden name="MaThQuIlL_AnSwEr0001" id="MaThQuIlL_AnSwEr0001" value="" >},


### PR DESCRIPTION
Specifically the following changes are made:

Remove the size attribute from hidden inputs created via NAMED_HIDDEN_ANS_RULE.  That is not a valid attribute for a hidden input.

Remove the type="text/css" attribute from style tags and type="text/javascript" attribute from script tags.  In modern html those should be omitted.

Remove the wrap attribute from textarea answer rules. The "virtual" value for that attribute hasn't been valid for a long time.  Just use the default "soft" value.

Remove the invalid autocorrect attribute from inputs for answer rules.

The debug and warning messages in PGcore should not add html formatting to the arrays of messages that are stored.  Let the caller deal with formatting it the in the desired way.  The only result of this is that we end up removing this html later almost every single time it is handled.
    
Also output better and valid html for translator errors.  A pre can not contain a <hr> tag.

This is just a collection of issues that I have been accumulating in a branch. It is time to put this in.