### PR TITLE
input field correctness indicators

### DIFF
--- a/htdocs/js/InputColor/color.js
+++ b/htdocs/js/InputColor/color.js
@@ -17,7 +17,10 @@
 					if (!radioGroups[input.name]) radioGroups[input.name] = [];
 					radioGroups[input.name].push(input);
 				} else {
-					input.classList.add(type);
+					if (input.type.toLowerCase() === 'text') {
+						if (type === 'correct' || input.value !== '') input.classList.add(type);
+					} else
+						input.classList.add(type);
 				}
 			});
 

--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -501,7 +501,9 @@
 			if (answerLabel.includes(tableLink.dataset.answerId)) {
 				if (tableLink.parentNode.classList.contains('ResultsWithoutError'))
 					answerQuill.classList.add('correct');
-				else answerQuill.classList.add('incorrect');
+				else {
+					if (answerQuill.input.value !== '') answerQuill.classList.add('incorrect');
+				}
 			}
 
 			// Make a click on the results table link give focus to the mathquill answer box.

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -88,7 +88,7 @@
 
 		&.incorrect {
 			padding-right: 29px;
-			background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+			background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23AE5757'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23AE5757' stroke='none'/%3e%3c/svg%3e");
 		}
 	}
 

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -77,18 +77,18 @@
 	}
 
 	input[type=text], span.mq-editable-field {
-		background-size: auto 80%;
+		background-size: 20px auto;
 		background-position: right;
 		background-repeat: no-repeat;
 
 		&.correct {
-			padding-right: 30px;
-			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='20px' width='30px'><text x='24' y='16' fill='%23060' text-anchor='end'>✓</text></svg>");
+			padding-right: 27px;
+			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='20px' width='27px'><text x='18' y='16' fill='%23060' text-anchor='end'>✓</text></svg>");
 		}
 
 		&.incorrect {
-			padding-right: 30px;
-			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='22px' width='30px'><text x='28' y='18' fill='%23943D3D' text-anchor='end'>⚠</text></svg>");
+			padding-right: 27px;
+			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='22px' width='27px'><text x='24' y='18' fill='%23AE5757' text-anchor='end'>⚠</text></svg>");
 		}
 	}
 

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -76,6 +76,24 @@
 		}
 	}
 
+	input[type=text], span.mq-editable-field {
+		background-size: auto 80%;
+		background-position: right;
+		background-repeat: no-repeat;
+
+		&.correct {
+			padding-right: 30px;
+			background-color: #8F8; /* green */
+			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='20px' width='30px'><text x='24' y='16' fill='%23060' text-anchor='end'>✓</text></svg>");
+		}
+
+		&.incorrect {
+			padding-right: 30px;
+			background-color: #DAA; /* red */
+			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='22px' width='30px'><text x='28' y='18' fill='%23943D3D' text-anchor='end'>⚠</text></svg>");
+		}
+	}
+
 	input[type=radio] {
 		margin-right: 0.25rem;
 	}

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -78,17 +78,17 @@
 
 	input[type=text], span.mq-editable-field {
 		background-size: 20px auto;
-		background-position: right;
+		background-position: right 4px center;
 		background-repeat: no-repeat;
 
 		&.correct {
-			padding-right: 27px;
-			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='20px' width='27px'><text x='18' y='16' fill='%23060' text-anchor='end'>✓</text></svg>");
+			padding-right: 29px;
+			background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23198754' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
 		}
 
 		&.incorrect {
-			padding-right: 27px;
-			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='22px' width='27px'><text x='24' y='18' fill='%23AE5757' text-anchor='end'>⚠</text></svg>");
+			padding-right: 29px;
+			background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
 		}
 	}
 

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -83,13 +83,11 @@
 
 		&.correct {
 			padding-right: 30px;
-			background-color: #8F8; /* green */
 			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='20px' width='30px'><text x='24' y='16' fill='%23060' text-anchor='end'>✓</text></svg>");
 		}
 
 		&.incorrect {
 			padding-right: 30px;
-			background-color: #DAA; /* red */
 			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='22px' width='30px'><text x='28' y='18' fill='%23943D3D' text-anchor='end'>⚠</text></svg>");
 		}
 	}


### PR DESCRIPTION
This adds indicators that a text or MathQuill input field is (in)correct, beyond the current colored glow. It also colors the background. This is what PTX does for embedded WW exercises.

<img width="950" alt="Screen Shot 2023-08-06 at 3 05 54 AM" src="https://github.com/openwebwork/pg/assets/4732672/2bf47ca9-3e3e-4fe8-8271-70c4c8780703">

<img width="950" alt="Screen Shot 2023-08-06 at 3 05 17 AM" src="https://github.com/openwebwork/pg/assets/4732672/6f73edd8-6e0c-4b7a-8471-559cd307176e">

This could bee a way to address the second item at https://github.com/openwebwork/webwork2/issues/2157.

Similar things can be done with select, radio, and checkbox inputs. I'll see what people think about this first.

