### PR TITLE
Revised handling of PERSISTENCE_HASH data

### DIFF
--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -242,6 +242,11 @@ sub defineProblemEnvironment ($pg_envir, $options = {}, $image_generator = undef
 		pastDue            => $options->{pastDue}            // 0,
 		answersAvailable   => $options->{answersAvailable}   // 0,
 		isInstructor       => $options->{isInstructor}       // 0,
+		PERSISTENCE_HASH   => $options->{PERSISTENCE_HASH}   // {},
+
+		# The next has marks what data was updated and needs to be saved
+		# by the front end.
+		PERSISTENCE_HASH_UPDATED => {},
 
 		inputs_ref => $options->{inputs_ref},
 

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -307,7 +307,18 @@ sub ANS_NUM_TO_NAME {
 }
 
 sub store_persistent_data {
-	$PG->store_persistent_data(@_);    #needs testing
+	my ($label, @values) = @_;
+	$PG->store_persistent_data($label, @values);
+}
+
+sub update_persistent_data {
+	my ($label, @values) = @_;
+	$PG->update_persistent_data($label, @values);
+}
+
+sub get_persistent_data {
+	my ($label) = @_;
+	return $PG->get_persistent_data($label);
 }
 
 sub RECORD_FORM_LABEL {    # this stores form data (such as sticky answers), but does nothing more
@@ -600,8 +611,7 @@ sub ENDDOCUMENT {
 			warn "$key is ", join("|", %{ $PG->{PG_ANSWERS_HASH}->{$key} });
 		}
 	}
-	push @KEPT_EXTRA_ANSWERS, keys %{ $PG->{PERSISTENCE_HASH} };
-	#Hackish way to store other persistence data
+
 	$PG->{flags}->{KEPT_EXTRA_ANSWERS} = \@KEPT_EXTRA_ANSWERS;
 	$PG->{flags}->{ANSWER_ENTRY_ORDER} = \@PG_ANSWER_ENTRY_ORDER;
 


### PR DESCRIPTION
Persistent problem data - modify to retrieve from `$envir` and to allow update and get operations.
Paired with https://github.com/openwebwork/webwork2/pull/1940
The webwork2 side will now store this in a special field.
