### PR TITLE
Update the JSXGraph library to the latest version and other tweaks.

### DIFF
--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -115,6 +115,8 @@
 				},
 
 				pairedPointDrag(gt, e) {
+					if (e.type === 'keydown') return;
+
 					const coords = gt.getMouseCoords(e);
 					let left_x = this.X(), right_x = this.X();
 

--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -54,8 +54,9 @@ window.graphTool = (containerId, options) => {
 	gt.snapSizeX = options.snapSizeX ? options.snapSizeX : 1;
 	gt.snapSizeY = options.snapSizeY ? options.snapSizeY : 1;
 	gt.isStatic = options.isStatic ? true : false;
-	const availableTools = options.availableTools ? options.availableTools
-		: ['LineTool', 'CircleTool', 'VerticalParabolaTool', 'HorizontalParabolaTool', 'FillTool', 'SolidDashTool'];
+	if (!(options.availableTools instanceof Array))
+		options.availableTools =
+			['LineTool', 'CircleTool', 'VerticalParabolaTool', 'HorizontalParabolaTool', 'FillTool', 'SolidDashTool'];
 
 	// This is the icon used for the fill tool and fill graph object.
 	gt.fillIcon = (color) => "data:image/svg+xml," +
@@ -363,9 +364,9 @@ window.graphTool = (containerId, options) => {
 							}
 						}
 					});
-				} else {
-					gt.activeTool?.handleKeyEvent(e);
 				}
+
+				for (const tool of gt.tools) tool.handleKeyEvent(e);
 
 				if (!gt.buttonBox.contains(document.activeElement) && e.key === 'N' && e.shiftKey) {
 					// Shift-N moves focus to the first tool button after the select button unless the tool bar already
@@ -380,12 +381,6 @@ window.graphTool = (containerId, options) => {
 				} else if (e.key === 'Delete' && gt.activeTool === gt.selectTool) {
 					// If the select tool is active and Delete is pressed, then ask to delete the selected object.
 					gt.deleteSelected();
-				} else if (e.key === 's') {
-					// If 's' is pressed change to drawing solid.
-					gt.toggleSolidity(e, true);
-				} else if (e.key === 'd') {
-					// If 'd' is pressed change to drawing dashed.
-					gt.toggleSolidity(e, false);
 				}
 			});
 		}
@@ -1836,6 +1831,16 @@ window.graphTool = (containerId, options) => {
 			solidDashBox.append(dashedButtonDiv);
 			container.append(solidDashBox);
 		}
+
+		handleKeyEvent(e) {
+			if (e.key === 's') {
+				// If 's' is pressed change to drawing solid.
+				gt.toggleSolidity(e, true);
+			} else if (e.key === 'd') {
+				// If 'd' is pressed change to drawing dashed.
+				gt.toggleSolidity(e, false);
+			}
+		}
 	}
 
 	gt.toolTypes = {
@@ -1928,10 +1933,11 @@ window.graphTool = (containerId, options) => {
 			});
 		}
 
