### PR TITLE
Add a dynamic help system to the graph tool.

### DIFF
--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -156,9 +156,11 @@
 
 		CubicTool: {
 			iconName: 'cubic',
-			tooltip: '4-Point Cubic Tool',
+			tooltip: '4-Point Cubic Tool: Graph a cubic function.',
 
 			initialize(gt) {
+				this.supportsSolidDash = true;
+
 				this.phase1 = (coords) => {
 					// Don't allow the point to be created off the board.
 					if (!gt.boardHasPoint(coords[1], coords[2])) return;
@@ -174,6 +176,9 @@
 					if (newX > gt.board.getBoundingBox()[2]) newX = this.point1.X() - gt.snapSizeX;
 
 					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.point1.Y()], gt.board));
+
+					this.helpText = 'Plot three more points on the cubic.';
+					gt.updateHelp();
 
 					gt.board.on('up', (e) => this.phase2(gt.getMouseCoords(e).usrCoords));
 
@@ -201,6 +206,9 @@
 					if (newX === this.point1.X()) newX -= gt.snapSizeX;
 
 					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.point2.Y()], gt.board));
+
+					this.helpText = 'Plot two more points on the cubic.';
+					gt.updateHelp();
 
 					gt.board.on('up', (e) => this.phase3(gt.getMouseCoords(e).usrCoords));
 
@@ -233,6 +241,9 @@
 					}
 
 					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.point3.Y()], gt.board));
+
+					this.helpText = 'Plot one more point on the cubic.';
+					gt.updateHelp();
 
 					gt.board.on('up', (e) => this.phase4(gt.getMouseCoords(e).usrCoords));
 
@@ -346,6 +357,7 @@
 			},
 
 			deactivate(gt) {
+				delete this.helpText;
 				gt.board.off('up');
 				['point1', 'point2', 'point3'].forEach(function(point) {
 					if (this[point]) gt.board.removeObject(this[point]);
@@ -359,6 +371,9 @@
 
 				// Draw a highlight point on the board.
 				this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [0, 0], gt.board));
+
+				this.helpText = 'Plot four points on the cubic.';
+				gt.updateHelp();
 
 				gt.board.on('up', (e) => this.phase1(gt.getMouseCoords(e).usrCoords));
 			}

--- a/htdocs/js/apps/GraphTool/graphtool.scss
+++ b/htdocs/js/apps/GraphTool/graphtool.scss
@@ -88,6 +88,10 @@
 			color: #000;
 			border: 1px solid #ccc !important;
 
+			&.gt-text-button {
+				padding: 1px 6px;
+			}
+
 			&:disabled {
 				box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
 			}
@@ -312,6 +316,14 @@
 	border-width: 1px;
 	margin-top: 0.5rem;
 	padding: 0.25rem 0.5rem;
+
+	&.gt-disabled-help:empty {
+		min-height: 0;
+		opacity: 0;
+		margin-top: 0;
+		padding: 0;
+		border: none;
+	}
 }
 
 .graphtool-answer-container {

--- a/htdocs/js/apps/GraphTool/graphtool.scss
+++ b/htdocs/js/apps/GraphTool/graphtool.scss
@@ -1,6 +1,8 @@
 @use 'sass:color';
 
 .graphtool-container {
+	position: relative;
+	box-sizing: border-box;
 	width: 442px;
 	padding: 15px 20px;
 	border-radius: 10px;
@@ -37,6 +39,36 @@
 		}
 	}
 
