### PR TITLE
vertical alignment for images

### DIFF
--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -35,3 +35,7 @@
 % semantic macro definitions used by PG
 \newcommand{\answerRule}[2][]{\raisebox{-3pt}{\parbox[t]{#2ex}{\hrulefill}}}
 
+% height of a strut, used for example to possition the top border of an inline image
+% unit is initialized here, but value is set locally where needed
+\newlength{\strutheight}
+

--- a/htdocs/js/ImageView/imageview.css
+++ b/htdocs/js/ImageView/imageview.css
@@ -2,6 +2,18 @@
 	cursor: pointer;
 }
 
+.image-view-elt.top {
+	vertical-align: text-top;
+}
+
+.image-view-elt.middle {
+	vertical-align: middle;
+}
+
+.image-view-elt.bottom {
+	vertical-align: baseline;
+}
+
 .image-view-dialog.modal {
 	padding: 0 !important;
 }

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -636,7 +636,7 @@ my $balanceAll = qr/[\{\[\'\"]/;
 		terminator         => qr/!\]/,
 		terminateMethod    => 'terminateGetString',
 		cancelNL           => 1,
-		options            => [ "source", "width", "height" ]
+		options            => [ "source", "width", "height", "image_options" ]
 	},
 	"[<" => {
 		type               => 'link',
@@ -1362,11 +1362,12 @@ sub Text {
 
 sub Image {
 	my ($self, $item) = @_;
-	my $text   = $item->{text};
-	my $source = $item->{source};
-	my $width  = $item->{width}  || '';
-	my $height = $item->{height} || '';
-	return (main::image($source, alt => $text, width => $width, height => $height));
+	my $text          = $item->{text};
+	my $source        = $item->{source};
+	my $width         = $item->{width}         || '';
+	my $height        = $item->{height}        || '';
+	my $image_options = $item->{image_options} || {};
+	return (main::image($source, alt => $text, width => $width, height => $height, %$image_options));
 }
 
 ######################################################################

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3054,13 +3054,13 @@ sub image {
 			# alias should have given us the path to a PNG image.
 			if ($imagePath) {
 				if ($valign eq 'top') {
-					$out =
-						"\\raisebox{-\\height + \\fontcharht\\font`I}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
+					$out = '\settoheight{\strutheight}{\strut}'
+						. "\\raisebox{-\\height + \\strutheight}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
 				} elsif ($valign eq 'bottom') {
 					$out = "\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}\n";
 				} else {
-					$out =
-						"\\raisebox{-0.5\\height + 0.5\\fontcharht\\font`I}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
+					$out = '\settoheight{\strutheight}{\strut}'
+						. "\\raisebox{-0.5\\height + 0.5\\strutheight}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
 				}
 			} else {
 				$out = "";

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2940,7 +2940,7 @@ sub row {
 
 Usage:
 
-    image($image, width => 200, height => 200, tex_size => 800, alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
+    image($image, width => 200, height => 200, tex_size => 800, valign => 'middle', alt => 'alt text', extra_html_tags => 'style="border:solid black 1pt"');
 
 where C<$image> can be a local file path, URL, WWPlot object, PGlateximage object,
 PGtikz object, or parser::GraphTool object.
@@ -2956,6 +2956,9 @@ For example 800 leads to 0.8\linewidth. If over 1000, then 1000 will be used.
 If missing, this defaults to C<int(width/0.6)> so the image is proportional to its
 HTML version with a 600 pixel wide reading area. If C<width> is missing and C<height>
 is declared, we presume this is a wide image and then C<tex_size> defaults to 800.
+
+C<valign> can be 'top', 'middle', or 'bottom'.  This aligns the image relative to
+the surrounding line of text.
 
     image([$image1,$image2], width => 200, height => 200, tex_size => 800, alt => ['alt text 1','alt text 2'], extra_html_tags => 'style="border:solid black 1pt"');
     image([$image1,$image2], width => 200, height => 200, tex_size => 800, alt => 'common alt text', extra_html_tags => 'style="border:solid black 1pt"');
@@ -2976,6 +2979,7 @@ sub image {
 		width    => '',
 		height   => '',
 		tex_size => '',
+		valign   => 'middle',
 		# default value for alt is undef, since an empty string is the explicit indicator of a decorative image
 		alt             => undef,
 		extra_html_tags => '',
@@ -3004,6 +3008,9 @@ sub image {
 	my $width_ratio = $tex_size * (.001);
 	my @image_list  = ();
 	my @alt_list    = ();
+	my $valign      = 'middle';
+	$valign = 'top'    if ($out_options{valign} eq 'top');
+	$valign = 'bottom' if ($out_options{valign} eq 'bottom');
 
 	# if width and/or height are explicit, create string for attribute to be used in HTML, LaTeX2HTML
 	my $width_attrib  = ($width)  ? qq{ width="$width"}   : '';
@@ -3046,7 +3053,15 @@ sub image {
 			# We're going to create PDF files with our TeX (using pdflatex), so
 			# alias should have given us the path to a PNG image.
 			if ($imagePath) {
-				$out = "\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}\n";
+				if ($valign eq 'top') {
+					$out =
+						"\\raisebox{-\\height + \\fontcharht\\font`I}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
+				} elsif ($valign eq 'bottom') {
+					$out = "\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}\n";
+				} else {
+					$out =
+						"\\raisebox{-0.5\\height + 0.5\\fontcharht\\font`I}{\\includegraphics[width=$width_ratio\\linewidth]{$imagePath}}\n";
+				}
 			} else {
 				$out = "";
 			}
@@ -3067,7 +3082,7 @@ sub image {
 			my $altattrib = '';
 			if (defined $alt_list[0]) { $altattrib = 'alt="' . encode_pg_and_html(shift @alt_list) . '"' }
 			$out =
-				qq!<IMG SRC="$imageURL" class="image-view-elt" tabindex="0" role="button"$width_attrib$height_attrib $out_options{extra_html_tags} $altattrib>!;
+				qq!<IMG SRC="$imageURL" class="image-view-elt $valign" tabindex="0" role="button"$width_attrib$height_attrib $out_options{extra_html_tags} $altattrib>!;
 		} elsif ($displayMode eq 'PTX') {
 			my $ptxwidth = ($width ? int($width / 6) : 80);
 			if (defined $alt) {

--- a/t/tikz_test/tikz_image.t
+++ b/t/tikz_test/tikz_image.t
@@ -28,7 +28,7 @@ ok my $img = image($drawing), 'img tag is generated';
 like $img, qr!
 	^<IMG\s
 	SRC="/pg_files/tmp/images/([a-z0-9_-]*)\.svg"\s
-	class="image-view-elt"\s
+	class="image-view-elt\smiddle"\s
 	tabindex="0"\s
 	role="button"\s
 	width="200"\s*


### PR DESCRIPTION
This lets you declare vertical alignment for an image relative to the ~~baseline of any surrounding text~~ surrounding line of text. Note that right now, an image within text will be middle-aligned in HTML output and bottom-aligned in hardcopy, so there is already an inconsistency there.  This changes the default to be "middle", so changing the behavior with hardcopy but not changing it with HTML. 

To test, take your favorite image as `$image` and run the following. Make sure to look at HTML and hardcopy.

```
BEGIN_PGML
Top top top top top top top top top top top top top top top top top top top top top top [! alt text !]{$image}{image_options => {valign => 'top'}} top top top top top top top top top top top top top top top top top top top top

Middle middle middle middle middle middle middle middle middle middle middle middle middle [! alt text !]{$image}{image_options => {valign => 'middle'}} middle middle middle middle middle middle middle middle middle middle middle 

Bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom [! alt text !]{$image}{image_options => {valign => 'bottom'}}  bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom
END_PGML

BEGIN_TEXT
Top top top top top top top top top top top top top top top top top top top top top top \{image($image, valign => 'top')\} top top top top top top top top top top top top top top top top top top top top

Middle middle middle middle middle middle middle middle middle middle middle middle middle \{image($image, valign => 'middle')\} middle middle middle middle middle middle middle middle middle middle middle middle middle middle 

Bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom \{image($image, valign => 'bottom')\} bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom
END_TEXT
```