### PR TITLE
Image markup for PGML

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1366,11 +1366,7 @@ sub Image {
 	my $width    = $item->{width}  || 100;
 	my $height   = $item->{height} || '';
 	my $tex_size = $width / 600 * 1000;
-	if (ref $source eq 'parser::GraphTool') {
-		return ($source->generateAnswerGraph(ariaDescription => $text));
-	} else {
-		return (main::image($source, alt => $text, width => $width, height => $height, tex_size => $tex_size));
-	}
+	return (main::image($source, alt => $text, width => $width, height => $height, tex_size => $tex_size));
 }
 
 ######################################################################

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -185,6 +185,7 @@ sub All {
 		/\{/           && do { return $self->Brace($token) };
 		/\[]/          && do { return $self->NOOP($token) };
 		/\[\|/         && do { return $self->Verbatim($token) };
+		/\[!/          && do { return $self->Image($token) };
 		/\[./          && do { return $self->Answer($token) };
 		/_/            && do { return $self->Emphasis($token) };
 		/\*/           && do { return $self->Star($token) };
@@ -367,6 +368,11 @@ sub Verbatim {
 	$bars =~ s/[^|]//g;
 	$bars = "\\" . join("\\", split('', $bars));
 	$self->Begin($token, ' [|', { terminator => qr/ ?$bars\]/ });
+}
+
+sub Image {
+	my ($self, $token) = @_;
+	$self->Item("image", $token);
 }
 
 sub Answer {
@@ -629,7 +635,7 @@ my $balanceAll = qr/[\{\[\'\"]/;
 		terminator         => qr/!\]/,
 		terminateMethod    => 'terminateGetString',
 		cancelNL           => 1,
-		options            => ["title"]
+		options            => [ "source", "width", "height" ]
 	},
 	"[<" => {
 		type               => 'link',
@@ -1200,6 +1206,7 @@ sub string {
 			/code/     && do { $string = $self->Code($item);                      last };
 			/pre/      && do { $string = $self->Pre($item);                       last };
 			/verbatim/ && do { $string = $self->Verbatim($item);                  last };
+			/image/    && do { $string = $self->Image($item);                     last };
 			/break/    && do { $string = $self->Break($item);                     last };
 			/forced/   && do { $string = $self->Forced($item);                    last };
 			/comment/  && do { $string = $self->Comment($item);                   last };
@@ -1350,6 +1357,20 @@ sub Text {
 	my $text = $self->{parser}->replaceText($item);
 	$text =~ s/^\n+// if substr($text, 0, 1) eq "\n" && $self->nl eq "";
 	return $self->Escape($text);
+}
+
+sub Image {
+	my ($self, $item) = @_;
+	my $text     = $item->{text};
+	my $source   = $item->{source};
+	my $width    = $item->{width}  || 100;
+	my $height   = $item->{height} || '';
+	my $tex_size = $width / 600 * 1000;
+	if (ref $source eq 'parser::GraphTool') {
+		return ($source->generateAnswerGraph(ariaDescription => $text));
+	} else {
+		return (main::image($source, alt => $text, width => $width, height => $height, tex_size => $tex_size));
+	}
 }
 
 ######################################################################

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3022,6 +3022,10 @@ sub image {
 	my @output_list = ();
 	while (@image_list) {
 		my $image_item = shift @image_list;
+		if (ref $image_item eq 'parser::GraphTool') {
+			push(@output_list, $image_item->generateAnswerGraph(ariaDescription => shift @alt_list // ''));
+			next;
+		}
 		$image_item = insertGraph($image_item)
 			if (ref $image_item eq 'WWPlot' || ref $image_item eq 'PGlateximage' || ref $image_item eq 'PGtikz');
 		my $imageURL = alias($image_item) // '';


### PR DESCRIPTION
This lets you use `[! alt text!]{image source}{optional width}{optional height}` to display an image in PGML. It works for static images files relative to the problem file, WWPlot images, PGtikz images, and PGlateximages.

It also works with GraphTool images once #841 is merged.

The attached problem file demonstrates it. If you use it as is, put this image file in the same folder for the demo of the static image.

![webwork-logo](https://github.com/openwebwork/pg/assets/4732672/46aedc4e-0698-4c59-9033-ed2a5f1dd1a6)

Here is the sample problem file (change the extension).
[PGMLimage.txt](https://github.com/openwebwork/pg/files/11672997/PGMLimage.txt)
