### PR TITLE
Update the drag handlers for the graphtool graph objects.

### DIFF
--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -115,6 +115,8 @@
 				},
 
 				pairedPointDrag(gt, e) {
+					if (e.type === 'keydown') return;
+
 					const coords = gt.getMouseCoords(e);
 					let left_x = this.X(), right_x = this.X();
 

--- a/htdocs/js/apps/GraphTool/cubictool.js
+++ b/htdocs/js/apps/GraphTool/cubictool.js
@@ -19,29 +19,6 @@
 				this.focusPoint = point1;
 			},
 
-			handleKeyEvent(gt, e, el) {
-				if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-
-				// Make sure that this point is not moved onto the same vertical line as another point.
-				const pointIndex = this.definingPts.findIndex((pt) => pt.id === el.id);
-				if (pointIndex > -1) {
-					let x = el.X();
-					const dir = (e.key === 'ArrowLeft' ? -1 : 1) * gt.snapSizeX;
-
-					while (this.definingPts.some((other, i) => i !== pointIndex && x === other.X())) x += dir;
-
-					// If the computed new x coordinate is off the board, then we need to move the point back instead.
-					const boundingBox = gt.board.getBoundingBox();
-					if (x < boundingBox[0] || x > boundingBox[2]) {
-						x = el.X() - dir;
-						while (this.definingPts.some((other, i) => i !== pointIndex && x === other.X())) x -= dir;
-					}
-
-					el.setPosition(JXG.COORDS_BY_USER, [x, el.Y()]);
-					gt.board.update();
-				}
-			},
-
 			stringify(gt) {
 				return [
 					this.baseObj.getAttribute('dash') == 0 ? 'solid' : 'dashed',
@@ -114,50 +91,63 @@
 					});
 				},
 
