### PR TITLE
add cells when texalignment suggest more cells than data

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -426,6 +426,46 @@ sub DataTable {
 	# $alignment is a 1D array of hash references, with options for each column
 	my $alignment = ParseAlignment($tableOpts->{texalignment});
 
+	# if the user's data implies fewer cells in any row than what is in texalignment
+	# then we add empty data cells, update $colCount, $tableOpts, and $alignment
+	my $needToUpdate;
+	for my $j (0 .. $#$tableArray) {
+		my $lastCol = $tableArray->[$j][-1]{rightcol};
+		for my $i ($lastCol + 1 .. $#$alignment) {
+			$needToUpdate = 1;
+			push(
+				@{ $tableArray->[$j] },
+				{
+					data      => '',
+					leftcol   => $i,
+					rightcol  => $i,
+					halign    => '',
+					header    => '',
+					tex       => '',
+					noencase  => 0,
+					colspan   => 1,
+					cellcss   => '',
+					texpre    => '',
+					texpost   => '',
+					rowcolor  => '',
+					rowcss    => {},
+					headerrow => '',
+					rowtop    => 0,
+					rowbottom => 0,
+					top       => 0,
+					bottom    => 0,
+					valign    => ''
+				}
+			);
+		}
+	}
+
+	if ($needToUpdate) {
+		$colCount  = ColumnCount($tableArray);
+		$tableOpts = TableOptions($colCount, @_);
+		$alignment = ParseAlignment($tableOpts->{texalignment});
+	}
+
 	# if the user's data implies more columns than what they specified in texalignment
 	# then we add columns to both $alignment and $tableOpts->{texalignment}
 	for my $i ($#$alignment + 1 .. $colCount) {
@@ -1393,6 +1433,7 @@ sub suffix {
 
 sub css {
 	my ($a, $b) = @_;
+	$a //= '';
 	my $return = '';
 	if (ref $a eq 'HASH') {
 		my %css = %{$a};


### PR DESCRIPTION
This addresses #831.

First, the variable that caused the warning is initialized to an empty string if needed.

But also if a problem has more columns in the tex alignment string than actually shows up in a row, this adds empty cells to that row to fill it out. This will make the author see that they have too many things in the alignment string, if that is the case. Or you can use this intentionally if you want a lot of empty cells without actually coding them into the data array.