### PR TITLE
Escape MathJax characters in PGML.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1382,6 +1382,9 @@ sub Escape {
 	$string =~ s/</&lt;/g;
 	$string =~ s/>/&gt;/g;
 	$string =~ s/"/&quot;/g;
+
+	# Wrap the characters \, `, and $ in span tags to prevent MathJax from processing them.
+	$string =~ s/([\\`\$]+)/<span class="tex2jax_ignore">$1<\/span>/;
 	return $string;
 }
 


### PR DESCRIPTION
Wrap `\`, `` ` ``, and `$` in span tags to prevent MathJax from processing the characters using the `tex2jax_ignore` class.  For more information see https://github.com/openwebwork/webwork2/issues/1980.