### PR TITLE
Fix algorithm for Euler's totient function

### DIFF
--- a/macros/contexts/contextInteger.pl
+++ b/macros/contexts/contextInteger.pl
@@ -184,11 +184,12 @@ sub phi {
 	$self->Error("Cannot phi on Zero.") if $a == 0;
 	$result = $a;
 	$n      = $a;
-	for (my $i = 2; ($i**2) < $n; $i++) {
+	for (my $i = 2; ($i**2) <= $n; $i++) {
+		next unless ($n % $i == 0);
 		while ($n % $i == 0) {
 			$n      /= $i;
-			$result -= $result / $i;
 		}
+		$result -= $result / $i;
 	}
 	$result -= $result / $n if $n > 1;
 	return $result;

--- a/macros/contexts/contextInteger.pl
+++ b/macros/contexts/contextInteger.pl
@@ -187,7 +187,7 @@ sub phi {
 	for (my $i = 2; ($i**2) <= $n; $i++) {
 		next unless ($n % $i == 0);
 		while ($n % $i == 0) {
-			$n      /= $i;
+			$n /= $i;
 		}
 		$result -= $result / $i;
 	}


### PR DESCRIPTION
There were two issues:

* We were stopping the for loop too soon and missing the case where the number in question is a prime squared.  For example, if the input is 9, then we want to check if both 2 and 3 are divisors, but we stopped after 2 because 3^2 < 9 is false.
* According to Euler's product formula, we only multiply by (1 - 1/p) one time for each prime factor p, but for example, when the input was 4, we were multiplying by (1 - 1/2) twice, once for each iteration of the while loop.  So we move this operation outside the while loop.