### PR TITLE
Fix knowls in lists.

### DIFF
--- a/htdocs/js/apps/Knowls/knowl.js
+++ b/htdocs/js/apps/Knowls/knowl.js
@@ -60,10 +60,9 @@
 			} else {
 				insertElt = knowl.closest('li');
 				if (insertElt) {
-					const newLi = document.createElement('li');
-					newLi.style.listStyle = 'none';
-					newLi.append(knowl.knowlContainer);
-					insertElt.after(newLi);
+					const newDiv = document.createElement('div');
+					newDiv.append(knowl.knowlContainer);
+					insertElt.append(newDiv);
 				} else {
 					let append = false;
 					insertElt = knowl;


### PR DESCRIPTION
When knowls are added in a list, instead of adding an `li` tag and inserting that into the list, add a `div` tag and insert that inside the existing `li` tag.  This results in the same appearance, is valid html, and does not affect numbering inside an ordered list.

This fixes issue #794.