### PR TITLE
Recover a lost style for the attempts table.

### DIFF
--- a/htdocs/js/apps/Problem/problem.scss
+++ b/htdocs/js/apps/Problem/problem.scss
@@ -183,6 +183,11 @@ table.attemptResults {
 		}
 	}
 
+	.parsehilight {
+		color: inherit;
+		background-color: yellow;
+	}
+
 	.popover {
 		max-width: 100%;
 	}


### PR DESCRIPTION
This seems to have been lost when the styles for the attempts table were moved here from the old math4.css file in webwork2/pg version 2.17. This is the style that highlights parsing errors in student answers. One easy way to see this in action is to enter an answer using a variable that is not in the context.