### PR TITLE
Add `nonstopmode` when LaTeXImage.pm runs latex or pdflatex.

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -203,7 +203,7 @@ sub draw {
 		close $fh;
 		system "cd $working_dir && "
 			. WeBWorK::PG::IO::externalCommand('latex')
-			. " image-dvisvgm.tex > latex.stdout 2> /dev/null && "
+			. " --interaction=nonstopmode image-dvisvgm.tex > latex.stdout 2> /dev/null && "
 			. WeBWorK::PG::IO::externalCommand('mv')
 			. " image-dvisvgm.dvi image.dvi";
 		chmod(0777, "$working_dir/image.dvi");
@@ -218,7 +218,7 @@ sub draw {
 		close $fh;
 		system "cd $working_dir && "
 			. WeBWorK::PG::IO::externalCommand('pdflatex')
-			. " image.tex > pdflatex.stdout 2> /dev/null";
+			. " --interaction=nonstopmode image.tex > pdflatex.stdout 2> /dev/null";
 		chmod(0777, "$working_dir/image.pdf");
 	}
 


### PR DESCRIPTION
Currently if a LaTeX error is encountered when latex or pdflatex is run, user interaction is required for the execution to continue.  Since this is run by the server no such interaction can occur.  Thus the request waits until the timeout, and then dies.  This causes several problems.

See issues [#2041](https://github.com/openwebwork/webwork2/issues/2041) and [#2148](https://github.com/openwebwork/webwork2/issues/2148) for details.  This may not entirely fix those issues, but it is part of what is happening.

This fix is certainly needed independent of if it does fix those issues. Create a problem that uses LaTeXImage.pm and make the TeX have an error. For example, in TikZ don't add a semicolon at the end of a line that should have it.  Without this pull request the problem will hang until the timeout (typically 60 seconds), and with this pull request it will return immediately and show the TeX error that occurred.

This also adds some clean up to the `insertGraph` method of PGcore.pm. Basically, instead of just warning when errors occur and then continuing on to code that is guaranteed to fail, the warnings are given and the later code is skipped.  In adition if the `draw` method does not return any content, the temporary image file is not written.  Previously an empty file  was written.