### PR TITLE
replace MathObjects negative space with \mathopen{}

### DIFF
--- a/lib/Parser/BOP/multiply.pm
+++ b/lib/Parser/BOP/multiply.pm
@@ -145,7 +145,7 @@ sub TeX {
 			&& $self->{rop}{isConstant}
 			&& $self->{rop}->type eq 'Number'
 			&& $self->{rop}->class ne 'Constant');
-	$right = '\!' . $right if $mult eq '' && substr($right, 0, 5) eq '\left';
+	$right = '\mathopen{}' . $right if $mult eq '' && substr($right, 0, 5) eq '\left';
 	$TeX   = $left . $mult . $right;
 
 	$TeX = '\left(' . $TeX . '\right)' if $addparens;

--- a/lib/Parser/Function.pm
+++ b/lib/Parser/Function.pm
@@ -328,7 +328,7 @@ sub TeX {
 	$name = $fn->{TeX} if defined($fn->{TeX});
 	foreach my $x (@{ $self->{params} }) { push(@pstr, $x->TeX) }
 	if ($fn->{braceTeX}) { $TeX = $name . '{' . join(',', @pstr) . '}' }
-	else                 { $TeX = $name . "$power" . '\!\left(' . join(',', @pstr) . '\right)' }
+	else                 { $TeX = $name . "$power" . '\mathopen{}\left(' . join(',', @pstr) . '\right)' }
 	$TeX = '\left(' . $TeX . '\right)'
 		if $showparens eq 'all'
 		or $showparens eq 'extra'


### PR DESCRIPTION
See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8303 for an explanation. I think this would be a safe way to drop the negative space without introducing a big gap. The cases I know of where this use of `\mathopen{}` could cause things to look bad are not situations that will come up in these two places.