+	.gt-button {
+		box-sizing: border-box;
+		height: 34px;
+		text-align: center;
+		padding: 0.375rem 0.75rem;
+		border-radius: 4px;
+		box-shadow: inset 0 1px 0 #ffffff26, 0 1px 1px rgba(0, 0, 0, 0.075);
+		display: inline-block;
+		text-align: center;
+		transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+		user-select: none;
+		vertical-align: middle;
+
+		&:not(:disabled) {
+			cursor: pointer;
+		}
+
+		&:first-child:active {
+			box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+		}
+
+		&:hover {
+			text-decoration: none;
+		}
+
+		&:focus-visible {
+			outline: 0;
+		}
+	}
+
 	.gt-toolbar-container {
 		margin: 0.5rem 0 0;
 		text-align: right;
@@ -50,24 +82,42 @@
 		}
 
 		.gt-button {
-			box-sizing: border-box;
-			height: 34px;
-			text-align: center;
 			padding: 1px;
 			margin: 2px;
-			border-radius: 4px;
+			background-color: #f8f9fa;
+			color: #000;
 			border: 1px solid #ccc !important;
+
+			&:disabled {
+				box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
+			}
+
+			&:hover {
+				background-color: #d3d4d5;
+				border-color: #c6c7c8;
+			}
+
+			&:first-child:active {
+				background-color: #c6c7c8;
+			}
+
+			&:focus-visible {
+				background-color: #d3d4d5;
+				box-shadow: inset 0 1px 0 #ffffff26, 0 1px 1px rgba(0, 0, 0, 0.075),
+					0 0 0 0.2rem rgba(211, 212, 213, 0.5);
+			}
+
+			&:disabled {
+				background-color: #f8f9fa;
+				box-shadow: none;
+				opacity: 0.65;
+				pointer-events: none;
+			}
 		}
 
 		.gt-tool-button {
 			width: 34px;
 			background-position: 0;
-
-			&:disabled {
-				box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.05);
-				outline: 0;
-				opacity: unset;
-			}
 		}
 
 		.gt-tool-button-pair {
@@ -172,6 +222,96 @@
 			}
 		}
 	}
+
+	.gt-confirm-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 9;
+		width: 100%;
+		height: 100%;
+		border-radius: 10px;
+		background-color: #000;
+		opacity: 0.25;
+	}
+
+	.gt-message-box {
+		position: absolute;
+		display: flex;
+		z-index: 10;
+		justify-content: center;
+		text-align: center;
+		align-items: center;
+		flex-direction: column;
+		width: calc(100% - 40px);
+		background-color: #fff;
+		opacity: 0;
+		transition: all 0.2s ease-in-out;
+
+		&:not(:empty) {
+			opacity: 1;
+			margin-top: 0.5rem;
+			padding: 0.25rem 0.5rem;
+			border: 1px solid #356aa0;
+			border-radius: 10px;
+		}
+
+		.gt-message-content {
+			margin: 0;
+			user-select: none;
+			opacity: 0;
+			transition: opacity 0.1s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+			&.gt-message-fade {
+				opacity: 1;
+				transition: opacity 0.2s cubic-bezier(0.55, 0.085, 0.68, 0.53);
+			}
+
+			&.gt-confirm {
+				padding: 0.25rem;
+				width: 100%;
+
+				.gt-confirm-buttons {
+					display: flex;
+					justify-content: end;
+					gap: 0.5rem;
+					margin-top: 0.5rem;
+				}
+
+				.gt-confirm-button {
+					background-color: #6c757d;
+					color: #fff;
+					border: 1px solid #6c757d;
+
+					&:hover {
+						background-color: #5c636a;
+						border-color: #565e64;
+					}
+
+					&:first-child:active {
+						background-color: #565e64;
+						border-color: #51585e;
+					}
+
+					&:focus-visible {
+						background-color: #5c636a;
+						border-color: #565e64;
+						box-shadow: inset 0 1px 0 #ffffff26, 0 1px 1px rgba(0, 0, 0, 0.075),
+							0 0 0 0.2rem rgba(130, 138, 145, 0.5);
+					}
+				}
+			}
+		}
+	}
+}
+
+.JXG_wrap_private:fullscreen .gt-message-box {
+	position: relative;
+	min-height: 92px;
+	width: 100%;
+	border-width: 1px;
+	margin-top: 0.5rem;
+	padding: 0.25rem 0.5rem;
 }
 
 .graphtool-answer-container {
@@ -194,12 +334,5 @@
 		@media only screen and (max-width: 600px) {
 			height: 52px;
 		}
-	}
-}
-
-.gt-modal {
-	h3 {
-		margin: 0;
-		font-size: 1.2rem;
 	}
 }

