### PR TITLE
image size defaults

### DIFF
--- a/htdocs/js/GraphTool/graphtool.scss
+++ b/htdocs/js/GraphTool/graphtool.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-
 .graphtool-container {
 	position: relative;
 	box-sizing: border-box;

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1361,12 +1361,11 @@ sub Text {
 
 sub Image {
 	my ($self, $item) = @_;
-	my $text     = $item->{text};
-	my $source   = $item->{source};
-	my $width    = $item->{width}  || 100;
-	my $height   = $item->{height} || '';
-	my $tex_size = $width / 600 * 1000;
-	return (main::image($source, alt => $text, width => $width, height => $height, tex_size => $tex_size));
+	my $text   = $item->{text};
+	my $source = $item->{source};
+	my $width  = $item->{width}  || '';
+	my $height = $item->{height} || '';
+	return (main::image($source, alt => $text, width => $width, height => $height));
 }
 
 ######################################################################

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3008,9 +3008,9 @@ sub image {
 	}
 
 	# Get options for width, height, and tex_size, with a sanity check for integer values.
-	my $width    = $out_options{width}    =~ /[1-9]\d*/ ? $out_options{width}    : '';
-	my $height   = $out_options{height}   =~ /[1-9]\d*/ ? $out_options{height}   : '';
-	my $tex_size = $out_options{tex_size} =~ /[1-9]\d*/ ? $out_options{tex_size} : '';
+	my $width    = $out_options{width}    =~ /^[1-9]\d*$/ ? $out_options{width}    : '';
+	my $height   = $out_options{height}   =~ /^[1-9]\d*$/ ? $out_options{height}   : '';
+	my $tex_size = $out_options{tex_size} =~ /^[1-9]\d*$/ ? $out_options{tex_size} : '';
 	$width = 200 unless ($width || $height);
 
 	$tex_size = $width ? int($width / 0.6) : 800 unless $tex_size;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2963,7 +2963,9 @@ PGtikz object, or parser::GraphTool object.
 
 C<width> and C<height> are positive integer pixel counts for HTML display. If both
 are missing, C<width> will default to 200 and C<height> will remain undeclared,
-letting the browser display the image with its natural aspect ratio.
+letting the browser display the image with its natural aspect ratio. Except with
+a parser::GraphTool object, if both are missing then nothing will be passed along
+to the GraphTool method for display, and that macro's defaults will be used.
 
 C<tex_size> is also a positive integer, per 1000 applied to the line width in TeX.
 For example 800 leads to 0.8\linewidth. If over 1000, then 1000 will be used.
@@ -3043,8 +3045,7 @@ sub image {
 			push(
 				@output_list,
 				$image_item->generateAnswerGraph(
-					width           => $width,
-					height          => $height,
+					$out_options{width} || $out_options{height} ? (width => $width, height => $height) : (),
 					ariaDescription => shift @alt_list // ''
 				)
 			);

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3006,18 +3006,16 @@ sub image {
 				display_options2(%known_options);
 		}
 	}
-	my $width    = $out_options{width};
-	my $height   = $out_options{height};
-	my $tex_size = $out_options{tex_size};
-	# sanity check some of the above
-	$width    = ''  unless ($width    =~ /[1-9]\d*/);
-	$height   = ''  unless ($height   =~ /[1-9]\d*/);
-	$tex_size = ''  unless ($tex_size =~ /[1-9]\d*/);
-	$width    = 200 unless ($width || $height);
-	if (!$tex_size) {
-		$tex_size = ($width ? int($width / 0.6) : 800);
-	}
-	$tex_size = 1000 if ($tex_size > 1000);
+
+	# Get options for width, height, and tex_size, with a sanity check for integer values.
+	my $width    = $out_options{width}    =~ /[1-9]\d*/ ? $out_options{width}    : '';
+	my $height   = $out_options{height}   =~ /[1-9]\d*/ ? $out_options{height}   : '';
+	my $tex_size = $out_options{tex_size} =~ /[1-9]\d*/ ? $out_options{tex_size} : '';
+	$width = 200 unless ($width || $height);
+
+	$tex_size = $width ? int($width / 0.6) : 800 unless $tex_size;
+	$tex_size = 1000 if $tex_size > 1000;
+
 	my $alt         = $out_options{alt};
 	my $width_ratio = $tex_size * (.001);
 	my @image_list  = ();
@@ -3045,7 +3043,8 @@ sub image {
 			push(
 				@output_list,
 				$image_item->generateAnswerGraph(
-					$out_options{width} || $out_options{height} ? (width => $width, height => $height) : (),
+					$out_options{width}    || $out_options{height} ? (width   => $width, height => $height) : (),
+					$out_options{tex_size} || $out_options{width}  ? (texSize => $tex_size)                 : (),
 					ariaDescription => shift @alt_list // ''
 				)
 			);

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2956,13 +2956,13 @@ sub row {
 
 Usage:
 
-    image($image, width => 100, height => 100, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
+    image($image, width => 200, height => 200, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
 where C<$image> can be a local file path, URL, WWPlot object, PGlateximage object,
 PGtikz object, or parser::GraphTool object.
 
 C<width> and C<height> are positive integer pixel counts for HTML display. If both
-are missing, C<width> will default to 100 and C<height> will remain undeclared,
+are missing, C<width> will default to 200 and C<height> will remain undeclared,
 letting the browser display the image with its natural aspect ratio.
 
 C<tex_size> is also a positive integer, per 1000 applied to the line width in TeX.
@@ -2971,8 +2971,8 @@ If missing, this defaults to C<int(width/0.6)> so the image is proportional to i
 HTML version with a 600 pixel wide reading area. If C<width> is missing and C<height>
 is declared, we presume this is a wide image and then C<tex_size> defaults to 800.
 
-    image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => ['alt text 1','alt text 2'], extra_html_tags => 'style="border:solid black 1pt"');
-    image([$image1,$image2], width => 100, height => 100, tex_size => 800, alt => 'common alt text', extra_html_tags => 'style="border:solid black 1pt"');
+    image([$image1,$image2], width => 200, height => 200, tex_size => 800, alt => ['alt text 1','alt text 2'], extra_html_tags => 'style="border:solid black 1pt"');
+    image([$image1,$image2], width => 200, height => 200, tex_size => 800, alt => 'common alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
 this produces an array in array context and joins the elements with C<' '> in scalar context
 
@@ -3011,7 +3011,7 @@ sub image {
 	$width    = ''  unless ($width    =~ /[1-9]\d*/);
 	$height   = ''  unless ($height   =~ /[1-9]\d*/);
 	$tex_size = ''  unless ($tex_size =~ /[1-9]\d*/);
-	$width    = 100 unless ($width || $height);
+	$width    = 200 unless ($width || $height);
 	if (!$tex_size) {
 		$tex_size = ($width ? int($width / 0.6) : 800);
 	}
@@ -3201,7 +3201,7 @@ sub video {
 			</VIDEO>\n
 			!
 		} elsif ($displayMode eq 'PTX') {
-			my $ptxwidth = 100 * $width / 600;
+			my $ptxwidth = 400 * $width / 600;
 			$out = qq!<video source="$videoURL" width="$ptxwidth%" />!;
 		} else {
 			$out = "Error: PGbasicmacros: video: Unknown displayMode: $displayMode.\n";
@@ -3255,8 +3255,8 @@ sub imageRow {
 	# standard options
 	my %options = (
 		'tex_size' => 200,    # width for fitting 4 across
-		'height'   => 100,
-		'width'    => 100,
+		'height'   => 200,
+		'width'    => 200,
 		@_                    # overwrite any default options
 	);
 

--- a/t/tikz_test/tikz_image.t
+++ b/t/tikz_test/tikz_image.t
@@ -31,7 +31,7 @@ like $img, qr!
 	class="image-view-elt"\s
 	tabindex="0"\s
 	role="button"\s
-	width="100"\s*
+	width="200"\s*
 	>$!x, 'img tag has correct format';
 
 # Note that the image file is not generated until after the `image($drawing)` call.

--- a/t/tikz_test/tikz_image.t
+++ b/t/tikz_test/tikz_image.t
@@ -31,7 +31,7 @@ like $img, qr!
 	class="image-view-elt"\s
 	tabindex="0"\s
 	role="button"\s
-	WIDTH="100"\s*
+	width="100"\s*
 	>$!x, 'img tag has correct format';
 
 # Note that the image file is not generated until after the `image($drawing)` call.


### PR DESCRIPTION
This tweaks what defaults are used for the size of an image from `image()`.

Before this, `width` always defaults to 100 when unspecified, and `tex_size` always to 800 when unspecified.

Now it's more nuanced. An unspecified `width` will default to 100 _only_ when `height` is also undeclared. If `height` is specified, then `width` is left unspecified, and so you can specify a height and let the browser maintain the image's natural aspect ratio.

Also `tex_size` will default to 800 _only_ when `width` has no value (no value passed to `image()`, and the above has not set it to 100). When `width` does have a value, `tex_size` defaults to something that tries to respect whatever `width` is, translating from a presumed 600px wide reading area to something proportional out of 1000.