### PR TITLE
Replace bin/run-perltidy with bin/run-perltidy.pl

### DIFF
--- a/bin/perltidy-pg.pl
+++ b/bin/perltidy-pg.pl
@@ -82,7 +82,7 @@ my $postfilter = sub {
 	$evalString =~ s/\h*SOLUTION\(EV3P\(<<'END_SOLUTION'\)\);/BEGIN_SOLUTION/g;
 	$evalString =~ s/\h*HINT\(EV3P\(<<'END_HINT'\)\);/BEGIN_HINT/g;
 	$evalString =~ s/(.*)->tex\(<<END_TIKZ\);/$1->BEGIN_TIKZ/g;
-	$evalString =~ s/(.*)->tex\(<<END_LATEX_IMAGE\);/(.*)->BEGIN_LATEX_IMAGE/g;
+	$evalString =~ s/(.*)->tex\(<<END_LATEX_IMAGE\);/$1->BEGIN_LATEX_IMAGE/g;
 
 	# Care is needed to reverse the preprocessing here.
 	# First in all occurences of an odd number of backslashes the first backslash is replaced with two tildes.

--- a/bin/run-perltidy
+++ b/bin/run-perltidy
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
-INPUTDIR=$(dirname $SCRIPT_DIR)
-
-shopt -s extglob globstar nullglob
-perltidy --pro=$INPUTDIR/.perltidyrc -b -bext='/' $INPUTDIR/**/*.p[lm] $INPUTDIR/**/*.t

--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -1,0 +1,112 @@
+#!/usr/bin/env perl
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+run-perltidy.pl -- Run perltidy on pg source files.
+
+=head1 SYNOPSIS
+
+    run-perltidy.pl [options] file1 file2 ...
+
+=head1 DESCRIPTION
+
+Run perltidy on pg source files.
+
+=head1 OPTIONS
+
+For this script to work the PG_ROOT environment variable must be set, and the
+.perltidyrc file in the PG root directory must be readable.
+
+This script accepts all of the options that are accepted by perltidy.  See the
+perltidy documentation for details.
+
+However, the C<-pro> option is not allowed.  This script will use the
+.perltidyrc file in the PG root directory for this option instead.
+
+In addition the default value of C<-bext> for this script is C<'/'>, which means
+that backup files will be created with the C<.bak> extension, and will be
+deleted if there are no errors.  Note that this behavior may be changed by
+passing a different value for the C<-bext> option.
+
+Finally, if no files are passed on the command line, then perltidy will be
+executed on all files with the extensions C<.pl>, C<.pm>, or C<.t> in the
+PG_ROOT directory.  If files are passed on the command line, then perltidy will
+only be executed on the listed files.
+
+=cut
+
+use strict;
+use warnings;
+use feature 'say';
+
+use Perl::Tidy;
+use File::Find qw(find);
+
+die "Version 20220613 or newer of perltidy is required for this script.\n"
+	. "The installed version is $Perl::Tidy::VERSION.\n"
+	unless $Perl::Tidy::VERSION >= 20220613;
+die "The pg directory must be defined in PG_ROOT.\n" unless -e $ENV{PG_ROOT} && -r "$ENV{PG_ROOT}/.perltidyrc";
+
+# Validate options that were passed.
+my %options;
+my $err = Perl::Tidy::perltidy(dump_options => \%options);
+exit $err                                               if $err;
+die "The -pro option is not suppored by this script.\n" if defined $options{profile};
+
+my (@args, @files);
+for (@ARGV) {
+	if   ($_ =~ /^-/) { push(@args,  $_); }
+	else              { push(@files, $_); }
+}
+unshift(@args, '-bext=/') unless defined $options{'backup-file-extension'};
+
+if (@files) {
+	for (@files) {
+		push(@args, $_);
+		say "Tidying file: $_";
+		Perl::Tidy::perltidy(argv => \@args, perltidyrc => "$ENV{PG_ROOT}/.perltidyrc");
+		pop(@args);
+	}
+} else {
+	find(
+		{
+			wanted => sub {
+				my $path   = $File::Find::name;
+				my $dir    = $File::Find::dir;
+				my ($name) = $path =~ m|^$dir(?:/(.*))?$|;
+				$name = '' unless defined $name;
+
+				if (-d $path && $name =~ /^(\.git|\.github|htdocs|\.vscode)$/) {
+					$File::Find::prune = 1;
+					return;
+				}
+
+				return unless $path =~ /\.p[lm]$/ || $path =~ /\.t$/;
+
+				say "Tidying file: $path";
+
+				push(@args, $path);
+				Perl::Tidy::perltidy(argv => \@args, perltidyrc => "$ENV{PG_ROOT}/.perltidyrc");
+				pop(@args);
+			},
+			no_chdir => 1
+		},
+		$ENV{PG_ROOT}
+	);
+}
+
+1;

--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -42,6 +42,9 @@ that backup files will be created with the C<.bak> extension, and will be
 deleted if there are no errors.  Note that this behavior may be changed by
 passing a different value for the C<-bext> option.
 
+Note that the C<-v> flag makes this script verbose, and does not output the
+perltidy version as it would usually do for perltidy.
+
 Finally, if no files are passed on the command line, then perltidy will be
 executed on all files with the extensions C<.pl>, C<.pm>, or C<.t> in the
 PG_ROOT directory.  If files are passed on the command line, then perltidy will
@@ -61,23 +64,26 @@ die "Version 20220613 or newer of perltidy is required for this script.\n"
 	unless $Perl::Tidy::VERSION >= 20220613;
 die "The pg directory must be defined in PG_ROOT.\n" unless -e $ENV{PG_ROOT} && -r "$ENV{PG_ROOT}/.perltidyrc";
 
+my $verbose = 0;
+my (@args, @files);
+for (@ARGV) {
+	if    ($_ eq '-v') { $verbose = 1 }
+	elsif ($_ =~ /^-/) { push(@args, $_) }
+	else               { push(@files, $_) }
+}
+
 # Validate options that were passed.
 my %options;
-my $err = Perl::Tidy::perltidy(dump_options => \%options);
+my $err = Perl::Tidy::perltidy(argv => \@args, dump_options => \%options);
 exit $err                                               if $err;
 die "The -pro option is not suppored by this script.\n" if defined $options{profile};
 
-my (@args, @files);
-for (@ARGV) {
-	if   ($_ =~ /^-/) { push(@args,  $_); }
-	else              { push(@files, $_); }
-}
 unshift(@args, '-bext=/') unless defined $options{'backup-file-extension'};
 
 if (@files) {
 	for (@files) {
 		push(@args, $_);
-		say "Tidying file: $_";
+		say "Tidying file: $_" if $verbose;
 		Perl::Tidy::perltidy(argv => \@args, perltidyrc => "$ENV{PG_ROOT}/.perltidyrc");
 		pop(@args);
 	}
@@ -97,7 +103,7 @@ if (@files) {
 
 				return unless $path =~ /\.p[lm]$/ || $path =~ /\.t$/;
 
-				say "Tidying file: $path";
+				say "Tidying file: $path" if $verbose;
 
 				push(@args, $path);
 				Perl::Tidy::perltidy(argv => \@args, perltidyrc => "$ENV{PG_ROOT}/.perltidyrc");


### PR DESCRIPTION
The primary advantage of this perl script over the previous shell script is that it used File::Find instead of relying on the extglob, globstar, and nullglob shell options.  Those options are not supported by all shells.

If this script is run with no arguments, then it does the same thing that the previous shell script did, and runs perltidy on all .pm, .pl, and .t files in the PG_ROOT directory.

If file names are passed on the command line, then perltidy is only executed on the passed filenames.  Another advantage of this script over the previous shell script.

The script enforces the use of the .perltidyrc file in the PG_ROOT directory.  It also makes the default for -bext to be '/', which means that backup files are created with the .bak extension, and deleted if no errors occur.  That can be overridden if backups are desired.  Other that those things, all options accepted by perltidy are also accepted by this script.

One other thing that this script does is enforces that the version of perltidy used is version 20220613 or newer.  Older versions have an issue with the -vxl='q' option.

This also fixes the reverse translation of BEGIN_LATEX_IMAGE in the perltidy-pg.pl script.