### PR TITLE
use \hiderowcolors to address possible colortbl bug

### DIFF
--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -4,7 +4,8 @@
 % packages that are needed for some PG macro to function for tex output or that
 % support math mode tex macros that could reasonably appear in a PG problem
 \usepackage{amsmath, amsfonts, amssymb}                                           % math macros
-\usepackage{booktabs, tabularx, colortbl, caption, xcolor}                        % niceTables.pl
+\usepackage{booktabs, tabularx, colortbl, caption}                                % niceTables.pl
+\usepackage[table]{xcolor}                                                        % niceTables.pl
 \usepackage{multicol}                                                             % DragNDrop.pm
 \usepackage[version=4]{mhchem}                                                    % chemistry macros
 

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -758,6 +758,10 @@ sub Rows {
 					if $x->{bottom};
 			}
 
+			# if this row had a row color, disable that now or else with nested tables
+			# the row color will extend into subsequent rows (this seems like a colortbl bug)
+			$row = suffix($row, '\hiderowcolors', ' ') if $rowcolor;
+
 			push(@rows, $row);
 		} elsif ($main::displayMode eq 'PTX') {
 			my $ptxbottom = '';


### PR DESCRIPTION
If you have nested niceTables (say a DataTable within a LayoutTable) there seems to be a bug with the `colortbl` package's `\rowcolor` command, and if you use it in the inner table, you end up coloring more than just the one row. You can see this with:

```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl niceTables.pl));
BEGIN_PGML
[@LayoutTable([[
    DataTable([
        [['', rowcolor => 'lightgray'], 'A', 'B'],
        [1, 2, 3],
    ])
]])@]*
END_PGML
ENDDOCUMENT();
```
which should only make the first row gray, but what I think is a bug is making both rows gray.

This commit addresses that by applying `\hiderowcolors` at the end of any row that set a row color. Note that you can give the second row a color, and that still works; this is not permanently taking away row colors.