### PR TITLE
Fix invalid `L<...>` usage in POD.

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -13,40 +13,40 @@ MathObject Matrix methods: L<http://webwork.maa.org/wiki/Matrix_(MathObject_Clas
 MathObject Contexts: L<http://webwork.maa.org/wiki/Common_Contexts>
 CPAN RealMatrix docs: L<http://search.cpan.org/~leto/Math-MatrixReal-2.09/lib/Math/MatrixReal.pm>
 
-Allowing Matrices in Fractions: 
-L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2978>	
+Allowing Matrices in Fractions:
+L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2978>
 
      Context()->parens->set("[" => {formMatrix => 1});
 
 Files interacting with Matrices:
 
-L<lib/MatrixReal1.pm>
+L<MatrixReal1>
 
-L<macros/MatrixReduce.pl>
+L<MatrixReduce.pl>
 
-L<lib/Matrix.pm> 
+L<Matrix>
 
-L<macros/MatrixCheckers.pl> -- checking whether vectors form a basis
+L<MatrixCheckers.pl> -- checking whether vectors form a basis
 
-L<macros/MatrixReduce.pl>  -- tools for  row reduction via elementary matrices
+L<MatrixReduce.pl>  -- tools for  row reduction via elementary matrices
 
-L<macros/MatrixUnits.pl>   -- Generates unimodular matrices with real entries
+L<MatrixUnits.pl>   -- Generates unimodular matrices with real entries
 
-L<macros/PGmatrixmacros.pl>
+L<PGmatrixmacros.pl>
 
-L<macros/PGmorematrixmacros.pl>
+L<PGmorematrixmacros.pl>
 
-L<macros/PGnumericalmacros.pl>
+L<PGnumericalmacros.pl>
 
-L<macros/tableau.pl>
+L<tableau.pl>
 
-L<macros/quickMatrixEntry.pl>
+quickMatrixEntry.pl
 
-L<macros/LinearProgramming.pl>	
+L<LinearProgramming.pl>
 
 Contexts
 
-	Matrix -- allows students to enter [[3,4],[3,6]] 
+	Matrix -- allows students to enter [[3,4],[3,6]]
 	       -- formMatrix =>1 also allows this?
 	Complex-Matrix -- allows complex entries
 
@@ -56,7 +56,7 @@ Creation methods
    		 $M2 = Matrix([5,6],[7,8]);
     	  $v = Vector(9,10);
     	  $w = ColumnVector(9,10); # differs in how it is printed
-  
+
 Commands added in Value::matrix
 
 	Conversion
@@ -75,28 +75,28 @@ Commands added in Value::matrix
 	Assign values
 
 		these need to be added:
-		
+
 see C<change_matrix_entry()> in MatrixReduce and L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2970>
-	
+
 	Advanced
 		$matrix->data:  ARRAY reference (internal data) of MathObjects (Real,Complex, Fractions)
 		                stored at each location.
 
 
-Passthrough methods covering subroutines in Matrix.pm which overrides or 
+Passthrough methods covering subroutines in Matrix.pm which overrides or
 augment CPAN's MatrixReal1.pm.  Matrix is a specialized subclass of MatrixReal1.pm
 
 The actual calculations for these methods are done in C<pg/lib/Matrix.pm>
 
-	trace 
-	proj 
-	proj_coeff 
-	L 
-	R 
-	PL 
+	trace
+	proj
+	proj_coeff
+	L
+	R
+	PL
 	PR
 
-Passthrough methods covering subroutines in C<pg/lib/MatrixReal1.pm> 
+Passthrough methods covering subroutines in C<pg/lib/MatrixReal1.pm>
 (this has been modified to handle complex numbers)
 The actual calculations are done in C<MatrixReal1.pm> subroutines
 The commands below are Value::Matrix B<methods> unless otherwise noted.
@@ -104,23 +104,23 @@ The commands below are Value::Matrix B<methods> unless otherwise noted.
 
 
 	condition
-	det 
-	inverse 
+	det
+	inverse
 	is_symmetric
-	decompose_LR 
-	dim 
-	norm_one 
-	norm_max 
-	kleene 
-	normalize 
+	decompose_LR
+	dim
+	norm_one
+	norm_max
+	kleene
+	normalize
 	solve_LR($v)    - LR decomposition
 	solve($M,$v)    - function version of solve_LR
 	order_LR        - order of LR decomposition matrix (number of non-zero equations)(also order() )
 	order($M)       - function version of order_LR
-	solve_GSM 
-	solve_SSM 
-	solve_RM 
- 
+	solve_GSM
+	solve_SSM
+	solve_RM
+
 =cut
 
 #

--- a/macros/answers/PGfunctionevaluators.pl
+++ b/macros/answers/PGfunctionevaluators.pl
@@ -23,8 +23,8 @@ PGfunctionevaluators.pl - Macros that generate function answer evaluators.
 
 	ANS(function_cmp($correctEqn, $var, $llimit, $ulimit, $relTol, $numPoints, $zeroLevel,
 	                 $zeroLevelTol));
