### PR TITLE
make graphtool provide answer fillin with PTX output

### DIFF
--- a/macros/parsers/parserGraphTool.pl
+++ b/macros/parsers/parserGraphTool.pl
@@ -762,24 +762,24 @@ sub constructJSXGraphOptions {
 # to generate a printable graph instead.  An attempt is made to make the printable graph look
 # as much as possible like the JavaScript graph.
 sub ans_rule {
-	my $self = shift;
-	my $out  = main::NAMED_HIDDEN_ANS_RULE($self->ANS_NAME);
+	my $self         = shift;
+	my $answer_value = $main::envir{inputs_ref}{ $self->ANS_NAME } // '';
+	my $ans_name     = main::RECORD_ANS_NAME($self->ANS_NAME, $answer_value);
 
-	if ($main::displayMode =~ /^(TeX|PTX)$/) {
-		if ($self->{showInStatic}) {
-			return &{ $self->{printGraph} }
-				if defined($self->{printGraph}) && ref($self->{printGraph}) eq 'CODE';
+	if ($main::displayMode =~ /^(TeX|PTX)$/ && $self->{showInStatic}) {
+		return &{ $self->{printGraph} }
+			if defined($self->{printGraph}) && ref($self->{printGraph}) eq 'CODE';
 
-			my @size = $self->{numberLine} ? (500, 100) : (500, 500);
+		my @size = $self->{numberLine} ? (500, 100) : (500, 500);
 
-			my $graph = main::createTikZImage();
-			$graph->tikzLibraries('arrows.meta');
-			$graph->tikzOptions('x='
-					. ($size[0] / 96 / ($self->{bBox}[2] - $self->{bBox}[0])) . 'in,y='
-					. ($size[1] / 96 / ($self->{bBox}[1] - $self->{bBox}[3]))
-					. 'in');
+		my $graph = main::createTikZImage();
+		$graph->tikzLibraries('arrows.meta');
+		$graph->tikzOptions('x='
+				. ($size[0] / 96 / ($self->{bBox}[2] - $self->{bBox}[0])) . 'in,y='
+				. ($size[1] / 96 / ($self->{bBox}[1] - $self->{bBox}[3]))
+				. 'in');
 
-			my $tikz = <<END_TIKZ;
+		my $tikz = <<END_TIKZ;
 \n\\tikzset{
 	>={Stealth[scale=1.8]},
 	clip even odd rule/.code={\\pgfseteorule},
@@ -798,125 +798,134 @@ sub ans_rule {
 \\end{pgfonlayer}
 END_TIKZ
 
-			unless ($self->{numberLine}) {
-				# Vertical grid lines
-				my @xGridLines =
-					grep { $_ < $self->{bBox}[2] } map { $_ * $self->{gridX} } (1 .. $self->{bBox}[2] / $self->{gridX});
-				push(@xGridLines,
-					grep { $_ > $self->{bBox}[0] }
-					map { -$_ * $self->{gridX} } (1 .. -$self->{bBox}[0] / $self->{gridX}));
-				$tikz .=
-					"\\foreach \\x in {"
-					. join(',', @xGridLines)
-					. "}{\\draw[line width=0.2pt,color=lightgray] (\\x,$self->{bBox}[3]) -- (\\x,$self->{bBox}[1]);}\n"
-					if (@xGridLines);
-
-				# Horizontal grid lines
-				my @yGridLines =
-					grep { $_ < $self->{bBox}[1] } map { $_ * $self->{gridY} } (1 .. $self->{bBox}[1] / $self->{gridY});
-				push(@yGridLines,
-					grep { $_ > $self->{bBox}[3] }
-					map { -$_ * $self->{gridY} } (1 .. -$self->{bBox}[3] / $self->{gridY}));
-				$tikz .=
-					"\\foreach \\y in {"
-					. join(',', @yGridLines)
-					. "}{\\draw[line width=0.2pt,color=lightgray] ($self->{bBox}[0],\\y) -- ($self->{bBox}[2],\\y);}\n"
-					if (@yGridLines);
-			}
-
-			# Axis and labels.
-			$tikz .= "\\huge\n\\draw[<->,thick] ($self->{bBox}[0],0) -- ($self->{bBox}[2],0)\n"
-				. "node[above left,outer sep=2pt]{\\($self->{xAxisLabel}\\)};\n";
-			unless ($self->{numberLine}) {
-				$tikz .= "\\draw[<->,thick] (0,$self->{bBox}[3]) -- (0,$self->{bBox}[1])\n"
-					. "node[below right,outer sep=2pt]{\\($self->{yAxisLabel}\\)};\n";
-			}
-
-			# Horizontal axis ticks and labels
-			my @xTicks = grep { $_ < $self->{bBox}[2] }
-				map { $_ * $self->{ticksDistanceX} } (1 .. $self->{bBox}[2] / $self->{ticksDistanceX});
-			push(@xTicks,
+		unless ($self->{numberLine}) {
+			# Vertical grid lines
+			my @xGridLines =
+				grep { $_ < $self->{bBox}[2] } map { $_ * $self->{gridX} } (1 .. $self->{bBox}[2] / $self->{gridX});
+			push(@xGridLines,
 				grep { $_ > $self->{bBox}[0] }
-				map { -$_ * $self->{ticksDistanceX} } (1 .. -$self->{bBox}[0] / $self->{ticksDistanceX}));
-			# Add zero if this is a number line and 0 is in the given range.
-			push(@xTicks, 0) if ($self->{numberLine} && $self->{bBox}[2] > 0 && $self->{bBox}[0] < 0);
-			my $tickSize = $self->{numberLine} ? '9' : '5';
+				map { -$_ * $self->{gridX} } (1 .. -$self->{bBox}[0] / $self->{gridX}));
 			$tikz .=
 				"\\foreach \\x in {"
-				. join(',', @xTicks)
-				. "}{\\draw[thin] (\\x,${tickSize}pt) -- (\\x,-${tickSize}pt) node[below]{\\(\\x\\)};}\n"
-				if (@xTicks);
+				. join(',', @xGridLines)
+				. "}{\\draw[line width=0.2pt,color=lightgray] (\\x,$self->{bBox}[3]) -- (\\x,$self->{bBox}[1]);}\n"
+				if (@xGridLines);
 
-			# Vertical axis ticks and labels
-			unless ($self->{numberLine}) {
-				my @yTicks = grep { $_ < $self->{bBox}[1] }
-					map { $_ * $self->{ticksDistanceY} } (1 .. $self->{bBox}[1] / $self->{ticksDistanceY});
-				push(@yTicks,
-					grep { $_ > $self->{bBox}[3] }
-					map { -$_ * $self->{ticksDistanceY} } (1 .. -$self->{bBox}[3] / $self->{ticksDistanceY}));
-				$tikz .=
-					"\\foreach \\y in {"
-					. join(',', @yTicks)
-					. "}{\\draw[thin] (5pt,\\y) -- (-5pt,\\y) node[left]{\$\\y\$};}\n"
-					if (@yTicks);
-			}
+			# Horizontal grid lines
+			my @yGridLines =
+				grep { $_ < $self->{bBox}[1] } map { $_ * $self->{gridY} } (1 .. $self->{bBox}[1] / $self->{gridY});
+			push(@yGridLines,
+				grep { $_ > $self->{bBox}[3] }
+				map { -$_ * $self->{gridY} } (1 .. -$self->{bBox}[3] / $self->{gridY}));
+			$tikz .=
+				"\\foreach \\y in {"
+				. join(',', @yGridLines)
+				. "}{\\draw[line width=0.2pt,color=lightgray] ($self->{bBox}[0],\\y) -- ($self->{bBox}[2],\\y);}\n"
+				if (@yGridLines);
+		}
 
-			# Border box
-			$tikz .= "\\draw[borderblue,rounded corners=14pt,thick] "
+		# Axis and labels.
+		$tikz .= "\\huge\n\\draw[<->,thick] ($self->{bBox}[0],0) -- ($self->{bBox}[2],0)\n"
+			. "node[above left,outer sep=2pt]{\\($self->{xAxisLabel}\\)};\n";
+		unless ($self->{numberLine}) {
+			$tikz .= "\\draw[<->,thick] (0,$self->{bBox}[3]) -- (0,$self->{bBox}[1])\n"
+				. "node[below right,outer sep=2pt]{\\($self->{yAxisLabel}\\)};\n";
+		}
+
+		# Horizontal axis ticks and labels
+		my @xTicks = grep { $_ < $self->{bBox}[2] }
+			map { $_ * $self->{ticksDistanceX} } (1 .. $self->{bBox}[2] / $self->{ticksDistanceX});
+		push(@xTicks,
+			grep { $_ > $self->{bBox}[0] }
+			map { -$_ * $self->{ticksDistanceX} } (1 .. -$self->{bBox}[0] / $self->{ticksDistanceX}));
+		# Add zero if this is a number line and 0 is in the given range.
+		push(@xTicks, 0) if ($self->{numberLine} && $self->{bBox}[2] > 0 && $self->{bBox}[0] < 0);
+		my $tickSize = $self->{numberLine} ? '9' : '5';
+		$tikz .=
+			"\\foreach \\x in {"
+			. join(',', @xTicks)
+			. "}{\\draw[thin] (\\x,${tickSize}pt) -- (\\x,-${tickSize}pt) node[below]{\\(\\x\\)};}\n"
+			if (@xTicks);
+
+		# Vertical axis ticks and labels
+		unless ($self->{numberLine}) {
+			my @yTicks = grep { $_ < $self->{bBox}[1] }
+				map { $_ * $self->{ticksDistanceY} } (1 .. $self->{bBox}[1] / $self->{ticksDistanceY});
+			push(@yTicks,
+				grep { $_ > $self->{bBox}[3] }
+				map { -$_ * $self->{ticksDistanceY} } (1 .. -$self->{bBox}[3] / $self->{ticksDistanceY}));
+			$tikz .=
+				"\\foreach \\y in {"
+				. join(',', @yTicks)
+				. "}{\\draw[thin] (5pt,\\y) -- (-5pt,\\y) node[left]{\$\\y\$};}\n"
+				if (@yTicks);
+		}
+
+		# Border box
+		$tikz .= "\\draw[borderblue,rounded corners=14pt,thick] "
+			. "($self->{bBox}[0],$self->{bBox}[3]) rectangle ($self->{bBox}[2],$self->{bBox}[1]);\n";
+
+		# Graph the points, lines, circles, and parabolas.
+		if (@{ $self->{staticObjects} }) {
+			my $obj = $self->SUPER::new($self->{context}, @{ $self->{staticObjects} });
+
+			# Switch to the foreground layer and clipping box for the objects.
+			$tikz .= "\\begin{pgfonlayer}{foreground}\n";
+			$tikz .= "\\clip[rounded corners=14pt] "
 				. "($self->{bBox}[0],$self->{bBox}[3]) rectangle ($self->{bBox}[2],$self->{bBox}[1]);\n";
 
-			# Graph the points, lines, circles, and parabolas.
-			if (@{ $self->{staticObjects} }) {
-				my $obj = $self->SUPER::new($self->{context}, @{ $self->{staticObjects} });
+			my @obj_data;
 
-				# Switch to the foreground layer and clipping box for the objects.
-				$tikz .= "\\begin{pgfonlayer}{foreground}\n";
-				$tikz .= "\\clip[rounded corners=14pt] "
-					. "($self->{bBox}[0],$self->{bBox}[3]) rectangle ($self->{bBox}[2],$self->{bBox}[1]);\n";
-
-				my @obj_data;
-
-				# First graph lines, parabolas, and circles.  Cache the clipping path and a function
-				# for determining which side of the object to shade for filling later.
-				for (@{ $obj->{data} }) {
-					next
-						unless (ref($graphObjectTikz{ $_->{data}[0] }) eq 'HASH'
-							&& ref($graphObjectTikz{ $_->{data}[0] }{code}) eq 'CODE'
-							&& !$graphObjectTikz{ $_->{data}[0] }{fillType});
-					my ($object_tikz, $object_data) = $graphObjectTikz{ $_->{data}[0] }{code}->($self, $_);
-					$tikz .= $object_tikz;
-					push(@obj_data, $object_data);
-				}
-
-				# Switch from the foreground layer to the background layer for the fills.
-				$tikz .= "\\end{pgfonlayer}\n\\begin{pgfonlayer}{background}\n";
-
-				# Now shade the fill regions.
-				for (@{ $obj->{data} }) {
-					next
-						unless (ref($graphObjectTikz{ $_->{data}[0] }) eq 'HASH'
-							&& ref($graphObjectTikz{ $_->{data}[0] }{code}) eq 'CODE'
-							&& $graphObjectTikz{ $_->{data}[0] }{fillType});
-					$tikz .= $graphObjectTikz{fill}{code}->($self, $_, [@obj_data], $obj);
-				}
-
-				# End the background layer.
-				$tikz .= "\\end{pgfonlayer}";
+			# First graph lines, parabolas, and circles.  Cache the clipping path and a function
+			# for determining which side of the object to shade for filling later.
+			for (@{ $obj->{data} }) {
+				next
+					unless (ref($graphObjectTikz{ $_->{data}[0] }) eq 'HASH'
+						&& ref($graphObjectTikz{ $_->{data}[0] }{code}) eq 'CODE'
+						&& !$graphObjectTikz{ $_->{data}[0] }{fillType});
+				my ($object_tikz, $object_data) = $graphObjectTikz{ $_->{data}[0] }{code}->($self, $_);
+				$tikz .= $object_tikz;
+				push(@obj_data, $object_data);
 			}
 
-			$graph->tex($tikz);
+			# Switch from the foreground layer to the background layer for the fills.
+			$tikz .= "\\end{pgfonlayer}\n\\begin{pgfonlayer}{background}\n";
 
-			$out = main::image(
-				main::insertGraph($graph),
-				width    => $size[0],
-				height   => $size[1],
-				tex_size => $self->{texSize}
-			);
+			# Now shade the fill regions.
+			for (@{ $obj->{data} }) {
+				next
+					unless (ref($graphObjectTikz{ $_->{data}[0] }) eq 'HASH'
+						&& ref($graphObjectTikz{ $_->{data}[0] }{code}) eq 'CODE'
+						&& $graphObjectTikz{ $_->{data}[0] }{fillType});
+				$tikz .= $graphObjectTikz{fill}{code}->($self, $_, [@obj_data], $obj);
+			}
+
+			# End the background layer.
+			$tikz .= "\\end{pgfonlayer}";
 		}
+
+		$graph->tex($tikz);
+
+		return main::image(
+			main::insertGraph($graph),
+			width    => $size[0],
+			height   => $size[1],
+			tex_size => $self->{texSize}
+		) . ($main::displayMode eq 'PTX' ? qq!<p><fillin name="$ans_name"/></p>! : '');
+	} elsif ($main::displayMode eq 'PTX') {
+		return qq!<p><fillin name="$ans_name"/></p>!;
+	} elsif ($main::displayMode eq 'TeX') {
+		return '';
 	} else {
 		$self->constructJSXGraphOptions;
-		my $ans_name = $self->ANS_NAME;
-		$out .= <<END_SCRIPT;
+		return main::tag('input', type => 'hidden', name => $ans_name, id => $ans_name, value => $answer_value)
+			. main::tag(
+				'input',
+				type  => 'hidden',
+				name  => "previous_$ans_name",
+				id    => "previous_$ans_name",
+				value => $answer_value
+			) . <<END_SCRIPT;
 <div id='${ans_name}_graphbox' class='graphtool-container'></div>
 <script>
 (() => {
@@ -944,8 +953,6 @@ END_TIKZ
 </script>
 END_SCRIPT
 	}
-
-	return $out;
 }
 
 sub cmp_defaults {


### PR DESCRIPTION
Much of the diff here is again indentation changes.

Previously, an `$out` variable is initialized before all the conditional code. Some blocks of the conditional code append to `$out`, and some simply replace it. After the conditional code, it returns `$out`, but it's confusing that some pathways have overwritten what it was initialized to be and others appended to that. So this moves the `return` commands to within each block, and I think it is more clear what each scenario is returning.

Also this helped me handle the `showInStatic -> 0` situation better for TeX. Without this commit, it was showing an answer blank in that situation (from the hidden answer field). There may be an issue that hidden answer fields are displayed in hardcopy output in the first place, but I did not pursue this.

And then the main thing that led to this is that now PTX produces its own form of "hidden input" field (regardless of `showInStatic`). Which is a `fillin` element inside a `p` with nothing else inside the `p`. It's a bit hackish but that is the convention we have. This way PTX will recognize that something was asking for an answer, and then for example in the answers at the back of the book, an answer will be listed. For now it will just be those strings like `{interval,(0,1)}` and that's OK.