-		availableTools.forEach((tool) => {
-			if (tool in gt.toolTypes) new gt.toolTypes[tool](gt.buttonBox);
-			else console.log('Unknown tool: ' + tool);
-		});
+		gt.tools = [ gt.selectTool ];
+		for (const tool of options.availableTools) {
+			if (tool in gt.toolTypes) gt.tools.push(new gt.toolTypes[tool](gt.buttonBox));
+			else console.log(`Unknown tool: ${tool}`);
+		}
 
 		const confirmDialog = (title, titleId, message, yesAction) => {
 			// Keep the graph tool active while this dialog is open.

--- a/htdocs/js/apps/GraphTool/graphtool.scss
+++ b/htdocs/js/apps/GraphTool/graphtool.scss
@@ -1,10 +1,13 @@
 @use 'sass:color';
 
 .graphtool-container {
-	width: 402px;
+	width: 442px;
+	padding: 15px 20px;
+	border-radius: 10px;
+	box-shadow: inset 0 0 5px 5px rgba(0, 0, 0, 0.15);
 
 	@media only screen and (max-width: 600px) {
-		width: 302px;
+		width: 342px;
 	}
 
 	.graphtool-graph {
@@ -35,7 +38,7 @@
 	}
 
 	.gt-toolbar-container {
-		margin: 0.5rem 0;
+		margin: 0.5rem 0 0;
 		text-align: right;
 		width: 100%;
 		padding: 0;
@@ -160,11 +163,11 @@
 				background-image: url('images/ExcludePointParenthesisTool.svg');
 			}
 
-			&.gt-bounded-interval-tool {
+			&.gt-interval-tool {
 				background-image: url('images/IntervalTool.svg');
 			}
 
-			&.gt-bounded-interval-bracket-tool {
+			&.gt-interval-bracket-tool {
 				background-image: url('images/IntervalBracketTool.svg');
 			}
 		}

--- a/htdocs/js/apps/GraphTool/intervaltools.js
+++ b/htdocs/js/apps/GraphTool/intervaltools.js
@@ -250,7 +250,9 @@
 					this.focusPoint?.setAttribute({
 						fillColor: include ? gt.color.curve : 'transparent',
 						highlightFillColor: include ? gt.color.pointHighlightDarker : gt.color.pointHighlight,
-						highlightFillOpacity: gt.options.useBracketEnds ? 0 : include ? 1 : 0.5
+						highlightFillOpacity: (gt.options.useBracketEnds || this.focusPoint.arrow)
+							? 0
+							: include ? 1 : 0.5
 					});
 				},
 
@@ -277,12 +279,6 @@
 						if (this.focused && point.getAttribute('highlightFillOpacity') !== 0)
 							attributes.highlightFillOpacity = 0.5;
 					}
-
-					// Setting the layer makes JSXGraph reinsert the point into the DOM.  This moves it to the front.
-					// Note that layer 9 is default layer for points, so the actual layer is not changed.  The size
-					// attribute is checked to guarantee that this is only done when focus is initially obtained.
-					// Otherwise there are "maximum call stack size exceeded" errors in Chrome.
-					if (this.focused && point.getAttribute('size') !== 4) point.setAttribute({ layer: 9 });
 
 					point.setAttribute(attributes);
 				},
