### PR TITLE
Lock the MathQuill version installed by npm (hotfix).

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -10,7 +10,7 @@
                 "jsxgraph": "^1.4.2",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
-                "mathquill": "github:openwebwork/mathquill",
+                "mathquill": "github:openwebwork/mathquill#WeBWorK-2.17",
                 "x3dom": "^1.8.1"
             },
             "devDependencies": {
@@ -2266,7 +2266,7 @@
         },
         "mathquill": {
             "version": "git+ssh://git@github.com/openwebwork/mathquill.git#5b5b651f2ac1496304d5d7bcd56e112ddc8b7bd0",
-            "from": "mathquill@github:openwebwork/mathquill"
+            "from": "mathquill@github:openwebwork/mathquill#WeBWorK-2.17"
         },
         "mdn-data": {
             "version": "2.0.14",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
         "jsxgraph": "^1.4.2",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",
-        "mathquill": "github:openwebwork/mathquill",
+        "mathquill": "github:openwebwork/mathquill#WeBWorK-2.17",
         "x3dom": "^1.8.1"
     },
     "devDependencies": {


### PR DESCRIPTION
With breaking changes coming to MathQuill, PG-2.17 needs to be locked into using the current version of MathQuill.  This locks PG-2.17 to the WeBWorK-2.17 tag in our MathQuill repository.

Obviously this needs to be a hotfix.  It can't be anything else.