### PR TITLE
Add an essay field preview button and restructure the equation editors a bit.

### DIFF
--- a/htdocs/js/apps/Essay/essay.js
+++ b/htdocs/js/apps/Essay/essay.js
@@ -1,0 +1,72 @@
+'use strict';
+
+(() => {
+	const addPreviewButton = (latexEntry) => {
+		if (latexEntry.dataset.previewBtnAdded) return;
+		latexEntry.dataset.previewBtnAdded = 'true';
+
+		const buttonContainer = document.createElement('div');
+		buttonContainer.classList.add('latexentry-button-container', 'mt-1');
+
+		const button = document.createElement('button');
+		button.type = 'button';
+		button.classList.add('latexentry-preview', 'btn', 'btn-secondary', 'btn-sm');
+		button.textContent = 'Preview';
+
+		button.addEventListener('click', () => {
+			button.dataset.bsContent = latexEntry.value
+				.replace(/</g, '< ')
+				.replace(/>/g, ' >')
+				.replace(/&/g, '&amp;')
+				.replace(/\n/g, '<br>');
+			if (button.dataset.bsContent) {
+				if (button.dataset.popoverShown) button.dispatchEvent(new Event('hidden.bs.popover'));
+				button.dataset.popoverShown = 'true';
+				const popover = new bootstrap.Popover(button, {
+					html: true,
+					trigger: 'focus',
+					placement: 'bottom',
+					delay: { show: 0, hide: 200 }
+				});
+				button.addEventListener(
+					'hidden.bs.popover',
+					() => {
+						delete button.dataset.popoverShown;
+						popover.dispose();
+					},
+					{ once: true }
+				);
+				if (window.MathJax) {
+					button.addEventListener(
+						'show.bs.popover',
+						() => {
+							MathJax.startup.promise =
+								MathJax.startup.promise.then(() => MathJax.typesetPromise(['.popover-body']));
+						},
+						{ once: true }
+					);
+				}
+				popover.show();
+			}
+		});
+
+		buttonContainer.append(button);
+		latexEntry.after(buttonContainer);
+	};
+
+	document.querySelectorAll('.latexentryfield').forEach(addPreviewButton);
+
+	const observer = new MutationObserver((mutationsList) => {
+		for (const mutation of mutationsList) {
+			for (const node of mutation.addedNodes) {
+				if (node instanceof Element) {
+					if (node.classList.contains('latexentryfield')) addPreviewButton(node);
+					else node.querySelectorAll('.latexentryfield').forEach(addPreviewButton);
+				}
+			}
+		}
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+
+	window.addEventListener('unload', () => observer.disconnect());
+})();

--- a/htdocs/js/apps/MathQuill/mqeditor.scss
+++ b/htdocs/js/apps/MathQuill/mqeditor.scss
@@ -98,12 +98,6 @@ input[type='text'].codeshard.mq-edit {
 			}
 		}
 
-		.collapse,
-		.card {
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-		}
-
 		.mq-editable-field {
 			flex-grow: 1;
 		}

--- a/htdocs/js/apps/MathQuill/mqeditor.scss
+++ b/htdocs/js/apps/MathQuill/mqeditor.scss
@@ -34,14 +34,21 @@ input[type='text'].codeshard.mq-edit {
 	max-width: 100%;
 
 	.mq-latex-editor-inner-container {
-		max-width: calc(100% - 34px);
 		display: inline-block;
+		max-width: 100%;
 
 		.mq-latex-editor-textarea-container {
 			position: relative;
 
+			// This is redundant for the textarea in a problem, but is needed for a latex editor that is not in a
+			// problem (for instance the comment textareas for the problem graders).
 			.latexentryfield {
-				border-top-right-radius: 0;
+				margin-bottom: 0;
+				padding: 4px 6px;
+				vertical-align: middle;
+				font-weight: 400;
+				line-height: 18px;
+				font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
 			}
 
 			.mq-latex-editor-backdrop-container {
@@ -100,13 +107,6 @@ input[type='text'].codeshard.mq-edit {
 		.mq-editable-field {
 			flex-grow: 1;
 		}
-	}
-
-	.mq-latex-editor-btn {
-		margin-left: 0;
-		vertical-align: top;
-		border-top-left-radius: 0;
-		border-bottom-left-radius: 0;
 	}
 }
 

--- a/htdocs/js/apps/MathView/mathview.scss
+++ b/htdocs/js/apps/MathView/mathview.scss
@@ -10,62 +10,71 @@
 		&.latexentryfield-btn {
 			margin-left: 0;
 			vertical-align: top;
-			border-top-left-radius: 0;
-			border-bottom-left-radius: 0;
 		}
 	}
 
-	.mv-textarea-container {
-		position: relative;
+	.mv-inner-container {
 		display: inline-block;
-		max-width: calc(100% - 34px);
+		max-width: 100%;
 
-		.latexentryfield {
+		.mv-textarea-container {
+			position: relative;
 			max-width: 100%;
-			border-top-right-radius: 0;
-		}
 
-		.mv-backdrop-container {
-			pointer-events: none;
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			overflow: auto;
-			text-size-adjust: none;
-			visibility: hidden;
-
-			.mv-backdrop {
-				border: 1px solid transparent;
+			.latexentryfield {
+				max-width: 100%;
+				// This is redundant for the textarea in a problem, but is needed for a latex editor that is not in a
+				// problem (for instance the comment textareas for the problem graders).
+				margin-bottom: 0;
 				padding: 4px 6px;
+				vertical-align: middle;
+				font-weight: 400;
 				line-height: 18px;
-				white-space: pre-wrap;
-				word-wrap: break-word;
-				font-family: Helvetica Neue, Helvetica, Arial, Helvetica, sans-serif;
-				color: transparent;
+				font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+			}
+
+			.mv-backdrop-container {
+				pointer-events: none;
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				overflow: auto;
+				text-size-adjust: none;
 				visibility: hidden;
 
-				mark {
+				.mv-backdrop {
+					border: 1px solid transparent;
+					padding: 4px 6px;
+					line-height: 18px;
+					white-space: pre-wrap;
+					word-wrap: break-word;
+					font-family: Helvetica Neue, Helvetica, Arial, Helvetica, sans-serif;
+					color: transparent;
 					visibility: hidden;
-				}
 
-				&.mv-backdrop-show {
-					visibility: visible;
-
-					.mv-selection {
-						visibility: visible;
-						padding: 0;
-						color: white;
-						background-color: color.adjust(#3373e5, $lightness: 20%);
-
-						&:empty {
-							border-left: 1px solid #b0b0b0;
-						}
+					mark {
+						visibility: hidden;
 					}
 
-					&.mv-backdrop-blink .mv-selection:empty {
-						visibility: hidden;
+					&.mv-backdrop-show {
+						visibility: visible;
+
+						.mv-selection {
+							visibility: visible;
+							padding: 0;
+							color: white;
+							background-color: color.adjust(#3373e5, $lightness: 20%);
+
+							&:empty {
+								border-left: 1px solid #b0b0b0;
+							}
+						}
+
+						&.mv-backdrop-blink .mv-selection:empty {
+							visibility: hidden;
+						}
 					}
 				}
 			}

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -220,6 +220,7 @@ sub load_js() {
 	ADD_JS_FILE('js/apps/Base64/Base64.js',       0, { defer => undef });
 	ADD_JS_FILE('js/apps/Knowls/knowl.js',        0, { defer => undef });
 	ADD_JS_FILE('js/apps/ImageView/imageview.js', 0, { defer => undef });
+	ADD_JS_FILE('js/apps/Essay/essay.js',         0, { defer => undef });
 
 	if ($envir{useMathQuill}) {
 		ADD_JS_FILE('node_modules/mathquill/dist/mathquill.js', 0, { defer => undef });

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -106,6 +106,7 @@ is(
 			{ file => 'js/apps/Base64/Base64.js',                 external => 0, attributes => { defer => undef } },
 			{ file => 'js/apps/Knowls/knowl.js',                  external => 0, attributes => { defer => undef } },
 			{ file => 'js/apps/ImageView/imageview.js',           external => 0, attributes => { defer => undef } },
+			{ file => 'js/apps/Essay/essay.js',                   external => 0, attributes => { defer => undef } },
 			{ file => 'node_modules/mathquill/dist/mathquill.js', external => 0, attributes => { defer => undef } },
 			{ file => 'js/apps/MathQuill/mqeditor.js',            external => 0, attributes => { defer => undef } }
 		],


### PR DESCRIPTION
The essay preview button is added via the htdocs/js/apps/Essay/essay.js javascript.  This javascript is now always added to the problem page (via load_js in PG.pl).  This preview button is added below essay answers regardless of the entry assist method.

The restructuring is to accomodate the usage of these editors for the webwork2 manual problem grader comment boxes (see https://github.com/openwebwork/webwork2/pull/1959), but I think is better in general.  The button attached to the top right corner of the textarea doesn't really look that great.

For the MathQuill equation editor, the button that activates the equation editor is now placed below the essay textarea and to the left of the new preview button.  In addition, the "Insert" and "Clear" buttons of the equation editor are placed in the card footer below the MathQuill input instead of to the right of it.

For the MathView equation editor, the button that activates the equation editor is also placed below the essay textarea, but to the right of the preview button.  Furthermore, those buttons are wrapped in a div that aligns its content to the right.  This makes it so that when the equaiton editor popover opens it does not obscure the textarea.  The fallback placements have been modified so that the popover prefers to go to the right if there is room, but if not it tries to first go down, and then up.  It is not allowed to go to the left.  In some extreme situations (short windows with the button already on the far right) this will cause the page to be extended to the right to make room for the popover.

Also for the MathView equation editor, a "Clear" button is added and the "Insert" and "Clear" buttons are placed right justified below the equation editor input instead of to the right of it.

Note that this is built on top of #807 and is to address requests made by @Alex-Jordan there.