### PR TITLE
refactor hardcopy themes

### DIFF
--- a/assets/tex/CAPA.tex
+++ b/assets/tex/CAPA.tex
@@ -1,0 +1,15 @@
+% capa tex macros
+
+\newcommand{\capa}{{\sl C\kern-.10em\raise-.00ex\hbox{\rm A}\kern-.22em%
+{\sl P}\kern-.14em\kern-.01em{\rm A}}}
+  
+\newenvironment{choicelist}
+{\begin{list}{}
+	{\setlength{\rightmargin}{0in}\setlength{\leftmargin}{0.13in}
+	\setlength{\topsep}{0.05in}\setlength{\itemsep}{0.022in}
+	\setlength{\parsep}{0in}\setlength{\belowdisplayskip}{0.04in}
+	\setlength{\abovedisplayskip}{0.05in}
+	\setlength{\abovedisplayshortskip}{-0.04in}
+	\setlength{\belowdisplayshortskip}{0.04in}}
+	}
+{\end{list}}

--- a/assets/tex/CAPA.tex
+++ b/assets/tex/CAPA.tex
@@ -2,7 +2,7 @@
 
 \newcommand{\capa}{{\sl C\kern-.10em\raise-.00ex\hbox{\rm A}\kern-.22em%
 {\sl P}\kern-.14em\kern-.01em{\rm A}}}
