### PR TITLE
remove remnant from original WeBWorK-MBX bridge

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2491,18 +2491,7 @@ A wide variety of google widgets, youtube videos, and other online resources can
 =cut
 
 sub beginproblem {
-	my $out = "";
-	$out .= MODES(
-		TeX => "\n%%% BEGIN PROBLEM PREAMBLE\n"
-		,    #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
-		HTML => ""
-	);
-	$out .= MODES(%{ main::PG_restricted_eval(q!$main::problemPreamble!) });
-	$out .= MODES(
-		TeX => "\n%%% END PROBLEM PREAMBLE\n"
-		,    #Marker used in PreTeXt LaTeX extraction; contact alex.jordan@pcc.edu before modifying
-		HTML => ""
-	);
+	my $out = MODES(%{ main::PG_restricted_eval(q!$main::problemPreamble!) });
 	if ($displayMode eq 'PTX') { $out = '' }
 	$out;
 }


### PR DESCRIPTION
These are old artifacts from the original 2016 WeBWorK-PTX bridge, that tried to use WeBWorK tex output directly. Now just clutter in the tex output.

Probably the special line of PTX output can be taken out and folded into `conf/pg_config.dist.yml`, but I don't know what that file is for so leaving it be.