### PR TITLE
Fix moving points that have been graphed.

### DIFF
--- a/htdocs/js/apps/GraphTool/pointtool.js
+++ b/htdocs/js/apps/GraphTool/pointtool.js
@@ -24,7 +24,7 @@
 				if (!gt.isStatic) {
 					this.on('down', () => gt.board.containerObj.style.cursor = 'none');
 					this.on('up', () => gt.board.containerObj.style.cursor = 'auto');
-					this.on('drag', (e) => { gt.adjustDragPosition(e, this.baseObj); gt.updateText; });
+					this.on('drag', (e) => { gt.adjustDragPosition(e, this.baseObj); gt.updateText(); });
 				}
 			},
 


### PR DESCRIPTION
Currently if you graph a point, and then move it, and then click one of the problem submit buttons, the point is moved back to its initial position.  This was caused by an obvious mistake.  The `updateText` method needs to be called, not just stated.