-  
+
 \newenvironment{choicelist}
 {\begin{list}{}
 	{\setlength{\rightmargin}{0in}\setlength{\leftmargin}{0.13in}

--- a/assets/tex/PGML.tex
+++ b/assets/tex/PGML.tex
@@ -1,0 +1,71 @@
+% definitions for PGML
+
+\newcount\pgmlCount
+\newdimen\pgmlPercent
+\newdimen\pgmlPixels
+
+\pgmlPixels=.5pt
+
+{\catcode`\^^M=\active%
+  \gdef\pgmlSetup{%
+    \pgmlPercent=.01\hsize%
+    \parskip=0pt%
+    \def\par{\ifmmode\else\endgraf\fi\ignorespaces}%
+    \catcode`\^^M=\active%
+    \def^^M{\ifmmode\else\space\fi\ignorespaces}}
+  \global\let^^M\par}%
+
+\def\pgmlIndent{\par\advance\leftskip by 2em \advance\pgmlPercent by .02em \pgmlCount=0}%
+\def\pgmlbulletItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
+\def\pgmldiscItem{\par\indent\llap{$\bullet$ }\ignorespaces}%
+\def\pgmlcircleItem{\par\indent\llap{$\circ$ }\ignorespaces}%
+\def\pgmlsquareItem{\par\indent\llap{\vrule height 1ex width .75ex depth -.25ex\ }\ignorespaces}%
+\def\pgmlnumericItem{\par\indent\advance\pgmlCount by 1 \llap{\the\pgmlCount. }\ignorespaces}%
+\def\pgmlalphaItem{\par\indent{\advance\pgmlCount by `\a \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%
+\def\pgmlAlphaItem{\par\indent{\advance\pgmlCount by `\A \llap{\char\pgmlCount. }}\advance\pgmlCount by 1\ignorespaces}%
+\def\pgmlromanItem{\par\indent\advance\pgmlCount by 1 \llap{\romannumeral\pgmlCount. }\ignorespaces}%
+\def\pgmlRomanItem{\par\indent\advance\pgmlCount by 1 \llap{\uppercase\expandafter{\romannumeral\pgmlCount}. }\ignorespaces}%
+
+\def\pgmlCenter{%
+  \par \parfillskip=0pt
+  \advance\leftskip by 0pt plus .5\hsize
+  \advance\rightskip by 0pt plus .5\hsize
+  \def\pgmlBreak{\break}%
+}%
+\def\pgmlRight{%
+  \par \parfillskip=0pt
+  \advance\leftskip by 0pt plus \hsize
+  \def\pgmlBreak{\break}%
+}%
+
+\def\pgmlBreak{\\}%
+
+\def\pgmlHeading#1{%
+  \par\bfseries
+  \ifcase#1 \or\huge \or\LARGE \or\large \or\normalsize \or\footnotesize \or\scriptsize \fi
+}%
+
+\def\pgmlRule#1#2{%
+  \par\noindent
+  \hbox{%
+    \strut%
+    \dimen1=\ht\strutbox%
+    \advance\dimen1 by -#2%
+    \divide\dimen1 by 2%
+    \advance\dimen2 by -\dp\strutbox%
+    \raise\dimen1\hbox{\vrule width #1 height #2 depth 0pt}%
+  }%
+  \par
+}%
+
+\def\pgmlIC#1{\futurelet\pgmlNext\pgmlCheckIC}%
+\def\pgmlCheckIC{\ifx\pgmlNext\pgmlSpace \/\fi}%
+{\def\getSpace#1{\global\let\pgmlSpace= }\getSpace{} }%
+
+{\catcode`\ =12\global\let\pgmlSpaceChar= }%
+{\catcode`\^^M=\active%
+    \gdef\pgmlPreformatted{\par\small\ttfamily\hsize=10\hsize\obeyspaces\catcode`\^^M=\active\let^^M=\pgmlNL\pgmlNL}}%
+\def\pgmlNL{\par\bgroup\catcode`\ =12\pgmlTestSpace}%
+\def\pgmlTestSpace{\futurelet\next\pgmlTestChar}%
+\def\pgmlTestChar{\ifx\next\pgmlSpaceChar\ \pgmlTestNext\fi\egroup}%
+\def\pgmlTestNext\fi\egroup#1{\fi\pgmlTestSpace}%

--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -5,6 +5,7 @@
 % support math mode tex macros that could reasonably appear in a PG problem
 \usepackage{amsmath, amsfonts, amssymb}                                           % math macros
 \usepackage{booktabs, tabularx, colortbl, caption, xcolor}                        % niceTables.pl
+\usepackage{multicol}                                                             % DragNDrop.pm
 \usepackage[version=4]{mhchem}                                                    % chemistry macros
 
 % some packages need to be handled differently for xelatex vs pdflatex

--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -1,5 +1,36 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{pg}[2023/06/26 version 2.18]
 
+% packages that are needed for some PG macro to function for tex output or that
+% support math mode tex macros that could reasonably appear in a PG problem
+\usepackage{amsmath, amsfonts, amssymb}                                           % math macros
+\usepackage{booktabs, tabularx, colortbl, caption, xcolor}                        % niceTables.pl
+\usepackage[version=4]{mhchem}                                                    % chemistry macros
+
+% some packages need to be handled differently for xelatex vs pdflatex
+\usepackage{iftex}
+\ifXeTeX
+  \usepackage{graphicx}                                                           % PGbasicmacros.pl, LiveGraphics3D.pl, unionImage.pl
+\else
+  \usepackage[pdftex]{graphicx}                                                   % PGbasicmacros.pl, LiveGraphics3D.pl, unionImage.pl
+  \usepackage{epstopdf}                                                           % eps images with pdftex
+  \usepackage[utf8]{inputenc}
+  \usepackage{eurosym}                                                            % the euro symbol
+  \DeclareUnicodeCharacter{20AC}{\euro}                                           % allow direct use of the UTF-8 euro symbol in problems
+\fi
+
+% PG macro collections
+\input{CAPA.tex}
+\input{PGML.tex}
+
+% The macro alternatives for < should be used in math in PG problems to help
+% avoid issus with a bare < in HMTL or XML output. The alternatives for > are
+% provided for parity.
+\newcommand{\lt}{<}
+\newcommand{\gt}{>}
+\newcommand{\less}{<}
+\newcommand{\grt}{>}
+
+% semantic macro definitions used by PG
 \newcommand{\answerRule}[2][]{\raisebox{-3pt}{\parbox[t]{#2ex}{\hrulefill}}}
 


### PR DESCRIPTION
This pairs with openwebwork/webwork2#2099 that refactors hardcopy themes.

Part of that refactor is cleanly separating:

- tex packags and macros that supports PG directly
- tex packags and macros that `webwork2` uses for hardcopy production
- tex packags and macros that a particular theme needs

This PR moves everything of the first flavor over to the `pg` repo. Now in theory something other than `webwork2` can fully process individual problem files via tex to PDF, without needing something from the `webwork2` repo.