### PR TITLE
Add random_subset macro to PGbasicmacros.pl.

### DIFF
--- a/macros/core/PGauxiliaryFunctions.pl
+++ b/macros/core/PGauxiliaryFunctions.pl
@@ -15,12 +15,12 @@
 
 =head1 NAME
 
-A set of auxiliary functions that are often used in PG problems.  
+A set of auxiliary functions that are often used in PG problems.
 
 
 =head1 DESCRIPTION
 
-This macro creates the following functions that are available for PG: 
+This macro creates the following functions that are available for PG:
 
 	step($number)
 	ceil($number)
@@ -52,7 +52,8 @@ sub _PGauxiliaryFunctions_init {
 
 	Usage: step(x);
 
-returns the step function (or Heaviside function) with jump at x=0.  That is when x<0, it returns 0, when x>=0 the function returns 1. 
+returns the step function (or Heaviside function) with jump at x=0.  That is when x<0, it returns 0,
+when x>=0 the function returns 1.
 
 Example:
 
@@ -71,9 +72,9 @@ sub step {    # Heaviside function (1 or x>0)
 
 	Usage: ceil(x);
 
-returns the ceiling function of x.  This rounds up to the nearest integer.  
+returns the ceiling function of x.  This rounds up to the nearest integer.
 
-Examples: 
+Examples:
 
 	ceil(3.14159) returns 4
 	ceil(-9.75) return -9
@@ -91,9 +92,9 @@ sub ceil {
 
 	Usage: floor(x);
 
-returns the floor function of x.  This rounds down to the nearest integer.  
+returns the floor function of x.  This rounds down to the nearest integer.
 
-Examples: 
+Examples:
 
 	floor(3.14159) returns 3
 	floor(-9.75) return -10
@@ -107,13 +108,13 @@ sub floor {
 	$out;
 }
 
-=head3 max function 
+=head3 max function
 
 =pod
 
 	Usage: max(@arr);
 
-returns the maximum of the values in the array @arr. 
+returns the maximum of the values in the array @arr.
 
 Example
 
@@ -134,13 +135,13 @@ sub max {
 
 }
 
-=head3 min function 
+=head3 min function
 
 =pod
 
 	Usage: min(@arr);
 
-returns the minimum of the values in the array @arr. 
+returns the minimum of the values in the array @arr.
 
 Example
 
@@ -163,13 +164,13 @@ sub min {
 
 # round added 6/12/2000 by David Etlinger. Edited by AKP 3-6-03
 
-=head3 round function 
+=head3 round function
 
 =pod
 
 	Usage: round(x);
 
-returns integer nearest x. 
+returns integer nearest x.
 
 Example:
 
@@ -184,17 +185,17 @@ sub round {
 	$out;
 }
 
-=head3 Round function 
+=head3 Round function
 
 =pod
 
 	Usage: Round(x);
 
-returns integer nearest x.  
+returns integer nearest x.
 
 	Usage: Round(x,n);
 
-returns the number rounded to n digits.  
+returns the number rounded to n digits.
 
 Example:
 
@@ -208,19 +209,19 @@ sub Round {
 	elsif (@_ == 2) { $_[0] > 0 ? Round($_[0] * 10**$_[1]) / 10**$_[1] : Round($_[0] * 10**$_[1]) / 10**$_[1] }
 }
 
-=head3 lcm function 
+=head3 lcm function
 
 =pod
 
 	Usage: lcm(@arr);
 
-returns the lowest common multiple of the array @arr of integers.  
+returns the lowest common multiple of the array @arr of integers.
 
 Example:
 
-	 lcm(3,4,5,6) returns 60.
+	lcm(3,4,5,6) returns 60.
 
-Note: it checks for an empty array, however doesn't check if the inputs are integers. 
+Note: it checks for an empty array, however doesn't check if the inputs are integers.
 
 =cut
 
@@ -234,19 +235,19 @@ sub lcm {
 	return lcm($a * $b / gcf($a, $b), @_);
 }
 
-=head3 gcf function 
+=head3 gcf function
 
 =pod
 
 	Usage: gcf(@arr);
 
-returns the greatest common factor of the array @arr of integers.  
+returns the greatest common factor of the array @arr of integers.
 
 Example:
  
  	gcf(20,30,45) returns 5.
 
-Note: it checks for an empty array, however doesn't check if the inputs are integers. 
+Note: it checks for an empty array, however doesn't check if the inputs are integers.
 
 =cut
 
@@ -267,18 +268,19 @@ sub gcf {
 	return gcf($b, @_);
 }
 
-=head3 gcd function 
+=head3 gcd function
 
 =pod
 
 	Usage: gcd(@arr);
 
-returns the greatest common divisor of the array @arr of integers.  
+returns the greatest common divisor of the array @arr of integers.
 
 Example:
+
 	gcd(20,30,45) returns 5.
 
-Note: this is just an alias for gcf. 
+Note: this is just an alias for gcf.
 
 =cut
 
@@ -286,38 +288,39 @@ sub gcd {
 	return gcf(@_);
 }
 
-=head3 random_coprime function 
+=head3 random_coprime function
 
 =pod
 
 	Usage: random_coprime(array of array_refs);
 
-returns relatively prime integers. The arguments should be references to arrays of integers.  This returns an n-tuple of relatively prime integers, 
-each one coming from the corresponding array. Random selection is uniform among all possible tuples that are relatively prime.
-This does not consider (0,0) to be relatively prime.
+returns relatively prime integers.  The arguments should be references to arrays of integers.  This returns an
+n-tuple of relatively prime integers, each one coming from the corresponding array. Random selection is uniform
+among all possible tuples that are relatively prime.  This does not consider (0,0) to be relatively prime.
 
-This function may return an n-tuple where pairs are not coprime.  This returns n-tuples where the largest (in absolute) common factor is 1. 
+This function may return an n-tuple where pairs are not coprime.  This returns n-tuples where the largest
+(in absolute) common factor is 1.
 
 In array context, returns an array. Otherwise, an array ref.
 
-Examples: 
+Examples:
 
 	random_coprime([1..9],[1..9]) may return (2,9) or (1,1) but not (6,8)
 	random_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4), (-1,1,1), or (-2,2,3) but not (-2,2,4)
 
-Note: in the example above (-2,2,3) is valid because not all three share a factor greater than 1.  If you don't want to 
-allow pairs of numbers to be coprime, see random_pairwise_coprime. 
+Note: in the example above (-2,2,3) is valid because not all three share a factor greater than 1.
+If you don't want to allow pairs of numbers to be coprime, see random_pairwise_coprime.
 
 	random_pairwise_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4) or (-1,1,1) but not (-2,2,3)
 
 WARNING: random_coprime() will use a lot of memory and CPU resources if used with too many/too large arguments.
-For example, random_coprime([-20..20],[-20..20],[-20..20],[-20..20],[-20..20]) involves processing 41^5 arrays.	
+For example, random_coprime([-20..20],[-20..20],[-20..20],[-20..20],[-20..20]) involves processing 41^5 arrays.
 Consider using random_pairwise_coprime() instead. Or breaking things up like:
 random_coprime([-20..20],[-20..20]),random_coprime([-20..20],[-20..20],[-20..20])
 
-Note for Problem Authors: one reason for developing this function is to be able to create polynomials that don't have a constant factor.  
-For example, if random_coprime([-9..-1,1..9],[1..9],[1..9]) returns (-5,5,3)
-then building the quadratic 3x^2+5x-5 doesn't lead to a constant multiple to be factored.  
+Note for Problem Authors: one reason for developing this function is to be able to create polynomials that don't have
+a constant factor.  For example, if random_coprime([-9..-1,1..9],[1..9],[1..9]) returns (-5,5,3) then building the
+quadratic 3x^2+5x-5 doesn't lead to a constant multiple to be factored.
 
 =cut
 
@@ -326,11 +329,12 @@ sub random_coprime {
 	# Expect first argument to be an array reference
 	my $c          = shift;
 	my @candidates = @$c if $c;
-# @candidates has numbers on the first iteration
-# On subsequent iterations it has two array references
-# The first of these is full of array references to tuples where we already know the gcf is 1
-# The second is full of array references to tuples where the gcf is not 1, but these may become usable on later iterations
-# If it has numbers, initialize the two array refs
+	# @candidates has numbers on the first iteration
+	# On subsequent iterations it has two array references
+	# The first of these is full of array references to tuples where we already know the gcf is 1
+	# The second is full of array references to tuples where the gcf is not 1, but these may become
+	# usable on later iterations
+	# If it has numbers, initialize the two array refs
 	if (ref $candidates[0] eq '') {
 		do { warn "Unable to find a coprime tuple from input"; return; } unless (@candidates);
 		my @refcandidates = ([], []);
@@ -381,15 +385,16 @@ sub random_coprime {
 	}
 }
 
-=head3 random_pairwise_coprime function 
+=head3 random_pairwise_coprime function
 
 =pod
 
 	Usage: random_pairwise_coprime($arr);
 
-This is similar to the random_coprime function with the additional constraint that all pairs of numbers are also coprime.  
+This is similar to the random_coprime function with the additional constraint that all pairs of numbers are
+also coprime.
 
-Examples: 
+Examples:
 
 	random_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4), (-1,1,1), or (-2,2,3) but not (-2,2,4)
 	random_pairwise_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4) or (-1,1,1) but not (-2,2,3) or (3,5,6)
@@ -440,20 +445,20 @@ sub random_pairwise_coprime {
 	}
 }
 
