### PR TITLE
add DropDown variant of PopUp

### DIFF
--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -39,8 +39,8 @@ by default, but can be customized with a C<placeholder> option.
 
 C<DropDownTF()> is like C<DropDown> with options being "True" or "False".
 In this case, C<correct> is initerpreted as a perl boolean. Except strings
-like "false" are recognized as false. Also, in static output (PDF, PTX) the
-menu is not printed. It is assumed that context makes the menu redundant.
+like "false" and "F" are recognized as false. Also, in static output (PDF, PTX)
+the menu is not printed. It is assumed that context makes the menu redundant.
 
 By default, the choices are left in the order that you provide them,
 but you can cause some or all of them to be ordered randomly by
@@ -271,7 +271,7 @@ sub DropDown {
 sub DropDownTF {
 	my ($self, $value, %options) = @_;
 	my $sanitized_value = $value ? 'True' : 'False';
-	$sanitized_value = 'False' if (defined $value && $value =~ /^\s*false\s*$/i);
+	$sanitized_value = 'False' if (defined $value && $value =~ /^\s*(false|f)\s*$/i);
 	return parser::PopUp->DropDown([ 'True', 'False' ], $sanitized_value, %options, static => 0);
 }
 

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -287,10 +287,12 @@ sub DropDownTF {
 		0          => $false
 	);
 	if (lc(substr($true, 0, 1)) ne lc(substr($false, 0, 1))) {
-		$sanitization{ substr($true,  0, 1) } = $true;
-		$sanitization{ substr($false, 0, 1) } = $false;
+		$sanitization{ lc(substr($true,  0, 1)) } = $true;
+		$sanitization{ lc(substr($false, 0, 1)) } = $false;
+		$sanitization{ uc(substr($true,  0, 1)) } = $true;
+		$sanitization{ uc(substr($false, 0, 1)) } = $false;
 	}
-	my $sanitized_value = $sanitization{ lc($value) };
+	my $sanitized_value = $sanitization{$value};
 	Value->Error("The value should be one of $true or $false") unless defined $sanitized_value;
 	return parser::PopUp->DropDown([ $true, $false ], $sanitized_value, %options);
 }

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -289,8 +289,6 @@ sub DropDownTF {
 	if (lc(substr($true, 0, 1)) ne lc(substr($false, 0, 1))) {
 		$sanitization{ lc(substr($true,  0, 1)) } = $true;
 		$sanitization{ lc(substr($false, 0, 1)) } = $false;
-		$sanitization{ uc(substr($true,  0, 1)) } = $true;
-		$sanitization{ uc(substr($false, 0, 1)) } = $false;
 	}
 	my $sanitized_value = $sanitization{$value};
 	Value->Error("The value should be one of $true or $false") unless defined $sanitized_value;


### PR DESCRIPTION
This follows https://github.com/openwebwork/pg/discussions/782.

Here is a small test file, demonstrating the original `PopUp()`, but also `DropDown()` with and without a custom prompt.

```
DOCUMENT();
loadMacros("PGstandard.pl", "PGML.pl", "parserPopUp.pl",);

$p = PopUp(['a'..'d'], 2);
$d1 = DropDown(['a'..'d'], 2);
$d2 = DropDown(['a'..'d'], 2, placeholder => 'Choose one:');

BEGIN_PGML
[_]{$p}  
[_]{$d1}  
[_]{$d2}
END_PGML

ENDDOCUMENT();
```

I plan to also add a `TrueFalse()` subroutine as well. Maybe I will name it `TFPopUp` or `PopUpTF` to be safer from a namespace collision. It would just take one argument (true/false) and effectively make `PopUp(['True', 'False'], answer)` except in static output forms (TeX and PTX) it won't print anything. (Elsewhere instructions in the exercise are already asking something like "Is the following true or false?")

Any feedback on the `TrueFalse()` method also welcome here.