### PR TITLE
Update mqeditor for recent mathquill updates

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -35,8 +35,11 @@
 			restrictMismatchedBrackets: true,
 			sumStartsWithNEquals: true,
 			supSubsRequireOperand: true,
-			autoCommands: 'pi sqrt root vert inf union abs',
+			autoCommands: ['pi', 'sqrt', 'root', 'vert', 'inf', 'union', 'abs', 'deg', 'AA', 'angstrom', 'ln', 'log']
+				.concat(['sin', 'cos', 'tan', 'sec', 'csc', 'cot'].reduce((a, t) =>
+					a.concat([t, `arc${t}`]), [])).join(' '),
 			rootsAreExponents: true,
+			logsChangeBase: true,
 			maxDepth: 10
 		};
 

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -768,7 +768,7 @@
         },
         "node_modules/mathquill": {
             "version": "0.10.1",
-            "resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#5b5b651f2ac1496304d5d7bcd56e112ddc8b7bd0",
+            "resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
             "license": "MPL-2.0"
         },
         "node_modules/mdn-data": {
@@ -2182,7 +2182,7 @@
             "dev": true
         },
         "mathquill": {
-            "version": "git+ssh://git@github.com/openwebwork/mathquill.git#5b5b651f2ac1496304d5d7bcd56e112ddc8b7bd0",
+            "version": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
             "from": "mathquill@github:openwebwork/mathquill"
         },
         "mdn-data": {


### PR DESCRIPTION
This updates the mqeditor to work with changes to MathQuill.  See [openwebwork/mathquill](https://github.com/openwebwork/mathquill).

Make sure to run `npm install` to test this.  Don't just run `./generate-assets` or `npm run generate-assets`.  In fact, you don't even need to run `./generate-assets`.  So you can run `npm install --ignore-scripts` to just install the updated MathQuill library.

Also note that you will need to do a hard refresh on a page that loads MathQuill in order to make the new MathQuill javascript load.  This is something we need to think about for javascript updates for those things installed by npm in general.  In most cases updated third party libraries use the same file names.