### PR TITLE
Add the capability to set input value for radios and checks

### DIFF
--- a/htdocs/js/apps/RadioButtons/RadioButtons.js
+++ b/htdocs/js/apps/RadioButtons/RadioButtons.js
@@ -1,0 +1,59 @@
+// ################################################################################
+// # WeBWorK Online Homework Delivery System
+// # Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+// #
+// # This program is free software; you can redistribute it and/or modify it under
+// # the terms of either: (a) the GNU General Public License as published by the
+// # Free Software Foundation; either version 2, or (at your option) any later
+// # version, or (b) the "Artistic License" which comes with this package.
+// #
+// # This program is distributed in the hope that it will be useful, but WITHOUT
+// # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// # FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+// # Artistic License for more details.
+// ################################################################################
+'use strict';
+
+(() => {
+	// Setup uncheckable radios.
+	const setupUncheckableRadio = (radio) => {
+		if (!radio.dataset.uncheckableRadioButton) return;
+		delete radio.dataset.uncheckableRadioButton;
+
+		if (radio.checked) radio.dataset.currentlyChecked = '1';
+
+		radio.addEventListener('click', (e) => {
+			if (radio.dataset.shift && !e.shiftKey) {
+				radio.dataset.currentlyChecked = '1';
+				return;
+			}
+			const currentlyChecked = radio.dataset.currentlyChecked;
+			if (currentlyChecked) {
+				delete radio.dataset.currentlyChecked;
+				radio.checked = false;
+			} else {
+				radio.dataset.currentlyChecked = '1';
+			}
+		});
+	};
+
+	// Deal with uncheckable radios already in the page.
+	document.querySelectorAll('input[type="radio"]').forEach(setupUncheckableRadio);
+
+	// Deal with radios that are added to the page later.
+	const observer = new MutationObserver((mutationsList) => {
+		for (const mutation of mutationsList) {
+			for (const node of mutation.addedNodes) {
+				if (node instanceof Element) {
+					if (node.tagName.toLowerCase() === 'input' && node.type.toLowerCase() === 'radio')
+						setupUncheckableRadio(node);
+					else node.querySelectorAll('input[type="radio"]').forEach(setupUncheckableRadio);
+				}
+			}
+		}
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+
+	// Stop the mutation observer when the window is closed.
+	window.addEventListener('unload', () => observer.disconnect());
+})();

--- a/lib/PGresponsegroup.pm
+++ b/lib/PGresponsegroup.pm
@@ -13,106 +13,77 @@
 # Artistic License for more details.
 ################################################################################
 package PGresponsegroup;
+use parent qw(PGanswergroup);
 
 use strict;
-use Exporter;
-use PGUtil qw(not_null);
-use PGanswergroup;
-use Tie::IxHash;
+use warnings;
 
-#############################################
-# An object which contains the student response(s)
-# 1. needs to be able to hold one or more responses
-# 2. needs space for auxiliary answer labels
-#      for example all of the entries in an array
-# 3. needs to coordinate answer labels with the PGanswergroup holding it
-#    We'll accomplish this by having it point to it's enclosing answergroup
-# 4. may have additional methods for processing and storing response strings
-#      the responses for radio buttons should be of the form   response_label=>[button1, button2, button3,  ...]
-# 5. should be called with at least one label, response pair
+use PGUtil qw(not_null);
+
+# An object which contains student response(s).
+# 1. Needs to be able to hold one or more responses.
+# 2. Needs space for auxiliary answer labels. For example, all of the entries in an array.
+# 3. Needs to coordinate answer labels with the PGanswergroup holding it.
+#    This is accomplished by having it point to it's enclosing answergroup.
+# 4. May have additional methods for processing and storing response strings.
+#      The responses for radio buttons and check boxes should be of the form:
+#          response_label => [['value1', 'CHECKED'], ['value2', ''], ['value3', ''],  ...]
+# 5. Should be called with at least one label, response pair.
 # 6. By convention the first response usually has the same label as the parent answergroup.
 #    This is always true if there is only a single response.
-#############################################
-our @ISA = qw(PGanswergroup);
 
-###
-# new ( label, response, label, response)
-#
-# create a new empty response group object
-# Optionally append label/response pairs
-###
+# Create a new empty response group object.
+# Optionally append label/response pairs.
 sub new {
-	my $class             = shift;
-	my $answergroup_label = shift;
-	my $self              = {
+	my ($class, $answergroup_label, @responses) = @_;
+	my $self = bless {
 		answergroup_label => $answergroup_label,    # enclosing answergroup that created this responsegroup
 		response_order    => [],                    # response labels
 		responses         => {},                    # response label/response value pair,
 													# value could be an arrayref in the case of radio or checkbox groups
-	};
-	bless $self, $class;
-	$self->append_responses(@_);
+	}, $class;
+	$self->append_responses(@responses);
 	return $self;
 
 }
-###############
-# append_response (label, response)
-#
+
 # Append label/response pairs to the response hash.
-# order is recorded in the response_order array
-###############
-
+# Response order is recorded in the response_order array.
 sub append_response {
-
-	my $self           = shift;
-	my $response_label = shift;
-	my $response_value = shift;
+	my ($self, $response_label, $response_value) = @_;
 	if (not_null($response_label)) {
-		if (not exists($self->{responses}->{$response_label})) {
+		if (not exists($self->{responses}{$response_label})) {
 			push @{ $self->{response_order} }, $response_label;
-			$self->{responses}->{$response_label} = $response_value;
+			$self->{responses}{$response_label} = $response_value;
 		} else {
 			$self->internal_debug_message(
 				"PGresponsegroup::append_response error: there is already an answer labeled $response_label",
 				caller(2), "\n");
 		}
 	} else {
-		$self->internal_debug_message("PGresponsegroup::append_response error: undefined or empty response label");
+		$self->internal_debug_message('PGresponsegroup::append_response error: undefined or empty response label');
 	}
-	#warn "\n content of responses  is ",join(' ',%{$self->{responses}});
+	return;
 }
 
-###############
-# append_response (label, response, label, responses)
-#
 # Append label/response pairs to the response hash.
-# order is recorded in the response_order array
-###############
-
-sub append_responses {    #no error checking
-	my $self          = shift;
-	my @response_list = @_;
-	#warn "working with @response_list,", caller(2);
+sub append_responses {
+	my ($self, @response_list) = @_;
 	while (@response_list) {
 		$self->append_response(shift @response_list, shift @response_list);
 	}
+	return;
 }
 
-################
-# replace_response(label, response)
-#
-# replace the response to one response label entry
-################
+# Replace the response to one response label entry.
 sub replace_response {
-	my $self           = shift;
-	my $response_label = shift;
-	my $response_value = shift;
-	if (defined $self->{responses}->{$response_label}) {
-		$self->{responses}->{$response_label} = $response_value if defined $response_value;
-		return $self->{responses}->{$response_label};
+	my ($self, $response_label, $response_value) = @_;
+	if (defined $self->{responses}{$response_label}) {
+		$self->{responses}{$response_label} = $response_value if defined $response_value;
+		return $self->{responses}{$response_label};
 	} else {
 		warn "response label |$response_label| not defined";
-		return undef;
+		return;
 	}
 }
 
@@ -144,72 +115,55 @@ sub extend_response {
 	}
 }
 
-################
-# get_response(label)
-#
-# returns  response for that label entry
-################
+# Get the responses for a label.
 sub get_response {
-	my $self           = shift;
-	my $response_label = shift;
-	$self->{responses}->{$response_label};
+	my ($self, $response_label) = @_;
+	return $self->{responses}{$response_label};
 }
 
 sub get_answergroup_label {
 	my $self = shift;
-	if (!not_null($self->{answergroup_label})) {    #if $answergroup is not yet defined
+	if (!not_null($self->{answergroup_label})) {
 		$self->{answergroup_label} = ${ $self->{response_order} }[0];
 	}
-	if (not_null($self->{answergroup_label})) {     #if $answergroup is now defined
-		return $self->{answergroup_label};
-	} else {
-		warn "This answer group has no labeled responses.";
-	}
+	return $self->{answergroup_label} if not_null($self->{answergroup_label});
+	warn 'This answer group has no labeled responses.';
+	return;
 }
 
-################
-# clear()
-#
-# sets PGresponse group to empty
-################
+# Sets the PGresponsegroup to empty
 sub clear {
 	my $self = shift;
 	$self->{response_order} = [];
 	$self->{responses}      = {};
+	return;
 }
-################
-# response_labels()
-#
-# returns entry ordered list of response labels
-################
 
+# Returns the entry ordered list of response labels
 sub response_labels {
 	my $self = shift;
-	@{ $self->{response_order} };
+	return @{ $self->{response_order} };
 }
 
-################
-#values()
-#
-# returns entry ordered list of response values
-################
-
+# Returns the entry ordered list of response values.
 sub values {
 	my $self = shift;
-	my @out  = ();
-	foreach my $key (@{ $self->{response_order} }) {
+	my @out;
+	for my $key (@{ $self->{response_order} }) {
 		push @out, $self->get_response($key);
 	}
-	@out;
+	return @out;
 }
-# synonym for values #FIXME?  should this be the content of {responses}?
+
+# Synonym for values.
 sub responses {
-	my $self = shift;
-	$self->values(@_);
+	my ($self, @responses) = shift;
+	return $self->values(@responses);
 }
 
 sub data {
 	my $self = shift;
 	return {%$self};
 }
+
 1;

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -139,15 +139,13 @@ sub new_helper ($invocant, %options) {
 		}
 	}
 
-	$translator->rf_safety_filter(sub { return shift, 0; });
-
 	$translator->translate();
 
 	# IMPORTANT: The translator environment should not be trusted after the problem code runs.
 
 	my ($result, $state);
 	if ($options{processAnswers}) {
-		$translator->process_answers($options{inputs_ref});
+		$translator->process_answers;
 
 		$translator->rh_problem_state({
 			recorded_score       => $options{recorded_score}       // 0,

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -104,7 +104,7 @@ characters, and "Button 1", "Button 2", etc., otherwise.
 
 Values are the form of the student answer that will be displayed in the past
 answers table for this answer.  By default these are B0, B1, etc.  However, that
-can be changed either with this option or by specifying the choices with 
+can be changed either with this option or by specifying the choices with
 C<< { label => [ text, value ] } >> as described previously.  If this option is
 used, then the value of the option should be a reference to an array containing
 the values for the choices.  For example:
@@ -353,7 +353,8 @@ sub getCorrectChoices {
 	}
 
 	# Sort the correct choices into display order.
-	$self->{data} = [ main::PGsort(sub { $_[0] lt $_[1] }, @{ $self->{data} }) ];
+	$self->{data} =
+		[ main::PGsort(sub { $self->getIndexByValue($_[0]) < $self->getIndexByValue($_[1]) }, @{ $self->{data} }) ];
 
 	Value::Error('The correct choices must be among the label values') unless @{ $self->{data} };
 


### PR DESCRIPTION
This is done for the parserRadioButtons.pl, parserCheckboxList.pl, and parserRadioMultiAnswer.pl macros.
    
The values for the choices are the student "original" answers which are displayed in the past answers table (or answer log).  Currently for this macro those are always B0, B1, etc.  This changes that so those can be customized to show more informative "original" answers in the results table.  Note that if using a custom checker, these are also the values that you would need to use for comparison there.

These values can be specified in two ways for parserRadioButton.pl and parserCheckboxList.pl.  One extends to the previous method of providing a label with a choice. For example, a choice could have been give as { label => text }.  To give a value with that now use { label => [ text, value ] }.  For a full example:

```
$radio = RadioButtons(
        [
                { A => [ 'answer 1', 'always first answer' ] },
                [
                        { B => [ 'answer 2', 'random order second answer' ] },
                        { C => [ 'answer 3', 'random order third answer' ] }
                ]
                { D => [ 'answer 4', 'always last answer' ] }
        ],
        1,
        displayLabels => 1
);
```
Note that with this approach the labels, text, and value are all randomized together and everything is shown in that random order.  So in the problem you will get for instance
* A. answer 1 (the value of this radio will be 'always first answer')
* C. answer 3 (the value of this radio will be 'random order third answer')
* B. answer 2 (the value of this radio will be 'random order second answer')
* D. answer 4 (the value of this radio will be 'always last answer')

Of course B and C might be switched.

The other way of specifying the values is to give a reference to an array containing values for each of the choices.  This works for all three macros.  For example,
```
$radio = RadioButtons(
        [
                'answer 1',
                [

                       'answer 2',
                        'answer 3',
                ]
                'answer 4',
        ],
        1,
        labels => 'ABC',
        values => [
                'always first answer',
                'random order second answer',
                'random order third answer',
                'always last answer'
        ]
);
```
Note that with this approach the values are still randomized with the choices, but the labels are not.  So in the problem you will get for instance
* A. answer 1 (the value of this radio will be 'always first answer')
* B. answer 3 (the value of this radio will be 'random order third answer')
* C. answer 2 (the value of this radio will be 'random order second answer')
* D. answer 4 (the value of this radio will be 'always last answer')

Of course the text for B and C might be switched and the values with them, but the labels B and C will always be with the corresponding text as shown.

Of course one should choose the values to not give the correct answer away.

This also moves the "uncheckable" javascript out of the macro and into a separate javascript file loaded via ADD_JS_FILE.  The javascript is updated to not pollute the global namespace.

Note that the NAMED_ANS_RADIO_EXTENSION of PGbasicmacros.pl needed to be extended to allow setting of the input `id` by the caller.  Previously "${name}_$value" was used.  The values set by the author could make those invalid id's.

Both that method and the NAMED_ANS_RADIO method also needed to be extended to allow the caller to add attributes to the input.  This is to that data attributes could be added that are used by the javascript.  Previosly this macro used a regular expression substitution to add an `onclick` handler.  Really what is needed is for the PGbasicmacros.pl macro to have a generic method to generate html tags with attributes.

To make this easier to deal with a new `tag` method was added to PGbasicmacros.pl.  This method is similar in usage to the `tag` method of Mojolicious::Plugin::TagHelpers.  It is intended to extend this usage to more of the methods in PGbasicmacros.pl and elsewhere.  Note that it does not include the capability to open a tag without closing it, and never should be extended to do so.  That promotes bad practice and leads to invalid html.