### PR TITLE
parse derivatives instead of just relying on tree

### DIFF
--- a/lib/Parser/Differentiation.pm
+++ b/lib/Parser/Differentiation.pm
@@ -39,7 +39,11 @@ sub Parser::D {
 		return (0 * $self)->reduce('0*x' => 1) unless defined $self->{variables}{$x};
 		$f = $f->D($x);
 	}
-	return $self->new($f);
+	my $deriv = $self->new($f);
+	$deriv->{string} = $deriv->{tree}->string;
+	$deriv->tokenize;
+	$deriv->parse;
+	return $deriv;
 }
 
 #


### PR DESCRIPTION
Taking derivatives using the `D` method ends up creating formulas that refuse to reduce (e.g. constant products appearing in the derivative of a polynomial).

This PR modifies the behavior of the `D` method -- preserving the existing tree structure of the derivative, but now processing the result of that process (respecting the existing context flags for free).