### PR TITLE
Fix q( ), q{ }, and q[ ] quotes inside PGML [@ @] blocks.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -522,7 +522,7 @@ sub Preformatted {
 sub Quoted {
 	my $self  = shift;
 	my $token = shift;
-	my $next  = $self->{split}[ $self->{i} ];
+	my $next  = $self->{split}[ $self->{i} ] || $self->{split}[ ++$self->{i} ];
 	my $quote = substr($next, 0, 1);
 	$self->{split}[ $self->{i} ] = substr($next, 1);
 	my $pcount = 0;
@@ -542,7 +542,8 @@ sub Quoted {
 			my $i = index($text, $close);
 			if ($i > -1) {
 				$self->Text(substr($text, 0, $i + 1));
-				$text = $self->{split}[ $self->{i} ] = substr($text, $i + 1);
+				$self->{split}[ $self->{i} ] = substr($text, $i + 1);
+				++$self->{i} if $open && $self->{split}[ $self->{i} ] =~ /\s*/;
 				return;
 			}
 		}

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -538,12 +538,12 @@ sub Quoted {
 			$pcount++;
 		} elsif ($open && $text eq $close && $pcount > 0) {
 			$pcount--;
-		} elsif (!$open || ($text ne $qclose && $pcount == 0)) {
+		} elsif ($pcount == 0 && $text ne $qclose) {
 			my $i = index($text, $close);
 			if ($i > -1) {
 				$self->Text(substr($text, 0, $i + 1));
 				$self->{split}[ $self->{i} ] = substr($text, $i + 1);
-				++$self->{i} if $open && $self->{split}[ $self->{i} ] =~ /\s*/;
+				$self->Text($self->{split}[ $self->{i}++ ]) if $self->{i} % 2;
 				return;
 			}
 		}


### PR DESCRIPTION
What was happening is that the
`my $quoted = '[$@%]q[qr]?|\bq[qr]?\s+(?=.)|\bq[qr]?(?=\W)';` pattern combined with the later
`my $chars = '\\\\.|[{}[\]()\'"]';`
pattern in the PGML::Parse $splitPattern combined such that an empty string was injected between the `q` and the beginning `(`, `{`, or `[` delimiter.  For example the PGML block `[@ q(string) @]` was split into `['[@', ' ', 'q', '', '(', 'string', ')', ' ', '@]']`.  The `Quoted` method expected the delimiter to be in the next position after `q`.  So this skips that empty string and moves on to the next position in the split in that case.

The next part I do not fully understand, and hopefully @dpvc can shed some light on this.  When this is parsed until the matching end delimiter is reached it ends by gobbling the end parenthesis (the ending ')' in the list above), and leaves the empty string.  If the parser is left with that to continue then a later PGML::Eval is called, and this results in the error `Use of uninitialized value $code in concatenation (.) or string at [PG]/lib/WeBWorK/PG/Translator.pm line 1246` when `PG_restricted_eval` is called.  So this also skips to the next split in this case.

Furthermore, if the PGML block is `[@ q(string q) @]`, then this is split into `['[@', ' ', 'q', '', '(', 'string ', 'q) ', '', '@]'`.  Then at the end of parsing the `q` expression and gobbling the ending parenthesis the split that is left is the space at the end of `'q) '`.  This results in the same PGML::Eval error later.  So this also skips to the next split in this case.  Both this case and the previous are handled on line 546 of PGML.pl in this pull request.

This fixes issue #894.