### PR TITLE
Implement workaround for JSXGraph issue with points created off the board.

### DIFF
--- a/htdocs/js/GraphTool/cubictool.js
+++ b/htdocs/js/GraphTool/cubictool.js
@@ -129,9 +129,12 @@
 				},
 
 				createPoint(gt, x, y, grouped_points) {
-					const point = gt.board.create('point', [x, y], {
-						size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
-					});
+					const point = gt.board.create(
+						'point',
+						[gt.snapRound(x, gt.snapSizeX), gt.snapRound(y, gt.snapSizeY)],
+						{ size: 2, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false }
+					);
+					point.setAttribute({ snapToGrid: true });
 					if (typeof grouped_points !== 'undefined' && grouped_points.length) {
 						point.grouped_points = [];
 						grouped_points.forEach((paired_point) => {

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -678,8 +678,9 @@ window.graphTool = (containerId, options) => {
 	};
 
 	gt.createPoint = (x, y, paired_point, restrict) => {
-		const point = gt.board.create('point', [x, y],
-			{ snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, ...gt.definingPointAttributes });
+		const point = gt.board.create('point', [gt.snapRound(x, gt.snapSizeX), gt.snapRound(y, gt.snapSizeY)],
+			{ snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, ...gt.definingPointAttributes });
+		point.setAttribute({ snapToGrid: true });
 		point.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
 		point.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
 		if (typeof paired_point !== 'undefined') {

--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -347,11 +347,12 @@
 				},
 
 				createPoint(gt, x, _y, paired_point) {
-					const point = gt.board.create('point', [x, 0], {
-						snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY,
+					const point = gt.board.create('point', [gt.snapRound(x, gt.snapSizeX), 0], {
+						snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY,
 						...gt.graphObjectTypes.interval.definingPointAttributes(),
 						...gt.graphObjectTypes.interval.maybeBracketAttributes()
 					});
+					point.setAttribute({ snapToGrid: true });
 					point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
 					point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
 					if (typeof paired_point !== 'undefined') {

--- a/htdocs/js/GraphTool/quadratictool.js
+++ b/htdocs/js/GraphTool/quadratictool.js
@@ -107,9 +107,12 @@
 				},
 
 				createPoint(gt, x, y, grouped_points) {
-					const point = gt.board.create('point', [x, y], {
-						size: 2, snapToGrid: true, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false
-					});
+					const point = gt.board.create(
+						'point',
+						[gt.snapRound(x, gt.snapSizeX), gt.snapRound(y, gt.snapSizeY)],
+						{ size: 2, snapSizeX: gt.snapSizeX, snapSizeY: gt.snapSizeY, withLabel: false }
+					);
+					point.setAttribute({ snapToGrid: true });
 					if (typeof grouped_points !== 'undefined' && grouped_points.length) {
 						point.grouped_points = [];
 						grouped_points.forEach((paired_point) => {

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -194,7 +194,7 @@ These are the distances between successive grid lines in the x and y directions,
 These are the distances between successive major (labeled) ticks on the x and y axes,
 respectively.
 
-=item minorTicksX, minorTicksY (Default: C<< minorTicksX => 1, minorTicksY => 2 >>)
+=item minorTicksX, minorTicksY (Default: C<< minorTicksX => 1, minorTicksY => 1 >>)
 
 These are the number of minor (unlabeled) ticks between major ticks on the x and y axes,
 respectively.


### PR DESCRIPTION
If a point is created off the board with `snapSizeGrid` true, then the coordinate that is outside of the board's bounding box range is moved one snap size unit toward the bounding box range.  See https://github.com/jsxgraph/jsxgraph/issues/545 for issues on this bug in JSXGraph.

To fix this points need to be created with `snapToGrid` false (the default value), and then that attribute set to true afterward.  In order for this to work the coordinates of the point need to be manually rounded to the snap size.

This is only done for initial creation of objects (answers or static objects).  It does not need to be done for objects that are created dynamically (by student interaction) since those points are forced to be on the board anyway.  This is also not done for 'point' graph tool objects, since the correct answer should not be a point off the board anyway.

This workaround fixes issue #849.