### PR TITLE
set column halign correctly for HTML

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -952,6 +952,8 @@ sub Row {
 			my $css = '';
 
 			# col level
+			$css .= css('text-align', 'left')
+				if ($cellAlign->{halign} eq 'l');
 			$css .= css('text-align', 'center')
 				if ($cellAlign->{halign} eq 'c');
 			$css .= css('text-align', 'right')
@@ -964,6 +966,7 @@ sub Row {
 				if ($cellAlign->{tex} =~ /\\itshape/);
 			$css .= css('font-family', 'monospace')
 				if ($cellAlign->{tex} =~ /\\ttfamily/);
+
 			if ($cellAlign->{tex} =~ /\\color(\[HTML\])?\{(.*?)[}!]/) {
 				$css .= css('color', ($1 ? '#' : '') . $2);
 			}


### PR DESCRIPTION
In HTML, the default styling for a cell's text-align is center. So this was wrongly explicitly writing it to be center when the author wants center. And worse, it was failing to respect the author's wishes when then author wanted the column to be left-aligned.

PTX defaults to left-alignment in this situation, which probably confused me.