### PR TITLE
Add unicode degree units.

### DIFF
--- a/htdocs/helpFiles/Entering-Units.html
+++ b/htdocs/helpFiles/Entering-Units.html
@@ -178,7 +178,7 @@
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mol</td>
 	</tr>
 	<tr>
-		<td style="padding: 0.5rem; border: 1px solid black">Degrees Centrigrade</td>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Celsius</td>
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degC</td>
 	</tr>
 	<tr>
@@ -186,8 +186,8 @@
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degF</td>
 	</tr>
 	<tr>
-		<td style="padding: 0.5rem; border: 1px solid black">Degrees Kelvin</td>
-		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degK</td>
+		<td style="padding: 0.5rem; border: 1px solid black">Kelvin</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">K</td>
 	</tr>
 	<tr>
 		<td style="padding: 0.5rem; border: 1px solid black">Angle degrees</td>

--- a/htdocs/helpFiles/Units.html
+++ b/htdocs/helpFiles/Units.html
@@ -178,7 +178,7 @@
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">mol</td>
 	</tr>
 	<tr>
-		<td style="padding: 0.5rem; border: 1px solid black">Degrees Centrigrade</td>
+		<td style="padding: 0.5rem; border: 1px solid black">Degrees Celsius</td>
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degC</td>
 	</tr>
 	<tr>
@@ -186,8 +186,8 @@
 		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degF</td>
 	</tr>
 	<tr>
-		<td style="padding: 0.5rem; border: 1px solid black">Degrees Kelvin</td>
-		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">degK</td>
+		<td style="padding: 0.5rem; border: 1px solid black">Kelvin</td>
+		<td style="padding: 0.5rem; border: 1px solid black; text-align: center">K</td>
 	</tr>
 	<tr>
 		<td style="padding: 0.5rem; border: 1px solid black">Angle degrees</td>

--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -18,20 +18,6 @@ use utf8;
 # there can be only one / in a unit.
 # powers can be negative integers as well as positive integers.
 
-# These subroutines return a unit hash.
-# A unit hash has the entries
-#      factor => number   number can be any real number
-#      m      => power    power is a signed integer
-#      kg     => power
-#      s      => power
-#      rad    => power
-#      degC   => power
-#      degF   => power
-#      degK   => power
-#      mol	  => power
-#	   amp	  => power
-#	   cd	  => power
-
 # Unfortunately there will be no automatic conversion between the different
 # temperature scales since we haven't allowed for affine conversions.
 
