### PR TITLE
Fix a minor mqeditor console log error.

### DIFF
--- a/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/htdocs/js/apps/MathQuill/mqeditor.js
@@ -226,7 +226,7 @@
 			answerQuill.toolbar.setPosition();
 
 			answerQuill.after(answerQuill.toolbar);
-			setTimeout(() => answerQuill.toolbar.style.opacity = 1, 0);
+			setTimeout(() => { if (answerQuill.toolbar) answerQuill.toolbar.style.opacity = 1; }, 0);
 		});
 
 		// Add a context menu to toggle whether the toolbar is enabled or not.


### PR DESCRIPTION
The timeout that sets the toolbar opacity to 1 to start the css transition to its visible state can be called when the toolbar has already been removed.  To see this click in a MathQuill input, then click on some other application beside the browser while the toolbar is still visible (and the toolbar will disappear), and then click somewhere in the browser window but not in the MathQuill input.  You will see a console error.  It is rather minor and doesn't hinder functionality, but still don't want a console error.