-				pairedPointDrag(gt, e) {
-					if (e.type === 'keydown') return;
+				// Prevent a point from being moved off the board by a drag. If a group of other points is provided,
+				// then also prevent the point from being moved into the same vertical line as any of those points.
+				// Note that when this method is called, the point has already been moved by JSXGraph.  Note that this
+				// ensures that the graphed object is a function, but does not prevent the cubic from degenerating into
+				// a quadratic or a line.
+				adjustDragPosition(gt, e, point, groupedPoints) {
+					const bbox = gt.board.getBoundingBox();
 
-					const coords = gt.getMouseCoords(e);
-					let left_x = this.X(), right_x = this.X();
+					let left_x = point.X() < bbox[0] ? bbox[0] : point.X() > bbox[2] ? bbox[2] : point.X();
+					let right_x = left_x;
+					let y = point.Y() < bbox[3] ? bbox[3] : point.Y() > bbox[1] ? bbox[1] : point.Y();
 
-					while (this.paired_points.some((pairedPoint) => left_x == pairedPoint.X()))
-						left_x -= gt.snapSizeX;
-					while (this.paired_points.some((pairedPoint) => right_x == pairedPoint.X()))
-						right_x += gt.snapSizeX;
+					while (groupedPoints.some((groupedPoint) => left_x === groupedPoint.X())) left_x -= gt.snapSizeX;
+					while (groupedPoints.some((groupedPoint) => right_x === groupedPoint.X())) right_x += gt.snapSizeX;
 
-					if (this.X() != left_x && this.X() != right_x) {
-						const left_dist = Math.abs(coords.usrCoords[1] - left_x);
-						const right_dist = Math.abs(coords.usrCoords[1] - right_x);
-						this.setPosition(JXG.COORDS_BY_USER, [
-							left_x < gt.board.getBoundingBox()[0] ? right_x
-								: (left_dist < right_dist || right_x > gt.board.getBoundingBox()[2]) ? left_x : right_x,
-							this.Y()
+					if (!gt.boardHasPoint(point.X(), point.Y()) || point.X() !== left_x || point.X() !== right_x) {
+						let preferLeft;
+						if (e.type === 'pointermove') {
+							const mouseX = gt.getMouseCoords(e).usrCoords[1];
+							preferLeft = Math.abs(mouseX - left_x) < Math.abs(mouseX - right_x);
+						} else if (e.type === 'keydown') {
+							preferLeft = e.key === 'ArrowLeft';
+						}
+
+						point.setPosition(JXG.COORDS_BY_USER, [
+							left_x < bbox[0] ? right_x : (preferLeft || right_x > bbox[2]) ? left_x : right_x,
+							y
 						]);
 					}
+				},
+
+				groupedPointDrag(gt, e) {
+					gt.graphObjectTypes.cubic.adjustDragPosition(e, this, this.grouped_points);
 					gt.updateObjects();
 					gt.updateText();
 				},
 
-				createPoint(gt, x, y, paired_points) {
+				createPoint(gt, x, y, grouped_points) {
 					const point = gt.board.create('point', [x, y], {
 						size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
 					});
-					if (typeof paired_points !== 'undefined' && paired_points.length) {
-						point.paired_points = [];
-						paired_points.forEach((paired_point) => {
-							point.paired_points.push(paired_point);
-							if (!paired_point.paired_points) {
-								paired_point.paired_points = [];
-								paired_point.on('drag', gt.graphObjectTypes.cubic.pairedPointDrag);
+					if (typeof grouped_points !== 'undefined' && grouped_points.length) {
+						point.grouped_points = [];
+						grouped_points.forEach((paired_point) => {
+							point.grouped_points.push(paired_point);
+							if (!paired_point.grouped_points) {
+								paired_point.grouped_points = [];
+								paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
 							}
-							paired_point.paired_points.push(point);
+							paired_point.grouped_points.push(point);
 							if (!paired_point.eventHandlers.drag ||
 								paired_point.eventHandlers.drag.every((dragHandler) =>
-									dragHandler.handler !== gt.graphObjectTypes.cubic.pairedPointDrag)
+									dragHandler.handler !== gt.graphObjectTypes.cubic.groupedPointDrag)
 							)
-								paired_point.on('drag', gt.graphObjectTypes.cubic.pairedPointDrag);
+								paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
 						});
-						point.on('drag', gt.graphObjectTypes.cubic.pairedPointDrag, point);
+						point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag, point);
 					}
 					return point;
 				}
@@ -176,7 +166,7 @@
 					gt.board.off('up');
 
 					this.point1 = gt.graphObjectTypes.cubic.createPoint(coords[1], coords[2]);
-					this.point1.setAttribute({ fixed: true });
+					this.point1.setAttribute({ fixed: true, highlight: false });
 
 					// Get a new x coordinate that is to the right, unless that is off the board.
 					// In that case go left instead.
@@ -200,7 +190,7 @@
 					gt.board.off('up');
 
 					this.point2 = gt.graphObjectTypes.cubic.createPoint(coords[1], coords[2], [this.point1]);
-					this.point2.setAttribute({ fixed: true });
+					this.point2.setAttribute({ fixed: true, highlight: false });
 
 					// Get a new x coordinate that is to the right, unless that is off the board.
 					// In that case go left instead.
@@ -228,7 +218,7 @@
 					gt.board.off('up');
 					this.point3 = gt.graphObjectTypes.cubic.createPoint(coords[1], coords[2],
 						[this.point1, this.point2]);
-					this.point3.setAttribute({ fixed: true });
+					this.point3.setAttribute({ fixed: true, highlight: false });
 
 					// Get a new x coordinate that is to the right, unless that is off the board.
 					// In that case go left instead.
@@ -286,59 +276,44 @@
 					else if (this.point2) this.phase3(this.hlObjs.hl_point.coords.usrCoords);
 					else if (this.point1) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
 					else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
-				} else if (['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
-					if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-						// Make sure the highlight point is not moved onto the same vertical line as any of the other
-						// points that have already been created.
-						const others = [];
-						if (this.point1) others.push(this.point1);
-						if (this.point2) others.push(this.point2);
-						if (this.point3) others.push(this.point3);
-
-						let x = this.hlObjs.hl_point.X();
-						while (others.some((other) => x === other.X()))
-							x += (e.key === 'ArrowRight' ? 1 : -1) * gt.snapSizeX;
-
-						// If the computed new x coordinate is off the board,
-						// then we need to move the point back instead.
-						const boundingBox = gt.board.getBoundingBox();
-						if (x < boundingBox[0] || x > boundingBox[2]) {
-							x = this.hlObjs.hl_point.X();
-							while (others.some((other) => x === other.X()))
-								x += (e.key === 'ArrowRight' ? -1 : 1) * gt.snapSizeX;
-						}
-
-						if (x !== this.hlObjs.hl_point.X())
-							this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [x, this.hlObjs.hl_point.Y()]);
-					}
-
-					this.updateHighlights(this.hlObjs.hl_point.coords);
 				}
 			},
 
-			updateHighlights(gt, coords) {
-				if (this.hlObjs.hl_line) this.hlObjs.hl_line.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
-				if (this.hlObjs.hl_parabola) this.hlObjs.hl_parabola.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
-				if (this.hlObjs.hl_cubic) this.hlObjs.hl_cubic.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+			updateHighlights(gt, e) {
+				this.hlObjs.hl_line?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+				this.hlObjs.hl_parabola?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+				this.hlObjs.hl_cubic?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
 				this.hlObjs.hl_point?.rendNode.focus();
 
-				if (typeof coords === 'undefined') return;
+				let coords;
+				if (e instanceof MouseEvent && e.type === 'pointermove') {
+					coords = gt.getMouseCoords(e);
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+				} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+					coords = this.hlObjs.hl_point.coords;
+				} else if (e instanceof JXG.Coords) {
+					coords = e;
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+				} else
+					return false;
 
-				const new_x = gt.snapRound(coords.usrCoords[1], gt.snapSizeX);
-				if ((this.point1 && new_x == this.point1.X()) ||
-					(this.point2 && new_x == this.point2.X()) ||
-					(this.point3 && new_x == this.point3.X()))
-					return;
-
-				if (this.hlObjs.hl_point) {
-					this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
-				} else {
+				if (!this.hlObjs.hl_point) {
 					this.hlObjs.hl_point = gt.board.create('point', [coords.usrCoords[1], coords.usrCoords[2]], {
 						size: 2, color: gt.color.underConstruction, snapToGrid: true,
 						snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY,
 						highlight: false, withLabel: false
 					});
 					this.hlObjs.hl_point.rendNode.focus();
+				}
+
+				// Make sure the highlight point is not moved off the board or onto the same
+				// vertical line as any of the other points that have already been created.
+				if (e instanceof Event) {
+					const groupedPoints = [];
+					if (this.point1) groupedPoints.push(this.point1);
+					if (this.point2) groupedPoints.push(this.point2);
+					if (this.point3) groupedPoints.push(this.point3);
+					gt.graphObjectTypes.cubic.adjustDragPosition(e, this.hlObjs.hl_point, groupedPoints)
 				}
 
 				if (this.point3 && !this.hlObjs.hl_cubic) {

--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -41,6 +41,7 @@ window.graphTool = (containerId, options) => {
 	gt.definingPointAttributes = {
 		size: 3,
 		fixed: false,
+		highlight: true,
 		withLabel: false,
 		strokeWidth: 1,
 		strokeColor: gt.color.focusCurve,
@@ -185,13 +186,35 @@ window.graphTool = (containerId, options) => {
 			gt.board.containerObj.tabIndex = -1;
 
 			gt.board.on('move', (e) => {
-				// JSXGraph now sends keydown events to the move handler.  In this case this is handled by the graphtool
-				// keydown event handler.  Obviously, this event won't have the mouse coordinates.
-				if (e.type === 'keydown') return;
-				const coords = gt.getMouseCoords(e);
-				if (gt.activeTool?.updateHighlights(coords)) return;
-				if (!gt.selectedObj || !gt.selectedObj.updateTextCoords(coords))
-					gt.setTextCoords(coords.usrCoords[1], coords.usrCoords[2]);
+				if (e.type === 'keydown') {
+					if (
+						gt.activeTool === gt.selectTool &&
+						gt.board.containerObj.contains(document.activeElement) &&
+						gt.graphedObjs.length
+					) {
+						gt.graphedObjs.some((obj) => {
+							const el = obj.definingPts.find((point) => point.rendNode === e.target);
+							if (el) {
+								// None of the current graph objects use the handleKeyEvent handler anymore.  This is
+								// still provided in case a new graph object is written that needs it.  However, in that
+								// case it is the responsibility of the calling method to call gt.updateObjects() and
+								// gt.updateText() when it is finished if those are needed.
+								obj.handleKeyEvent(e, el);
+
+								if (!gt.selectedObj || !gt.selectedObj.updateTextCoords(el.coords))
+									gt.setTextCoords(el.coords.usrCoords[1], el.coords.usrCoords[2]);
+							}
+						});
+					} else {
+						gt.activeTool?.updateHighlights(e);
+					}
+				} else if (e.type === 'pointermove') {
+					if (gt.activeTool?.updateHighlights(e)) return;
+
+					const coords = gt.getMouseCoords(e);
+					if (!gt.selectedObj || !gt.selectedObj.updateTextCoords(coords))
+						gt.setTextCoords(coords.usrCoords[1], coords.usrCoords[2]);
+				}
 			});
 
 			gt.hasFocus = false;
@@ -348,24 +371,6 @@ window.graphTool = (containerId, options) => {
 			});
 
 			gt.graphContainer.addEventListener('keydown', (e) => {
-				if (gt.activeTool === gt.selectTool &&
-					gt.board.containerObj.contains(document.activeElement) && gt.graphedObjs.length &&
-					['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)
-				) {
-					gt.graphedObjs.some((obj) => {
-						const el = obj.definingPts.find((point) => point.rendNode === e.target);
-						if (el) {
-							obj.handleKeyEvent(e, el);
-							gt.updateObjects();
-							gt.updateText();
-							if (!gt.activeTool?.updateHighlights(el.coords)) {
-								if (!gt.selectedObj || !gt.selectedObj.updateTextCoords(el.coords))
-									gt.setTextCoords(el.coords.usrCoords[1], el.coords.usrCoords[2]);
-							}
-						}
-					});
-				}
-
 				for (const tool of gt.tools) tool.handleKeyEvent(e);
 
 				if (!gt.buttonBox.contains(document.activeElement) && e.key === 'N' && e.shiftKey) {
@@ -479,76 +484,104 @@ window.graphTool = (containerId, options) => {
 
 	gt.pointRegexp = /\( *(-?[0-9]*(?:\.[0-9]*)?), *(-?[0-9]*(?:\.[0-9]*)?) *\)/g;
 
-	// This method makes the actual adjustment for the gt.keyboardMovementAdjust and
-	// gt.keyboardMovementAdjustRestricted methods below.
-	gt.keyboardMovementAdjustPosition = (key, point1) => {
-		let x = point1.X() + (key === 'ArrowLeft' ? -1 : key === 'ArrowRight' ? 1 : 0) * gt.snapSizeX;
-		let y = point1.Y() + (key === 'ArrowUp' ? 1 : key === 'ArrowDown' ? -1 : 0) * gt.snapSizeY;
+	// Prevent a point from being moved off the board by a drag. If a paired point is provided, then also prevent the
+	// point from being moved into the same position as the paired point by a drag.  Note that when this method is
+	// called, the point has already been moved by JSXGraph.  This prevents lines and circles from being made
+	// degenerate.
+	gt.adjustDragPosition = (e, point, pairedPoint) => {
+		if ((point.X() == pairedPoint?.X() && point.Y() == pairedPoint?.Y()) ||
+			!gt.boardHasPoint(point.X(), point.Y()))
+		{
+			const bbox = gt.board.getBoundingBox();
 
-		// If the computed new coordinates are off the board, then we need to move the point back instead.
-		const boundingBox = gt.board.getBoundingBox();
-		if (x < boundingBox[0]) x = boundingBox[0] + gt.snapSizeX;
-		else if (x > boundingBox[2]) x = boundingBox[2] - gt.snapSizeX;
-		if (y < boundingBox[3]) y = boundingBox[3] + gt.snapSizeY;
-		else if (y > boundingBox[1]) y = boundingBox[1] - gt.snapSizeY;
+			// Clamp the coordinates to the board.
+			let x = point.X() < bbox[0] ? bbox[0] : point.X() > bbox[2] ? bbox[2] : point.X();
+			let y = point.Y() < bbox[3] ? bbox[3] : point.Y() > bbox[1] ? bbox[1] : point.Y();
 
-		point1.setPosition(JXG.COORDS_BY_USER, [x, y]);
-		gt.board.update();
+			// Adjust position of the point if it has the same coordinates as its paired point.
+			if (pairedPoint && x === pairedPoint.X() && y === pairedPoint.Y()) {
+				let xDir, yDir;
+
+				if (e.type === 'pointermove') {
+					const coords = gt.getMouseCoords(e);
+					const x_trans = coords.usrCoords[1] - pairedPoint.X(),
+						y_trans = coords.usrCoords[2] - pairedPoint.Y();
+					[ xDir, yDir ] = Math.abs(x_trans) < Math.abs(y_trans)
+						? [ 0, y_trans < 0 ? -1 : 1 ]
+						: [ x_trans < 0 ? -1 : 1, 0 ];
+				} else if (e.type === 'keydown') {
+					xDir = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+					yDir = e.key === 'ArrowUp' ? 1 : e.key === 'ArrowDown' ? -1 : 0;
+				}
+
+				y += yDir * gt.snapSizeY;
+				x += xDir * gt.snapSizeX;
+
+				// If the computed new coordinates are off the board,
+				// then move the coordinates the other direction instead.
+				if (x < bbox[0]) x = bbox[0] + gt.snapSizeX;
+				else if (x > bbox[2]) x = bbox[2] - gt.snapSizeX;
+				if (y < bbox[3]) y = bbox[3] + gt.snapSizeY;
+				else if (y > bbox[1]) y = bbox[1] - gt.snapSizeY;
+			}
+
+			point.setPosition(JXG.COORDS_BY_USER, [x, y]);
+		}
 	};
 
-	// Prevent paired points from being moved into the same position by a drag.  This
-	// prevents lines and circles from being made degenerate.
-	gt.pairedPointDrag = (point, e) => {
-		if (e.type === 'keydown') return;
-		if (point.X() == point.paired_point.X() && point.Y() == point.paired_point.Y()) {
-			const coords = gt.getMouseCoords(e);
-			const x_trans = coords.usrCoords[1] - point.paired_point.X(),
-				y_trans = coords.usrCoords[2] - point.paired_point.Y();
-			if (y_trans > Math.abs(x_trans))
-				point.setPosition(JXG.COORDS_BY_USER, [point.X(), point.Y() + gt.snapSizeY]);
-			else if (x_trans > Math.abs(y_trans))
-				point.setPosition(JXG.COORDS_BY_USER, [point.X() + gt.snapSizeX, point.Y()]);
-			else if (x_trans < -Math.abs(y_trans))
-				point.setPosition(JXG.COORDS_BY_USER, [point.X() - gt.snapSizeX, point.Y()]);
-			else
-				point.setPosition(JXG.COORDS_BY_USER, [point.X(), point.Y() - gt.snapSizeY]);
-		}
+	gt.pairedPointDrag = (e, point) => {
+		gt.adjustDragPosition(e, point, point.paired_point);
 		gt.updateObjects();
 		gt.updateText();
 	};
 
-	// This does much the same as the above method, except for keyboard movement of a point.  Note that for this method,
-	// point1 has already moved, but if that point is now located at the same place as point2, then point1 is made to
-	// jump over point2 (or back to where it came from if that is off the board).
-	gt.keyboardMovementAdjust = (key, point1, point2) => {
-		if (point1.X() === point2.X() && point1.Y() === point2.Y()) gt.keyboardMovementAdjustPosition(key, point1);
+	// Prevent a point from being moved off the board by a drag, and prevent the point from being moved onto the same
+	// horizontal or vertical line as its paired point by a drag. Note that when this method is called, the point has
+	// already been moved by JSXGraph.  This prevents parabolas from being made degenerate.
+	gt.adjustDragPositionRestricted = (e, point, pairedPoint) => {
+		if (point.X() == pairedPoint?.X() ||
+			point.Y() == pairedPoint?.Y() ||
+			!gt.boardHasPoint(point.X(), point.Y()))
+		{
+			const bbox = gt.board.getBoundingBox();
+
+			// Clamp the coordinates to the board.
+			let x = point.X() < bbox[0] ? bbox[0] : point.X() > bbox[2] ? bbox[2] : point.X();
+			let y = point.Y() < bbox[3] ? bbox[3] : point.Y() > bbox[1] ? bbox[1] : point.Y();
+
+			if (pairedPoint) {
+				// Adjust the position of the point if it is on the same
+				// horizontal or vertical line as its paired point.
+				let xDir, yDir;
+
+				if (e.type === 'pointermove') {
+					const coords = gt.getMouseCoords(e);
+					xDir = coords.usrCoords[1] > pairedPoint.X() ? 1 : -1;
+					yDir = coords.usrCoords[2] > pairedPoint.Y() ? 1 : -1;
+				} else if (e.type === 'keydown') {
+					xDir = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+					yDir = e.key === 'ArrowUp' ? 1 : e.key === 'ArrowDown' ? -1 : 0;
+				}
+
+				if (x == pairedPoint.X()) x += xDir * gt.snapSizeX;
+				if (y == pairedPoint.Y()) y += yDir * gt.snapSizeY;
+
+				// If the computed new coordinates are off the board,
+				// then move the coordinates the other direction instead.
+				if (x < bbox[0]) x = bbox[0] + gt.snapSizeX;
+				else if (x > bbox[2]) x = bbox[2] - gt.snapSizeX;
+				if (y < bbox[3]) y = bbox[3] + gt.snapSizeY;
+				else if (y > bbox[1]) y = bbox[1] - gt.snapSizeY;
+			}
+
+			point.setPosition(JXG.COORDS_BY_USER, [x, y]);
+		}
 	};
 
-	// Prevent paired points from being moved onto the same horizontal or vertical
-	// line by a drag.  This prevents parabolas from being made degenerate.
-	gt.pairedPointDragRestricted = (point, e) => {
-		if (e.type === 'keydown') return;
-		const coords = gt.getMouseCoords(e);
-		let new_x = point.X(), new_y = point.Y();
-		if (point.X() == point.paired_point.X()) {
-			if (coords.usrCoords[1] > point.paired_point.X()) new_x += gt.snapSizeX;
-			else new_x -= gt.snapSizeX;
-		}
-		if (point.Y() == point.paired_point.Y()) {
-			if (coords.usrCoords[2] > point.paired_point.Y()) new_y += gt.snapSizeX;
-			else new_y -= gt.snapSizeX;
-		}
-		if (point.X() == point.paired_point.X() || point.Y() == point.paired_point.Y())
-			point.setPosition(JXG.COORDS_BY_USER, [new_x, new_y]);
+	gt.pairedPointDragRestricted = (e, point) => {
+		gt.adjustDragPositionRestricted(e, point, point.paired_point);
 		gt.updateObjects();
 		gt.updateText();
-	};
-
-	// This does much the same as the above method, except for keyboard movement of a point.  Note that for this method,
-	// point1 has already moved, but if that point is now located on the same horizontal or vertical line as point2,
-	// then point1 is made to jump over that line (or back to where it came from if that is off the board).
-	gt.keyboardMovementAdjustRestricted = (key, point1, point2) => {
-		if (point1.X() === point2.X() || point1.Y() === point2.Y()) gt.keyboardMovementAdjustPosition(key, point1);
 	};
 
 	gt.createPoint = (x, y, paired_point, restrict) => {
@@ -561,13 +594,13 @@ window.graphTool = (containerId, options) => {
 			paired_point.paired_point = point;
 			paired_point.on('drag',
 				restrict
-					? (e) => gt.pairedPointDragRestricted(paired_point, e)
-					: (e) => gt.pairedPointDrag(paired_point, e)
+					? (e) => gt.pairedPointDragRestricted(e, paired_point)
+					: (e) => gt.pairedPointDrag(e, paired_point)
 			);
 			point.on('drag',
 				restrict
-					? (e) => gt.pairedPointDragRestricted(point, e)
-					: (e) => gt.pairedPointDrag(point, e)
+					? (e) => gt.pairedPointDragRestricted(e, point)
+					: (e) => gt.pairedPointDrag(e, point)
 			);
 		}
 		return point;
@@ -578,8 +611,7 @@ window.graphTool = (containerId, options) => {
 		gt.staticObjs.forEach((obj) => obj.update());
 	};
 
-	// Generic graph object class from which all the specific graph objects
-	// derive.
+	// Generic graph object class from which all the specific graph objects derive.
 	class GraphObject {
 		constructor(jsxGraphObject) {
 			this.baseObj = jsxGraphObject;
@@ -670,13 +702,6 @@ window.graphTool = (containerId, options) => {
 			this.focusPoint = point1;
 		}
 
-		handleKeyEvent(e, el) {
-			// Make sure that one point is not moved on top of the other.
-			if (el.id === this.focusPoint.id)
-				gt.keyboardMovementAdjust(e.key,
-					el, el.id === this.definingPts[0].id ? this.definingPts[1] : this.definingPts[0]);
-		}
-
 		stringify() {
 			return [
 				Line.strId,
@@ -720,13 +745,6 @@ window.graphTool = (containerId, options) => {
 			// that a pointer over the center point will give focus to the object with the center point activated.
 			const circleHasPoint = this.baseObj.hasPoint.bind(this.baseObj);
 			this.baseObj.hasPoint = (x, y) => circleHasPoint(x, y) || center.hasPoint(x, y);
-		}
-
-		handleKeyEvent(e, el) {
-			// Make sure that one point is not moved on top of the other.
-			if (el.id === this.focusPoint.id)
-				gt.keyboardMovementAdjust(e.key,
-					el, el.id === this.definingPts[0].id ? this.definingPts[1] : this.definingPts[0]);
 		}
 
 		stringify() {
@@ -799,13 +817,6 @@ window.graphTool = (containerId, options) => {
 			this.focusPoint = vertex;
 		}
 
-		handleKeyEvent(e, el) {
-			// Make sure that one point is not moved onto the same horizontal or vertical line as the other.
-			if (el.id === this.focusPoint.id)
-				gt.keyboardMovementAdjustRestricted(e.key,
-					el, el === this.definingPts[0] ? this.definingPts[1] : this.definingPts[0]);
-		}
-
 		stringify() {
 			return [
 				Parabola.strId,
@@ -867,7 +878,13 @@ window.graphTool = (containerId, options) => {
 				{ withLabel: false, highlight: false, layer: 8, name: 'FillIcon', fixed: true }
 			);
 
-			if (!gt.isStatic) this.on('drag', () => { this.update(); gt.updateText(); });
+			if (!gt.isStatic) {
+				this.on('drag', (e) => {
+					gt.adjustDragPosition(e, this.baseObj);
+					this.update();
+					gt.updateText();
+				});
+			}
 		}
 
 		// The fill object has an invisible focus object.  So the focus/blur methods need to be overridden.
@@ -1141,9 +1158,9 @@ window.graphTool = (containerId, options) => {
 			gt.selectTool.activate();
 		}
 
-		handleKeyEvent(/* e */) {}
+		handleKeyEvent(/* e: KeyboardEvent */) {}
 
-		updateHighlights(/* coords */) { return false; }
+		updateHighlights(/* e: MouseEvent | KeyboardEvent | JXG.Coords | undefined */) { return false; }
 
 		removeHighlights() {
 			for (const obj in this.hlObjs) {
@@ -1319,21 +1336,23 @@ window.graphTool = (containerId, options) => {
 
 				if (this.point1) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
 				else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
-			} else if (['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
-				// Make sure the highlight point is not moved onto the other point.
-				if (this.point1) gt.keyboardMovementAdjust(e.key, this.hlObjs.hl_point, this.point1);
-				this.updateHighlights(this.hlObjs.hl_point.coords);
 			}
 		}
 
-		updateHighlights(coords) {
-			if (this.hlObjs.hl_line) this.hlObjs.hl_line.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+		updateHighlights(e) {
+			this.hlObjs.hl_line?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
 			this.hlObjs.hl_point?.rendNode.focus();
 
-			if (typeof coords === 'undefined') return false;
-			if (this.point1 &&
-				gt.snapRound(coords.usrCoords[1], gt.snapSizeX) == this.point1.X() &&
-				gt.snapRound(coords.usrCoords[2], gt.snapSizeY) == this.point1.Y())
+			let coords;
+			if (e instanceof MouseEvent && e.type === 'pointermove') {
+				coords = gt.getMouseCoords(e);
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+				coords = this.hlObjs.hl_point.coords;
+			} else if (e instanceof JXG.Coords) {
+				coords = e;
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else
 				return false;
 
 			if (!this.hlObjs.hl_point) {
@@ -1342,8 +1361,10 @@ window.graphTool = (containerId, options) => {
 					snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
 				});
 				this.hlObjs.hl_point.rendNode.focus();
-			} else
-				this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			}
+
+			// Make sure the highlight point is not moved off the board or on the other point.
+			if (e instanceof Event) gt.adjustDragPosition(e, this.hlObjs.hl_point, this.point1);
 
 			if (this.point1 && !this.hlObjs.hl_line) {
 				this.hlObjs.hl_line = gt.board.create('line', [this.point1, this.hlObjs.hl_point], {
@@ -1386,8 +1407,10 @@ window.graphTool = (containerId, options) => {
 
 			gt.board.off('up');
 
-			this.point1 = gt.board.create('point', [coords[1], coords[2]],
-				{ size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false });
+			this.point1 = gt.board.create('point', [coords[1], coords[2]], {
+				size: 2, withLabel: false, highlight: false,
+				snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY
+			});
 			this.point1.setAttribute({ fixed: true });
 
 			// Get a new x coordinate that is to the right, unless that is off the board.
@@ -1442,20 +1465,23 @@ window.graphTool = (containerId, options) => {
 
 				if (this.center) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
 				else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
-			} else if (['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
-				// Make sure the highlight point is not moved onto the other point.
-				if (this.center) gt.keyboardMovementAdjust(e.key, this.hlObjs.hl_point, this.center);
-				this.updateHighlights(this.hlObjs.hl_point.coords);
 			}
 		}
 
-		updateHighlights(coords) {
-			if (this.hlObjs.hl_circle) this.hlObjs.hl_circle.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+		updateHighlights(e) {
+			this.hlObjs.hl_circle?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
 			this.hlObjs.hl_point?.rendNode.focus();
 
-			if (typeof coords === 'undefined') return false;
-			if (this.center && gt.snapRound(coords.usrCoords[1], gt.snapSizeX) == this.center.X() &&
-				gt.snapRound(coords.usrCoords[2], gt.snapSizeY) == this.center.Y())
+			let coords;
+			if (e instanceof MouseEvent && e.type === 'pointermove') {
+				coords = gt.getMouseCoords(e);
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+				coords = this.hlObjs.hl_point.coords;
+			} else if (e instanceof JXG.Coords) {
+				coords = e;
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else
 				return false;
 
 			if (!this.hlObjs.hl_point) {
@@ -1464,8 +1490,10 @@ window.graphTool = (containerId, options) => {
 					snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
 				});
 				this.hlObjs.hl_point.rendNode.focus();
-			} else
-				this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			}
+
+			// Make sure the highlight point is not moved off the board or on the center.
+			if (e instanceof Event) gt.adjustDragPosition(e, this.hlObjs.hl_point, this.center);
 
 			if (this.center && !this.hlObjs.hl_circle) {
 				this.hlObjs.hl_circle = gt.board.create('circle', [this.center, this.hlObjs.hl_point], {
@@ -1504,8 +1532,10 @@ window.graphTool = (containerId, options) => {
 			if (!gt.boardHasPoint(coords[1], coords[2])) return;
 			gt.board.off('up');
 
-			this.center = gt.board.create('point', [coords[1], coords[2]],
-				{ size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false });
+			this.center = gt.board.create('point', [coords[1], coords[2]], {
+				size: 2, withLabel: false, highlight: false,
+				snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY
+			});
 			this.center.setAttribute({ fixed: true });
 
 			// Get a new x coordinate that is to the right, unless that is off the board.
@@ -1563,21 +1593,23 @@ window.graphTool = (containerId, options) => {
 
 				if (this.vertex) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
 				else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
-			} else if (['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
-				// Make sure the highlight point is not moved onto the same horizontal or vertical line as the vertex.
-				if (this.vertex) gt.keyboardMovementAdjustRestricted(e.key, this.hlObjs.hl_point, this.vertex);
-				this.updateHighlights(this.hlObjs.hl_point.coords);
 			}
 		}
 
-		updateHighlights(coords) {
-			if (this.hlObjs.hl_parabola) this.hlObjs.hl_parabola.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+		updateHighlights(e) {
+			this.hlObjs.hl_parabola?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
 			this.hlObjs.hl_point?.rendNode.focus();
 
-			if (typeof coords === 'undefined') return false;
-			if (this.vertex &&
-				(gt.snapRound(coords.usrCoords[1], gt.snapSizeX) == this.vertex.X() ||
-					gt.snapRound(coords.usrCoords[2], gt.snapSizeY) == this.vertex.Y()))
+			let coords;
+			if (e instanceof MouseEvent && e.type === 'pointermove') {
+				coords = gt.getMouseCoords(e);
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+				coords = this.hlObjs.hl_point.coords;
+			} else if (e instanceof JXG.Coords) {
+				coords = e;
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else
 				return false;
 
 			if (!this.hlObjs.hl_point) {
@@ -1587,8 +1619,11 @@ window.graphTool = (containerId, options) => {
 					highlight: false, withLabel: false
 				});
 				this.hlObjs.hl_point.rendNode.focus();
-			} else
-				this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			}
+
+			// Make sure the highlight point is not moved off the board or
+			// onto the same horizontal or vertical line as the vertex.
+			if (e instanceof Event) gt.adjustDragPositionRestricted(e, this.hlObjs.hl_point, this.vertex);
 
 			if (this.vertex && !this.hlObjs.hl_parabola) {
 				this.hlObjs.hl_parabola = createParabola(this.vertex, this.hlObjs.hl_point, this.vertical,
@@ -1624,8 +1659,10 @@ window.graphTool = (containerId, options) => {
 
 			gt.board.off('up');
 
-			this.vertex = gt.board.create('point', [coords[1], coords[2]],
-				{ size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false });
+			this.vertex = gt.board.create('point', [coords[1], coords[2]], {
+				size: 2, withLabel: false, highlight: false,
+				snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY
+			});
 			this.vertex.setAttribute({ fixed: true });
 
 			// Get a new x coordinate that is to the right, unless that is off the board.
@@ -1688,58 +1725,52 @@ window.graphTool = (containerId, options) => {
 		}
 
 		handleKeyEvent(e) {
-			if (!this.hlObjs.hl_point || !gt.board.containerObj.contains(document.activeElement) ||
-				!['Enter', ' ', 'ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key))
-				return;
-
-			// The highlight fill icon will have moved but only by 1 pixel and not the snap size, because it does
-			// not snap to the grid.  So undo that move and redo it in an increment of the snap size.  Note that the
-			// coordinate also needs to be translated back to the correct integer lattice point.
-			let x = this.hlObjs.hl_point.coords.usrCoords[1] +
-				(e.key === 'ArrowLeft' ? 1 : e.key === 'ArrowRight' ? -1 : 0) / gt.board.unitX +
-				(e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0) * gt.snapSizeX +
-				12 / gt.board.unitX;
-			let y = this.hlObjs.hl_point.coords.usrCoords[2] +
-				(e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0) / gt.board.unitY +
-				(e.key === 'ArrowUp' ? 1 : e.key === 'ArrowDown' ? -1 : 0) * gt.snapSizeX +
-				12 / gt.board.unitY;
-
-			// Don't allow the fill point to be moved off the board.
-			const boundingBox = gt.board.getBoundingBox();
-			if (x < boundingBox[0]) x = boundingBox[0];
-			else if (x > boundingBox[2]) x = boundingBox[2];
-			if (y < boundingBox[3]) y = boundingBox[3];
-			else if (y > boundingBox[1]) y = boundingBox[1];
+			if (!this.hlObjs.hl_point || !gt.board.containerObj.contains(document.activeElement)) return;
 
 			if (e.key === 'Enter' || e.key === ' ') {
 				e.preventDefault();
 				e.stopPropagation();
 
-				this.phase1(new JXG.Coords(JXG.COORDS_BY_USER, [x, y], gt.board).usrCoords);
-			} else {
-				this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [x, y], gt.board));
+				this.phase1(this.hlObjs.hl_point.coords.usrCoords);
 			}
 		}
 
-		updateHighlights(coords) {
+		updateHighlights(e) {
 			this.hlObjs.hl_point?.rendNode.focus();
 
-			if (typeof coords === 'undefined') return false;
+			let coords;
+			if (e instanceof MouseEvent && e.type === 'pointermove') {
+				coords = gt.getMouseCoords(e);
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+				coords = this.hlObjs.hl_point.coords;
+			} else if (e instanceof JXG.Coords) {
+				coords = e;
+				this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+			} else
+				return false;
 
 			if (!this.hlObjs.hl_point) {
-				this.hlObjs.hl_point = gt.board.create('image', [
+				this.hlObjs.hl_point = gt.board.create('point', [coords.usrCoords[1], coords.usrCoords[2]], {
+					size: 2, strokeColor: 'transparent', fillColor: 'transparent', strokeOpacity: 0, fillOpacity: 0,
+					highlight: false, withLabel: false, snapToGrid: true,
+					snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY
+				});
+				this.hlObjs.hl_point.rendNode.classList.add('hidden-fill-point');
+
+				this.hlObjs.hl_icon = gt.board.create('image', [
 					gt.fillIcon(gt.color.fill), [
-						gt.snapRound(coords.usrCoords[1], gt.snapSizeX) - 12 / gt.board.unitX,
-						gt.snapRound(coords.usrCoords[2], gt.snapSizeY) - 12 / gt.board.unitY
-					], [24 / gt.board.unitX, 24 / gt.board.unitY]
-				], { withLabel: false, highlight: false, layer: 9 });
+						() => this.hlObjs.hl_point.X() - 12 / gt.board.unitX,
+						() => this.hlObjs.hl_point.Y() - 12 / gt.board.unitY
+					],
+					[() => 24 / gt.board.unitX, () => 24 / gt.board.unitY]
+				], { withLabel: false, highlight: false, fixed: true, layer: 8 });
+
 				this.hlObjs.hl_point.rendNode.focus();
-			} else {
-				this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [
-					gt.snapRound(coords.usrCoords[1], gt.snapSizeX) - 12 / gt.board.unitX,
-					gt.snapRound(coords.usrCoords[2], gt.snapSizeY) - 12 / gt.board.unitY
-				]);
 			}
+
+			// Make sure the point/icon is not moved off the board.
+			if (e instanceof Event) gt.adjustDragPosition(e, this.hlObjs.hl_point);
 
 			gt.setTextCoords(coords.usrCoords[1], coords.usrCoords[2]);
 			gt.board.update();
@@ -1901,7 +1932,7 @@ window.graphTool = (containerId, options) => {
 
 					updateHighlights(coords) {
 						if ('updateHighlights' in toolObject) return toolObject.updateHighlights.call(this, gt, coords);
-						if (parentTool) return super.updateHighlights();
+						if (parentTool) return super.updateHighlights(coords);
 						return false;
 					}
 

--- a/htdocs/js/apps/GraphTool/graphtool.js
+++ b/htdocs/js/apps/GraphTool/graphtool.js
@@ -54,8 +54,9 @@ window.graphTool = (containerId, options) => {
 	gt.snapSizeX = options.snapSizeX ? options.snapSizeX : 1;
 	gt.snapSizeY = options.snapSizeY ? options.snapSizeY : 1;
 	gt.isStatic = options.isStatic ? true : false;
-	const availableTools = options.availableTools ? options.availableTools
-		: ['LineTool', 'CircleTool', 'VerticalParabolaTool', 'HorizontalParabolaTool', 'FillTool', 'SolidDashTool'];
+	if (!(options.availableTools instanceof Array))
+		options.availableTools =
+			['LineTool', 'CircleTool', 'VerticalParabolaTool', 'HorizontalParabolaTool', 'FillTool', 'SolidDashTool'];
 
 	// This is the icon used for the fill tool and fill graph object.
 	gt.fillIcon = (color) => "data:image/svg+xml," +
@@ -363,9 +364,9 @@ window.graphTool = (containerId, options) => {
 							}
 						}
 					});
-				} else {
-					gt.activeTool?.handleKeyEvent(e);
 				}
+
+				for (const tool of gt.tools) tool.handleKeyEvent(e);
 
 				if (!gt.buttonBox.contains(document.activeElement) && e.key === 'N' && e.shiftKey) {
 					// Shift-N moves focus to the first tool button after the select button unless the tool bar already
@@ -380,12 +381,6 @@ window.graphTool = (containerId, options) => {
 				} else if (e.key === 'Delete' && gt.activeTool === gt.selectTool) {
 					// If the select tool is active and Delete is pressed, then ask to delete the selected object.
 					gt.deleteSelected();
-				} else if (e.key === 's') {
-					// If 's' is pressed change to drawing solid.
-					gt.toggleSolidity(e, true);
-				} else if (e.key === 'd') {
-					// If 'd' is pressed change to drawing dashed.
-					gt.toggleSolidity(e, false);
 				}
 			});
 		}
@@ -1836,6 +1831,16 @@ window.graphTool = (containerId, options) => {
 			solidDashBox.append(dashedButtonDiv);
 			container.append(solidDashBox);
 		}
+
+		handleKeyEvent(e) {
+			if (e.key === 's') {
+				// If 's' is pressed change to drawing solid.
+				gt.toggleSolidity(e, true);
+			} else if (e.key === 'd') {
+				// If 'd' is pressed change to drawing dashed.
+				gt.toggleSolidity(e, false);
+			}
+		}
 	}
 
 	gt.toolTypes = {
@@ -1928,10 +1933,11 @@ window.graphTool = (containerId, options) => {
 			});
 		}
 
-		availableTools.forEach((tool) => {
-			if (tool in gt.toolTypes) new gt.toolTypes[tool](gt.buttonBox);
-			else console.log('Unknown tool: ' + tool);
-		});
+		gt.tools = [ gt.selectTool ];
+		for (const tool of options.availableTools) {
+			if (tool in gt.toolTypes) gt.tools.push(new gt.toolTypes[tool](gt.buttonBox));
+			else console.log(`Unknown tool: ${tool}`);
+		}
 
 		const confirmDialog = (title, titleId, message, yesAction) => {
 			// Keep the graph tool active while this dialog is open.

--- a/htdocs/js/apps/GraphTool/graphtool.scss
+++ b/htdocs/js/apps/GraphTool/graphtool.scss
@@ -1,10 +1,13 @@
 @use 'sass:color';
 
 .graphtool-container {
-	width: 402px;
+	width: 442px;
+	padding: 15px 20px;
+	border-radius: 10px;
+	box-shadow: inset 0 0 5px 5px rgba(0, 0, 0, 0.15);
 
 	@media only screen and (max-width: 600px) {
-		width: 302px;
+		width: 342px;
 	}
 
 	.graphtool-graph {
@@ -35,7 +38,7 @@
 	}
 
 	.gt-toolbar-container {
-		margin: 0.5rem 0;
+		margin: 0.5rem 0 0;
 		text-align: right;
 		width: 100%;
 		padding: 0;
@@ -160,11 +163,11 @@
 				background-image: url('images/ExcludePointParenthesisTool.svg');
 			}
 
-			&.gt-bounded-interval-tool {
+			&.gt-interval-tool {
 				background-image: url('images/IntervalTool.svg');
 			}
 
-			&.gt-bounded-interval-bracket-tool {
+			&.gt-interval-bracket-tool {
 				background-image: url('images/IntervalBracketTool.svg');
 			}
 		}

--- a/htdocs/js/apps/GraphTool/intervaltools.js
+++ b/htdocs/js/apps/GraphTool/intervaltools.js
@@ -250,7 +250,9 @@
 					this.focusPoint?.setAttribute({
 						fillColor: include ? gt.color.curve : 'transparent',
 						highlightFillColor: include ? gt.color.pointHighlightDarker : gt.color.pointHighlight,
-						highlightFillOpacity: gt.options.useBracketEnds ? 0 : include ? 1 : 0.5
+						highlightFillOpacity: (gt.options.useBracketEnds || this.focusPoint.arrow)
+							? 0
+							: include ? 1 : 0.5
 					});
 				},
 
@@ -277,12 +279,6 @@
 						if (this.focused && point.getAttribute('highlightFillOpacity') !== 0)
 							attributes.highlightFillOpacity = 0.5;
 					}
-
-					// Setting the layer makes JSXGraph reinsert the point into the DOM.  This moves it to the front.
-					// Note that layer 9 is default layer for points, so the actual layer is not changed.  The size
-					// attribute is checked to guarantee that this is only done when focus is initially obtained.
-					// Otherwise there are "maximum call stack size exceeded" errors in Chrome.
-					if (this.focused && point.getAttribute('size') !== 4) point.setAttribute({ layer: 9 });
 
 					point.setAttribute(attributes);
 				},
@@ -356,6 +352,8 @@
 				// This also prevents a point from being moved off the board.
 				// This ignores the y-coordinate.
 				pairedPointDrag(gt, point, e) {
+					if (e.type === 'keydown') return;
+
 					const bbox = gt.board.getBoundingBox();
 					if (point.X() >= bbox[2]) {
 						if (point.paired_point.X() === bbox[2])
@@ -478,13 +476,13 @@
 		},
 
 		IntervalTool: {
-			iconName: 'bounded-interval',
-			tooltip: 'Bounded Interval Tool',
+			iconName: 'interval',
+			tooltip: 'Interval Tool',
 
 			initialize(gt) {
 				if (gt.options.useBracketEnds) {
-					this.button.classList.remove('gt-bounded-interval-tool');
-					this.button.classList.add('gt-bounded-interval-bracket-tool');
+					this.button.classList.remove('gt-interval-tool');
+					this.button.classList.add('gt-interval-bracket-tool');
 				}
 
 				this.phase1 = (coords) => {

--- a/htdocs/js/apps/GraphTool/intervaltools.js
+++ b/htdocs/js/apps/GraphTool/intervaltools.js
@@ -852,6 +852,16 @@
 				container.append(includePointBox);
 			},
 
+			handleKeyEvent(gt, e) {
+				if (e.key === 'e') {
+					// If 'e' is pressed change to excluding interval endpoints.
+					gt.toolTypes.IncludeExcludePointTool.toggleIncludeExcludePoint(e, false);
+				} else if (e.key === 'i') {
+					// If 'i' is pressed change to including interval endpoints.
+					gt.toolTypes.IncludeExcludePointTool.toggleIncludeExcludePoint(e, true);
+				}
+			},
+
 			helperMethods: {
 				toggleIncludeExcludePoint(gt, e, include) {
 					e.preventDefault();

--- a/htdocs/js/apps/GraphTool/intervaltools.js
+++ b/htdocs/js/apps/GraphTool/intervaltools.js
@@ -177,21 +177,6 @@
 				else this.setFiniteEndPoint(1);
 			},
 
-			handleKeyEvent(gt, e, el) {
-				if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
-
-				if (el.id === this.focusPoint.id) {
-					// Make sure the point stays at a height of 0.
-					if (el.Y() !== 0) el.setPosition(JXG.COORDS_BY_USER, [el.X(), 0]);
-					// Make sure that one point is not moved on top of the other.
-					gt.keyboardMovementAdjust(
-						e.key,
-						el,
-						el.id === this.definingPts[0].id ? this.definingPts[1] : this.definingPts[0]
-					);
-				}
-			},
-
 			stringify(gt) {
 				const leftEndPoint =
 					this.definingPts[0].X() < this.definingPts[1].X() ? this.definingPts[0] : this.definingPts[1];
@@ -348,37 +333,11 @@
 			},
 
 			helperMethods: {
-				// Prevent paired points from being moved into the same position by a drag.
-				// This also prevents a point from being moved off the board.
-				// This ignores the y-coordinate.
-				pairedPointDrag(gt, point, e) {
-					if (e.type === 'keydown') return;
-
-					const bbox = gt.board.getBoundingBox();
-					if (point.X() >= bbox[2]) {
-						if (point.paired_point.X() === bbox[2])
-							point.setPosition(JXG.COORDS_BY_USER, [bbox[2] - gt.snapSizeX, 0]);
-						else if (point.X() > bbox[2])
-							point.setPosition(JXG.COORDS_BY_USER, [bbox[2], 0]);
-					}
-					if (point.X() <= bbox[0]) {
-						if (point.paired_point.X() === bbox[0])
-							point.setPosition(JXG.COORDS_BY_USER, [bbox[0] + gt.snapSizeX, 0]);
-						else if (point.X() < bbox[0])
-							point.setPosition(JXG.COORDS_BY_USER, [bbox[0], 0]);
-					}
-
-					if (point.X() == point.paired_point.X()) {
-						const coords = gt.getMouseCoords(e);
-						if (coords.usrCoords[1] > point.paired_point.X())
-							point.setPosition(JXG.COORDS_BY_USER, [point.X() + gt.snapSizeX, 0]);
-						else
-							point.setPosition(JXG.COORDS_BY_USER, [point.X() - gt.snapSizeX, 0]);
-					}
-
-					// Make sure the point stays at a height of 0.
+				// gt.adjustDragPosition prevents paired points from being moved into the same position by a drag, and
+				// prevents a point from being moved off the board.  This also ensures that the y coordinate stays at 0.
+				pairedPointDrag(gt, e, point) {
+					gt.adjustDragPositionRestricted(e, point, point.paired_point);
 					if (point.Y() !== 0) point.setPosition(JXG.COORDS_BY_USER, [point.X(), 0]);
-
 					gt.updateObjects();
 					gt.updateText();
 				},
@@ -394,8 +353,8 @@
 					if (typeof paired_point !== 'undefined') {
 						point.paired_point = paired_point;
 						paired_point.paired_point = point;
-						paired_point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(paired_point, e));
-						point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(point, e));
+						paired_point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(e, paired_point));
+						point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(e, point));
 					}
 					if (!gt.options.useBracketEnds) return point;
 
@@ -498,6 +457,7 @@
 						fillColor: gt.toolTypes.IncludeExcludePointTool.include
 							? gt.color.underConstructionFixed
 							: 'transparent',
+						highlight: false,
 						snapToGrid: true,
 						snapSizeX: gt.snapSizeX,
 						snapSizeY: gt.snapSizeY,
@@ -596,21 +556,26 @@
 
 					if (this.point1) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
 					else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
-				} else if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-					// Make sure the highlight point is not moved onto the other point.
-					if (this.point1) gt.keyboardMovementAdjust(e.key, this.hlObjs.hl_point, this.point1);
-					this.updateHighlights(this.hlObjs.hl_point.coords);
 				}
 			},
 
-			updateHighlights(gt, coords) {
+			updateHighlights(gt, e) {
 				this.hlObjs.hl_point?.setAttribute({
 					fillColor: gt.toolTypes.IncludeExcludePointTool.include ? gt.color.underConstruction : 'transparent'
 				});
 				this.hlObjs.hl_point?.rendNode.focus();
 
-				if (typeof coords === 'undefined' || !gt.boardHasPoint(coords)) return false;
-				if (this.point1 && gt.snapRound(coords.usrCoords[1], gt.snapSizeX) == this.point1.X()) return false;
+				let coords;
+				if (e instanceof MouseEvent && e.type === 'pointermove') {
+					coords = gt.getMouseCoords(e);
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+				} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+					coords = this.hlObjs.hl_point.coords;
+				} else if (e instanceof JXG.Coords) {
+					coords = e;
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+				} else
+					return false;
 
 				if (!this.hlObjs.hl_point) {
 					this.hlObjs.hl_point = gt.board.create(
@@ -659,8 +624,10 @@
 					}
 
 					this.hlObjs.hl_point.rendNode.focus();
-				} else
-					this.hlObjs.hl_point.setPosition(JXG.COORDS_BY_USER, [ coords.usrCoords[1], 0 ]);
+				}
+
+				// Make sure the highlight point is not moved of the board or onto the other point.
+				if (e instanceof Event) gt.adjustDragPositionRestricted(e, this.hlObjs.hl_point, this.point1);
 
 				if (this.point1 && !this.hlObjs.hl_segment) {
 					this.hlObjs.hl_segment = gt.board.create(

--- a/htdocs/js/apps/GraphTool/pointtool.js
+++ b/htdocs/js/apps/GraphTool/pointtool.js
@@ -36,7 +36,7 @@
 			focus(gt) {
 				this.focused = true;
 				this.baseObj.setAttribute(
-					{ fixed: false, highlight: true, strokeColor: gt.color.focusCurve, strokeWidth: 3, layer: 9 });
+					{ fixed: false, highlight: true, strokeColor: gt.color.focusCurve, strokeWidth: 3 });
 
 				this.focusPoint.rendNode.focus();
 				return false;

--- a/htdocs/js/apps/GraphTool/quadratictool.js
+++ b/htdocs/js/apps/GraphTool/quadratictool.js
@@ -93,6 +93,8 @@
 				},
 
 				pairedPointDrag(gt, e) {
+					if (e.type === 'keydown') return;
+
 					const coords = gt.getMouseCoords(e);
 					let left_x = this.X(), right_x = this.X();
 

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "jsxgraph": "^1.4.6",
+                "jsxgraph": "^1.5.0",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
                 "mathquill": "github:openwebwork/mathquill",
@@ -714,9 +714,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/jsxgraph": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.4.6.tgz",
-            "integrity": "sha512-HecQJ0AGdwJW+HbHwmIb4Yy3J/7tPK2SBxJOArFQOFPWZbmMxL7cXcc6gAOdHNwHQEaU21QC/L+d/Y5x9jsACA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.5.0.tgz",
+            "integrity": "sha512-mXsW1LG9AEZpiYDM+nScs5G5ZKw6xrQIrVLszRXeXFX+XYbS1Abx9oMmk7WMDbCXerYFzNo5/vZ9MRZpFeABpQ==",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -2135,9 +2135,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "jsxgraph": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.4.6.tgz",
-            "integrity": "sha512-HecQJ0AGdwJW+HbHwmIb4Yy3J/7tPK2SBxJOArFQOFPWZbmMxL7cXcc6gAOdHNwHQEaU21QC/L+d/Y5x9jsACA=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.5.0.tgz",
+            "integrity": "sha512-mXsW1LG9AEZpiYDM+nScs5G5ZKw6xrQIrVLszRXeXFX+XYbS1Abx9oMmk7WMDbCXerYFzNo5/vZ9MRZpFeABpQ=="
         },
         "jszip": {
             "version": "3.10.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -11,7 +11,7 @@
         "prepare": "npm run generate-assets"
     },
     "dependencies": {
-        "jsxgraph": "^1.4.6",
+        "jsxgraph": "^1.5.0",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",
         "mathquill": "github:openwebwork/mathquill",


### PR DESCRIPTION
This takes advantage of the keyboard motion events that are now sent by JSXGraph to drag and move handlers as of version 1.5.0.  Now the graphtool drag and move handlers that previously only handled pointer events also handle keyboard motion events.

This also fixes an issue on touch screen devices where it is possible (and actually quite easy) to drag objects off the board.

Note that this obviously includes #797.  However, it is independent of #800, and (surprisingly) does not conflict with that pull request.