### PR TITLE
PG Text post processing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,7 @@ jobs:
             libjson-perl \
             libjson-xs-perl \
             liblocale-maketext-lexicon-perl \
+            libmojolicious-perl \
             libtest2-suite-perl \
             libtie-ixhash-perl \
             libuuid-tiny-perl \

--- a/cpanfile
+++ b/cpanfile
@@ -18,6 +18,7 @@ on runtime => sub {
 	requires 'JSON::XS';
 	requires 'Locale::Maketext';
 	requires 'Locale::Maketext::Lexicon';
+	requires 'Mojolicious';
 	requires 'Tie::IxHash';
 	requires 'Types::Serialiser';
 	requires 'UUID::Tiny';

--- a/docker/pg.Dockerfile
+++ b/docker/pg.Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
 		libjson-perl \
 		libjson-xs-perl \
 		liblocale-maketext-lexicon-perl \
+		libmojolicious-perl \
 		libtest2-suite-perl \
 		libtie-ixhash-perl \
 		libuuid-tiny-perl \

--- a/htdocs/js/InputColor/color.js
+++ b/htdocs/js/InputColor/color.js
@@ -42,7 +42,7 @@
 				answerInput.focus();
 			});
 		} else {
-			answerLink.href = '';
+			answerLink.removeAttribute('href');
 		}
 	};
 

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -97,6 +97,7 @@ sub new {
 		PG_alias                     => undef,
 		PG_problem_grader            => undef,
 		displayMode                  => undef,
+		content_post_processors      => [],
 		envir                        => $envir,
 		WARNING_messages             => [],
 		DEBUG_messages               => [],
@@ -559,6 +560,12 @@ sub update_persistent_data {    # will store strings only (so far)
 sub get_persistent_data {
 	my ($self, $label) = @_;
 	return $self->{PERSISTENCE_HASH}{$label};
+}
+
+sub add_content_post_processor {
+	my ($self, $handler) = @_;
+	push(@{ $self->{content_post_processors} }, $handler) if ref($handler) eq 'CODE';
+	return;
 }
 
 sub check_answer_hash {

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -140,7 +140,7 @@ sub new_helper ($invocant, %options) {
 		}
 	}
 
-	$translator->translate();
+	$translator->translate;
 
 	# IMPORTANT: The translator environment should not be trusted after the problem code runs.
 
@@ -174,6 +174,8 @@ sub new_helper ($invocant, %options) {
 	}
 
 	# HTML_dpng uses an ImageGenerator. We have to render the queued equations.
+	# This must be done before the post processing, since the image tags output by the image generator initially
+	# include markers which are invalid html. Mojo::DOM will change these markers into attributes and this will fail.
 	if ($image_generator) {
 		my $sourceFile = "$options{templateDirectory}$options{sourceFilePath}";
 		$image_generator->render(
@@ -181,6 +183,8 @@ sub new_helper ($invocant, %options) {
 			body_text => $translator->r_text,
 		);
 	}
+
+	$translator->post_process_content if ref($translator->{rh_pgcore}) eq 'PGcore';
 
 	return bless {
 		translator       => $translator,

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -173,9 +173,9 @@ sub new_helper ($invocant, %options) {
 		);
 	}
 
-	# HTML_dpng uses an ImageGenerator. We have to render the queued equations.
-	# This must be done before the post processing, since the image tags output by the image generator initially
-	# include markers which are invalid html. Mojo::DOM will change these markers into attributes and this will fail.
+	# HTML_dpng uses an ImageGenerator. We have to render the queued equations.  This must be done before the post
+	# processing, since the image tags output by the image generator initially include markers which are invalid html.
+	# Mojo::DOM will change these markers into attributes with values and this will fail.
 	if ($image_generator) {
 		my $sourceFile = "$options{templateDirectory}$options{sourceFilePath}";
 		$image_generator->render(
@@ -185,6 +185,7 @@ sub new_helper ($invocant, %options) {
 	}
 
 	$translator->post_process_content if ref($translator->{rh_pgcore}) eq 'PGcore';
+	$translator->stringify_answers;
 
 	return bless {
 		translator       => $translator,

--- a/lib/WeBWorK/PG/ImageGenerator.pm
+++ b/lib/WeBWorK/PG/ImageGenerator.pm
@@ -477,7 +477,7 @@ sub fix_markers ($self) {
 	my %depths = %{ $self->{depths} };
 	for my $depthkey (keys %depths) {
 		if ($depths{$depthkey} eq 'none') {
-			${ $self->{body_text} } =~ s/MaRkEr$depthkey/style="vertical-align:"$self->{dvipng_align}"/g;
+			${ $self->{body_text} } =~ s/MaRkEr$depthkey/style="vertical-align:$self->{dvipng_align}"/g;
 		} else {
 			my $ndepth = 0 - $depths{$depthkey};
 			${ $self->{body_text} } =~ s/MaRkEr$depthkey/style="vertical-align:${ndepth}px"/g;

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -49,6 +49,7 @@ WeBWorK::PG::Translator - Evaluate PG code and evaluate answers safely
     my $rh_problem_result = $pt->grade_problem(%options); # grades the problem.
 
     $pt->post_process_content;   # Execute macro or problem hooks that further modify the problem content.
+    $pt->stringify_answers;      # Convert objects to strings in the answer hash
 
 =head1 DESCRIPTION
 
@@ -1036,7 +1037,6 @@ sub grade_problem {
 	use strict;
 
 	die $@ if $@;
-	$self->stringify_answers;
 	return ($self->{rh_problem_result}, $self->{rh_problem_state});
 }
 

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -15,6 +15,47 @@
 
 package WeBWorK::PG::Translator;
 
+=head1 NAME
+
+WeBWorK::PG::Translator - Evaluate PG code and evaluate answers safely
+
+=head1 SYNPOSIS
+
+    my $pt = WeBWorK::PG::Translator->new;   # create a translator
+    $pt->environment(\%envir);               # provide the environment variable for the problem
+    $pt->initialize;                         # initialize the translator
+    $pt->set_mask;                           # set the operation mask for the translator safe compartment
+
+    $pt->source_string($source);             # provide the source string for the problem
+                                             # or
+    $pt->source_file($sourceFilePath);       # provide the proble file containing the source
+
+    # Load the unprotected macro files.
+    # These files are evaluated with the Safe compartment wide open.
+    # Other macros are loaded from within the problem using loadMacros.
+    # This should not be done if the safe cache is used which is only the case if $ENV{MOJO_MODE} exists.
+    $pt->unrestricted_load("${pgMacrosDirectory}PG.pl");
+
+    $pt->translate;    # translate the problem (the following pieces of information are created)
+
+    $PG_PROBLEM_TEXT_REF = $pt->r_text;               # reference to output text for the body of problem
+    $PG_HEADER_TEXT_REF = $pt->r_header;              # reference to text for the header in HTML output
+    $PG_POST_HEADER_TEXT_REF = $pt->r_post_header;
+    $PG_ANSWER_HASH_REF = $pt->rh_correct_answers;    # a hash of answer evaluators
+    $PG_FLAGS_REF = $pt->rh_flags;                    # misc. status flags.
+
+    $pt->process_answers;                                 # evaluates all of the answers
+    my $rh_answer_results = $pt->rh_evaluated_answers;    # provides a hash of the results of evaluating the answers.
+    my $rh_problem_result = $pt->grade_problem(%options); # grades the problem.
+
+    $pt->post_process_content;   # Execute macro or problem hooks that further modify the problem content.
+
+=head1 DESCRIPTION
+
+This module defines an object which will translate a problem written in the Problem Generating (PG) language
+
+=cut
+
 use strict;
 use warnings;
 
@@ -24,47 +65,11 @@ binmode(STDOUT, ":encoding(UTF-8)");
 
 use Opcode;
 use Carp;
+use Mojo::DOM;
 
 use WWSafe;
 use PGUtil qw(pretty_print);
 use WeBWorK::PG::IO qw(fileFromPath);
-
-=head1 NAME
-
-WeBWorK::PG::Translator - Evaluate PG code and evaluate answers safely
-
-=head1 SYNPOSIS
-
-    my $pt = new WeBWorK::PG::Translator;    # create a translator
-    $pt->environment(\%envir);               # provide the environment variable for the problem
-    $pt->initialize();                       # initialize the translator
-    $pt-> set_mask();                        # set the operation mask for the translator safe compartment
-    $pt->source_string($source);             # provide the source string for the problem
-
-    # Load the unprotected macro files.
-    # These files are evaluated with the Safe compartment wide open.
-    # Other macros are loaded from within the problem using loadMacros.
-    $pt->unrestricted_load("${courseScriptsDirectory}PG.pl");
-
-    $pt->translate();    # translate the problem (the following pieces of information are created)
-
-    $PG_PROBLEM_TEXT_ARRAY_REF = $pt->ra_text();      # output text for the body of the HTML file (in array form)
-    $PG_PROBLEM_TEXT_REF = $pt->r_text();             # output text for the body of the HTML file
-    $PG_HEADER_TEXT_REF = $pt->r_header;              # text for the header of the HTML file
-    $PG_POST_HEADER_TEXT_REF = $pt->r_post_header
-    $PG_ANSWER_HASH_REF = $pt->rh_correct_answers;    # a hash of answer evaluators
-    $PG_FLAGS_REF = $pt->rh_flags;                    # misc. status flags.
-
-    $pt->process_answers;    # evaluates all of the answers
-
-    my $rh_answer_results = $pt->rh_evaluated_answers;  # provides a hash of the results of evaluating the answers.
-    my $rh_problem_result = $pt->grade_problem;         # grades the problem using the default problem grading method.
-
-=head1 DESCRIPTION
-
-This module defines an object which will translate a problem written in the Problem Generating (PG) language
-
-=cut
 
 =head2 be_strict
 
@@ -146,15 +151,18 @@ BEGIN {
 	}
 
 	# Also define in Main:: for PG modules.
-	sub Main::be_strict { return &be_strict; }
+	sub Main::be_strict { return be_strict(); }
 }
 
 =head2 evaluate_modules
 
-    Usage:  $obj->evaluate_modules('WWPlot', 'Fun', 'Circle');
+Adds modules to the list of modules which can be used by the PG problems.
 
-Adds the modules WWPlot.pm, Fun.pm and Circle.pm in the courseScripts directory to the list of modules
-which can be used by the PG problems.
+For example,
+
+    $obj->evaluate_modules('LaTeXImage', 'DragNDrop');
+
+adds modules to the C<LaTeXImage> and C<DragNDrop> modules.
 
 =cut
 
@@ -179,13 +187,13 @@ sub evaluate_modules {
 
 =head2 load_extra_packages
 
-    Usage:  $obj->load_extra_packages('AlgParserWithImplicitExpand',
-                                      'Expr','ExprWithImplicitExpand');
+Loads extra packages for modules that contain more than one package.  Works in
+conjunction with evaluate_modules.  It is assumed that the file containing the
+extra packages (along with the base package name which is the same as the name
+of the file minus the .pm extension) has already been loaded using
+evaluate_modules.
 
-Loads extra packages for modules that contain more than one package.  Works in conjunction with
-evaluate_modules.  It is assumed that the file containing the extra packages (along with the base
-package name which is the same as the name of the file minus the .pm extension) has already been
-loaded using evaluate_modules
+    Usage:  $obj->load_extra_packages('AlgParserWithImplicitExpand', 'ExprWithImplicitExpand');
 
 =cut
 
@@ -209,7 +217,7 @@ sub load_extra_packages {
 
 =head2 new
 
-    Creates the translator object.
+Creates the translator object.
 
 =cut
 
@@ -220,25 +228,24 @@ sub new {
 	my $safe_cmpt = exists($ENV{MOJO_MODE}) ? $WeBWorK::Translator::safeCache : WWSafe->new;
 
 	my $self = {
-		preprocess_code           => \&default_preprocess_code,
-		postprocess_code          => \&default_postprocess_code,
-		envir                     => undef,
-		PG_PROBLEM_TEXT_ARRAY_REF => [],
-		PG_PROBLEM_TEXT_REF       => 0,
-		PG_HEADER_TEXT_REF        => 0,
-		PG_POST_HEADER_TEXT_REF   => 0,
-		PG_ANSWER_HASH_REF        => {},
-		PG_FLAGS_REF              => {},
-		rh_pgcore                 => undef,
-		safe                      => $safe_cmpt,
-		safe_compartment_name     => $safe_cmpt->root,
-		errors                    => '',
-		source                    => '',
-		rh_correct_answers        => {},
-		rh_student_answers        => {},
-		rh_evaluated_answers      => {},
-		rh_problem_result         => {},
-		rh_problem_state          => {
+		preprocess_code         => \&default_preprocess_code,
+		postprocess_code        => \&default_postprocess_code,
+		envir                   => undef,
+		PG_PROBLEM_TEXT_REF     => 0,
+		PG_HEADER_TEXT_REF      => 0,
+		PG_POST_HEADER_TEXT_REF => 0,
+		PG_ANSWER_HASH_REF      => {},
+		PG_FLAGS_REF            => {},
+		rh_pgcore               => undef,
+		safe                    => $safe_cmpt,
+		safe_compartment_name   => $safe_cmpt->root,
+		errors                  => '',
+		source                  => '',
+		rh_correct_answers      => {},
+		rh_student_answers      => {},
+		rh_evaluated_answers    => {},
+		rh_problem_result       => {},
+		rh_problem_state        => {
 			recorded_score       => 0,
 			num_of_correct_ans   => 0,
 			num_of_incorrect_ans => 0,
@@ -249,38 +256,19 @@ sub new {
 	return bless $self, $class;
 }
 
-=pod
+=head2 initialize
 
-(b) The following routines defined within the PG module are shared:
+The following translator methods are shared to the safe compartment:
 
-    &be_strict
-    &read_whole_problem_file
-    &surePathToTmpFile
-    &fileFromPath
-    &directoryFromPath
-    &PG_answer_eval
-    &PG_restricted_eval
-    &send_mail_to
+	&PG_answer_eval
+	&PG_restricted_eval
+	&PG_macro_file_eval
+	&be_strict
+
+Also all methods that are exported by WeBWorK::PG::IO are shared.
 
 In addition the environment hash C<%envir> is shared.  This variable is unpacked
-when PG.pl is run and provides most of the environment variables for each problem
-template.
-
-=for html
-    <a href = "${Global::webworkDocsURL}techdescription/pglanguage/PGenvironment.html">environment variables</a>
-
-(c) Sharing macros:
-
-The macros shared with the safe compartment are
-
-    '&read_whole_problem_file'
-    '&surePathToTmpFile'
-    '&fileFromPath'
-    '&directoryFromPath'
-    '&PG_answer_eval'
-    '&PG_restricted_eval'
-    '&be_strict'
-    '&send_mail_to'
+when PG.pl is run.
 
 =cut
 
@@ -443,11 +431,6 @@ sub nameSpace {
 	return $self->{safe}->root;
 }
 
-sub a_text {
-	my $self = shift;
-	return @{ $self->{PG_PROBLEM_TEXT_ARRAY_REF} };
-}
-
 sub header {
 	my $self = shift;
 	return ${ $self->{PG_HEADER_TEXT_REF} };
@@ -471,11 +454,6 @@ sub rh_flags {
 sub h_answers {
 	my $self = shift;
 	return %{ $self->{PG_ANSWER_HASH_REF} };
-}
-
-sub ra_text {
-	my $self = shift;
-	return $self->{PG_PROBLEM_TEXT_ARRAY_REF};
 }
 
 sub r_text {
@@ -524,10 +502,10 @@ sub errors {
 
 =head2 set_mask
 
-(e) Now we close the safe compartment.  Only the certain operations can be used
-within PG problems and the PG macro files.  These include the subroutines
-shared with the safe compartment as defined above and most Perl commands which
-do not involve file access, access to the system or evaluation.
+Limit allowed operations in the safe compartment.  Only the certain operations
+can be used within PG problems and the PG macro files.  These include the
+subroutines shared with the safe compartment as defined above and most Perl
+commands which do not involve file access, access to the system or evaluation.
 
 Specifically the following are allowed:
 
@@ -644,7 +622,7 @@ sub PG_errorMessage {
 
 =head2 Translate
 
-(3) B<Preprocess the problem text>
+B<Preprocess the problem text>
 
 The input text is subjected to some global replacements.
 
@@ -701,26 +679,23 @@ Note that there are several other replacements that are now done that are not
 documented here.  See the C<default_preprocess_code> method for all
 replacements that are done.
 
-(4) B<Evaluate the problem text>
+B<Evaluate the problem text>
 
 Evaluate the text within the safe compartment.  Save the errors. The safe
 compartment is a new one unless the $safeCompartment was set to zero in which
 case the previously defined safe compartment is used. (See item 1.)
 
-(5) B<Process errors>
+B<Process errors>
 
 The error provided by Perl is truncated slightly and returned. In the text
 string which would normally contain the rendered problem.
 
 The original text string is given line numbers and concatenated to the errors.
 
-(6) B<Prepare return values>
+B<Prepare return values>
 
 Sets the following hash keys of the translator object:
-    PG_PROBLEM_TEXT_ARRAY_REF:  Reference to an array of strings containing the
-        rendered text.
-    PG_PROBLEM_TEXT_REF: Reference to a string resulting from joining the above
-        array with the empty string.
+    PG_PROBLEM_TEXT_REF: Reference to a string containing the rendered text.
     PG_HEADER_TEXT_REF:  Reference to a string containing material to be placed
         in the header.
     PG_POST_HEADER_TEXT_REF:  Reference to a string containing material to
@@ -737,10 +712,9 @@ Sets the following hash keys of the translator object:
 my %XML = ('&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', '\'' => '&#39;');
 
 sub translate {
-	my $self                = shift;
-	my @PROBLEM_TEXT_OUTPUT = ();
-	my $safe_cmpt           = $self->{safe};
-	my $evalString          = $self->{source};
+	my $self       = shift;
+	my $safe_cmpt  = $self->{safe};
+	my $evalString = $self->{source};
 	$self->{errors} .= qq{ERROR:  This problem file was empty!\n} unless ($evalString);
 	$self->{errors} .= qq{ERROR:  You must define the environment before translating.}
 		unless defined($self->{envir});
@@ -783,6 +757,7 @@ sub translate {
 	# WARNING and DEBUG tracks are being handled elsewhere (in Problem.pm?)
 	$self->{errors} .= "ERRORS from evaluating PG file:\n$@\n" if $@;
 
+	my @PROBLEM_TEXT_OUTPUT;
 	push(@PROBLEM_TEXT_OUTPUT, split(/^/, $$PG_PROBLEM_TEXT_REF)) if ref($PG_PROBLEM_TEXT_REF) eq 'SCALAR';
 	# This is better than using defined($$PG_PROBLEM_TEXT_REF)
 	# Because more pleasant feedback is given when the problem doesn't render.
@@ -836,11 +811,10 @@ sub translate {
 		}
 	}
 
-	$PG_FLAGS_REF->{'error_flag'} = 1 if $self->{errors};
+	$PG_FLAGS_REF->{error_flag} = 1 if $self->{errors};
 	my $PG_PROBLEM_TEXT = join("", @PROBLEM_TEXT_OUTPUT);
 
-	$self->{PG_PROBLEM_TEXT_REF}       = \$PG_PROBLEM_TEXT;
-	$self->{PG_PROBLEM_TEXT_ARRAY_REF} = \@PROBLEM_TEXT_OUTPUT;
+	$self->{PG_PROBLEM_TEXT_REF} = \$PG_PROBLEM_TEXT;
 
 	# Make sure that these variables are defined.  If the eval failed with
 	# errors, one or more of these variables won't be defined.
@@ -858,7 +832,7 @@ sub translate {
 
 =cut
 
-=head3  access methods
+=head3 access methods
 
     $obj->rh_student_answers
 
@@ -1177,6 +1151,68 @@ sub avg_problem_grader {
 	return (\%problem_result, \%problem_state);
 }
 
+=head2 post_process_content
+
+Call hooks added via macros or the problem via C<add_content_post_processor> to
+post process content.  Hooks are called in the order they were added.
+
+This method should be called in the rendering process after answer processing
+has occurred.
+
+If the display mode is TeX, then each hook subroutine is passed a reference to
+the problem text string generated in the C<translate> method.
+
+For all other display modes each hook subroutine is passed two Mojo::DOM
+objects.  The first containing the parsed problem text string, and the second
+contains the parsed header text string, both of which were generated in the
+C<translate> method.  After all hooks are called and modifications are made to
+the Mojo::DOM contents by the hooks, the Mojo::DOM objects are converted back to
+strings and the translator problem text and header references are updated with
+the contents of those strings.
+
+=cut
+
+sub post_process_content {
+	my $self = shift;
+
+	my $outer_sig_warn = $SIG{__WARN__};
+	my @warnings;
+	local $SIG{__WARN__} = sub { push(@warnings, $_[0]) };
+
+	my $outer_sig_die = $SIG{__DIE__};
+	local $SIG{__DIE__} = sub {
+		ref $outer_sig_die eq "CODE"
+			? $outer_sig_die->(PG_errorMessage('traceback', $_[0]))
+			: die PG_errorMessage('traceback', $_[0]);
+	};
+
+	if ($self->{rh_pgcore}{displayMode} eq 'TeX') {
+		our $PG_PROBLEM_TEXT_REF = $self->{PG_PROBLEM_TEXT_REF};
+		$self->{safe}->share('$PG_PROBLEM_TEXT_REF');
+		$self->{safe}->reval('for (@{ $main::PG->{content_post_processors} }) { $_->($PG_PROBLEM_TEXT_REF); }', 1);
+		warn "ERRORS from post processing PG text:\n$@\n" if $@;
+	} else {
+		$self->{safe}->share_from('main', [qw(%Mojo::Base:: %Mojo::Collection:: %Mojo::DOM::)]);
+		our $problemDOM = Mojo::DOM->new(${ $self->{PG_PROBLEM_TEXT_REF} });
+		$problemDOM->xml(1) if $self->{rh_pgcore}{displayMode} eq 'PTX';
+		our $pageHeader = Mojo::DOM->new(${ $self->{PG_HEADER_TEXT_REF} });
+		$self->{safe}->share('$problemDOM', '$pageHeader');
+		$self->{safe}->reval('for (@{ $main::PG->{content_post_processors} }) { $_->($problemDOM, $pageHeader); }', 1);
+		warn "ERRORS from post processing PG text:\n$@\n" if $@;
+
+		$self->{PG_PROBLEM_TEXT_REF} = \($problemDOM->to_string);
+		$self->{PG_HEADER_TEXT_REF}  = \($pageHeader->to_string);
+	}
+
+	if (@warnings) {
+		ref $outer_sig_warn eq "CODE"
+			? $outer_sig_warn->(PG_errorMessage('message', @warnings))
+			: warn PG_errorMessage('message', @warnings);
+	}
+
+	return;
+}
+
 =head2 PG_restricted_eval
 
     PG_restricted_eval($string)
@@ -1205,7 +1241,7 @@ sub PG_restricted_eval {
 
 	my $out        = PG_restricted_eval_helper($string);
 	my $err        = $@;
-	my $err_report = $err if $err =~ /\S/;
+	my $err_report = $err =~ /\S/ ? $err : undef;
 	return wantarray ? ($out, $err, $err_report) : $out;
 }
 

--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -44,17 +44,15 @@ the section.  For example:
     Scaffold::Begin();
 
     Section::Begin("Part 1: The first part");
-    BEGIN_TEXT
-    This is the text for part 1.  \(1+1\) = \{ans_rule\}
-    END_TEXT
-    ANS(Real(2)->cmp);
+    BEGIN_PGML
+    This is the text for part 1.  [`1+1 =`] [_]{Real(2)}
+    END_PGML
     Section::End();
 
     Section::Begin("Part 2: The second part");
-    BEGIN_TEXT
-    This is text for the second part.  \(2*2\) = \{ans_rule\}
-    END_TEXT
-    ANS(Real(4)->cmp);
+    BEGIN_PGML
+    This is text for the second part.  [`2*2 =`] [_]{Real(4)}
+    END_PGML
     Section::End();
 
     Scaffold::End();
@@ -75,7 +73,7 @@ determining when a section is correct.  You can also force a non-empty
 answer blank to be considered correct by using the C<scaffold_force>
 option on the answer checker.  For example:
 
-    ANS(Real(123)->cmp(scaffold_force => 1));
+    [_]{ Real(123)->cmp(scaffold_force => 1) };
 
 would mean that this answer would not have to be correct for the
 section to be considered correct.
@@ -85,7 +83,7 @@ checkers) between the sections, or before the first one, or after the
 last one, if you wish.  That material would always be showing,
 regardless of which sections are open. So, for example, you could put
 a data table in the area before the first section, so that it would be
-visible throughtout the problem, no matter which section the student
+visible through out the problem, no matter which section the student
 is working on.
 
 The C<Scaffold::Begin()> function accepts optional parameters that
@@ -264,11 +262,9 @@ sub _scaffold_init {
 	# Load style and javascript for opening and closing the scaffolds.
 	ADD_CSS_FILE("js/Scaffold/scaffold.css");
 	ADD_JS_FILE("js/Scaffold/scaffold.js", 0, { defer => undef });
+	return;
 }
 
-#
-#  The Scaffoling package
-#
 package Scaffold;
 
 our $forceOpen       = $main::envir{forceScaffoldsOpen};
@@ -277,31 +273,30 @@ our $isHardcopy      = $main::displayMode eq "TeX";
 our $isPTX           = $main::displayMode eq "PTX";
 our $afterAnswerDate = $main::envir{answersAvailable};
 
-our $scaffold;              # the active scaffold (set by Begin() below)
-my @scaffolds      = ();    # array of nested scaffolds
-my $scaffold_no    = 0;     # each scaffold gets a unique number
-my $scaffold_depth = 1;     # each scaffold has a nesting depth
+our $scaffold;             # the active scaffold (set by Begin() below)
+my @scaffolds;             # array of nested scaffolds
+my $scaffold_no    = 0;    # each scaffold gets a unique number
+my $scaffold_depth = 1;    # each scaffold has a nesting depth
 
 our $PG_ANSWERS_HASH = $main::PG->{PG_ANSWERS_HASH};    # where PG stores answer evaluators
 our $PG_OUTPUT       = $main::PG->{OUTPUT_ARRAY};       # where PG stores the TEXT() output
 
 our $PREFIX = "$main::envir{QUIZ_PREFIX}Prob-$main::envir{probNum}";
 
+# Scaffold::Begin() is used to start a new scaffold section, passing
+# it any options that need to be overridden (e.g. is_open, can_open,
+# open_first_section, etc).
 #
-#  Scaffold::Begin() is used to start a new scaffold section, passing
-#  it any options that need to be overriden (e.g. is_open, can_open,
-#  open_first_section, etc).
+# Problems can include more than one scaffold, if desired,
+# and they can be nested.
 #
-#  Problems can include more than one scaffold, if desired,
-#  and they can be nested.
-#
-#    We save the current PG_OUTPUT, which will be put back durring
-#    the Scaffold::End() call.  The sections use PG_OUTPUT to create
-#    their own text, which is added to the $scaffold->{output}
-#    during the Section::End() call.
-#
+# We save the current PG_OUTPUT, which will be put back during
+# the Scaffold::End() call.  The sections use PG_OUTPUT to create
+# their own text, which is added to the $scaffold->{output}
+# during the Section::End() call.
 sub Begin {
-	my $self = Scaffold->new(@_);
+	my %options = @_;
+	my $self    = Scaffold->new(%options);
 	unshift(@scaffolds, $self);
 	$scaffold = $self;
 	$scaffold_depth++;
@@ -311,47 +306,49 @@ sub Begin {
 	return $self;
 }
 
+# Scaffold::End() is used to end the scaffold.
 #
-#  Scaffold::End() is used to end the scaffold.
-#
-#    This puts the scaffold into the page output
-#    and opens the sections that should be open.
-#    Then the next nested scaffold (if any) is poped off
-#    the stack and returned.
-#
+# This puts the scaffold into the page output and opens the sections that should be open.
+# Then the next nested scaffold (if any) is popped off the stack and returned.
 sub End {
 	Scaffold->Error("Scaffold::End() without a corresponding Scaffold::Begin") unless @scaffolds;
 	Scaffold->Error("Scaffold ended with section was still open") if $self->{current_section};
 	my $self = $scaffold;
-	push(@{ $self->{output} }, splice(@$PG_OUTPUT, 0));    # collect any final non-section output
-	$self->hide_other_results(@{ $self->{open} });         # hide results of unnopened sections in the results table
-	push(@$PG_OUTPUT, @{ $self->{previous_output} }, @{ $self->{output} })
-		;                                                  # put back original output and scaffold output
+
+	# collect any final non-section output
+	push(@{ $self->{output} }, splice(@$PG_OUTPUT, 0));
+
+	# hide results of unopened sections in the results table
+	main::add_content_post_processor(sub {
+		my ($problemContents, $headerContents) = @_;
+		return if $main::displayMode eq 'TeX';
+		$self->hide_other_results($headerContents, @{ $self->{open} });
+	});
+
+	# put back original output and scaffold output
+	push(@$PG_OUTPUT, @{ $self->{previous_output} }, @{ $self->{output} });
+
 	delete $self->{previous_output};
-	delete $self->{output};                                # don't need these any more
+	delete $self->{output};
 	shift(@scaffolds);
 	$scaffold = $scaffolds[0];
 	$scaffold_depth--;
 	return $scaffold;
 }
 
-#
-#  Report an error and die
-#
+# Report an error and die
 sub Error {
 	my $self  = shift;
 	my $error = shift;
 	die $error;
 }
 
+# Create a new Scaffold object.
 #
-#  Create a new Scaffold object.
-#
-#    Set the defaults for can_open, is_open, etc., but allow
-#    the author to override them.
-#
+# Set the defaults for can_open, is_open, etc., but allow
+# the author to override them.
 sub new {
-	my $class = shift;
+	my ($class, %options) = @_;
 	$class = ref($class) if ref($class);
 	my $self = bless {
 		can_open                  => "when_previous_correct",
@@ -361,7 +358,7 @@ sub new {
 		hardcopy_is_open          => "always",                  # open all possible sections in hardcopy
 		open_first_section        => 1,                         # 0 means don't open any sections initially
 		numbered                  => 0,                         # 1 means sections will be printed with their number
-		@_,
+		%options,
 		number     => ++$scaffold_no,                           # the number for this scaffold
 		depth      => $scaffold_depth,                          # the nesting depth for this scaffold
 		sections   => {},                                       # the sections within this scaffold
@@ -373,11 +370,9 @@ sub new {
 	return $self;
 }
 
-#
-#  Add a section to the scaffold and give it a unique number (within
-#  the scaffold).  Determine its label and save it as current_section
-#  so that we know which section is active.
-#
+# Add a section to the scaffold and give it a unique number (within
+# the scaffold).  Determine its label and save it as current_section
+# so that we know which section is active.
 sub start_section {
 	my $self    = shift;
 	my $section = shift;
@@ -389,127 +384,84 @@ sub start_section {
 	return $section;
 }
 
-#
-#  Add the content from the current section into the scaffold's output
-#  and remove the current_section (so we can tell that no sectionis open).
-#
+# Add the content from the current section into the scaffold's output
+# and remove the current_section (so we can tell that no section is open).
 sub end_section {
 	my $self = shift;
 	push(@{ $self->{output} }, splice(@{$PG_OUTPUT}, 0));    # save the section output
 	delete $self->{current_section};
+	return;
 }
 
-#
-#  Record the answers for a section, and evaluate them, if non-empty,
-#  keeping the scores for future reference.
-#
+# Record the answers for a section.
+# Scores are obtained when post processing is done.
 sub section_answers {
-	my $self = shift;
-	my %answers;
-	#
-	#  MultiAnswer objects can set the answer hash score when the last answer is evaluated,
-	#    so save the hashes and look up the scores after they have all been called.
-	#  Essay answers never return as correct, so special case them, and provide a
-	#    "scaffold_force" option in the AnswerHash that can be used to force Scaffold
-	#    to consider the score to be 1 (bug in PGessaymacros.pl prevents us from using
-	#    it for essay_cmp(), though).
-	#
-	push(@{ $self->{ans_names} }, @_);
-	foreach my $name (@_) {
-		my $input     = $main::inputs_ref->{$name};
-		my $evaluator = $PG_ANSWERS_HASH->{$name}->ans_eval;
-		Parser::Eval(sub { $answers{$name} = $evaluator->evaluate($input) }) if defined($input) && $input ne "";
-		$answers{$name}{score} = 1
-			if $answers{$name} && (($answers{$name}{type} || "") eq "essay" || $answers{$name}{"scaffold_force"});
-		$evaluator->{rh_ans}{ans_message} = "";
-		delete $evaluator->{rh_ans}{error_message};
-	}
-	foreach my $name (@_) { $self->{scores}{$name} = $answers{$name}{score} if $answers{$name} }
+	my ($self, @section_answers) = @_;
+	push(@{ $self->{ans_names} }, @section_answers);
+	return;
 }
 
-#
-#  Add the given sections to the list of sections to be openned
-#  for this scaffold
-#
+# Add the given sections to the list of sections to be opened for this scaffold.
 sub is_open {
-	my $self = shift;
-	push(@{ $self->{open} }, map { $_->{number} } @_) if @_;
+	my ($self, @open_sections) = @_;
+	push(@{ $self->{open} }, map { $_->{number} } @open_sections) if @open_sections;
 	return $self->{open};
 }
 
-#
-#  Add CSS to dim the rows of the table that are not in the open
-#  section.  (When a section is marked correct, the next section will
-#  be opened, so the correct answers will be dimmed, and the new
-#  section's blank rows will be active.  That may be a downside to the
-#  dimming.)
-#
+# Add CSS to dim the rows of the table that are not in the open section and that are not correct.
+# This is run in post processing after all of the section post processing has been completed.  So at this point
+# everything is known about the status of all answers in this scaffold.
 sub hide_other_results {
-	my $self = shift;
-	#
-	#  Record the row for each answer evaluator, and
-	#  mark which sections to show
-	#
+	my ($self, $headerContents, @openSections) = @_;
+
+	# Record the row for each answer evaluator, and mark which sections to show.
 	my %row;
 	my $i = 2;
-	foreach my $name (keys %{$PG_ANSWERS_HASH}) { $row{$name} = $i; $i++ };    # record the rows for all answers
+	for (keys %{$PG_ANSWERS_HASH}) { $row{$_} = $i; ++$i };    # record the rows for all answers
 	my %show;
-	map { $show{$_} = 1 } @_;
-	#
-	#  Get the row numbers for the answers from OTHER sections
-	#
-	my @hide = ();
-	foreach $i (keys %{ $self->{sections} }) {
-		push(@hide, map { $row{$_} } @{ $self->{sections}{$i}{ans_names} }) if !$show{$i};
-	}
-	#
-	#  Add styles that dim the hidden rows
-	#  (the other possibility would be to use display:none)
-	#
-	if (@hide) {
-		my @styles = (map {".attemptResults > tbody > tr:nth-child($_) {opacity:.5}"} @hide);
-		main::HEADER_TEXT('<style>' . join('', @styles) . '</style>');
-	}
-}
+	map { $show{$_} = 1 } @openSections;
 
-#
-#  Check if a scaffold is completely correct.
-#  (Must be called after the last section is ended.)
-#
-sub is_correct {
-	my $self   = shift;
-	my $scores = $self->{scores};
-	foreach my $name (@{ $self->{ans_names} }) { return 0 unless ($scores->{$name} || 0) >= 1 }
-	return 1;
+	# Get the row numbers for the answers from OTHER sections
+	my @hide;
+	for my $section (keys %{ $self->{sections} }) {
+		push(@hide, map { $row{$_} } @{ $self->{sections}{$section}{ans_names} })
+			if !$show{$section} && !$self->{sections}{$section}{is_correct};
+	}
+
+	# Add styles that dim the hidden rows that are not correct (the other possibility would be to use display:none)
+	if (@hide) {
+		$headerContents->append_content('<style>'
+				. join('', map {".attemptResults > tbody > tr:nth-child($_) {opacity:.5}"} @hide)
+				. '</style>');
+	}
+
+	return;
 }
 
 package Section;
 
-#
-#  Shortcuts for Scaffold data
-#
+# Shortcuts for Scaffold data
 $PG_ANSWERS_HASH = $Scaffold::PG_ANSWERS_HASH;
 $PG_OUTPUT       = $Scaffold::PG_OUTPUT;
 
+# Section::Begin() is used to start a section in the scaffolding,
+# passing it the name of the section and any options (e.g., can_open,
+# is_open, etc.).
 #
-#  Section::Begin() is used to start a section in the scaffolding,
-#  passing it the name of the section and any options (e.g., can_open,
-#  is_open, etc.).
-#
-#    The section is added to the scaffold, and the names of the answer
-#    blanks for previous sections are recorded, along with information
-#    about the answer blanks that have evaluators assigned (so we can
-#    see which answers belong to this section when it closes).
-#
+# The section is added to the scaffold, and the names of the answer
+# blanks for previous sections are recorded, along with information
+# about the answer blanks that have evaluators assigned (so we can
+# see which answers belong to this section when it closes).
 sub Begin {
+	my ($section_name, %options) = @_;
 	my $scaffold = $Scaffold::scaffold;
 	Scaffold->Error("Sections must appear within a Scaffold") unless $scaffold;
 	Scaffold->Error("Section::Begin() while a section is already open") if $scaffold->{current_section};
-	my $self            = $scaffold->start_section(Section->new(@_));
+	my $self            = $scaffold->start_section(Section->new($section_name, %options));
 	my $number          = $self->{number};
 	my $number_at_depth = $number;
 	# Convert the number (e.g. 2) into a depth-styled version (e.g. b, ii, B)
-	# Supports numbers up to 99 and depth up to 3 but then leaves in arabic
+	# Supports numbers up to 99 and depth up to 3 but then leaves in Arabic
 	if ($scaffold->{depth} == 1 && $number <= 99) {
 		$number_at_depth = ('a' .. 'cu')[ $number - 1 ];
 	} elsif ($scaffold->{depth} == 2 && $number <= 99) {
@@ -538,19 +490,17 @@ sub Begin {
 		$number_at_depth = ('A' .. 'CU')[ $number - 1 ];
 	}
 	$self->{number_at_depth} = $number_at_depth;
-	$self->{previous_ans}    = [ @{ $scaffold->{ans_names} } ],    # copy of current list of answers in the scaffold
-		$self->{assigned_ans} = [ $self->assigned_ans ],           # array indicating which answers have evaluators
-		return $self;
+	$self->{previous_ans}    = [ @{ $scaffold->{ans_names} } ];    # copy of current list of answers in the scaffold
+	$self->{assigned_ans}    = [ $self->assigned_ans ];            # array indicating which answers have evaluators
+	return $self;
 }
 
+# Section::End() is used to end the active section.
 #
-#  Section::End() is used to end the active section.
-#
-#    We get the names of the answer blanks that are in this section,
-#    then add the HTML around the section that is used by jQuery
-#    for showing/hiding the section, and finally tell the scaffold
-#    that the section is complete (it adds the content to its output).
-#
+# We get the names of the answer blanks that are in this section,
+# then add the HTML around the section that is used by JavaScript
+# for showing/hiding the section, and finally tell the scaffold
+# that the section is complete (it adds the content to its output).
 sub End {
 	my $scaffold = $Scaffold::scaffold;
 	Scaffold->Error("Sections must appear within a Scaffold")  unless $scaffold;
@@ -560,19 +510,17 @@ sub End {
 	$scaffold->section_answers(@{ $self->{ans_names} });
 	$self->add_container();
 	$scaffold->end_section();
+	return;
 }
 
+# Create a new Section object.
 #
-#  Create a new Section object.
-#
-#    It takes default values for can_open, is_open, etc.
-#    from the active scaffold.  These can be overridden
-#    by the author.
-#
+# It takes default values for can_open, is_open, etc.
+# from the active scaffold.  These can be overridden
+# by the author.
 sub new {
-	my $class = shift;
+	my ($class, $name, %options) = @_;
 	$class = ref($class) if ref($class);
-	my $name     = shift;
 	my $scaffold = $Scaffold::scaffold;
 	my $self     = bless {
 		name                      => $name,
@@ -581,23 +529,16 @@ sub new {
 		after_AnswerDate_can_open => $scaffold->{after_AnswerDate_can_open},
 		is_open                   => $scaffold->{is_open},
 		hardcopy_is_open          => $scaffold->{hardcopy_is_open},
-		@_,
+		%options
 	}, $class;
 	return $self;
 }
 
-#
-#  Adds the necessary HTML around the content of the section.
-#
-#    First, determine the is_correct and can_open status and save them.
-#    Then check if the section is to be openned, and if so, add it
-#    to the open list of the scaffold.
-#
-#    The $PG_OUTPUT variable holds just the contents of this section,
-#    so we unshift the openning tags onto the front, and push
-#    the closing tags onto the back.  (This is added to the scaffold
-#    output when $scaffold->end_section() is called.)
-#
+# Adds the necessary HTML around the content of the section.  Initially a temporary "scaffold-section" tag is added that
+# wraps the content, and that is replaced with the correct HTML in post processing.  The content is also removed in post
+# processing if the scaffold can not be opened and is not correct.  The $PG_OUTPUT variable holds just the contents of
+# this section, so unshift the opening tags onto the front, and push the closing tags onto the back.  (This is added to
+# the scaffold output when $scaffold->end_section() is called.)
 sub add_container {
 	my $self     = shift;
 	my $scaffold = $Scaffold::scaffold;
@@ -605,63 +546,123 @@ sub add_container {
 	my $name     = $self->{name} // '';
 	my $title    = ($name || $scaffold->{numbered}) ? $name : "Part $self->{number}:";
 	my $number   = ($scaffold->{numbered} ? $self->{number_at_depth} . '.' : '');
-	my ($iscorrect, $canopen, $isopen);
 
-	$iscorrect = $self->{is_correct} = $self->is_correct;
-	$canopen   = $self->{can_open}   = $self->can_open;
-	$isopen    = $self->is_open;
-
-	$scaffold->is_open($self) if $isopen;
-	splice(@$PG_OUTPUT, 0, scalar(@$PG_OUTPUT))
-		if !($canopen || $iscorrect || $Scaffold::isPTX) || (!$isopen && $Scaffold::isHardcopy);
 	unshift(
 		@$PG_OUTPUT,
-		@{
-			main::MODES(
-				HTML => [
-					'<div class="accordion">',
-					'<div class="accordion-item section-div">',
-					'<div class="accordion-header '
-						. ($iscorrect ? 'iscorrect' : 'iswrong') . ' '
-						. ($canopen   ? 'canopen'   : 'cannotopen') . '" '
-						. qq{id="$label-header"} . '>',
-					'<button class="accordion-button'
-						. ($isopen ? '' : ' collapsed')
-						. '" type="button" '
-						. (
-							$canopen
-							? qq{data-bs-target="#$label" data-bs-toggle="collapse" aria-controls="$label" }
-							: 'tabindex="-1" '
-						)
-						. 'aria-expanded="'
-						. ($isopen ? 'true' : 'false') . '">'
-						. qq{<span class="section-number">$number</span>}
-						. qq{<span class="section-title">$title</span>}
-						. '</button>',
-					'</div>',
-					qq{<div id="$label" class="accordion-collapse collapse}
-						. ($isopen ? ' show' : '')
-						. qq{" aria-labelledby="$label-header">},
-					'<div class="accordion-body">'
-				],
-				TeX => ["\\par{\\bf $number $title}\\addtolength{\\leftskip}{15pt}\\par "],
-				PTX => $name ? [ "<task>\n", "<title>$name</title>\n" ] : ["<task>\n"],
-			)
-		}
+		main::MODES(
+			HTML => qq{<scaffold-section id="$label">},
+			TeX  =>
+				"\\par{\\bf $number $title}\\addtolength{\\leftskip}{15pt}\\par\n%scaffold-section-$label-start\n",
+			PTX => $name ? "<task>\n<title>$name</title>\n" : "<task>\n",
+		)
 	);
 	push(
 		@$PG_OUTPUT,
 		main::MODES(
-			HTML => '</div></div></div></div>',
-			TeX  => "\\addtolength{\\leftskip}{-15pt}\\par ",
+			HTML => '</scaffold-section>',
+			TeX  => "%scaffold-section-$label-end\n\\addtolength{\\leftskip}{-15pt}\\par ",
 			PTX  => "<\/task>\n",
 		)
 	);
+
+	main::add_content_post_processor(sub {
+		my $problemContents = shift;
+
+		# Nothing needs to be done for the PTX display mode.
+		return if $Scaffold::isPTX;
+
+		# Essay answers never return as correct, so there is a special for case them.  Also provide a "scaffold_force"
+		# option in the AnswerHash that can be used to force Scaffold to consider the score to be 1 (a bug in
+		# PGessaymacros.pl prevents it from working in essay_cmp() though -- it actually does work, both answer hashes
+		# defined in essay_cmp() need the setting though).
+		for (@{ $self->{ans_names} }) {
+			next unless defined $PG_ANSWERS_HASH->{$_};
+			$scaffold->{scores}{$_} = $PG_ANSWERS_HASH->{$_}{ans_eval}{rh_ans}{score};
+			$scaffold->{scores}{$_} = 1
+				if ($PG_ANSWERS_HASH->{$_}{ans_eval}{rh_ans}{type} || '') eq 'essay'
+				|| $PG_ANSWERS_HASH->{$_}{ans_eval}{rh_ans}{scaffold_force};
+		}
+
+		# Set the active scaffold to the scaffold for this section so that is_correct, can_open,
+		# and is_open methods use the correct one.
+		$Scaffold::scaffold = $scaffold;
+
+		# Now, determine the is_correct and can_open status and save them.
+		# Then check if the section is to be opened, and if so, add it
+		# to the open list of the scaffold.
+		my $iscorrect = $self->{is_correct} = $self->is_correct;
+		my $canopen   = $self->{can_open}   = $self->can_open;
+		my $isopen    = $self->is_open;
+
+		$scaffold->is_open($self) if $isopen;
+
+		if ($Scaffold::isHardcopy) {
+			$$problemContents =~ s/%scaffold-section-$label-start.*%scaffold-section-$label-end//ms
+				if !($canopen || $iscorrect) || !$isopen;
+		} else {
+			my $sectionElt = $problemContents->at(qq{scaffold-section[id="$label"]});
+			return unless $sectionElt;
+
+			$sectionElt->tag('div');
+			delete $sectionElt->attr->{id};
+			$sectionElt->attr(class => 'accordion');
+
+			$sectionElt->content('') if !($canopen || $iscorrect);
+
+			$sectionElt->wrap_content(
+				Mojo::DOM->new_tag(
+					'div',
+					class => 'accordion-item section-div',
+					sub {
+						Mojo::DOM->new_tag(
+							'div',
+							id                => $label,
+							class             => 'accordion-collapse collapse' . ($isopen ? ' show' : ''),
+							'aria-labelledby' => "$label-header",
+							sub { Mojo::DOM->new_tag('div', class => 'accordion-body') }
+						);
+					}
+				)->to_string
+			);
+
+			$sectionElt->at('.accordion-item.section-div')->prepend_content(
+				Mojo::DOM->new_tag(
+					'div',
+					class => 'accordion-header'
+						. ($iscorrect ? ' iscorrect' : ' iswrong')
+						. ($canopen   ? ' canopen'   : ' cannotopen'),
+					id => "$label-header",
+					sub {
+						Mojo::DOM->new_tag(
+							'button',
+							class => 'accordion-button' . ($isopen ? '' : ' collapsed'),
+							type  => 'button',
+							(
+								$canopen
+								? (
+									data            => { bs_target => "#$label", bs_toggle => 'collapse' },
+									'aria-controls' => $label
+									)
+								: (tabindex => '-1')
+							),
+							aria_expanded => ($isopen ? 'true' : 'false'),
+							sub {
+								Mojo::DOM->new_tag('span', class => 'section-number', $number)
+									. Mojo::DOM->new_tag('span', class => 'section-title', $title);
+							}
+						);
+					}
+				)->to_string
+			);
+		}
+
+		return;
+	});
+
+	return;
 }
 
-#
-#  Check if all the answers for this section are correct
-#
+# Check if all the answers for this section are correct
 sub is_correct {
 	my $self   = shift;
 	my $scores = $Scaffold::scaffold->{scores};
@@ -669,10 +670,8 @@ sub is_correct {
 	return 1;
 }
 
-#
-#  Perform the can_open check for this section:
-#    If the author supplied code, use it, otherwise use the routine from Section::can_open.
-#
+# Perform the can_open check for this section:
+#   If the author supplied code, use it, otherwise use the routine from Section::can_open.
 sub can_open {
 	my $self = shift;
 	return 1 if $Scaffold::forceOpen;
@@ -682,10 +681,8 @@ sub can_open {
 	return &{$method}($self);
 }
 
-#
-#  Peform the is_open check for this section:
-#    If the author supplied code, use it, otherwise use the routine from Section::is_open.
-#
+# Perform the is_open check for this section:
+#   If the author supplied code, use it, otherwise use the routine from Section::is_open.
 sub is_open {
 	my $self = shift;
 	return 1 if $Scaffold::forceOpen;
@@ -696,28 +693,23 @@ sub is_open {
 	return &{$method}($self);
 }
 
-#
-#  Return a boolean array where a 1 means that answer blank has
-#  an answer evaluator assigned to it and 0 means not.
-#
+# Return a boolean array where a 1 means that answer blank has
+# an answer evaluator assigned to it and 0 means not.
 sub assigned_ans {
-	my $self    = shift;
-	my @answers = ();
+	my $self = shift;
+	my @answers;
 	foreach my $name (keys %{$PG_ANSWERS_HASH}) {
 		push(@answers, $PG_ANSWERS_HASH->{$name}->ans_eval ? 1 : 0);
 	}
 	return @answers;
 }
 
-#
-#  Get the names of any of the original answer blanks that now have
-#  evaluators attached.
-#
+# Get the names of any of the original answer blanks that now have evaluators attached.
 sub new_answers {
 	my $self     = shift;
 	my @assigned = @{ $self->{assigned_ans} };    # 0 if previously unassigned, 1 if assigned
-	my @answers  = ();
-	my $i        = 0;
+	my @answers;
+	my $i = 0;
 	foreach my $name (keys %{$PG_ANSWERS_HASH}) {
 		push(@answers, $name) if $PG_ANSWERS_HASH->{$name}->ans_eval && !$assigned[$i];
 		$i++;
@@ -727,60 +719,49 @@ sub new_answers {
 }
 
 ########################################################################
-#
-#  Implements the possible values for the can_open option for scaffolds
-#  and sections
-#
+# Implements the possible values for the can_open option for scaffolds
+# and sections
+
 package Section::can_open;
 
-#
-#  Always can be openned
-#
+# Always can be opened
 sub always { return 1 }
-#
-#  Can be openned when all the answers from previous sections are correct
-#
+
+# Can be opened when all the answers from previous sections are correct
 sub when_previous_correct {
 	my $section = shift;
 	my $scores  = $Scaffold::scaffold->{scores};
 	foreach my $name (@{ $section->{previous_ans} }) { return 0 unless ($scores->{$name} || 0) >= 1 }
 	return 1;
 }
-#
-#  Can open when previous are correct but this one is not
-#
+
+# Can open when previous are correct but this one is not
 sub first_incorrect {
 	my $section = shift;
 	return when_previous_correct($section) && !$section->{is_correct};
 }
-#
-#  Can open when incorrect
-#
+
+# Can open when incorrect
 sub incorrect {
 	my $section = shift;
 	return !$section->{is_correct};
 }
-#
-#  Never can be openned
-#
+
+# Never can be opened
 sub never { return 0 }
 
 ########################################################################
-#
-#  Implements the possible values for the is_open option for scaffolds
-#  and sections
-#
+# Implements the possible values for the is_open option for scaffolds
+# and sections
+
 package Section::is_open;
 
-#
-#  Every section is open that can be
-#
+# Every section is open that can be
 sub always { return 1 }
-#
-#  Every incorrect section is open that can be
-#  (unless it is the first one, and everything is blank, and
-#   the scaffold doesn't have open_first_section set)
-#
+
+# Every incorrect section is open that can be
+# (unless it is the first one, and everything is blank, and
+# the scaffold doesn't have open_first_section set)
 sub incorrect {
 	my $section  = shift;
 	my $scaffold = $Scaffold::scaffold;
@@ -793,24 +774,21 @@ sub incorrect {
 	}
 	return 1;
 }
-#
-#  The first incorrect section is open that can be
-#
+
+# The first incorrect section is open that can be
 sub first_incorrect {
 	my $section = shift;
 	return Section::is_open::incorrect($section) && Section::can_open::when_previous_correct($section);
 }
-#
-#  All correct sections and the first incorrect section
-#  are open (that are allowed to be open)
-#
+
+# All correct sections and the first incorrect section
+# are open (that are allowed to be open)
 sub correct_or_first_incorrect {
 	my $section = shift;
-	return 1 if $section->{is_correct} || Section::is_open::first_incorrect($section);
+	return $section->{is_correct} || Section::is_open::first_incorrect($section);
 }
-#
-#  No sections are open
-#
+
+# No sections are open
 sub never { return 0 }
 
 1;

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -23,11 +23,11 @@ is(
 	qq{<div class="PGML">\n}
 		. qq{Enter a value for <script type="math/tex">\\pi</script>.\n}
 		. qq{<div style="margin-top:1em"></div>\n}
-		. qq{<input type=text class="codeshard" size=5 name="AnSwEr0001" id="AnSwEr0001" aria-label="answer 1 " }
-		. qq{dir="auto" autocomplete="off" autocapitalize="off" spellcheck="false" value="3.14159">}
-		. qq{<input type=hidden name="previous_AnSwEr0001" value="3.14159">\n}
-		. qq{</div>\n}
-		. qq{<input type=hidden name="MaThQuIlL_AnSwEr0001" id="MaThQuIlL_AnSwEr0001" value="" >},
+		. qq{<input aria-label="answer 1 " autocapitalize="off" autocomplete="off" class="codeshard" }
+		. qq{dir="auto" id="AnSwEr0001" name="AnSwEr0001" size="5" spellcheck="false" type="text" value="3.14159">}
+		. qq{<input id="MaThQuIlL_AnSwEr0001" name="MaThQuIlL_AnSwEr0001" type="hidden" value="">}
+		. qq{<input name="previous_AnSwEr0001" type="hidden" value="3.14159">\n}
+		. qq{</div>\n},
 	'body_text has correct content'
 );
 


### PR DESCRIPTION
Macros or problems can add a hook by calling `add_content_post_processor` with a subroutine that will be called after the translator has processed answers.  For all display modes except TeX, the subroutine will be passed the problem text parsed into a Mojo::DOM object and a reference to the header text.  For the TeX display mode a reference to the problem text is passed.  The subroutine can then modify the problem DOM or text, and header text.  The resulting Mojo::DOM object will be converted back to a string and the problem text reference returned by the translator set to point to that string.
    
The hidden MathQuill inputs for the latex string is added in this post processing stage (see the ENDDOCUMENT method in PG.pl).
    
The scaffold.pl macro is updated to use this post processing.  This means that answers are no longer evaluated by the macro.  Instead the scaffold sections are finalized after the answers are processed normally by the translator.