-=head3 isPrime function 
+=head3 isPrime function
 
 =pod
 
 	Usage: isPrime(n);
 
-returns 1 if n is prime and 0 otherwise. 
+returns 1 if n is prime and 0 otherwise.
 
-Example: 
-	
+Example:
+
 	isPrime(7) returns 1.
 	isPrime(8) returns 0
 
-Note: this doesn't check if n is negative. 
+Note: this doesn't check if n is negative.
 
 =cut
 
@@ -467,16 +472,16 @@ sub isPrime {
 	return 1;
 }
 
-=head3 reduce function 
+=head3 reduce function
 
 =pod
 
 	Usage: reduce(num,den);
 
-returns the fraction num/den as an array with first entry as the numerator and second as the denominator.  
+returns the fraction num/den as an array with first entry as the numerator and second as the denominator.
 
-Example:  
-	
+Example:
+
 	reduce(15,20) returns (3,4)
 
 =cut
@@ -499,13 +504,14 @@ sub reduce {
 	@frac;
 }
 
-=head3 preFormat function 
+=head3 preFormat function
 
 =pod
 
-	Usage: preFormat($scalar,"quoted string");
+	Usage: preFormat($scalar, "quoted string");
 
-returns the string preformatted with the $scalar as 0,1, or -1  takes a number and fixed object, as in "$a x" and formats
+returns the string preformatted with the $scalar as 0, 1, or -1.
+takes a number and fixed object, as in "$a x" and formats
 
 Example:  
 