--- a/htdocs/js/apps/GraphTool/pointtool.js
+++ b/htdocs/js/apps/GraphTool/pointtool.js
@@ -14,6 +14,8 @@
 			},
 
 			postInit(gt) {
+				this.supportsSolidDash = false;
+
 				// The base object is also a defining point for a Point.  This makes it so that a point can not steal
 				// focus from another focused object that has a defining point at the same location.
 				this.definingPts.push(this.baseObj);
@@ -30,6 +32,7 @@
 				this.focused = false;
 				this.baseObj.setAttribute(
 					{ fixed: true, highlight: false, strokeColor: gt.color.curve, strokeWidth: 2 });
+				gt.updateHelp();
 				return false;
 			},
 
@@ -39,6 +42,7 @@
 					{ fixed: false, highlight: true, strokeColor: gt.color.focusCurve, strokeWidth: 3 });
 
 				this.focusPoint.rendNode.focus();
+				gt.updateHelp();
 				return false;
 			},
 
@@ -70,7 +74,7 @@
 
 		PointTool: {
 			iconName: 'point',
-			tooltip: 'Point Tool',
+			tooltip: 'Point Tool: Plot a point.',
 
 			initialize(gt) {
 				this.phase1 = (coords) => {
@@ -129,6 +133,7 @@
 			},
 
 			deactivate(gt) {
+				delete this.helpText;
 				gt.board.off('up');
 				gt.board.containerObj.style.cursor = 'auto';
 			},
@@ -138,6 +143,9 @@
 
 				// Draw a highlight point on the board.
 				this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [0, 0], gt.board));
+
+				this.helpText = 'Plot a point.';
+				gt.updateHelp();
 
 				gt.board.on('up', (e) => this.phase1(gt.getMouseCoords(e).usrCoords));
 			}

--- a/htdocs/js/apps/GraphTool/quadratictool.js
+++ b/htdocs/js/apps/GraphTool/quadratictool.js
@@ -134,9 +134,11 @@
 
 		QuadraticTool: {
 			iconName: 'quadratic',
-			tooltip: '3-Point Quadratic Tool',
+			tooltip: '3-Point Quadratic Tool: Graph a quadratic function.',
 
 			initialize(gt) {
+				this.supportsSolidDash = true;
+
 				this.phase1 = (coords) => {
 					// Don't allow the point to be created off the board.
 					if (!gt.boardHasPoint(coords[1], coords[2])) return;
@@ -152,6 +154,9 @@
 					if (newX > gt.board.getBoundingBox()[2]) newX = this.point1.X() - gt.snapSizeX;
 
 					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.point1.Y()], gt.board));
+
+					this.helpText = 'Plot two more points on the quadratic.';
+					gt.updateHelp();
 
 					gt.board.on('up', (e) => this.phase2(gt.getMouseCoords(e).usrCoords));
 
@@ -179,6 +184,9 @@
 					if (newX === this.point1.X()) newX -= gt.snapSizeX;
 
 					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.point2.Y()], gt.board));
+
+					this.helpText = 'Plot one more point on the quadratic.';
+					gt.updateHelp();
 
 					gt.board.on('up', (e) => this.phase3(gt.getMouseCoords(e).usrCoords));
 
@@ -277,6 +285,7 @@
 			},
 
 			deactivate(gt) {
+				delete this.helpText;
 				gt.board.off('up');
 				if (this.point1) gt.board.removeObject(this.point1);
 				delete this.point1;
@@ -290,6 +299,9 @@
 
 				// Draw a highlight point on the board.
 				this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [0, 0], gt.board));
+
+				this.helpText = 'Plot three points on the quadratic.';
+				gt.updateHelp();
 
 				gt.board.on('up', (e) => this.phase1(gt.getMouseCoords(e).usrCoords));
 			}


### PR DESCRIPTION
Help messages are displayed as the user interacts with the graph tool.

There is a button that disables/enables help.  When clicked the button disables help for all graphtool graphs.  The setting is saved in local storage and so persists.  If clicked again, then help is enabled.

The bootstrap tooltips have been removed.  Instead those use the new help message box.  The tooltip messages are also bit more descriptive of the tool.

Instead of bootstrap modal dialogs for confirming object deletion or clearing the board, a sort of dialog in the content of the message box is used.

Button styles were added to replace the bootstrap button styles.

This makes the graph tool no longer dependent on bootstrap.

Note that this includes #797.