### PR TITLE
Fix a possible error that can occur when the MathQuill toolbar is removed.

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -97,7 +97,7 @@
 					window.removeEventListener('resize', toolbar.setPosition);
 					toolbar.tooltips.forEach((tooltip) => tooltip.dispose());
 					toolbar.remove();
-				});
+				}, { once: true });
 			}
 		};
 


### PR DESCRIPTION
This the 'transitionend' event can occur multiple times, which can result in the toolbar tooltips being disposed multiple times as well. This causes an error that is shown in the console.

This can be rather easily reproduced by setting focus to a MathQuill answer box and then holding down the tab button, letting focus cycle through the toolbar and beyond.