### PR TITLE
Make it possible to pass options to the cmp method with PGML

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -779,7 +779,7 @@ sub terminateOptions {
 	$self->{block} = $self->{block}{prev};
 	$self->{block}->popItem;
 	$block = $self->{block}->topItem;
-	if ($options =~ m/^[a-z_][a-z0-9_]*=>/i) {
+	if ($options =~ m/^\s*[a-z_][a-z0-9_]*\s*=>/i) {
 		my %allowed = (map { $_ => 1 } (@{ $block->{options} }));
 		my ($options, $error) = PGML::Eval("{$options}");
 		$options = {}, PGML::Warning "Error evaluating options: $error" if $error;

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -372,7 +372,7 @@ sub Verbatim {
 sub Answer {
 	my $self  = shift;
 	my $token = shift;
-	my $def   = { options => [ "answer", "width", "name", "array" ] };
+	my $def   = { options => [ "answer", "width", "name", "cmp_options" ] };
 	$def->{hasStar} = 1 if $token =~ m/\*$/;
 	$self->Item("answer", $token, $def);
 }
@@ -1305,9 +1305,9 @@ sub Answer {
 			$rule = PGML::LaTeX($rule);
 			if (!(ref($ans) eq 'parser::MultiAnswer' && $ans->{part} > 1)) {
 				if (defined($item->{name})) {
-					main::NAMED_ANS($item->{name} => $ans->cmp);
+					main::NAMED_ANS($item->{name} => $ans->cmp(%{ $item->{cmp_options} }));
 				} else {
-					main::ANS($ans->cmp);
+					main::ANS($ans->cmp(%{ $item->{cmp_options} }));
 				}
 			}
 		}


### PR DESCRIPTION
Currently passing options to the cmp method using PGML answer methods is not possible.  So instead you have to resort to using the basic PG approach of calling ans_rule or ans_array, and then calling the cmp method yourself.  For example to use a custom checker with a matrix object you must do something like:
```
$ans = Matrix([ [ 1, 2, 3 ], [ 4, 5, 6 ] ]);

BEGIN_PGML
Matrix answer: [@ $ans->ans_array @]*
END_PGML

ANS($ans->cmp(
	checker => sub { ... }
));

```

This pull request makes it so that you can pass those options using the PGML answer syntax.  This can be done for example with:
```
$ans = Matrix([ [ 1, 2, 3 ], [ 4, 5, 6 ] ]);
$ans_cmp_opts = {
	checker => sub { ... }
};

BEGIN_PGML
Matrix answer: [_]*{answer=>$ans, cmp_options=>$ans_cmp_opts}
END_PGML
```
You can also use: `Matrix answer: [_]*{$ans}{5}{NEW_ANS_NAME()}{$ans_cmp_opts}`.  Unfortunately, the order is answer, width, name, cmp_options, and that can't be changed for compatibility reasons.  So you  have to pass an answer name with this approach which should always be `NEW_ANS_NAME()` or a scalar variable whose value is the result of calling that method.

This new option is most useful for using a custom checker with a multitude of answer types like matrices (as demonstrated above), parserRadioButtons.pl answers, and I am sure there are many others.  I have implemented `cmpOptions` for some macros like `parserGraphTool.pl` and `draggableProof.pl` (in #774), but this gives a much better way that doesn't need to be implemented for each MathObject value type answer.

Edit:  Now you can also add space to the begining when using the hash options.  For example, `[_]*{ answer => $ans, width => 5, cmp_options => $ans_cmp_opts }` or `[_]*{$ans}{5}{ cmp_options => $ans_cmp_opts }`.