### PR TITLE
keep column styling when using multicolumn

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -942,6 +942,7 @@ sub Row {
 				$columntype =~ s/^p/b/ if ($valign eq 'bottom');
 				$columntype =~ s/^p/m/ if ($tableOpts->{valign} eq 'middle');
 				$columntype =~ s/^p/b/ if ($tableOpts->{valign} eq 'bottom');
+				$columntype = ">{$cellAlign->{tex}}" . $columntype if $cellAlign->{tex};
 				$columntype = getLaTeXcolumnWidth($alignment->[0]{left}) . $columntype
 					if ($i == 0 && $alignment->[0]{left} && !$cellOpts->{halign});
 


### PR DESCRIPTION
With a niceTables table in hardcopy, certain situations lead to cells using multicolumn as a way to change the column type (for example making a cell left-aligned instead when the column as a whole is centered). Before this PR, that obliterates other styling that may be in play for the column, such as a background color. This brings that styling back.

You can test with:
```
[@ DataTable([
            [1, 2],
            [3, 4],
        ],
        rowheaders => 1,
        align => '>{\columncolor{lightgray}}lr',
) @]*
```

Before this commit, the mechanism that makes the row headers all be in boldface overrides the lightgray background in the first column. With this commit, the background will still be light gray.