@@ -43,7 +29,7 @@ our %fundamental_units = (
 	'rad'    => 0,
 	'degC'   => 0,
 	'degF'   => 0,
-	'degK'   => 0,
+	'K'      => 0,
 	'mol'    => 0,    # moles, treated as a fundamental unit
 	'amp'    => 0,
 	'cd'     => 0,    # candela, SI unit of luminous intensity
@@ -77,7 +63,11 @@ our %known_units = (
 		'factor' => 1,
 		'degC'   => 1
 	},
-	'°C' => {    # unicode "\x{00B0}C"
+	"\x{00B0}C" => {    # Unicode degree symbol with text C
+		'factor' => 1,
+		'degC'   => 1
+	},
+	"\x{2103}" => {     # Unicode degree Celsius symbol
 		'factor' => 1,
 		'degC'   => 1
 	},
@@ -85,18 +75,29 @@ our %known_units = (
 		'factor' => 1,
 		'degF'   => 1
 	},
-	'°F' => {    # unicode "\x{00B0}F"
+	"\x{00B0}F" => {    # Unicode degree symbol with text F
 		'factor' => 1,
 		'degF'   => 1
 	},
-	# FIXME: Shouldn't this just be K?
+	"\x{2109}" => {     # Unicode degree Fahrenheit symbol
+		'factor' => 1,
+		'degF'   => 1
+	},
+	'K' => {
+		'factor' => 1,
+		'K'      => 1
+	},
 	'degK' => {
 		'factor' => 1,
-		'degK'   => 1
+		'K'      => 1
 	},
-	'°K' => {    # unicode "\x{00B0}K"
+	"\x{00B0}K" => {    # Unicode degree symbol with text K
 		'factor' => 1,
-		'degK'   => 1
+		'K'      => 1
+	},
+	"\x{212A}" => {     # Unicode Kelvin symbol
+		'factor' => 1,
+		'K'      => 1
 	},
 	'mol' => {
 		'factor' => 1,
@@ -117,11 +118,11 @@ our %known_units = (
 	# deg  -- degrees
 	# sr   -- steradian, a mesure of solid angle
 	#
-	'°' => {    # unicode "\x{00B0}"
+	'deg' => {
 		'factor' => 0.0174532925,
 		'rad'    => 1
 	},
-	'deg' => {
+	"\x{00B0}" => {    # Unicode degree symbol
 		'factor' => 0.0174532925,
 		'rad'    => 1
 	},
@@ -287,7 +288,7 @@ our %known_units = (
 		'factor' => 1E-10,
 		'm'      => 1
 	},
-	'Å' => {    # unicode "\x{00C5}"
+	"\x{00C5}" => {    # Unicode angstrom symbol
 		'factor' => 1E-10,
 		'm'      => 1
 	},

--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -1,17 +1,12 @@
-
-# This is the "exported" subroutine.  Use this to evaluate the units given in an answer.
-
-sub evaluate_units {
-	&Units::evaluate_units;
-}
-
 # Methods for evaluating units in answers
 package Units;
+use parent Exporter;
+
+use strict;
+use warnings;
 use utf8;
 
-#require Exporter;
-#@ISA = qw(Exporter);
-#@EXPORT = qw(evaluate_units);
+our @EXPORT_OK = qw(evaluate_units);
 
 # compound units are entered such as m/sec^2 or kg*m/sec^2
 # the format is unit[^power]*unit^[*power].../  unit^power*unit^power....
@@ -22,17 +17,17 @@ use utf8;
 # temperature scales since we haven't allowed for affine conversions.
 
 our %fundamental_units = (
-	'factor' => 1,
-	'm'      => 0,
-	'kg'     => 0,
-	's'      => 0,
-	'rad'    => 0,
-	'degC'   => 0,
-	'degF'   => 0,
-	'K'      => 0,
-	'mol'    => 0,    # moles, treated as a fundamental unit
-	'amp'    => 0,
-	'cd'     => 0,    # candela, SI unit of luminous intensity
+	factor => 1,
+	m      => 0,
+	kg     => 0,
+	s      => 0,
+	rad    => 0,
+	degC   => 0,
+	degF   => 0,
+	K      => 0,
+	mol    => 0,    # moles, treated as a fundamental unit
+	amp    => 0,
+	cd     => 0,    # candela, SI unit of luminous intensity
 );
 
 # This hash contains all of the units which will be accepted.  These must
@@ -40,984 +35,745 @@ our %fundamental_units = (
 # of the fundamental unit is not included it is assumed to be zero.
 
 our $PI = 4 * atan2(1, 1);
-#         9.80665 m/s^2  -- standard acceleration of gravity
+
+# 9.80665 m/s^2  -- standard acceleration of gravity
 
 our %known_units = (
-	'm' => {
-		'factor' => 1,
-		'm'      => 1
+	m => {
+		factor => 1,
+		m      => 1
 	},
-	'kg' => {
-		'factor' => 1,
-		'kg'     => 1
+	kg => {
+		factor => 1,
+		kg     => 1
 	},
-	's' => {
-		'factor' => 1,
-		's'      => 1
+	s => {
+		factor  => 1,
+		s       => 1,
+		aliases => [ 'second', 'seconds', 'sec' ]
 	},
-	'rad' => {
-		'factor' => 1,
-		'rad'    => 1
+	rad => {
+		factor  => 1,
+		rad     => 1,
+		aliases => [ 'radian', 'radians' ]
 	},
-	'degC' => {
-		'factor' => 1,
-		'degC'   => 1
+	degC => {
+		factor  => 1,
+		degC    => 1,
+		aliases => [ "\x{00B0}C", "\x{2103}" ]
 	},
-	"\x{00B0}C" => {    # Unicode degree symbol with text C
-		'factor' => 1,
-		'degC'   => 1
+	degF => {
+		factor  => 1,
+		degF    => 1,
+		aliases => [ "\x{00B0}F", "\x{2109}" ]
 	},
-	"\x{2103}" => {     # Unicode degree Celsius symbol
-		'factor' => 1,
-		'degC'   => 1
+	K => {
+		factor  => 1,
+		K       => 1,
+		aliases => [ "\x{212A}", 'degK', "\x{00B0}K" ]    # Should the degree forms be deleted? Probably.
 	},
-	'degF' => {
-		'factor' => 1,
-		'degF'   => 1
+	mol => {
+		factor => 1,
+		mol    => 1
 	},
-	"\x{00B0}F" => {    # Unicode degree symbol with text F
-		'factor' => 1,
-		'degF'   => 1
+	amp => {                                              # ampere
+		factor  => 1,
+		amp     => 1,
+		aliases => ['A']
 	},
-	"\x{2109}" => {     # Unicode degree Fahrenheit symbol
-		'factor' => 1,
-		'degF'   => 1
-	},
-	'K' => {
-		'factor' => 1,
-		'K'      => 1
-	},
-	'degK' => {
-		'factor' => 1,
-		'K'      => 1
-	},
-	"\x{00B0}K" => {    # Unicode degree symbol with text K
-		'factor' => 1,
-		'K'      => 1
-	},
-	"\x{212A}" => {     # Unicode Kelvin symbol
-		'factor' => 1,
-		'K'      => 1
-	},
-	'mol' => {
-		'factor' => 1,
-		'mol'    => 1
-	},
-	'amp' => {
-		'factor' => 1,
-		'amp'    => 1,
-	},
-	'cd' => {
-		'factor' => 1,
-		'cd'     => 1,
+	cd => {
+		factor => 1,
+		cd     => 1,
 	},
 	'%' => {
-		'factor' => 0.01,
-	},
-	# ANGLES
-	# deg  -- degrees
-	# sr   -- steradian, a mesure of solid angle
-	#
-	'deg' => {
-		'factor' => 0.0174532925,
-		'rad'    => 1
-	},
-	"\x{00B0}" => {    # Unicode degree symbol
-		'factor' => 0.0174532925,
-		'rad'    => 1
-	},
-	'degree' => {
-		'factor' => 0.0174532925,
-		'rad'    => 1
-	},
-	'degrees' => {
-		'factor' => 0.0174532925,
-		'rad'    => 1
-	},
-	'radian' => {
-		'factor' => 1,
-		'rad'    => 1
-	},
-	'radians' => {
-		'factor' => 1,
-		'rad'    => 1
-	},
-	'sr' => {
-		'factor' => 1,
-		'rad'    => 2
-	},
-	# TIME
-	# s     -- seconds
-	# ms    -- milliseconds
-	# us    -- microseconds
-	# ns    -- nanoseconds
-	# min   -- minutes
-	# hr    -- hours
-	# day   -- days
-	# yr    -- years  -- 365 days in a year
-	# fortnight	-- (FFF system) 2 weeks
-	#
-	'sec' => {
-		'factor' => 1,
-		's'      => 1
-	},
-	'second' => {
-		'factor' => 1,
-		's'      => 1
-	},
-	'seconds' => {
-		'factor' => 1,
-		's'      => 1
-	},
-	'ms' => {
-		'factor' => 0.001,
-		's'      => 1
-	},
-	'us' => {
-		'factor' => 1E-6,
-		's'      => 1
-	},
-	'ns' => {
-		'factor' => 1E-9,
-		's'      => 1
-	},
-	'min' => {
-		'factor' => 60,
-		's'      => 1
-	},
-	'minute' => {
-		'factor' => 60,
-		's'      => 1
-	},
-	'minutes' => {
-		'factor' => 60,
-		's'      => 1
-	},
-	'hr' => {
-		'factor' => 3600,
-		's'      => 1
-	},
-	'hour' => {
-		'factor' => 3600,
-		's'      => 1
-	},
-	'hours' => {
-		'factor' => 3600,
-		's'      => 1
-	},
-	'h' => {
-		'factor' => 3600,
-		's'      => 1
-	},
-	'day' => {
-		'factor' => 86400,
-		's'      => 1
-	},
-	'month' => {
-		'factor' => 60 * 60 * 24 * 30,
-		's'      => 1
-	},
-	'months' => {
-		'factor' => 60 * 60 * 24 * 30,
-		's'      => 1
-	},
-	'mo' => {
-		'factor' => 60 * 60 * 24 * 30,
-		's'      => 1
-	},
-	'yr' => {
-		'factor' => 31557600,
-		's'      => 1
-	},
-	'fortnight' => {
-		'factor' => 1209600,
-		's'      => 1
+		factor => 0.01,
 	},
 
-	# LENGTHS
-	# m    -- meters
-	# cm   -- centimeters
-	# km   -- kilometers
-	# mm   -- millimeters
-	# micron -- micrometer
-	# um   -- micrometer
-	# nm   -- nanometer
-	# angstrom -- angstrom
-	# Angstrom -- angstrom
-	# Å        -- angstrom
-	# pm   -- picometer
-	# fm   -- femtometer
-	#
-	'km' => {
-		'factor' => 1000,
-		'm'      => 1
+	# ANGLES: fundamental unit rad (radian)
+	deg => {    # degree
+		factor  => 0.0174532925,
+		rad     => 1,
+		aliases => [ "\x{00B0}", 'degree', 'degrees' ]
 	},
-	'cm' => {
-		'factor' => 0.01,
-		'm'      => 1
+	sr => {     # steradian, a mesure of solid angle
+		factor => 1,
+		rad    => 2
 	},
-	'mm' => {
-		'factor' => 0.001,
-		'm'      => 1
+
+	# TIME: fundamental unit s (second)
+	ms => {     # millisecond
+		factor => 0.001,
+		s      => 1
 	},
-	'micron' => {
-		'factor' => 1E-6,
-		'm'      => 1
+	us => {     # microsecond
+		factor  => 1E-6,
+		s       => 1,
+		aliases => ["\x{00B5}s"]
 	},
-	'um' => {
-		'factor' => 1E-6,
-		'm'      => 1
+	ns => {     # nanosecond
+		factor => 1E-9,
+		s      => 1
 	},
-	'nm' => {
-		'factor' => 1E-9,
-		'm'      => 1
+	minute => {
+		factor  => 60,
+		s       => 1,
+		aliases => [ 'minutes', 'min' ]
 	},
-	'angstrom' => {
-		'factor' => 1E-10,
-		'm'      => 1
+	hour => {
+		factor  => 3600,
+		s       => 1,
+		aliases => [ 'hours', 'hr', 'h' ]
 	},
-	'angstroms' => {
-		'factor' => 1E-10,
-		'm'      => 1
+	day => {
+		factor => 86400,
+		s      => 1
 	},
-	'Angstrom' => {
-		'factor' => 1E-10,
-		'm'      => 1
+	month => {    # 60 * 60 * 24 * 30
+		factor  => 2592000,
+		s       => 1,
+		aliases => [ 'months', 'mo' ]
 	},
-	'Angstroms' => {
-		'factor' => 1E-10,
-		'm'      => 1
+	year => {     # 365 days in a year
+		factor  => 31557600,
+		s       => 1,
+		aliases => [ 'years', 'yr' ]
 	},
-	"\x{00C5}" => {    # Unicode angstrom symbol
-		'factor' => 1E-10,
-		'm'      => 1
+	fortnight => {    # (FFF system) 2 weeks
+		factor => 1209600,
+		s      => 1
 	},
-	'pm' => {
-		'factor' => 1E-12,
-		'm'      => 1
+
+	# LENGTHS: fundamental unit m (meter)
+
+	# METRIC LENGTHS
+	km => {    # kilometer
+		factor => 1000,
+		m      => 1
 	},
-	'fm' => {
-		'factor' => 1E-15,
-		'm'      => 1
+	cm => {    # centimeter
+		factor => 0.01,
+		m      => 1
 	},
+	mm => {    # millimeter
+		factor => 0.001,
+		m      => 1
+	},
+	um => {    # micrometer
+		factor  => 1E-6,
+		m       => 1,
+		aliases => [ 'micron', "\x{00B5}m" ]
+	},
+	nm => {    # nanometer
+		factor => 1E-9,
+		m      => 1
+	},
+	angstrom => {
+		factor  => 1E-10,
+		m       => 1,
+		aliases => [ 'angstroms', 'Angstrom', 'Angstroms', "\x{00C5}" ]
+	},
+	pm => {    # picometer
+		factor => 1E-12,
+		m      => 1
+	},
+	fm => {    # femtometer
+		factor => 1E-15,
+		m      => 1
+	},
+
 	# ENGLISH LENGTHS
-	# in    -- inch
-	# ft    -- feet
-	# mi    -- mile
-	# furlong -- (FFF system) 0.125 mile
-	# light-year
-	# AU	-- Astronomical Unit
-	# parsec
-	#
-	'in' => {
-		'factor' => 0.0254,
-		'm'      => 1
+	inch => {
+		factor  => 0.0254,
+		m       => 1,
+		aliases => [ 'inches', 'in' ]
 	},
-	'inch' => {
-		'factor' => 0.0254,
-		'm'      => 1
+	foot => {
+		factor  => 0.3048,
+		m       => 1,
+		aliases => [ 'feet', 'ft' ]
 	},
-	'inches' => {
-		'factor' => 0.0254,
-		'm'      => 1
+	mile => {
+		factor  => 1609.344,
+		m       => 1,
+		aliases => [ 'miles', 'mi' ]
 	},
-	'ft' => {
-		'factor' => 0.3048,
-		'm'      => 1
+	furlong => {    # (FFF system) 0.125 mile
+		factor => 201.168,
+		m      => 1
 	},
-	'feet' => {
-		'factor' => 0.3048,
-		'm'      => 1
+	'light-year' => {    # 9.46E15,
+		factor => 9460730472580800,
+		m      => 1
 	},
-	'foot' => {
-		'factor' => 0.3048,
-		'm'      => 1
+	AU => {              # Astronomical Unit
+		factor => 149597870700,
+		m      => 1
 	},
-	'mi' => {
-		'factor' => 1609.344,
-		'm'      => 1
+	parsec => {          # 30.857E15,
+		factor => 3.08567758149137E16,
+		m      => 1
 	},
-	'furlong' => {
-		'factor' => 201.168,
-		'm'      => 1
+
+	# VOLUME: fundamental unit m^3 (cubic meter)
+	L => {               # liter
+		factor => 0.001,
+		m      => 3
 	},
-	'light-year' => {
-		#'factor'    => 9.46E15,
-		'factor' => 9460730472580800,
-		'm'      => 1
+	ml => {              # milliliter (cubic centimeter)
+		factor  => 1E-6,
+		m       => 3,
+		aliases => ['cc']
 	},
-	'AU' => {
-		'factor' => 149597870700,
-		'm'      => 1
+	dL => {              # deciliter
+		factor => 0.0001,
+		m      => 3
 	},
-	'parsec' => {
-		'factor' => 3.08567758149137E16,    #30.857E15,
-		'm'      => 1
+	cup => {
+		factor  => 0.000236588,
+		m       => 3,
+		aliases => ['cups']
 	},
-	# VOLUME
-	# L   -- liter
-	# ml -- milliliters
-	# cc -- cubic centermeters
-	# dL  -- deci-liter
-	#
-	'L' => {
-		'factor' => 0.001,
-		'm'      => 3
+
+	# VELOCITY: fundamental unit m/s (meters per second)
+	knots => {           # nautical miles per hour
+		factor => 0.5144444444,
+		m      => 1,
+		s      => -1
 	},
-	'cc' => {
-		'factor' => 1E-6,
-		'm'      => 3,
+	c => {               # exact speed of light
+		factor => 299792458,
+		m      => 1,
+		s      => -1
 	},
-	'ml' => {
-		'factor' => 1E-6,
-		'm'      => 3,
+	mph => {
+		factor => 0.44704,
+		m      => 1,
+		s      => -1
 	},
-	'dL' => {
-		'factor' => 0.0001,
-		'm'      => 3
+
+	# MASS: fundamental unit kg (kilogram)
+
+	# METRIC MASS
+	mg => {    # milligrams
+		factor => 0.000001,
+		kg     => 1
 	},
-	'cup' => {
-		'factor' => 0.000236588,
-		'm'      => 3
+	g => {     # gram
+		factor => 0.001,
+		kg     => 1
 	},
-	'cups' => {
-		'factor' => 0.000236588,
-		'm'      => 3
+	tonne => {    # metric ton
+		factor => 1000,
+		kg     => 1
 	},
-	# VELOCITY
-	# knots -- nautical miles per hour
-	# c		-- speed of light
-	#
-	'knots' => {
-		'factor' => 0.5144444444,
-		'm'      => 1,
-		's'      => -1
-	},
-	'c' => {
-		'factor' => 299792458,    # exact
-		'm'      => 1,
-		's'      => -1
-	},
-	'mph' => {
-		'factor' => 0.44704,
-		'm'      => 1,
-		's'      => -1
-	},
-	# MASS
-	# mg   -- milligrams
-	# g    -- grams
-	# kg   -- kilograms
-	# tonne -- metric ton
-	#
-	'mg' => {
-		'factor' => 0.000001,
-		'kg'     => 1
-	},
-	'g' => {
-		'factor' => 0.001,
-		'kg'     => 1
-	},
-	'tonne' => {
-		'factor' => 1000,
-		'kg'     => 1
-	},
+
 	# ENGLISH MASS
-	# slug -- slug
-	# firkin	-- (FFF system) 90 lb, mass of a firkin of water
-	#
-	'slug' => {
-		'factor' => 14.6,
-		'kg'     => 1
+	slug => {
+		factor => 14.6,
+		kg     => 1
 	},
-	'firkin' => {
-		'factor' => 40.8233133,
-		'kg'     => 1
+	firkin => {    # (FFF system) 90 lb, mass of a firkin of water
+		factor => 40.8233133,
+		kg     => 1
 	},
-	# FREQUENCY
-	# Hz    -- Hertz
-	# kHz   -- kilo Hertz
-	# MHz   -- mega Hertz
-	#
-	'Hz' => {
-		'factor' => 2 * $PI,    #2pi
-		's'      => -1,
-		'rad'    => 1
+
+	# FREQUENCY: fundamental unit rad/s (radians per second)
+	Hz => {        # hertz
+		factor => 2 * $PI,
+		s      => -1,
+		rad    => 1
 	},
-	'kHz' => {
-		'factor' => 2000 * $PI,    #1000*2pi,
-		's'      => -1,
-		'rad'    => 1
+	kHz => {       # kilohertz
+		factor => 2000 * $PI,
+		s      => -1,
+		rad    => 1
 	},
-	'MHz' => {
-		'factor' => (2E6) * $PI,    #10^6 * 2pi,
-		's'      => -1,
-		'rad'    => 1
+	MHz => {       # megahertz (10^6 * 2pi)
+		factor => (2E6) * $PI,
+		s      => -1,
+		rad    => 1
 	},
-	'rev' => {
-		'factor' => 2 * $PI,
-		'rad'    => 1
-	},
-	'cycles' => {
-		'factor' => 2 * $PI,
-		'rad'    => 1
+	cycles => {    # or revolutions
+		factor  => 2 * $PI,
+		rad     => 1,
+		aliases => ['rev']
 	},
 
 	# COMPOUND UNITS
-	#
-	# FORCE
-	# N      -- Newton
-	# microN -- micro Newton
-	# uN     -- micro Newton
-	# kN	 -- kilo Newton
-	# dyne   -- dyne
-	# lb     -- pound
-	# ton    -- ton
-	#
-	'N' => {
-		'factor' => 1,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+
+	# FORCE: fundamental unit m kg / s^2
+	N => {    # newton
+		factor => 1,
+		m      => 1,
+		kg     => 1,
+		s      => -2
 	},
-	'microN' => {
-		'factor' => 1E-6,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	uN => {    # micronewton
+		factor  => 1E-6,
+		m       => 1,
+		kg      => 1,
+		s       => -2,
+		aliases => [ 'microN', "\x{00B5}N" ]
 	},
-	'uN' => {
-		'factor' => 1E-6,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	kN => {    # kilonewton
+		factor => 1000,
+		m      => 1,
+		kg     => 1,
+		s      => -2
 	},
-	'kN' => {
-		'factor' => 1000,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	dyne => {
+		factor => 1E-5,
+		m      => 1,
+		kg     => 1,
+		s      => -2
 	},
-	'dyne' => {
-		'factor' => 1E-5,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	lb => {    # pound
+		factor  => 4.4482216152605,
+		m       => 1,
+		kg      => 1,
+		s       => -2,
+		aliases => [ 'pound', 'pounds', 'lbs' ]
 	},
-	'lb' => {
-		'factor' => 4.4482216152605,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	ton => {
+		factor => 8900,
+		m      => 1,
+		kg     => 1,
+		s      => -2
 	},
-	'lbs' => {
-		'factor' => 4.4482216152605,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+
+	# ENERGY: fundamental unit m^2 kg / s^2
+	J => {    # joule
+		factor => 1,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'ton' => {
-		'factor' => 8900,
-		'm'      => 1,
-		'kg'     => 1,
-		's'      => -2
+	kJ => {    # kilojoule
+		factor => 1000,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	# ENERGY
-	# J      -- Joule
-	# kJ     -- kilo Joule
-	# erg    -- erg
-	# lbf    -- foot pound
-	# kt	 -- kiloton (of TNT)
-	# Mt	 -- megaton (of TNT)
-	# cal    -- calorie
-	# kcal   -- kilocalorie
-	# eV     -- electron volt
-	# keV    -- kilo electron volt
-	# MeV    -- mega electron volt
-	# GeV    -- giga electron volt
-	# TeV    -- tera electron volt
-	# kWh    -- kilo Watt hour
-	#
-	'J' => {
-		'factor' => 1,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	erg => {
+		factor => 1E-7,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'kJ' => {
-		'factor' => 1000,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	lbf => {    # foot pound
+		factor => 1.35582,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'erg' => {
-		'factor' => 1E-7,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	kt => {     # kiloton
+		factor => 4.184E12,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'lbf' => {
-		'factor' => 1.35582,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	Mt => {     # megaton
+		factor => 4.184E15,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'kt' => {
-		'factor' => 4.184E12,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	cal => {    # calorie
+		factor => 4.19,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'Mt' => {
-		'factor' => 4.184E15,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	kcal => {    # kilocalorie
+		factor => 4190,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'cal' => {
-		'factor' => 4.19,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	eV => {      # electron volt
+		factor => 1.6022E-19,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'kcal' => {
-		'factor' => 4190,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	keV => {     # kilo electron volt
+		factor => 1.6022E-16,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'eV' => {
-		'factor' => 1.6022E-19,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	MeV => {     # mega electron volt
+		factor => 1.6022E-13,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'keV' => {
-		'factor' => 1.6022E-16,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	GeV => {     # giga electron volt
+		factor => 1.6022E-10,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'MeV' => {
-		'factor' => 1.6022E-13,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	TeV => {     # tera electron volt
+		factor => 1.6022E-7,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'GeV' => {
-		'factor' => 1.6022E-10,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	kWh => {     # kilo Watt hour
+		factor => 3.6E6,
+		m      => 2,
+		kg     => 1,
+		s      => -2
 	},
-	'TeV' => {
-		'factor' => 1.6022E-7,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+
+	# POWER: fundamental unit m kg / s^3
+	W => {       # watt
+		factor => 1,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-	'kWh' => {
-		'factor' => 3.6E6,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -2
+	kW => {      # kilowatt
+		factor => 1000,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-	# POWER
-	# W      -- Watt
-	# kW     -- kilo Watt
-	# MW     -- mega Watt
-	# mW     -- milli Watt
-	# hp     -- horse power  746 W
-	#
-	'W' => {
-		'factor' => 1,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
+	MW => {      # megawatt
+		factor => 1E6,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-	'kW' => {
-		'factor' => 1000,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
+	mW => {      # milliwatt
+		factor => 0.001,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-	'MW' => {
-		'factor' => 1E6,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
+	hp => {      # horse power
+		factor => 746,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-	'mW' => {
-		'factor' => 0.001,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
-	},
-	'hp' => {
-		'factor' => 746,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
-	},
+
 	# PRESSURE
-	# Pa     -- Pascal
-	# kPa    -- kilo Pascal
-	# MPa    -- mega Pascal
-	# GPa    -- giga Pascal
-	# atm    -- atmosphere
-	# bar	 -- 100 kilopascals
-	# cmH2O	 -- centimetres of water
-	#
-	'Pa' => {
-		'factor' => 1,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	Pa => {      # pascal
+		factor => 1,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'kPa' => {
-		'factor' => 1000,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	kPa => {     # kilopascal
+		factor => 1000,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'MPa' => {
-		'factor' => 1E6,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	MPa => {     # megapascal
+		factor => 1E6,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'GPa' => {
-		'factor' => 1E9,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	GPa => {     # gigapascal
+		factor => 1E9,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'atm' => {
-		'factor' => 1.01E5,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	atm => {     # atmosphere
+		factor => 1.01E5,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'bar' => {
-		'factor' => 100000,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	bar => {
+		factor => 100000,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'mbar' => {
-		'factor' => 100,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	mbar => {    # millibar
+		factor => 100,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'Torr' => {
-		'factor' => 133.322,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	Torr => {
+		factor => 133.322,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'mmHg' => {
-		'factor' => 133.322,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	mmHg => {
+		factor => 133.322,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'cmH2O' => {
-		'factor' => 98.0638,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	cmH2O => {    # centimeters of water
+		factor => 98.0638,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
-	'psi' => {
-		'factor' => 6895,
-		'm'      => -1,
-		'kg'     => 1,
-		's'      => -2
+	psi => {      # pounds per square inch
+		factor => 6895,
+		m      => -1,
+		kg     => 1,
+		s      => -2
 	},
+
 	# ELECTRICAL UNITS
-	# C      -- Coulomb
-	# mC     -- milliCoulomb
-	# uC     -- microCoulomb
-	# nC     -- nanoCoulomb
-	# V      -- volt
-	# mV     -- millivolt
-	# kV     -- kilovolt
-	# MV     -- megavolt
-	# F      -- Farad
-	# mF     -- milliFarad
-	# uF     -- microFarad
-	# ohm    -- ohm
-	# kohm   -- kilo-ohm
-	# Mohm	 -- mega-ohm
-	# S		 -- siemens
-	# A      -- ampere
-	# mA     -- milli-ampere
-	#
-	'C' => {
-		'factor' => 1,
-		'amp'    => 1,
-		's'      => 1,
+	C => {        # coulomb
+		factor => 1,
+		amp    => 1,
+		s      => 1,
 	},
-	'mC' => {
-		'factor' => 0.001,
-		'amp'    => 1,
-		's'      => 1,
+	mC => {       # millicoulomb
+		factor => 0.001,
+		amp    => 1,
+		s      => 1,
 	},
-	'uC' => {
-		'factor' => 1e-6,
-		'amp'    => 1,
-		's'      => 1,
+	uC => {       # microcoulomb
+		factor  => 1e-6,
+		amp     => 1,
+		s       => 1,
+		aliases => ["\x{00B5}C"]
 	},
-	'nC' => {
-		'factor' => 1e-9,
-		'amp'    => 1,
-		's'      => 1,
+	nC => {       # nanocoulomb
+		factor => 1e-9,
+		amp    => 1,
+		s      => 1,
 	},
-	'V' => {    # also J/C
-		'factor' => 1,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -1,
-		's'      => -3,
+	V => {        # volt (also J/C)
+		factor => 1,
+		kg     => 1,
+		m      => 2,
+		amp    => -1,
+		s      => -3,
 	},
-	'mV' => {
-		'factor' => 0.001,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -1,
-		's'      => -3,
+	mV => {       # millivolt
+		factor => 0.001,
+		kg     => 1,
+		m      => 2,
+		amp    => -1,
+		s      => -3,
 	},
-	'kV' => {
-		'factor' => 1000,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -1,
-		's'      => -3,
+	kV => {       # killivolt
+		factor => 1000,
+		kg     => 1,
+		m      => 2,
+		amp    => -1,
+		s      => -3,
 	},
-	'MV' => {
-		'factor' => 1E6,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -1,
-		's'      => -3,
+	MV => {       # megavolt
+		factor => 1E6,
+		kg     => 1,
+		m      => 2,
+		amp    => -1,
+		s      => -3,
 	},
-	'F' => {    # also C/V
-		'factor' => 1,
-		'amp'    => 2,
-		's'      => 4,
-		'kg'     => -1,
-		'm'      => -2,
+	F => {        # farad (also C/V)
+		factor => 1,
+		amp    => 2,
+		s      => 4,
+		kg     => -1,
+		m      => -2,
 	},
-	'mF' => {
-		'factor' => 0.001,
-		'amp'    => 2,
-		's'      => 4,
-		'kg'     => -1,
-		'm'      => -2,
+	mF => {       # millifarad
+		factor => 0.001,
+		amp    => 2,
+		s      => 4,
+		kg     => -1,
+		m      => -2,
 	},
-	'uF' => {
-		'factor' => 1E-6,
-		'amp'    => 2,
-		's'      => 4,
-		'kg'     => -1,
-		'm'      => -2,
+	uF => {       # microfarad
+		factor  => 1E-6,
+		amp     => 2,
+		s       => 4,
+		kg      => -1,
+		m       => -2,
+		aliases => [ "\x{00B5}F", "\x{338C}" ]
 	},
-	'ohm' => {    # V/amp
-		'factor' => 1,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -2,
-		's'      => -3,
+	ohm => {      # V/amp
+		factor  => 1,
+		kg      => 1,
+		m       => 2,
+		amp     => -2,
+		s       => -3,
+		aliases => ["\x{2126}"]
 	},
-	'kohm' => {
-		'factor' => 1000,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -2,
-		's'      => -3,
+	kohm => {     # kiloohm
+		factor  => 1000,
+		kg      => 1,
+		m       => 2,
+		amp     => -2,
+		s       => -3,
+		aliases => [ "k\x{2126}", "\x{33C0}" ]
 	},
-	'Mohm' => {
-		'factor' => 1E6,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -2,
-		's'      => -3,
+	Mohm => {     # megaohm
+		factor  => 1E6,
+		kg      => 1,
+		m       => 2,
+		amp     => -2,
+		s       => -3,
+		aliases => [ "M\x{2126}", "\x{33C1}" ]
 	},
-	'S' => {    # 1/ohm
-		'factor' => 1,
-		'kg'     => -1,
-		'm'      => -2,
-		'amp'    => 2,
-		's'      => 3,
+	S => {        # siemens (1/ohm)
+		factor => 1,
+		kg     => -1,
+		m      => -2,
+		amp    => 2,
+		s      => 3,
 	},
-	'A' => {    # ampere
-		'factor' => 1,
-		'amp'    => 1,
+	mA => {       # milliampere
+		factor => 0.001,
+		amp    => 1,
 	},
-	'mA' => {    # milliampere
-		'factor' => 0.001,
-		'amp'    => 1,
-	},
+
 	# MAGNETIC UNITS
-	# T      -- tesla
-	# mT     -- millitesla
-	# G      -- gauss
-	# Wb     -- weber
-	# H      -- henry
-	#
-	'T' => {    # also kg/A s^2		N s/C m
-		'factor' => 1,
-		'kg'     => 1,
-		'amp'    => -1,
-		's'      => -2,
+	T => {        # tesla (also kg / A s^2 or N s / C m)
+		factor => 1,
+		kg     => 1,
+		amp    => -1,
+		s      => -2,
 	},
-	'mT' => {
-		'factor' => 0.001,
-		'kg'     => 1,
-		'amp'    => -1,
-		's'      => -2,
+	mT => {       # millitesla
+		factor => 0.001,
+		kg     => 1,
+		amp    => -1,
+		s      => -2,
 	},
-	'G' => {
-		'factor' => 1E-4,
-		'kg'     => 1,
-		'amp'    => -1,
-		's'      => -2,
+	G => {        # gauss
+		factor => 1E-4,
+		kg     => 1,
+		amp    => -1,
+		s      => -2,
 	},
-	'Wb' => {    # also T m^2
-		'factor' => 1,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -1,
-		's'      => -2,
+	Wb => {       # weber (also T m^2)
+		factor => 1,
+		kg     => 1,
+		m      => 2,
+		amp    => -1,
+		s      => -2,
 	},
-	'H' => {     # also V s/amp
-		'factor' => 1,
-		'kg'     => 1,
-		'm'      => 2,
-		'amp'    => -2,
-		's'      => -2,
+	H => {        # henry (also V s/amp)
+		factor => 1,
+		kg     => 1,
+		m      => 2,
+		amp    => -2,
+		s      => -2,
 	},
+
 	# LUMINOSITY
-	# lm	-- lumen, luminous flux
-	# lx	-- lux, illuminance
-	#
-	'lm' => {
-		'factor' => 1,
-		'cd'     => 1,
-		'rad'    => -2,
+	lm => {       # lumen (luminous flux)
+		factor => 1,
+		cd     => 1,
+		rad    => -2,
 	},
-	'lx' => {
-		'factor' => 1,
-		'cd'     => 1,
-		'rad'    => -2,
-		'm'      => -2,
+	lx => {       # lux (illuminance)
+		factor => 1,
+		cd     => 1,
+		rad    => -2,
+		m      => -2,
 	},
 
 	# ATOMIC UNITS
-	# amu	-- atomic mass units
-	# dalton	-- 1 amu
-	# me	-- electron rest mass
-	# barn	-- cross-sectional area
-	# a0	-- Bohr radius
-	#
-	'amu' => {
-		'factor' => 1.660538921E-27,
-		'kg'     => 1,
+	amu => {      # atomic mass units
+		factor  => 1.660538921E-27,
+		kg      => 1,
+		aliases => ['dalton']
 	},
-	'dalton' => {
-		'factor' => 1.660538921E-27,
-		'kg'     => 1,
+	me => {       # electron rest mass
+		factor => 9.1093826E-31,
+		kg     => 1,
 	},
-	'me' => {
-		'factor' => 9.1093826E-31,
-		'kg'     => 1,
+	barn => {     # cross-sectional area
+		factor => 1E-28,
+		m      => 2,
 	},
-	'barn' => {
-		'factor' => 1E-28,
-		'm'      => 2,
+	a0 => {       # Bohr radius
+		factor => 0.5291772108E-10,
+		m      => 1,
 	},
-	'a0' => {
-		'factor' => 0.5291772108E-10,
-		'm'      => 1,
-	},
+
 	# RADIATION
-	# Sv	-- sievert, dose equivalent radiation	http://xkcd.com/radiation
-	# mSv	-- millisievert				http://blog.xkcd.com/2011/03/19/radiation-chart
-	# uSv	-- microsievert				http://blog.xkcd.com/2011/04/26/radiation-chart-update
-	# Bq    -- becquerel, radioactivity             https://en.wikipedia.org/wiki/Becquerel
-	#
-	'Sv' => {
-		'factor' => 1,
-		'm'      => 2,
-		's'      => -2,
+	Sv => {       # sievert, dose equivalent radiation (http://xkcd.com/radiation)
+		factor => 1,
+		m      => 2,
+		s      => -2,
 	},
-	'mSv' => {
-		'factor' => 0.001,
-		'm'      => 2,
-		's'      => -2,
+	mSv => {      # millisievert (http://blog.xkcd.com/2011/03/19/radiation-chart)
+		factor => 0.001,
+		m      => 2,
+		s      => -2,
 	},
-	'uSv' => {
-		'factor' => 0.000001,
-		'm'      => 2,
-		's'      => -2,
+	uSv => {      # microsievert (http://blog.xkcd.com/2011/04/26/radiation-chart-update)
+		factor  => 0.000001,
+		m       => 2,
+		s       => -2,
+		aliases => ["\x{00B5}Sv"]
 	},
-	'Bq' => {
-		'factor' => 1,
-		's'      => -1,
+	Bq => {       # becquerel, radioactivity (https://en.wikipedia.org/wiki/Becquerel)
+		factor => 1,
+		s      => -1,
 	},
+
 	# BIOLOGICAL & CHEMICAL UNITS
-	# mmol	-- milli mole
-	# micromol	-- micro mole
-	# nanomol	-- nano mole
-	# kat	-- katal, catalytic activity
-	#
-	'mmol' => {
-		'factor' => 0.001,
-		'mol'    => 1,
+	mmol => {     # millimole
+		factor => 0.001,
+		mol    => 1,
 	},
-	'micromol' => {
-		'factor' => 1E-6,
-		'mol'    => 1,
+	micromol => {    # micromole
+		factor => 1E-6,
+		mol    => 1,
 	},
-	'nanomol' => {
-		'factor' => 1E-9,
-		'mol'    => 1,
+	nanomol => {     # nanomole
+		factor => 1E-9,
+		mol    => 1,
 	},
-	'kat' => {
-		'factor' => 1,
-		'mol'    => 1,
-		's'      => -1,
+	kat => {         # katal (catalytic activity)
+		factor => 1,
+		mol    => 1,
+		s      => -1,
 	},
 
 	# ASTRONOMICAL UNITS
-	# kpc	-- kilo parsec
-	# Mpc	-- mega parsec
-	# solar-mass	-- solar mass
-	# solar-radii	-- solar radius
-	# solar-lum	-- solar luminosity
-	'kpc' => {
-		'factor' => 30.857E18,
-		'm'      => 1
+	kpc => {         # kiloparsec
+		factor => 30.857E18,
+		m      => 1
 	},
-	'Mpc' => {
-		'factor' => 30.857E21,
-		'm'      => 1
+	Mpc => {         # megaparsec
+		factor => 30.857E21,
+		m      => 1
 	},
-	'solar-mass' => {
-		'factor' => 1.98892E30,
-		'kg'     => 1,
+	'solar-mass' => {    # solar mass
+		factor => 1.98892E30,
+		kg     => 1,
 	},
-	'solar-radii' => {
-		'factor' => 6.955E8,
-		'm'      => 1,
+	'solar-radii' => {    # solar radius
+		factor => 6.955E8,
+		m      => 1,
 	},
-	'solar-lum' => {
-		'factor' => 3.8939E26,
-		'm'      => 2,
-		'kg'     => 1,
-		's'      => -3
+	'solar-lum' => {      # solar luminosity
+		factor => 3.8939E26,
+		m      => 2,
+		kg     => 1,
+		s      => -3
 	},
-
 );
+
+# Process aliases.
+for my $unit (keys %known_units) {
+	if (ref $known_units{$unit}{aliases} eq 'ARRAY') {
+		my $aliases = delete $known_units{$unit}{aliases};
+		$known_units{$_} = $known_units{$unit} for @$aliases;
+	}
+}
 
 sub process_unit {
 
@@ -1036,8 +792,9 @@ sub process_unit {
 		$known_units = $options->{known_units};
 	}
 
-	die("UNIT ERROR: No units were defined.") unless defined($string);    #
-		#split the string into numerator and denominator --- the separator is /
+	die("UNIT ERROR: No units were defined.") unless defined($string);
+
+	#split the string into numerator and denominator --- the separator is /
 	my ($numerator, $denominator) = split(m{/}, $string);
 
 	$denominator = "" unless defined($denominator);
@@ -1047,17 +804,16 @@ sub process_unit {
 		process_term($denominator, { fundamental_units => $fundamental_units, known_units => $known_units });
 
 	my %unit_hash = %$fundamental_units;
-	my $u;
-	foreach $u (keys %unit_hash) {
+	for my $u (keys %unit_hash) {
 		if ($u eq 'factor') {
-			$unit_hash{$u} = $numerator_hash{$u} / $denominator_hash{$u}; # calculate the correction factor for the unit
+			# calculate the correction factor for the unit
+			$unit_hash{$u} = $numerator_hash{$u} / $denominator_hash{$u};
 		} else {
-
-			$unit_hash{$u} =
-				$numerator_hash{$u} - $denominator_hash{$u};   # calculate the power of the fundamental unit in the unit
+			# calculate the power of the fundamental unit in the unit
+			$unit_hash{$u} = $numerator_hash{$u} - $denominator_hash{$u};
 		}
 	}
-	# return a unit hash.
+
 	return (%unit_hash);
 }
 
@@ -1080,28 +836,24 @@ sub process_term {
 	if ($string) {
 
 		#split the numerator or denominator into factors -- the separators are *
-
 		my @factors = split(/\*/, $string);
 
-		my $f;
-		foreach $f (@factors) {
+		for my $f (@factors) {
 			my %factor_hash =
 				process_factor($f, { fundamental_units => $fundamental_units, known_units => $known_units });
 
-			my $u;
-			foreach $u (keys %unit_hash) {
+			for my $u (keys %unit_hash) {
 				if ($u eq 'factor') {
-					$unit_hash{$u} = $unit_hash{$u} * $factor_hash{$u};   # calculate the correction factor for the unit
+					# calculate the correction factor for the unit
+					$unit_hash{$u} = $unit_hash{$u} * $factor_hash{$u};
 				} else {
-
-					$unit_hash{$u} =
-						$unit_hash{$u} + $factor_hash{$u};    # calculate the power of the fundamental unit in the unit
+					# calculate the power of the fundamental unit in the unit
+					$unit_hash{$u} = $unit_hash{$u} + $factor_hash{$u};
 				}
 			}
 		}
 	}
-	#returns a unit hash.
-	#print "process_term returns", %unit_hash, "\n";
+
 	return (%unit_hash);
 }
 
@@ -1127,22 +879,22 @@ sub process_factor {
 	my %unit_hash = %$fundamental_units;
 	if (defined($known_units->{$unit_name})) {
 		my %unit_name_hash = %{ $known_units->{$unit_name} };    # $reference_units contains all of the known units.
-		my $u;
-		foreach $u (keys %unit_hash) {
+		for my $u (keys %unit_hash) {
 			if ($u eq 'factor') {
 				$unit_hash{$u} = $unit_name_hash{$u}**$power;    # calculate the correction factor for the unit
 			} else {
 				my $fundamental_unit = $unit_name_hash{$u};
-				$fundamental_unit = 0
-					unless defined($fundamental_unit)
-					;    # a fundamental unit which doesn't appear in the unit need not be defined explicitly
-				$unit_hash{$u} = $fundamental_unit * $power;   # calculate the power of the fundamental unit in the unit
+				# a fundamental unit which doesn't appear in the unit need not be defined explicitly
+				$fundamental_unit = 0 unless defined($fundamental_unit);
+				# calculate the power of the fundamental unit in the unit
+				$unit_hash{$u} = $fundamental_unit * $power;
 			}
 		}
 	} else {
 		die "UNIT ERROR Unrecognizable unit: |$unit_name|";
 	}
-	%unit_hash;
+
+	return %unit_hash;
 }
 
 # This is the "exported" subroutine.  Use this to evaluate the units given in an answer.
@@ -1161,11 +913,13 @@ sub evaluate_units {
 		$known_units = $options->{known_units};
 	}
 
-	my %output = eval(q{process_unit( $unit, {fundamental_units => $fundamental_units, known_units => $known_units})});
-	%output          = %$fundamental_units if $@;    # this is what you get if there is an error.
-	$output{'ERROR'} = $@                  if $@;
-	%output;
+	my %output = eval { process_unit($unit, { fundamental_units => $fundamental_units, known_units => $known_units }) };
+	if ($@) {
+		%output = %$fundamental_units;
+		$output{'ERROR'} = $@;
+	}
+
+	return %output;
 }
-#################
 
 1;

--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -77,11 +77,24 @@ our %known_units = (
 		'factor' => 1,
 		'degC'   => 1
 	},
+	'°C' => {    # unicode "\x{00B0}C"
+		'factor' => 1,
+		'degC'   => 1
+	},
 	'degF' => {
 		'factor' => 1,
 		'degF'   => 1
 	},
+	'°F' => {    # unicode "\x{00B0}F"
+		'factor' => 1,
+		'degF'   => 1
+	},
+	# FIXME: Shouldn't this just be K?
 	'degK' => {
+		'factor' => 1,
+		'degK'   => 1
+	},
+	'°K' => {    # unicode "\x{00B0}K"
 		'factor' => 1,
 		'degK'   => 1
 	},
@@ -104,6 +117,10 @@ our %known_units = (
 	# deg  -- degrees
 	# sr   -- steradian, a mesure of solid angle
 	#
+	'°' => {    # unicode "\x{00B0}"
+		'factor' => 0.0174532925,
+		'rad'    => 1
+	},
 	'deg' => {
 		'factor' => 0.0174532925,
 		'rad'    => 1
@@ -258,7 +275,15 @@ our %known_units = (
 		'factor' => 1E-10,
 		'm'      => 1
 	},
+	'angstroms' => {
+		'factor' => 1E-10,
+		'm'      => 1
+	},
 	'Angstrom' => {
+		'factor' => 1E-10,
+		'm'      => 1
+	},
+	'Angstroms' => {
 		'factor' => 1E-10,
 		'm'      => 1
 	},

--- a/t/units/basic_module.t
+++ b/t/units/basic_module.t
@@ -7,7 +7,7 @@ do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
 
 use lib "$ENV{PG_ROOT}/lib";
 
-use Units;
+use Units qw(evaluate_units);
 
 # get unit hashes
 my %joule             = evaluate_units('J');

--- a/t/units/basic_parser.t
+++ b/t/units/basic_parser.t
@@ -115,7 +115,7 @@ subtest 'Check some known units' => sub {
 	ok my @unit_names = (split /\|/, $joule->getUnitNames), 'Can getUnitNames';
 
 	is \@unit_names, bag {
-		all_items(match qr/^(?:[-%\w]+|\p{Lu})$/);
+		all_items(match qr/^(?:[-%\w]+|\p{L}|\p{S}\w?)$/);
 		item 'J';
 		item 'N';
 		item 'm';
@@ -140,8 +140,8 @@ subtest 'Check display methods' => sub {
 
 	ok my $celsius = NumberWithUnits(1, 'degC');
 	ok my $kelvin  = NumberWithUnits(1, 'degK');
-	todo 'Fix the display of temperatures' => sub {
-		is $celsius->TeX, '1\ {\rm ^{\circ}C}', 'Displays LaTeX string for degrees (finally)';
+	ok 'Display of degrees' => sub {
+		is $celsius->TeX, '1\ {\rm ^{\circ}C}', 'Displays LaTeX string for degrees';
 		is $kelvin->TeX,  '1\ {\rm K}',         'Displays LaTeX string for kelvin, no degree sign';
 	};
 };

--- a/t/units/basic_parser.t
+++ b/t/units/basic_parser.t
@@ -70,7 +70,7 @@ subtest 'Check attributes' => sub {
 				rad    => 0,
 				degC   => 0,
 				degF   => 0,
-				degK   => 0,
+				K      => 0,
 			},
 			isValue => T(),
 			context => check_isa 'Parser::Context'

--- a/t/units/conversions.t
+++ b/t/units/conversions.t
@@ -6,7 +6,8 @@ die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
 do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
 
 use lib "$ENV{PG_ROOT}/lib";
-use Units;
+
+use Units qw(evaluate_units);
 
 subtest 'Check fundamental units' => sub {
 	is \%Units::fundamental_units,
@@ -29,7 +30,7 @@ subtest 'Check fundamental units' => sub {
 	is \%Units::known_units, hash {
 		field m => { factor => 1, m => 1 };
 
-		all_keys match qr/^(?:[a-z02]+(?:-\w+)?|%|\p{L}|\p{S}\w?)$/i;
+		all_keys match qr/^(?:[a-z\p{L}\p{S}]?[a-z\p{L}\p{S}\d]*(?:-\w+)?|%)$/i;
 		all_vals hash {
 			field factor => !number(0);
 

--- a/t/units/conversions.t
+++ b/t/units/conversions.t
@@ -29,7 +29,7 @@ subtest 'Check fundamental units' => sub {
 	is \%Units::known_units, hash {
 		field m => { factor => 1, m => 1 };
 
-		all_keys match qr/^(?:[a-z02]+(?:-\w+)?|%|\p{Lu})$/i;
+		all_keys match qr/^(?:[a-z02]+(?:-\w+)?|%|\p{L}|\p{S}\w?)$/i;
 		all_vals hash {
 			field factor => !number(0);
 

--- a/t/units/conversions.t
+++ b/t/units/conversions.t
@@ -18,7 +18,7 @@ subtest 'Check fundamental units' => sub {
 			rad    => 0,
 			degC   => 0,
 			degF   => 0,
-			degK   => 0,
+			K      => 0,
 			mol    => 0,
 			amp    => 0,
 			cd     => 0,
@@ -145,4 +145,3 @@ sub multiply_by {
 	$unit{factor} *= $conversion;
 	return \%unit;
 }
-

--- a/t/units/electron_volts.t
+++ b/t/units/electron_volts.t
@@ -5,7 +5,7 @@ use Test2::V0 '!E', { E => 'EXISTS' };
 die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
 use lib "$ENV{PG_ROOT}/lib";
 
-use Units;
+use Units qw(evaluate_units);
 
 my %joule        = evaluate_units('J');
 my %newton_metre = evaluate_units('N*m');


### PR DESCRIPTION
Add °C, °F, °K (shouldn't that just be K), and ° as alternate units for degC, degF, degK (again should this just be K), and deg.

Note that the correct SI unit for Kelvin is just K not °K (since 1967).  So shouldn't K be added for that?

Also add the plural forms of angstrom.

The unit tests are updated to handle these units.

Edit:  There are some additional changes now.

A basic alias system for units is now implemented.  Aliases can be added for a unit via the 'aliases' key.  The value should
be an array of aliases.  These are added as keys to the %known_units hash and the 'aliases' key deleted at compile time.

Also fix some perlcritic issues in the Units.pm, and clean it up a bit. 

The "degree Kelvin" units have been removed from the help files, but not from the actual units allowed (for now).

Also change Centrigrade to Celsius in the help files.  What is a Centrigrade?  Also, a Centigrade is not correct either.  It has been Celsius since 1948.