### PR TITLE
Update the CDN version of JSX graph and add the missing CDN version of plotly.

### DIFF
--- a/htdocs/third-party-assets.json
+++ b/htdocs/third-party-assets.json
@@ -1,6 +1,6 @@
 {
-	"node_modules/jsxgraph/distrib/jsxgraph.css": "https://cdn.jsdelivr.net/npm/jsxgraph@1.4.6/distrib/jsxgraph.min.css",
-	"node_modules/jsxgraph/distrib/jsxgraphcore.js": "https://cdn.jsdelivr.net/npm/jsxgraph@1.4.6/distrib/jsxgraphcore.js",
+	"node_modules/jsxgraph/distrib/jsxgraph.css": "https://cdn.jsdelivr.net/npm/jsxgraph@1.5.0/distrib/jsxgraph.min.css",
+	"node_modules/jsxgraph/distrib/jsxgraphcore.js": "https://cdn.jsdelivr.net/npm/jsxgraph@1.5.0/distrib/jsxgraphcore.js",
 	"node_modules/x3dom/x3dom.js": "https://cdn.jsdelivr.net/npm/x3dom@1.8.1/x3dom.min.js",
 	"node_modules/x3dom/x3dom.css": "https://cdn.jsdelivr.net/npm/x3dom@1.8.1/x3dom.min.css",
 	"node_modules/jszip/dist/jszip.min.js": "https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js",
@@ -8,5 +8,5 @@
 	"node_modules/mathquill/dist/mathquill.css": "node_modules/mathquill/dist/mathquill.css",
 	"node_modules/mathquill/dist/mathquill.js": "node_modules/mathquill/dist/mathquill.js",
 	"node_modules/sortablejs/Sortable.min.js": "https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js",
-	"node_modules/plotly.js-dist-min/plotly.min.js": "https://cdn.jsdelivr.net/npm/plotly.js-dist-min/plotly.min.js"
+	"node_modules/plotly.js-dist-min/plotly.min.js": "https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.18.2/plotly.min.js"
 }


### PR DESCRIPTION
The version update of JSX graph was forgotten when the npm version was updated, and the plotly version should have been added before.