@@ -356,6 +352,8 @@
 				// This also prevents a point from being moved off the board.
 				// This ignores the y-coordinate.
 				pairedPointDrag(gt, point, e) {
+					if (e.type === 'keydown') return;
+
 					const bbox = gt.board.getBoundingBox();
 					if (point.X() >= bbox[2]) {
 						if (point.paired_point.X() === bbox[2])
@@ -478,13 +476,13 @@
 		},
 
 		IntervalTool: {
-			iconName: 'bounded-interval',
-			tooltip: 'Bounded Interval Tool',
+			iconName: 'interval',
+			tooltip: 'Interval Tool',
 
 			initialize(gt) {
 				if (gt.options.useBracketEnds) {
-					this.button.classList.remove('gt-bounded-interval-tool');
-					this.button.classList.add('gt-bounded-interval-bracket-tool');
+					this.button.classList.remove('gt-interval-tool');
+					this.button.classList.add('gt-interval-bracket-tool');
 				}
 
 				this.phase1 = (coords) => {

--- a/htdocs/js/apps/GraphTool/intervaltools.js
+++ b/htdocs/js/apps/GraphTool/intervaltools.js
@@ -852,6 +852,16 @@
 				container.append(includePointBox);
 			},
 
+			handleKeyEvent(gt, e) {
+				if (e.key === 'e') {
+					// If 'e' is pressed change to excluding interval endpoints.
+					gt.toolTypes.IncludeExcludePointTool.toggleIncludeExcludePoint(e, false);
+				} else if (e.key === 'i') {
+					// If 'i' is pressed change to including interval endpoints.
+					gt.toolTypes.IncludeExcludePointTool.toggleIncludeExcludePoint(e, true);
+				}
+			},
+
 			helperMethods: {
 				toggleIncludeExcludePoint(gt, e, include) {
 					e.preventDefault();

--- a/htdocs/js/apps/GraphTool/pointtool.js
+++ b/htdocs/js/apps/GraphTool/pointtool.js
@@ -36,7 +36,7 @@
 			focus(gt) {
 				this.focused = true;
 				this.baseObj.setAttribute(
-					{ fixed: false, highlight: true, strokeColor: gt.color.focusCurve, strokeWidth: 3, layer: 9 });
+					{ fixed: false, highlight: true, strokeColor: gt.color.focusCurve, strokeWidth: 3 });
 
 				this.focusPoint.rendNode.focus();
 				return false;

--- a/htdocs/js/apps/GraphTool/quadratictool.js
+++ b/htdocs/js/apps/GraphTool/quadratictool.js
@@ -93,6 +93,8 @@
 				},
 
 				pairedPointDrag(gt, e) {
+					if (e.type === 'keydown') return;
+
 					const coords = gt.getMouseCoords(e);
 					let left_x = this.X(), right_x = this.X();
 

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "jsxgraph": "^1.4.6",
+                "jsxgraph": "^1.5.0",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
                 "mathquill": "github:openwebwork/mathquill",
@@ -714,9 +714,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/jsxgraph": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.4.6.tgz",
-            "integrity": "sha512-HecQJ0AGdwJW+HbHwmIb4Yy3J/7tPK2SBxJOArFQOFPWZbmMxL7cXcc6gAOdHNwHQEaU21QC/L+d/Y5x9jsACA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.5.0.tgz",
+            "integrity": "sha512-mXsW1LG9AEZpiYDM+nScs5G5ZKw6xrQIrVLszRXeXFX+XYbS1Abx9oMmk7WMDbCXerYFzNo5/vZ9MRZpFeABpQ==",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -2135,9 +2135,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "jsxgraph": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.4.6.tgz",
-            "integrity": "sha512-HecQJ0AGdwJW+HbHwmIb4Yy3J/7tPK2SBxJOArFQOFPWZbmMxL7cXcc6gAOdHNwHQEaU21QC/L+d/Y5x9jsACA=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.5.0.tgz",
+            "integrity": "sha512-mXsW1LG9AEZpiYDM+nScs5G5ZKw6xrQIrVLszRXeXFX+XYbS1Abx9oMmk7WMDbCXerYFzNo5/vZ9MRZpFeABpQ=="
         },
         "jszip": {
             "version": "3.10.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -11,7 +11,7 @@
         "prepare": "npm run generate-assets"
     },
     "dependencies": {
-        "jsxgraph": "^1.4.6",
+        "jsxgraph": "^1.5.0",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",
         "mathquill": "github:openwebwork/mathquill",


### PR DESCRIPTION
JSXGraph is now at version 1.5.0.  This version has changed event handling.  The JSXGraph 'hit' event no longer sends the 'focusin' event, so that is now just handled directly in the grpahtool 'focusin' event handler.

In addition a feature added in this release is keyboard keydown and keydrag handling.  The graphtool implements its own keyboard event handling because that was not available before.  In addition the JXSGraph keyboard events are only sent for arrow keys.  That could be tapped into, but doesn't help much over the current implementation, and wouldn't work at all for other keys that the graph tool needs to act on.

There are also some changes in this pull request to make the new interval tools work better. These are summarized below.

Fix an issue caused by toggling the layer of defining points when an object is focused.  Toggling the layer messes up the natural tab order, and so it can't be done.  This has the down side that points that are graphed later are always above previously graphed points.  This is not a big deal for any of the previous graph objects since their points are not visible when not focused, however for intervals this is noticeable as the end points are always visible.

Add some padding to the outer graph tool container and a visual border. This adds space between the actual graph board and the outer container's boundary.  This makes it so that clicking to the right or left of the graph but still inside the outer container does not deactivate tools. This is important for graphing points at infinity for intervals. Currently a click to the right or left to easily deactivates the tool when you want to graph one of these points at infinity.

Change the text of the 'Fullscreen' button to 'Exit Fullscreen' when fullscreen mode is entered.  Of course, change that back to 'Fullscreen' when fullscreen mode is exited.

Remove the "bounded" quantifier from the tooltip for the interval tool, as well as from the css classes for its icons.  That was a remnant from an initial implementation that was going to have separate bounded and unbounded interval tools.