### PR TITLE
Rewrite unionTables.pl to replace deprecated html attributes.

### DIFF
--- a/htdocs/js/UnionTables/union-tables.scss
+++ b/htdocs/js/UnionTables/union-tables.scss
@@ -1,0 +1,43 @@
+.union-table {
+	&.union-table-centered {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@each $name, $thickness in ('minor': 1px, 'medium': 2px, 'major': 3px) {
+		&.union-table-bordered-#{$name} {
+			& > :not(caption) > *,
+			& > :not(caption) > * > * {
+				border-width: $thickness;
+			}
+		}
+	}
+
+	@for $spacing from 1 to 10 {
+		&.union-table-s#{$spacing} {
+			border-collapse: separate;
+			border-spacing: #{$spacing}px;
+		}
+	}
+
+	@for $padding from 1 to 20 {
+		&.union-table-p#{$padding} {
+			& > :not(caption) > *,
+			& > :not(caption) > * > * {
+				padding: #{$padding}px;
+			}
+		}
+	}
+
+	tr.union-table-line {
+		td {
+			padding-top: 0;
+			padding-bottom: 0;
+
+			hr {
+				border: 1px solid black;
+				height: 1px;
+			}
+		}
+	}
+}


### PR DESCRIPTION
The deprecated attributes are replaced with css. Some is inline, and some is added via css classes and styles defined in the htdocs/js/UnionTables/union-tables.scss file.  One thing that works correctly again that didn't before is borders.  The reason that borders were not working is because of bootstrap styling which overrides the deprecated border attribute.

In addition the POD is rewritten in a nicer format.

Although this fixes the deprecated attributes and the borders now appear correctly, the only real conclusion that can be made in looking at the way this macro works is that this macro needs to be deprecated.  The likelyhood of invalid html being generated by this macro is quite high. Due to its design, there is no way to validate the usage by problem authors.  If the macro's TableSpace or TableLine methods are used, the html that is generated is almost guaranteed to be invalid unless the table has precisely 10 columns.

In addition, the usage of this macro in OPL problems is frequently for layout.  Using html tables for layout is always wrong.  To be fair, this used to be pretty much the only way to do these types of layouts.  Now it is just wrong, and there are better ways to do such layouts.