@@ -533,7 +539,7 @@ sub fact {
 	P($_[0], $_[0]);
 }
 
-=head3 random_subset function 
+=head3 random_subset function
 
 =pod
 

--- a/macros/core/PGauxiliaryFunctions.pl
+++ b/macros/core/PGauxiliaryFunctions.pl
@@ -309,7 +309,7 @@ Examples:
 	random_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4), (-1,1,1), or (-2,2,3) but not (-2,2,4)
 
 Note: in the example above (-2,2,3) is valid because not all three share a factor greater than 1.
-If you don't want to allow pairs of numbers to be coprime, see random_pairwise_coprime.
+If you don't want to allow pairs of numbers to have a common factor, see random_pairwise_coprime.
 
 	random_pairwise_coprime([-9..-1,1..9],[1..9],[1..9]) may return (-3,7,4) or (-1,1,1) but not (-2,2,3)
 

--- a/macros/core/PGauxiliaryFunctions.pl
+++ b/macros/core/PGauxiliaryFunctions.pl
@@ -15,7 +15,7 @@
 
 =head1 NAME
 
-A set of auxilliary functions that are often used in PG problems.  
+A set of auxiliary functions that are often used in PG problems.  
 
 
 =head1 DESCRIPTION
@@ -36,6 +36,7 @@ This macro creates the following functions that are available for PG:
 	preformat($scalar, "QuotedString")
 	random_pairwise_coprime($ar1, $ar2, ... )
 	random_coprime($ar1, $ar2, ... )