-	ANS(function_cmp_up_to_constant($correctEqn, $var, $llimit, $ulimit, $relpercentTol, 
-	                                $numOfPoints, $maxConstantOfIntegration, $zeroLevel, 
+	ANS(function_cmp_up_to_constant($correctEqn, $var, $llimit, $ulimit, $relpercentTol,
+	                                $numOfPoints, $maxConstantOfIntegration, $zeroLevel,
 	                                $zeroLevelTol));
 	ANS(function_cmp_abs($correctFunction, $var, $llimit, $ulimit, $absTol, $numOfPoints));
 	ANS(function_cmp_up_to_constant_abs($correctFunction, $var, $llimit, $ulimit,
@@ -171,12 +171,12 @@ The var parameter can contain a number, a string, or a reference to an array of
 variable names. If it contains a number, the variables are named automatically
 as follows:
 
-	 var | variables used     
+	 var | variables used
 	-----+--------------------
-	 1   | x                  
-	 2   | x, y               
-	 3   | x, y, z            
-	 4+  | x_1, x_2, x_3, ... 
+	 1   | x
+	 2   | x, y
+	 3   | x, y, z
+	 4+  | x_1, x_2, x_3, ...
 
 If the var parameter contains a reference to an array of variable names, then
 the number of variables is determined by the number of items in the array. For example:
@@ -373,7 +373,7 @@ parameters (other than the correct equation) are optional.
 
 function_cmp() uses standard comparison and relative tolerance. It takes a
 string representing a single-variable function and compares the student answer
-to that function numerically. $var, $relTol, $numPoints, $zeroLevel, and 
+to that function numerically. $var, $relTol, $numPoints, $zeroLevel, and
 $zeroLevelTol are equivalent to the identically-named options to fun_cmp(),
 above. $llimit and $ulimit are combined to form the value of limits above.
 
@@ -1061,7 +1061,7 @@ sub ORIGINAL_FUNCTION_CMP {
 
 =head1 SEE ALSO
 
-L<PGanswermacros.pl>, L<MathObjects>.
+L<PGanswermacros.pl>, L<UsingMathObjects>.
 
 =cut
 

--- a/macros/answers/PGmiscevaluators.pl
+++ b/macros/answers/PGmiscevaluators.pl
@@ -123,7 +123,7 @@ sub radio_cmp {
 
 =head1 SEE ALSO
 
-L<PGanswermacros.pl>, L<MathObjects>.
+L<PGanswermacros.pl>, L<UsingMathObjects>.
 
 =cut
 

--- a/macros/answers/PGstringevaluators.pl
+++ b/macros/answers/PGstringevaluators.pl
@@ -612,7 +612,7 @@ sub STR_CMP {
 
 =head1 SEE ALSO
 
-L<PGanswermacros.pl>, L<MathObjects>.
+L<PGanswermacros.pl>, L<UsingMathObjects>.
 
 =cut
 

--- a/macros/deprecated/PGtextevaluators.pl
+++ b/macros/deprecated/PGtextevaluators.pl
@@ -27,10 +27,10 @@ questionnaires.
 	If you disagree, why?
 	\{ ans_rule() \}
 	END_TEXT
-	
+
 	ANS(ansradio(1));
 	ANS(anstext(2));
-	
+
 	# FIXME show how to make a grader that sends email here!
 
 =head1 DESCRIPTION
@@ -331,7 +331,7 @@ Sends the text accumulated in $QUESTIONNAIRE_ANSWERS to the address specified in
 $to. The email is given the subject line $subject.
 
 The mail message is not sent right away; instead, the message is recorded and
-sent by WeBWorK after PG rendering has completed. 
+sent by WeBWorK after PG rendering has completed.
 
 =cut
 
@@ -400,7 +400,7 @@ sub DUMMY_ANSWER {
 
 =head1 SEE ALSO
 
-L<PGanswermacros.pl>, L<MathObjects>.
+L<PGanswermacros.pl>, L<UsingMathObjects>.
 
 =cut
 

--- a/macros/math/PGnumericevaluators.pl
+++ b/macros/math/PGnumericevaluators.pl
@@ -1267,7 +1267,7 @@ sub ORIGINAL_NUM_CMP {    # low level	numeric	compare
 
 =head1 SEE ALSO
 
-L<PGanswermacros.pl>, L<MathObjects>.
+L<PGanswermacros.pl>, L<UsingMathObjects>.
 
 =cut
 

--- a/macros/math/tableau.pl
+++ b/macros/math/tableau.pl
@@ -141,7 +141,7 @@ MathObject Matrix methods: L<http://webwork.maa.org/wiki/Matrix_(MathObject_Clas
 MathObject Contexts: L<http://webwork.maa.org/wiki/Common_Contexts>
 CPAN RealMatrix docs: L<http://search.cpan.org/~leto/Math-MatrixReal-2.09/lib/Math/MatrixReal.pm>
 
-More references: L<lib/Matrix.pm>
+More references: L<Matrix>
 
 =head2 Package tableau
 


### PR DESCRIPTION
With this change the current pod parsing script will still work. Without this change the updated pod parsing script in https://github.com/openwebwork/webwork2/pull/2083 will not correctly resolve these links, because the incorrect parsing that is currently being done for these invalid links is removed.

The most prevalent invalid `L<...>` usage comes in the form of `L<macros/macroName.pl>`.  Following the correct usage rules this means a link to the header "macroName.pl" in the "macros" package.  Clearly that is not correct.

See https://perldoc.perl.org/perlpod#L-a-hyperlink for the `L<...>` usage rules.  The updated script will honor those rules with the additional rules for local files that fit into that scheme:

* For a link to a PG module, use the package name (exactly as the rules for `L<...>` dictate).
* For a link to a `.pod` file, just use the basename without the `.pod` extension.  So for example for a link to doc/MathObjects/UsingMathObjects.pod, use L<UsingMathObjects>.  (See below)
* For a link to a macro file (or script), use the basename of the macro file with the `.pl` extension and no path.  This is actually how it already is in most files, except those fixed here.

This also fixes the `L<MathObjects>` links.  Those don't currently work, and won't start to work with the updated script.  There is no `MathObjects` module or pod file.  (There is a MathObjects.pl file, but that doesn't have good POD.) So this changes those to go to the `doc/MathObjects/UsingMathObjects.pod` file.