### PR TITLE
Nice tables fix

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -891,8 +891,14 @@ sub Row {
 				$columntype =~ s/^p/b/ if ($valign eq 'bottom');
 				$columntype =~ s/^p/m/ if ($tableOpts->{valign} eq 'middle');
 				$columntype =~ s/^p/b/ if ($tableOpts->{valign} eq 'bottom');
-				$columntype .= '|'
-					if ($i == 0 && $cellOpts->{colspan} == 1 && $tableOpts->{rowheaders} && $tableOpts->{headerrules});
+				$columntype = getLaTeXcolumnWidth($alignment->[0]{left}) . $columntype
+					if ($i == 0 && $alignment->[0]{left} && !$cellOpts->{halign});
+
+				if ($i == 0 && $cellOpts->{colspan} == 1 && $tableOpts->{rowheaders} && $tableOpts->{headerrules}) {
+					$columntype .= '|';
+				} elsif (!$cellOpts->{halign}) {
+					$columntype .= getLaTeXcolumnWidth($cellAlign->{right});
+				}
 				$cell = latexCommand('multicolumn', [ $cellOpts->{colspan}, $columntype, $cell ]);
 			}
 			$cell = suffix($cell, '&', ' ') unless ($i == $#$rowArray);
@@ -1430,6 +1436,16 @@ sub getLaTeXthickness {
 		$output = "$input";
 	}
 	return $output;
+}
+
+sub getLaTeXcolumnWidth {
+	my $input = shift;
+	return '' unless $input;
+	if ($input =~ /^\d+$/) {
+		return '|' x $input;
+	} else {
+		return "!{\\vrule width $input}";
+	}
 }
 
 sub getRuleCSS {

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1443,11 +1443,7 @@ sub getLaTeXthickness {
 sub getLaTeXcolumnWidth {
 	my $input = shift;
 	return '' unless $input;
-	if ($input =~ /^\d+$/) {
-		return '|' x $input;
-	} else {
-		return "!{\\vrule width $input}";
-	}
+	return ($input =~ /^\d+$/) ? '|' x $input : "!{\\vrule width $input}";
 }
 
 sub getRuleCSS {

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -878,8 +878,8 @@ sub Row {
 			if ($cellOpts->{colspan} > 1
 				|| $cellOpts->{halign}
 				|| $valign
-				|| ($tableOpts->{valign}     && $tableOpts->{valign} ne 'top')
-				|| ($tableOpts->{rowheaders} && $tableOpts->{headerrules}))
+				|| ($tableOpts->{valign} && $tableOpts->{valign} ne 'top')
+				|| ($tableOpts->{rowheaders} && $tableOpts->{headerrules} && $i == 0))
 			{
 				my $columntype = $cellOpts->{halign};
 				$columntype = $cellAlign->{halign} // 'l' unless $columntype;

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1301,6 +1301,8 @@ sub ParseAlignment {
 			$align[$i]->{tex} = $1;
 
 			# could parse these further for color identification, etc
+		} else {
+			main::WARN_MESSAGE("Token $token in texalignment could not be parsed");
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue with vertical rules in hardcopy. When there are vertical rules set in the `texalignment` string argument, and in some cell something was invoking `\multicolumn{}{}{}`, it was failing to use the vertical rules from the `texalignment` in situations when it should.

Also it was needlessly using `\multicolumn{}{}{}` on every cell in a row with a header, when that is only needed on the first cell (and only when `headerrules` is also used).

Test with the table I proposed using here:

https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8266&parent=20277

And I added a warning message if `texalignment` has something unrecognized. For example someone might do `texalignment => 'c!{2pt}c'` when they meant `texalignment => 'c!{\vrule height 2pt}c'` and this alerts them that `!{2pt}` is unrecognized.
