### PR TITLE
Remove the contextCurrency.pl `set` method override.

### DIFF
--- a/macros/contexts/contextCurrency.pl
+++ b/macros/contexts/contextCurrency.pl
@@ -329,17 +329,6 @@ sub addToken    { }    # no tokens are needed (only uses fixed pattern)
 sub removeToken { }
 
 #
-#  Do the usual set() method, but make sure patterns are
-#  updated, since the settings may affect the currency
-#  pattern.
-#
-sub set {
-	my $self = shift;
-	$self->SUPER::set(@_);
-	$self->update;
-}
-
-#
 #  Create, set and remove extra currency symbols
 #
 sub addSymbol {


### PR DESCRIPTION
The only thing the override did was call the `update` method to force patterns to be updated.  This is no longer needed since uddate is now always called by the SUPER method when tokens are added.  This was changed in #518 and #526.

This fixes issue #833 in what I believe is the correct way.  @dpvc please advise if this is incorrect, or if there is a better way to do this.