### PR TITLE
Remove CRLF line endings when a PG file is loaded.

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1403,6 +1403,8 @@ sub PG_answer_eval {
 sub default_preprocess_code {
 	my $evalString = shift // '';
 
+	$evalString =~ s/\r\n/\n/g;
+
 	# BEGIN_TEXT, END_TEXT, and the others that follow must occur on a line by themselves.
 	$evalString =~ s/\n\h*END_TEXT[\h;]*\n/\nEND_TEXT\n/g;
 	$evalString =~ s/\n\h*END_PGML[\h;]*\n/\nEND_PGML\n/g;


### PR DESCRIPTION
Currently a pg file that has CRLF line endings fails to render.  This fixes that by removing such line endings in the default_preprocess_code method.

An alternate approach that would also work would be to do this when the translator opens a file in the source_file method.  However, this would not catch cases when a source string that contains CRLF line endings is provided instead of a source file.  That may not be a real concern though?

I am not exactly sure what changed that caused files with CRLF line endings to fail.  They work for PG 2.17, but do not for the develop branch.