+	random_subset($n, @set)
 =cut
 
 # ^uses loadMacros
@@ -530,6 +531,46 @@ sub preformat {
 # ^uses P
 sub fact {
 	P($_[0], $_[0]);
+}
+
+=head3 random_subset function 
+
+=pod
+
+	Usage: random_subset($n, @set);
+
+This function returns a randomly ordered array of $n elements selected from the array @set
+without replacement. Accepts either an array or an array reference for @set.
+
+Example to choose 3 random elements (both do the same thing):
+
+	random_subset(3, 'first', 'second', 'third', 'fourth', 'fifth')
+	random_subset(3, ['first', 'second', 'third', 'fourth', 'fifth'])
+
+=cut
+
+sub random_subset {
+	my ($n, @set) = @_;
+	@set = @{ $set[0] } if (scalar(@set) == 1 && ref($set[0]) eq 'ARRAY');
+
+	unless ($n =~ /^\d+/) {
+		warn 'random_subset: The first input must be a non-negative integer';
+		return;
+	}
+	unless (@set) {
+		warn 'random_subset: The list of elements to choose from must contain at least one element.';
+		return;
+	}
+	if ($n > scalar(@set)) {
+		warn 'random_subset: The first input must be smaller than or equal to the number of elements.';
+		$n = scalar(@set);
+	}
+
+	my @out;
+	while (@set && @out < $n) {
+		push(@out, splice(@set, random(0, $#set, 1), 1));
+	}
+	return wantarray ? @out : \@out;
 }
 
 # return 1 so that this file can be included with require

--- a/macros/ui/PGchoicemacros.pl
+++ b/macros/ui/PGchoicemacros.pl
@@ -82,6 +82,8 @@ BEGIN {
 	be_strict;
 }
 
+loadMacros('PGauxiliaryFunctions.pl');
+
 package main;
 
 BEGIN {
@@ -787,6 +789,7 @@ sub invert {
  @b = NchooseK($N, $K);
 
 Selects $K random nonrepeating elements in the range 0 to $N-1.
+This is a wrapper for random_subset($K, 0 .. $N - 1);
 
 =cut
 
@@ -794,12 +797,7 @@ Selects $K random nonrepeating elements in the range 0 to $N-1.
 
 sub NchooseK {
 	my ($n, $k) = @_;
-	my @array = 0 .. ($n - 1);
-	my @out   = ();
-	while (@out < $k) {
-		push(@out, splice(@array, random(0, $#array, 1), 1));
-	}
-	@out;
+	return random_subset($k, 0 .. $n - 1);
 }
 
 =item [DEPRECATED] shuffle()
@@ -814,8 +812,7 @@ Returns the integers from 0 to $i-1 in random order.
 
 sub shuffle {
 	my ($i) = @_;
-	my @out = &NchooseK($i, $i);
-	@out;
+	return random_subset($i, 0 .. $i - 1);
 }
 
 =item [DEPRECATED] match_questions_list()


### PR DESCRIPTION
Takes the function `NchooseK` from `PGchoicemacros.pl` or `List.pm` and add it to `PGbasicmacros.pl` with a new name `random_subset($n, @array)` which returns a randomly ordered array containing `$n` elements from the provided `@array`. Optionally, an array ref can be used instead, `random_subset($n, $array_ref)`.

This function is useful when wanting to get a random list of unique items from a given array or to reorder the array. Moving it to `PGbasicmacros.pl` places it with the other random functions and makes it available to all problems without having to load the full `PGchoicemacros.pl`. I find many uses for this function when randomizing problems, and this was also mentioned in #761, where it was suggested renaming it, since `NchooseK` is also `n!/(k! (n-k)!)` instead of a subset.