### PR TITLE
fix hrule thickness argument

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1492,7 +1492,7 @@ sub getLaTeXthickness {
 	my $input  = shift;
 	my $output = '';
 	if ($input =~ /^\s*(\.\d+|\d+\.?\d*)\s*$/) {
-		$output = "$1px" if $1;
+		$output = $1 * 0.75 . 'pt' if $1;
 	} elsif ($input) {
 		$output = "$input";
 	}


### PR DESCRIPTION
With horizontal rules of any kind in a `niceTables.pl` table, you can declare their thickness. You can be explicit with a unit like `2pt` or you can just use a number. If you just use a number, it is supposed to come out as that many pixels.

In hardcopy, if you are not using booktabs, this is ignored and you just get the standard hline thickness. 

If you are using booktabs, we take advantage of the ability to declare thickness on the booktabs horizontal rule commands. But it turns out that px is not a legal unit of measure. So this change converts that number of pixels to pt, using the convention 1px is 0.75pt.

To test, try

```
[@ DataTable([[[1, rowbottom => 2]]]) @]*
```

and make a hardcopy. It should fail without this commit, and work with it.

Side note: When it fails, it takes a long time, and then reports `Hardcopy generation error: The operation was aborted.` I do not understand why it happens this way, instead of the usual thing when there is bad latex: it more quickly downloads the bundle with the tex file, log, etc.