### PR TITLE
'percent' alias for %

### DIFF
--- a/macros/contexts/contextPercent.pl
+++ b/macros/contexts/contextPercent.pl
@@ -216,6 +216,7 @@ sub Init {
 			TeX           => "\\%",
 			class         => 'Percent::UOP::percent'
 		},
+		"percent" => { alias => "%" },
 	);
 	$context->{parser}{Number} = "Percent::Number";
 	$context->{value}{Percent} = "Percent::Percent";


### PR DESCRIPTION
This lets an answer like "2%" be typed as "2 percent".