### PR TITLE
PTX checkbox

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -274,7 +274,7 @@ sub stringify_hash {
 		my $ref = ref($self->{$key});
 		next if !$ref;
 		if ($ref eq "HASH" or $ref eq "ARRAY") {
-			$self->{$key} = JSON->new->utf8->allow_unknown->allow_blessed->encode($self->{$key});
+			$self->{$key} = JSON->new->utf8->allow_unknown->convert_blessed->allow_blessed->encode($self->{$key});
 		} else {
 			$self->{$key} = "$self->{$key}";
 		}

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -1035,6 +1035,11 @@ sub string {
 	return $open . join($comma, @coords) . $close;
 }
 
+# This is called by JSON->encode when convert_blessed is true to convert this value object into a string.
+sub TO_JSON {
+	return shift->string;
+}
+
 =head4 ->TeX
 
 	Usage: $mathObj->TeX()

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2416,7 +2416,7 @@ sub PTX_cleanup {
 		do {
 			$previous = $string;
 			$string =~
-				s/(?s)(<tabular>(?:\s|<col (?:(?!width=").)*?>)((?!<\/tabular>).)*?<cell>((?!<\/tabular>).)*?)<p>(((?!<\/tabular>).)*?)<\/p>(((?!<\/tabular>).)*?<\/tabular>)/$1$4$6/g;
+				s/(?s)(<tabular[^>]*>(?:\s|<col (?:(?!width=").)*?>)((?!<\/tabular>).)*?<cell>((?!<\/tabular>).)*?)<p>(((?!<\/tabular>).)*?)<\/p>(((?!<\/tabular>).)*?<\/tabular>)/$1$4$6/g;
 		} until ($previous eq $string);
 
 	}

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2371,17 +2371,17 @@ sub PTX_cleanup {
 		#except not for certain "sub" structures that are also passed through EV3
 		$string = "<p>" . $string . "</p>" unless (($string =~ /^<fillin[^>]*\/>$/) or ($string =~ /^<var.*<\/var>$/s));
 
-		#inside a li, the only permissible children are p, image, video, and tabular
-		#insert opening and closing p, to be removed later if they enclose an image, video or tabular
+		#inside a li, the only permissible children are title, p, image, video, and tabular
+		#insert opening and closing p, to be removed later if they enclose a title, image, video or tabular
 		#we are not going to look to see if there is a nested list in there
 		$string =~ s/(<li[^>]*(?<!\/)>)/$1\n<p>/g;
 		$string =~ s/(<\/li>)/<\/p>\n$1/g;
 
-		#close p right before any blockquote, pre, image, video, or tabular
+		#close p right before any title, blockquote, pre, image, video, or tabular
 		#and open p immediately following. Later any potential side effects are cleaned up.
-		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
-		$string =~ s/(<\/(blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
-		$string =~ s/(<(blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
+		$string =~ s/(<(title|blockquote|pre|image|video|tabular)[^>]*(?<!\/)>)/<\/p>\n$1/g;
+		$string =~ s/(<\/(title|blockquote|pre|image|video|tabular)>)/$1\n<p>/g;
+		$string =~ s/(<(title|blockquote|pre|image|video|tabular)[^>]*(?<=\/)>)/<\/p>\n$1\n<p>/g;
 
 		#within a <cell>, we may have an issue if there was an image that had '<\p>' and '<p>' wrapped around
 		#it from the above block. If the '</p>' has a preceding '<p>' within the cell, no problem. Otherwise,

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -463,7 +463,8 @@ sub cmp_defaults {
 		list_type         => 'selection',
 		requireParenMatch => 0,
 		implicitList      => 0,
-		correct_choices   => $self->data
+		correct_choices   => $self->data,
+		correct_values    => [ map {"$_"} $self->value ]
 	);
 }
 

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -547,9 +547,10 @@ sub CHECKS {
 
 	for my $i (0 .. $#{ $self->{orderedChoices} }) {
 		my $value = $self->{values}[$i];
-		my $tag   = $self->{orderedChoices}[$i];
-		$value = '%' . $value                                   if (grep { $i == $_ } @{ $self->{checkedI} });
-		$tag   = $self->labelFormat($self->{labels}[$i]) . $tag if $self->{displayLabels};
+		$value = '%' . $value if (grep { $i == $_ } @{ $self->{checkedI} });
+
+		my $tag = $self->{orderedChoices}[$i];
+		$tag = $self->labelFormat($self->{labels}[$i]) . $tag if $self->{displayLabels};
 		if ($i > 0) {
 			push(
 				@checks,
@@ -578,18 +579,17 @@ sub CHECKS {
 			my $marker = '';
 			$marker = "1" if $originalLabels eq '123';
 			$marker = "a" if $originalLabels eq 'abc';
-			$marker = "A"
-				if uc($originalLabels) eq 'ABC' && $originalLabels ne 'abc';
+			$marker = "A" if uc($originalLabels) eq 'ABC' && $originalLabels ne 'abc';
 			$marker = "i" if $originalLabels eq 'roman';
-			$marker = "I"
-				if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
-			$list_type  = qq(ol	 marker="$marker.");
+			$marker = "I" if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
+
+			$list_type  = qq(ol marker="$marker.");
 			$close_list = 'ol';
 		} elsif ($self->{localLabels} || ref $originalLabels eq 'ARRAY') {
 			$list_type  = 'dl width="narrow"';
 			$close_list = 'dl';
 			my %checks_to_labels = map { $checks[$_] => $self->{labels}[$_] } (0 .. $#{ $self->{orderedChoices} });
-			map {s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/g} @checks;
+			map { $_ =~ s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/gr } @checks;
 		}
 		$checks[0] = qq{<$list_type name="$name">\n$checks[0]};
 		$checks[-1] .= "</$close_list>";

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -574,25 +574,27 @@ sub CHECKS {
 
 		# Do we want an ol, ul, or dl?
 		my $list_type      = 'ul';
-		my $marker         = '';
+		my $close_list     = 'ul';
 		my $originalLabels = $self->{originalLabels};
 		if ($originalLabels =~ m/^(123|abc|roman)$/i) {
-			$list_type = 'ol';
-			$marker    = "1" if $originalLabels eq '123';
-			$marker    = "a" if $originalLabels eq 'abc';
-			$marker    = "A"
+			my $marker = '';
+			$marker = "1" if $originalLabels eq '123';
+			$marker = "a" if $originalLabels eq 'abc';
+			$marker = "A"
 				if uc($originalLabels) eq 'ABC' && $originalLabels ne 'abc';
 			$marker = "i" if $originalLabels eq 'roman';
 			$marker = "I"
 				if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
+			$list_type  = qq(ol	 marker="$marker.");
+			$close_list = 'ol';
 		} elsif ($self->{localLabels} || ref $originalLabels eq 'ARRAY') {
-			$list_type = 'dl';
+			$list_type  = 'dl width="narrow"';
+			$close_list = 'dl';
 			my %checks_to_labels = map { $checks[$_] => $self->{labels}[$_] } (0 .. $#{ $self->{orderedChoices} });
 			map {s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/g} @checks;
 		}
-		$marker = ($marker ne '') ? qq{ marker="$marker."} : '';
-		$checks[0] = qq{<$list_type$marker name="$name">\n$checks[0]};
-		$checks[-1] .= "</$list_type>";
+		$checks[0] = qq{<$list_type name="$name">\n$checks[0]};
+		$checks[-1] .= "</$close_list>";
 
 		# Change math delimiters
 		@checks = map { $_ =~ s/\\\(/<m>/gr } @checks;

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -50,7 +50,7 @@ checkbox.
 
 The values set as described above are the answers that will be displayed in the
 past answers table.  See the C<values> option below for more information.
-Problem authors are encourages to set these values either as described above, or
+Problem authors are encouraged to set these values either as described above, or
 via the C<values> option.  This is useful for instructors viewing past answers.
 
 By default, the choices are left in the order that you provide them, but you can
@@ -98,7 +98,7 @@ choices in their original order (though the C<< { label => text } >> form is
 preferred).
 
 Default: labels are the text of the choice when they don't include any special
-characters, and "Button 1", "Button 2", etc., otherwise.
+characters, and "Choice 1", "Choice 2", etc., otherwise.
 
 =item C<S<< values => array reference >>>
 

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -463,8 +463,7 @@ sub cmp_defaults {
 		list_type         => 'selection',
 		requireParenMatch => 0,
 		implicitList      => 0,
-		correct_choices   => $self->data,
-		correct_values    => [ map {"$_"} $self->value ]
+		correct_choices   => $self->data
 	);
 }
 

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -573,7 +573,7 @@ sub CHECKS {
 
 		# Do we want an ol, ul, or dl?
 		my $list_type      = 'ul';
-		my $close_list     = 'ul';
+		my $subtype        = '';
 		my $originalLabels = $self->{originalLabels};
 		if ($originalLabels =~ m/^(123|abc|roman)$/i) {
 			my $marker = '';
@@ -583,16 +583,17 @@ sub CHECKS {
 			$marker = "i" if $originalLabels eq 'roman';
 			$marker = "I" if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
 
-			$list_type  = qq(ol marker="$marker.");
+			$list_type  = 'ol';
+			$subtype    = qq( marker="$marker");
 			$close_list = 'ol';
 		} elsif ($self->{localLabels} || ref $originalLabels eq 'ARRAY') {
-			$list_type  = 'dl width="narrow"';
-			$close_list = 'dl';
+			$list_type = 'dl';
+			$subtype   = ' width = "narrow"';
 			my %checks_to_labels = map { $checks[$_] => $self->{labels}[$_] } (0 .. $#{ $self->{orderedChoices} });
 			map { $_ =~ s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/gr } @checks;
 		}
-		$checks[0] = qq{<$list_type name="$name">\n$checks[0]};
-		$checks[-1] .= "</$close_list>";
+		$checks[0] = qq{<$list_type$subtype name="$name">\n$checks[0]};
+		$checks[-1] .= "</$list_type>";
 
 		# Change math delimiters
 		@checks = map { $_ =~ s/\\\(/<m>/gr } @checks;

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -568,9 +568,7 @@ sub CHECKS {
 	if ($main::displayMode eq 'TeX') {
 		$checks[0] = "\n\\begin{itemize}\n" . $checks[0];
 		$checks[-1] .= "\n\\end{itemize}\n";
-	}
-
-	if ($main::displayMode eq 'PTX') {
+	} elsif ($main::displayMode eq 'PTX') {
 
 		# Do we want an ol, ul, or dl?
 		my $list_type      = 'ul';
@@ -599,6 +597,9 @@ sub CHECKS {
 		# Change math delimiters
 		@checks = map { $_ =~ s/\\\(/<m>/gr } @checks;
 		@checks = map { $_ =~ s/\\\)/<\/m>/gr } @checks;
+	} else {
+		$checks[0] = qq(<div class="checkboxes-container">\n$checks[0]);
+		$checks[-1] .= "</div>";
 	}
 
 	return wantarray ? @checks : join($main::displayMode eq 'PTX' ? '' : $self->{separator}, @checks);

--- a/macros/parsers/parserRadioButtons.pl
+++ b/macros/parsers/parserRadioButtons.pl
@@ -668,8 +668,8 @@ sub BUTTONS {
 		$radio[$#radio_buttons] .= "\n\\end{itemize}\n";
 	}
 	if ($main::displayMode eq 'PTX') {
-		$radio[0] = qq(<var form="buttons" name="$name">) . "\n" . $radio[0];
-		$radio[$#radio_buttons] .= '</var>';
+		$radio[0] = qq(<ul name="$name">) . "\n" . $radio[0];
+		$radio[$#radio_buttons] .= '</ul>';
 		#turn any math delimiters
 		@radio = map { $_ =~ s/\\\(/<m>/g;   $_ } (@radio);
 		@radio = map { $_ =~ s/\\\)/<\/m>/g; $_ } (@radio);


### PR DESCRIPTION
This is mainly to handle PTX output. The checkboxes will come out as either a PTX `ol`, `ul`, or `dl`. It depends on how labels are being handled by the problem.

Also I added lowercase letter labeling, lowercase Roman numeral labeling, and uppercase Roman numeral labeling. The existing capital letter labeling only works for up to 26 items, so I stuck with that cap.

