### PR TITLE
pg.sty

### DIFF
--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -1,0 +1,4 @@
+\ProvidesFile{pg}
+
+\newcommand{\answerRule}[1]{\raisebox{-3pt}{\parbox[t]{#1ex}{\hrulefill}}}
+

--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -1,4 +1,4 @@
 \ProvidesFile{pg}
 
-\newcommand{\answerRule}[1]{\raisebox{-3pt}{\parbox[t]{#1ex}{\hrulefill}}}
+\newcommand{\answerRule}[2][]{\raisebox{-3pt}{\parbox[t]{#2ex}{\hrulefill}}}
 

--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -1,4 +1,5 @@
-\ProvidesFile{pg}
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{pg}[2023/06/26 version 2.18]
 
 \newcommand{\answerRule}[2][]{\raisebox{-3pt}{\parbox[t]{#2ex}{\hrulefill}}}
 

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -316,7 +316,7 @@ sub NAMED_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
+		TeX        => "\\answerRule[$name]{$tcol}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text size=$col name="$name" value="">\\end{rawhtml}!,
 
 		# Note: codeshard is used in the css to identify input elements that come from pg
@@ -360,7 +360,7 @@ sub NAMED_HIDDEN_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
+		TeX        => "\\answerRule[$name]{$tcol}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text name="$name" value="">\\end{rawhtml}!,
 		HTML       => qq!<input type=hidden name="$name" id="$name" value="$answer_value">!
 			. qq!<input type=hidden name="previous_$name" id="previous_$name" value="$answer_value">!,
@@ -413,7 +413,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    ## get max
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 	MODES(
-		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
+		TeX        => "\\answerRule[$name]{$tcol}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
@@ -1079,7 +1079,7 @@ sub NAMED_ANS_ARRAY_EXTENSION {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
+		TeX        => "\\answerRule[$name]{$tcol}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text size=$col name="$name" id="$name" class="codeshard" aria-label="$label" !

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -316,7 +316,7 @@ sub NAMED_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule{$tcol}",
+		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text size=$col name="$name" value="">\\end{rawhtml}!,
 
 		# Note: codeshard is used in the css to identify input elements that come from pg
@@ -360,7 +360,7 @@ sub NAMED_HIDDEN_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule{$tcol}",
+		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text name="$name" value="">\\end{rawhtml}!,
 		HTML       => qq!<input type=hidden name="$name" id="$name" value="$answer_value">!
 			. qq!<input type=hidden name="previous_$name" id="previous_$name" value="$answer_value">!,
@@ -413,7 +413,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    ## get max
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 	MODES(
-		TeX        => "\\answerRule{$tcol}",
+		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
@@ -1079,7 +1079,7 @@ sub NAMED_ANS_ARRAY_EXTENSION {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule{$tcol}",
+		TeX        => ($name ? "\\answerRule[$name]{$tcol}" : "\\answerRule{$tcol}"),
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text size=$col name="$name" id="$name" class="codeshard" aria-label="$label" !

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -316,7 +316,7 @@ sub NAMED_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
+		TeX        => "\\answerRule{$tcol}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text size=$col name="$name" value="">\\end{rawhtml}!,
 
 		# Note: codeshard is used in the css to identify input elements that come from pg
@@ -360,7 +360,7 @@ sub NAMED_HIDDEN_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
+		TeX        => "\\answerRule{$tcol}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text name="$name" value="">\\end{rawhtml}!,
 		HTML       => qq!<input type=hidden name="$name" id="$name" value="$answer_value">!
 			. qq!<input type=hidden name="previous_$name" id="previous_$name" value="$answer_value">!,
@@ -413,7 +413,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    ## get max
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 	MODES(
-		TeX        => "\\mbox{\\parbox[t]{${tcol}ex}{\\hrulefill}}",
+		TeX        => "\\answerRule{$tcol}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
@@ -1075,8 +1075,11 @@ sub NAMED_ANS_ARRAY_EXTENSION {
 	}
 	$answer_value = encode_pg_and_html($answer_value);
 
+	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    ## get max
+	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
+
 	MODES(
-		TeX        => "\\mbox{\\parbox[t]{10pt}{\\hrulefill}}\\hrulefill\\quad ",
+		TeX        => "\\answerRule{$tcol}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text size=$col name="$name" id="$name" class="codeshard" aria-label="$label" !

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -316,7 +316,7 @@ sub NAMED_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule[$name]{$tcol}",
+		TeX        => "{\\answerRule[$name]{$tcol}}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text size=$col name="$name" value="">\\end{rawhtml}!,
 
 		# Note: codeshard is used in the css to identify input elements that come from pg
@@ -360,7 +360,7 @@ sub NAMED_HIDDEN_ANS_RULE {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule[$name]{$tcol}",
+		TeX        => "{\\answerRule[$name]{$tcol}}",
 		Latex2HTML => qq!\\begin{rawhtml}<input type=text name="$name" value="">\\end{rawhtml}!,
 		HTML       => qq!<input type=hidden name="$name" id="$name" value="$answer_value">!
 			. qq!<input type=hidden name="previous_$name" id="previous_$name" value="$answer_value">!,
@@ -413,7 +413,7 @@ sub NAMED_ANS_RULE_EXTENSION {
 	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    ## get max
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 	MODES(
-		TeX        => "\\answerRule[$name]{$tcol}",
+		TeX        => "{\\answerRule[$name]{$tcol}}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text class="codeshard" size=$col name="$name" id="$name" aria-label="$label" !
@@ -1079,7 +1079,7 @@ sub NAMED_ANS_ARRAY_EXTENSION {
 	$tcol = $tcol < 40 ? $tcol : 40;           ## get min
 
 	MODES(
-		TeX        => "\\answerRule[$name]{$tcol}",
+		TeX        => "{\\answerRule[$name]{$tcol}}",
 		Latex2HTML =>
 			qq!\\begin{rawhtml}\n<input type=text size=$col name="$name" id="$name" value="">\n\\end{rawhtml}\n!,
 		HTML => qq!<input type=text size=$col name="$name" id="$name" class="codeshard" aria-label="$label" !


### PR DESCRIPTION
This introduces a latex sty file for PG macros. For getting started, it has one macro, `\answerRule{}` which takes a numerical argument and makes a rule so many ex wide. I sunk it 3pt lower from what answer rules have always been in `PGbasicmacros.pl`.

This pairs with https://github.com/openwebwork/webwork2/pull/2081.

To test, get on both branches. Have a problem with answer rules, preferably that includes an answer rule array. First visit the problem editor. Test that you can build the PDF (and see if the sunken underline is in effect.) Then test that you can download the tex and build it locally.

Then put the problem in a set. See if you can generate the PDF hardcopy. And see if you download the tex bundle if you can build the set.