### PR TITLE
Allow the attempts table to use a div for previews instead of a span.

### DIFF
--- a/htdocs/js/apps/Problem/problem.scss
+++ b/htdocs/js/apps/Problem/problem.scss
@@ -202,6 +202,7 @@ table.attemptResults {
 		}
 	}
 
+	div.answer-preview,
 	span.answer-preview {
 		display: block;
 		width: 100%;


### PR DESCRIPTION
A span that is set to display block really shouldn't be used, and results in invalid html in many cases with answer previews that use divs for layout.

Note that this change allows the front end to use either a `div` or a `span`.  Webwork2 will be switched to using `divs` for this, but this will not affect other front ends.