### PR TITLE
padding option for niceTables

### DIFF
--- a/t/output_macros/niceTables.t
+++ b/t/output_macros/niceTables.t
@@ -21,7 +21,7 @@ loadMacros('niceTables.pl', 'PGstandard.pl');
 use Data::Dumper;
 
 my $tab           = DataTable([ [ 1, 2, 3 ], [ 4, 5, 6 ] ]);
-my $std_pad       = 'padding:0pt 6pt;';
+my $std_pad       = 'padding:0rem 0.425rem;';
 my $talign_center = 'text-align:center;';
 
 is $tab, qq{<table style="margin:auto;">


### PR DESCRIPTION
This allows you to have a `padding` option for a table from `niceTables.pl`, as described in the POD.

It slightly changes the default padding so that (1) now it is based on the (present-day) default font sizes, (2) the default for top/down padding in hardcopy is unchanged, and (3) the left-right padding is measured on the same scale as top-down padding, which is the font size.

This makes the left-right padding a little bit smaller for a DataTable, and a little bit larger for a LayoutTable. And it changes the default HMTL top-down padding in a way I did not examine They could be adjusted to exactly match either what they currently are for HTML, or what they currently are for PDF, but not both. What I chose here is a happy medium, with "nice" numbers 0, 0.5, and 1.