### PR TITLE
Remove the usage of the system `cp`, `rm`, and `mv` external programs.

### DIFF
--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -52,7 +52,6 @@ directories:
     - $pg_root/macros/ui
     - $pg_root/macros/deprecated
 
-
 URLs:
   # The public URL of the html directory above.
   html: /pg_files
@@ -201,9 +200,10 @@ displayModeOptions:
       passwd: ''
 
 # PG modules to load
-# The first item of each list is the module to load. The remaining items are additional packages to import.
-# That is: If you wish to include a module MyModule.pm which depends on additional modules Dependency1.pm and
-# Dependency2.pm, these should appear as [Mymodule, Dependency1, Dependency2]
+# The first item of each list is the module file to load. The remaining items are additional packages to import that are
+# also contained in that file.
+# That is, if you wish to include a file MyModule.pm which containes the package MyModule and the additional packages
+# Dependency1 and Dependency2, then these should appear as [Mymodule, Dependency1, Dependency2].
 modules:
   - [Encode]
   - ['Encode::Encoding']
@@ -212,7 +212,8 @@ modules:
   - [DynaLoader]
   - [Exporter]
   - [GD]
-  - [AlgParser, AlgParserWithImplicitExpand, Expr, ExprWithImplicitExpand, utf8]
+  - [utf8]
+  - [AlgParser, AlgParserWithImplicitExpand, Expr, ExprWithImplicitExpand]
   - [AnswerHash, AnswerEvaluator]
   - [LaTeXImage]
   - [WWPlot] # required by Circle (and others)
@@ -235,14 +236,23 @@ modules:
   - [Select]
   - [Units]
   - [VectorField]
-  - [Parser, Value]
+  - [Parser]
+  - [Value]
   - ['Parser::Legacy']
   - [Statistics]
   - [Chromatic] # for Northern Arizona graph problems
   - [Applet]
-  - [PGcore, PGalias, PGresource, PGloadfiles, PGanswergroup, PGresponsegroup, 'Tie::IxHash']
+  - [PGcore]
+  - [PGalias]
+  - [PGresource]
+  - [PGloadfiles]
+  - [PGanswergroup]
+  - [PGresponsegroup]
+  - ['Tie::IxHash']
   - ['Locale::Maketext']
   - [JSON]
-  - [Rserve, 'Class::Tiny', 'IO::Handle']
+  - ['Class::Tiny']
+  - ['IO::Handle']
+  - ['Rserve']
   - [DragNDrop]
   - ['Types::Serialiser']

--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -84,9 +84,6 @@ equationCacheDB: ''
 
 externalPrograms:
   curl: /usr/bin/curl
-  cp: /bin/cp
-  mv: /bin/mv
-  rm: /bin/rm
   tar: /bin/tar
   latex: /usr/bin/latex --no-shell-escape
   pdflatex: /usr/bin/pdflatex --no-shell-escape

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -16,12 +16,15 @@
 
 # This is a Perl module which simplifies and automates the process of generating
 # simple images using LaTeX, and converting them into a web-useable format.  Its
-# typical usage is via the macro PGtikz.pl and is documented there.
+# typical usage is via the PGlateximage.pl or PGtikz.pl macros and is documented
+# there.
 
 package LaTeXImage;
 
 use strict;
 use warnings;
+
+use File::Copy qw(move);
 
 require WeBWorK::PG::IO;
 require WeBWorK::PG::ImageGenerator;
@@ -30,10 +33,9 @@ require WeBWorK::PG::ImageGenerator;
 sub new {
 	my $class = shift;
 	my $data  = {
-		tex         => '',
-		environment => '',
-		# if tikzOptions is nonempty, then environment
-		# will effectively be ['tikzpicture', tikzOptions]
+		tex => '',
+		# If tikzOptions is nonempty, then environment will effectively be [ 'tikzpicture', tikzOptions ].
+		environment    => '',
 		tikzOptions    => '',
 		tikzLibraries  => '',
 		texPackages    => [],
@@ -43,30 +45,27 @@ sub new {
 		convertOptions => { input => {}, output => {} },
 		imageName      => ''
 	};
-	my $self = sub {
-		my $field = shift;
-		if (@_) {
+	return bless sub {
+		my ($field, $value) = @_;
+		if (defined $value) {
 			# The ext field is protected to ensure that unsafe commands can not
 			# be passed to the command line in the system call it is used in.
 			if ($field eq 'ext') {
-				my $ext = shift;
-				$data->{ext} = $ext
-					if ($ext && ($ext =~ /^(png|gif|svg|pdf|tgz)$/));
+				$data->{ext} = $value if $value && ($value =~ /^(png|gif|svg|pdf|tgz)$/);
 			} else {
-				$data->{$field} = shift;
+				$data->{$field} = $value;
 			}
 		}
 		return $data->{$field};
-	};
-	return bless $self, $class;
+	}, $class;
 }
 
 # Accessors
 
-# Set LaTeX image code as a single string parameter.  Works best single quoted.
+# Set LaTeX image code as a single string parameter.
 sub tex {
-	my $self = shift;
-	return &$self('tex', @_);
+	my ($self, $tex) = @_;
+	return &$self('tex', $tex);
 }
 
 # Set an environment to surround the tex(). This can be a string naming the environment.
@@ -74,24 +73,24 @@ sub tex {
 # the environment. If there is a second element, it should be a string with options for
 # the environment. This could be extended to support environments with multiple option
 # fields that may use parentheses for delimiters.
-# If tikzOptions is nonempty, the input is ignored and output is ['tikzpicture',tikzOptions].
+# If tikzOptions is nonempty, the input is ignored and output is [ 'tikzpicture', tikzOptions ].
 sub environment {
-	my $self = shift;
-	return [ 'tikzpicture', $self->tikzOptions ] if ($self->tikzOptions ne '');
-	return [ &$self('environment', @_), '' ] if (ref(&$self('environment', @_)) ne 'ARRAY');
-	return &$self('environment', @_);
+	my ($self, $environment) = @_;
+	return [ 'tikzpicture', $self->tikzOptions ] if $self->tikzOptions ne '';
+	return [ &$self('environment', $environment), '' ] if ref(&$self('environment', $environment)) ne 'ARRAY';
+	return &$self('environment', $environment);
 }
 
 # Set TikZ picture options as a single string parameter.
 sub tikzOptions {
-	my $self = shift;
-	return &$self('tikzOptions', @_);
+	my ($self, $tikzOptions) = @_;
+	return &$self('tikzOptions', $tikzOptions);
 }
 
 # Set additional TikZ libraries to load as a single string parameter.
 sub tikzLibraries {
-	my $self = shift;
-	return &$self('tikzLibraries', @_);
+	my ($self, $tikzLibraries) = @_;
+	return &$self('tikzLibraries', $tikzLibraries);
 }
 
 # Set additional TeX packages to load.  This accepts an array parameter.  Note
@@ -99,15 +98,15 @@ sub tikzLibraries {
 # or two elements (the first element the package name, and the optional second
 # element the package options).
 sub texPackages {
-	my $self = shift;
-	return &$self('texPackages', $_[0]) if ref($_[0]) eq "ARRAY";
+	my ($self, $texPackages) = @_;
+	return &$self('texPackages', $texPackages) if ref($texPackages) eq 'ARRAY';
 	return &$self('texPackages');
 }
 
 # Additional TeX commands to add to the TeX preamble
 sub addToPreamble {
-	my $self = shift;
-	return &$self('addToPreamble', @_);
+	my ($self, $additionalPreamble) = @_;
+	return &$self('addToPreamble', $additionalPreamble);
 }
 
 # Set the image type.  The valid types are 'png', 'gif', 'svg', 'pdf', and 'tgz'.
@@ -115,31 +114,31 @@ sub addToPreamble {
 # The 'tgz' option should be set when 'PTX' is the display mode.
 # It creates a .tgz file containing .tex, .pdf, .png, and .svg versions of the image
 sub ext {
-	my $self = shift;
-	return &$self('ext', @_);
+	my ($self, $ext) = @_;
+	return &$self('ext', $ext);
 }
 
 # Set the method to use to generate svg images.  The valid methods are 'pdf2svg' and 'dvisvgm'.
 sub svgMethod {
-	my $self = shift;
-	return &$self('svgMethod', @_);
+	my ($self, $svgMethod) = @_;
+	return &$self('svgMethod', $svgMethod);
 }
 
 # Set the options to be used by ImageMagick convert.
 sub convertOptions {
-	my $self = shift;
-	return &$self('convertOptions', @_);
+	my ($self, $convertOptions) = @_;
+	return &$self('convertOptions', $convertOptions);
 }
 
 # Set the file name.
 sub imageName {
-	my $self = shift;
-	return &$self('imageName', @_);
+	my ($self, $imageName) = @_;
+	return &$self('imageName', $imageName);
 }
 
 sub header {
-	my $self   = shift;
-	my @output = ();
+	my $self = shift;
+	my @output;
 	push(@output, "\\documentclass{standalone}\n");
 	my @xcolorOpts = grep { ref $_ eq "ARRAY" && $_->[0] eq "xcolor" && defined $_->[1] } @{ $self->texPackages };
 	my $xcolorOpts = @xcolorOpts ? $xcolorOpts[0][1] : 'svgnames';
@@ -165,15 +164,15 @@ sub header {
 			if (defined $self->environment->[1] && $self->environment->[1] ne "");
 		push(@output, "\n");
 	}
-	@output;
+	return @output;
 }
 
 sub footer {
-	my $self   = shift;
-	my @output = ();
+	my $self = shift;
+	my @output;
 	push(@output, "\\end{", $self->environment->[0] . "}\n") if $self->environment->[0];
 	push(@output, "\\end{document}\n");
-	@output;
+	return @output;
 }
 
 # Generate the image file and return the stored location of the image.
@@ -181,45 +180,47 @@ sub draw {
 	my $self = shift;
 
 	my $working_dir = WeBWorK::PG::ImageGenerator::makeTempDirectory(WeBWorK::PG::IO::pg_tmp_dir(), "latex");
-	my $data;
 
 	my $ext       = $self->ext;
 	my $svgMethod = $self->svgMethod;
-
-	my $fh;
 
 	# Create either one or two tex files with one small difference:
 	# set pgfsysdriver to pgfsys-dvisvgm.def for a tex file that dvisvgm will use
 	# Then make only the dvi, only the pdf, or both in case we are making tgz with svg via dvisvgm
 	if (($ext eq 'svg' || $ext eq 'tgz') && $svgMethod eq 'dvisvgm') {
-		open($fh, ">", "$working_dir/image-dvisvgm.tex")
-			or warn "Can't open $working_dir/image-dvisvgm.tex for writing.";
-		my @header = $self->header;
-		splice @header, 1, 0, "\\def\\pgfsysdriver{pgfsys-dvisvgm.def}\n";
-		chmod(0777, "$working_dir/image-dvisvgm.tex");
-		print $fh @header;
-		print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
-		print $fh $self->footer;
-		close $fh;
-		system "cd $working_dir && "
-			. WeBWorK::PG::IO::externalCommand('latex')
-			. " --interaction=nonstopmode image-dvisvgm.tex > latex.stdout 2> /dev/null && "
-			. WeBWorK::PG::IO::externalCommand('mv')
-			. " image-dvisvgm.dvi image.dvi";
-		chmod(0777, "$working_dir/image.dvi");
+		if (open(my $fh, ">", "$working_dir/image-dvisvgm.tex")) {
+			my @header = $self->header;
+			splice @header, 1, 0, "\\def\\pgfsysdriver{pgfsys-dvisvgm.def}\n";
+			chmod(0777, "$working_dir/image-dvisvgm.tex");
+			print $fh @header;
+			print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
+			print $fh $self->footer;
+			close $fh;
+			system "cd $working_dir && "
+				. WeBWorK::PG::IO::externalCommand('latex')
+				. " --interaction=nonstopmode image-dvisvgm.tex > latex.stdout 2> /dev/null";
+			move("$working_dir/image-dvisvgm.dvi", "$working_dir/image.dvi");
+			chmod(0777, "$working_dir/image.dvi");
+		} else {
+			warn "Can't open $working_dir/image-dvisvgm.tex for writing.";
+			return '';
+		}
 	}
 	if ($ext ne 'svg' || ($ext eq 'svg' && $svgMethod ne 'dvisvgm')) {
-		open($fh, ">", "$working_dir/image.tex")
-			or warn "Can't open $working_dir/image.tex for writing.";
-		chmod(0777, "$working_dir/image.tex");
-		print $fh $self->header;
-		print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
-		print $fh $self->footer;
-		close $fh;
-		system "cd $working_dir && "
-			. WeBWorK::PG::IO::externalCommand('pdflatex')
-			. " --interaction=nonstopmode image.tex > pdflatex.stdout 2> /dev/null";
-		chmod(0777, "$working_dir/image.pdf");
+		if (open(my $fh, ">", "$working_dir/image.tex")) {
+			chmod(0777, "$working_dir/image.tex");
+			print $fh $self->header;
+			print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
+			print $fh $self->footer;
+			close $fh;
+			system "cd $working_dir && "
+				. WeBWorK::PG::IO::externalCommand('pdflatex')
+				. " --interaction=nonstopmode image.tex > pdflatex.stdout 2> /dev/null";
+			chmod(0777, "$working_dir/image.pdf");
+		} else {
+			warn "Can't open $working_dir/image.tex for writing.";
+			return '';
+		}
 	}
 
 	# Make derivatives of the dvi
@@ -267,6 +268,8 @@ sub draw {
 		warn "Failed to generate tgz file." unless -r "$working_dir/image.tgz";
 	}
 
+	my $data;
+
 	# Read the generated image file into memory
 	if (-r "$working_dir/image.$ext") {
 		open(my $in_fh, "<", "$working_dir/image.$ext")
@@ -279,16 +282,13 @@ sub draw {
 	}
 
 	# Delete the files used to generate the image.
-	if (-e $working_dir) {
-		system WeBWorK::PG::IO::externalCommand('rm') . " -rf $working_dir";
-	}
+	WeBWorK::PG::IO::remove_tree($working_dir) if -e $working_dir;
 
 	return $data;
 }
 
 sub use_svgMethod {
-	my $self        = shift;
-	my $working_dir = shift;
+	my ($self, $working_dir) = @_;
 	if ($self->svgMethod eq 'dvisvgm') {
 		system WeBWorK::PG::IO::externalCommand('dvisvgm')
 			. " $working_dir/image.dvi --no-fonts --output=$working_dir/image.svg > /dev/null 2>&1";
@@ -297,18 +297,20 @@ sub use_svgMethod {
 			. " $working_dir/image.pdf $working_dir/image.svg > /dev/null 2>&1";
 	}
 	warn "Failed to generate svg file." unless -r "$working_dir/image.svg";
+
+	return;
 }
 
 sub use_convert {
-	my $self        = shift;
-	my $working_dir = shift;
-	my $ext         = shift;
+	my ($self, $working_dir, $ext) = @_;
 	system WeBWorK::PG::IO::externalCommand('convert')
 		. join('', map { " -$_ " . $self->convertOptions->{input}->{$_} } (keys %{ $self->convertOptions->{input} }))
 		. " $working_dir/image.pdf"
 		. join('', map { " -$_ " . $self->convertOptions->{output}->{$_} } (keys %{ $self->convertOptions->{output} }))
 		. " $working_dir/image.$ext > /dev/null 2>&1";
 	warn "Failed to generate $ext file." unless -r "$working_dir/image.$ext";
+
+	return;
 }
 
 1;

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -18,13 +18,13 @@
 # simple images using LaTeX, and converting them into a web-useable format.  Its
 # typical usage is via the macro PGtikz.pl and is documented there.
 
+package LaTeXImage;
+
 use strict;
 use warnings;
-use Carp;
-use WeBWorK::PG::IO;
-use WeBWorK::PG::ImageGenerator;
 
-package LaTeXImage;
+require WeBWorK::PG::IO;
+require WeBWorK::PG::ImageGenerator;
 
 # The constructor (it takes no parameters)
 sub new {

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -32,7 +32,7 @@ use PGrandom;
 use PGalias;
 use PGloadfiles;
 use AnswerHash;
-use WeBWorK::PG::IO();    # don't important any command directly
+require WeBWorK::PG::IO;
 use Tie::IxHash;
 use MIME::Base64();
 use PGUtil();
@@ -764,7 +764,6 @@ sub getUniqueName {
 		convertPath
 		fileFromPath
 		directoryFromPath
-		createDirectory
 
 =cut
 
@@ -801,11 +800,6 @@ sub directoryFromPath {
 	WeBWorK::PG::IO::directoryFromPath(@_);
 }
 
-sub createDirectory {
-	my $self = shift;
-	WeBWorK::PG::IO::createDirectory(@_);
-}
-
 sub AskSage {
 	my $self    = shift;
 	my $python  = shift;
@@ -835,7 +829,6 @@ course temp directory.
 
 # ^function surePathToTmpFile
 # ^uses getCourseTempDirectory
-# ^uses createDirectory
 
 sub surePathToTmpFile {
 	# constructs intermediate directories if needed beginning at ${Global::htmlDirectory}tmp/
@@ -851,7 +844,7 @@ sub surePathToTmpFile {
 		$parentDirectory = $self->directoryFromPath($parentDirectory);
 		my ($perms, $groupID) = (stat $parentDirectory)[ 2, 5 ];
 		#warn "Creating tmp directory at $tmpDirectory, perms $perms groupID $groupID";
-		$self->createDirectory($tmpDirectory, $perms, $groupID)
+		WeBWorK::PG::IO::createDirectory($tmpDirectory, $perms, $groupID)
 			or warn "Failed to create parent tmp directory at $path";
 
 	}
@@ -872,7 +865,7 @@ sub surePathToTmpFile {
 		$path = $path . shift(@nodes) . "/";    #convertPath($path . shift (@nodes) . "/");
 
 		unless (-e $path) {
-			$self->createDirectory($path, $perms, $groupID)
+			WeBWorK::PG::IO::createDirectory($path, $perms, $groupID)
 				or $self->warning_message(
 					"Failed to create directory at $path with permissions $perms and groupID $groupID");
 		}

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -711,7 +711,7 @@ sub insertGraph {
 	my ($self, $graph) = @_;
 
 	my $fileName = $graph->imageName . '.' . $graph->ext;
-	my $filePath = $self->surePathToTmpFile($self->convertPath("images/$fileName"));
+	my $filePath = $self->surePathToTmpFile("images/$fileName");
 
 	# Check to see if we already have this graph, or if we have to make it.
 	if (!-e $filePath
@@ -761,7 +761,6 @@ sub getUniqueName {
 
 		includePGtext
 		read_whole_problem_file
-		convertPath
 		fileFromPath
 		directoryFromPath
 
@@ -785,11 +784,6 @@ sub read_whole_problem_file {
 	WeBWorK::PG::IO::read_whole_problem_file(@_);
 }
 
-sub convertPath {
-	my $self = shift;
-	WeBWorK::PG::IO::convertPath(@_);
-}
-
 sub fileFromPath {
 	my $self = shift;
 	WeBWorK::PG::IO::fileFromPath(@_);
@@ -804,7 +798,7 @@ sub AskSage {
 	my $self    = shift;
 	my $python  = shift;
 	my $options = shift;
-	$options->{curlCommand} = WeBWorK::PG::IO::curlCommand();
+	$options->{curlCommand} = WeBWorK::PG::IO::externalCommand('curl');
 	WeBWorK::PG::IO::AskSage($python, $options);
 }
 
@@ -862,7 +856,7 @@ sub surePathToTmpFile {
 	$path = $tmpDirectory;
 
 	while (@nodes > 1) {
-		$path = $path . shift(@nodes) . "/";    #convertPath($path . shift (@nodes) . "/");
+		$path = $path . shift(@nodes) . "/";
 
 		unless (-e $path) {
 			WeBWorK::PG::IO::createDirectory($path, $perms, $groupID)
@@ -872,7 +866,7 @@ sub surePathToTmpFile {
 
 	}
 
-	$path = $path . shift(@nodes);    #convertPath($path . shift(@nodes));
+	$path = $path . shift(@nodes);
 	return $path;
 }
 

--- a/lib/Statistics.pm
+++ b/lib/Statistics.pm
@@ -57,7 +57,6 @@ sub make_csv_alias {
 
 	# Define the file name, clean it up and convert to a url.
 	my $filePath = "data/$studentLogin-$problemSeed-set" . $setName . "prob$prob.html";
-	$filePath = $self->{PG}->convertPath($filePath);
 	$filePath = $self->{PG}->surePathToTmpFile($filePath);
 	my $url = $self->{PG}->{PG_alias}->make_alias($filePath);
 

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -16,80 +16,84 @@
 package WeBWorK::PG::IO;
 use parent qw(Exporter);
 
-use strict;
-use warnings;
-
-use Encode qw( encode decode);
-use JSON qw(decode_json);
-use File::Spec::Functions qw(canonpath);
-use PGUtil qw(not_null);
-use WeBWorK::PG::Environment;
-use utf8;
-#binmode(STDOUT,":encoding(UTF-8)");
-#binmode(STDIN,":encoding(UTF-8)");
-#binmode(INPUT,":encoding(UTF-8)");
-
-my $pg_envir = WeBWorK::PG::Environment->new;
-
 =head1 NAME
 
-WeBWorK::PG::IO - Functions used by WeBWorK::PG::Translator for file IO.
-
-=cut
-
-our @EXPORT_OK = qw(
-	includePGtext
-	read_whole_problem_file
-	read_whole_file
-	convertPath
-	fileFromPath
-	directoryFromPath
-);
+WeBWorK::PG::IO - Functions used by C<WeBWorK::PG::Translator> for file IO.
 
 =head1 DESCRIPTION
 
 This module defines several functions to be shared with a safe compartment by
 the PG translator.  All exported methods are shared.
 
+=cut
+
+use strict;
+use warnings;
+use utf8;
+
+use Encode qw(encode decode);
+use JSON qw(decode_json);
+use File::Spec::Functions qw(canonpath);
+
+use PGUtil qw(not_null);
+use WeBWorK::PG::Environment;
+
+our @EXPORT_OK = qw(
+	includePGtext
+	read_whole_problem_file
+	read_whole_file
+	fileFromPath
+	directoryFromPath
+);
+
+my $pg_envir = WeBWorK::PG::Environment->new;
+
 =head1 FUNCTIONS
 
-=over
+=head2 includePGtext
 
-=item includePGtext($string_ref)
+This is used in processing some of the sample CAPA files and in creating aliases
+to redirect calls to duplicate problems so that they go to the original problem
+instead.  It is called by includePGproblem.
 
-This is used in processing some of the sample CAPA files and
-in creating aliases to redirect calls to duplicate problems so that
-they go to the original problem instead.  It is called by includePGproblem.
+Usage: C<includePGtext($str)>
 
-It reads and evaluates the string in the same way that the Translator evaluates the string in a PG file.
+Note that the C<$str> parameter may be a string or a reference to a string.
+
+It reads and evaluates the string in the same way that the Translator evaluates
+the string in a PG file.
 
 =cut
 
 sub includePGtext {
 	my $evalString = shift;
-	if (ref($evalString) eq 'SCALAR') {
-		$evalString = $$evalString;
-	}
+	$evalString = $$evalString if ref($evalString) eq 'SCALAR';
 
 	no strict;
-	$evalString = eval(q! &{$main::PREPROCESS_CODE}($evalString) !);
-	$evalString = $evalString || '';
-	# current preprocessing code passed from Translator (see Translator::initialization)
+
+	# Preprocess code (this method is shared to the WWSafe compartment in Translator::initialize)
+	$evalString = eval(q!&{$main::PREPROCESS_CODE}($evalString)!) || '';
+
 	my $errors = $@;
 	eval("package main; $evalString");
 	$errors .= $@;
-	die eval(q! "ERROR in included file:\n$main::envir{probFileName}\n $errors\n$evalString"!) if $errors;
+	die eval(q!"ERROR in included file:\n$main::envir{probFileName}\n$errors\n$evalString"!) if $errors;
+
 	use strict;
-	return "";
+
+	return '';
 }
 
-=item read_whole_problem_file($filePath)
+=head2 read_whole_problem_file
+
+Read the contents of a pg file.
+
+Usage: C<read_whole_problem_file($filePath)>
 
 Don't use for huge files. The file name will have .pg appended to it if it
-doesn't already end in .pg.  Files may become double spaced.?  Check the join
-below. This is used in importing additional .pg files as is done in the sample
-problems translated from CAPA. Returns a reference to a string containing the
-contents of the file.
+doesn't already end in .pg.  This is used in importing additional .pg files as
+is done in the sample problems translated from CAPA. Returns a reference to a
+string containing the contents of the file.
 
 =cut
 
@@ -97,73 +101,77 @@ sub read_whole_problem_file {
 	my $filePath = shift;
 	$filePath =~ s/^\s*|\s$//g;    # get rid of leading and trailing spaces
 	$filePath = "$filePath.pg" unless $filePath =~ /\.pg$/;
-	read_whole_file($filePath);
+	return read_whole_file($filePath);
 }
+
+=head2 read_whole_file
+
+Read the contents of a file.  Don't use for huge files.
+
+Usage: C<read_whole_file($filePath)>
+
+=cut
 
 sub read_whole_file {
 	my $filePath = shift;
-	warn "Can't read file $filePath<br/>" unless -r $filePath;
-	return ""                             unless -r $filePath;
-	die "File path $filePath is unsafe."
-		unless path_is_readable_subdir($filePath);
 
-	local (*INPUT);
-	open(INPUT, "<:raw", $filePath) || die "$0: read_whole_file subroutine: <BR>Can't read file $filePath";
-	local ($/) = undef;
-	my $string        = <INPUT>;
-	my $backup_string = $string;
-	# can't append spaces because this causes trouble with <<'EOF'   \nEOF construction
-	my $success = utf8::decode($string);
-	unless ($success) {
-		warn "There was an error decoding $filePath as UTF-8, will try to upgrade";
-	utf8: upgrade($backup_string);
-		$string = $backup_string;
+	unless (-r $filePath) {
+		warn "Can't read file $filePath.";
+		return '';
 	}
-	close(INPUT);
-	\$string;
+	die "File path $filePath is unsafe." unless path_is_readable_subdir($filePath);
+
+	open(my $INPUT, "<:raw", $filePath) or die "$0: read_whole_file subroutine: Can't read file $filePath";
+	local $/ = undef;
+	my $string = <$INPUT>;
+	close($INPUT);
+
+	my $backup_string = $string;
+	unless (utf8::decode($string)) {
+		warn "There was an error decoding $filePath as UTF-8, will try to upgrade";
+		$string = utf8::upgrade($backup_string);
+	}
+
+	return \$string;
 }
 # <:utf8 is more relaxed on input, <:encoding(UTF-8) would be better, but
 # perhaps it's not so horrible to have lax input. encoding(UTF-8) tries to use require
 # to import Encode, Encode::Alias::find_encoding and Safe raises an exception.
 # haven't figured a way around this yet.
 
-=item convertPath($path)
+=head2 fileFromPath
 
-Currently a no-op. Returns $path unmodified.
+Usage: C<fileFromPath($path)>
 
-=cut
-
-sub convertPath {
-	return wantarray ? @_ : shift;
-}
-
-=item fileFromPath($path)
-
-Returns the last segment of the path (i.e. the text after the last forward slash).
+Returns the last segment of the path (i.e. the text after the last forward
+slash).
 
 =cut
 
 sub fileFromPath {
 	my $path = shift;
-	$path = convertPath($path);
 	$path =~ m|([^/]+)$|;
-	$1;
+	return $1;
 }
 
-=item directoryFromPath($path)
+=head2 directoryFromPath
 
-Returns the initial segments of the of the path (i.e. the text up to the last forward slash).
+Usage: C<directoryFromPath($path)>
+
+Returns the initial segments of the of the path (i.e. the text up to the last
+forward slash).
 
 =cut
 
 sub directoryFromPath {
 	my $path = shift;
-	$path = convertPath($path);
 	$path =~ s|[^/]*$||;
-	$path;
+	return $path;
 }
 
-=item createFile($fileName, $permission, $numgid)
+=head2 createFile
+
+Usage: C<createFile($fileName, $permission, $numgid)>
 
 Creates a file with the given name, permission bits, and group ID.
 
@@ -174,22 +182,25 @@ sub createFile {
 
 	die 'Path is unsafe' unless path_is_readable_subdir($fileName);
 
-	open(TEMPCREATEFILE, ">:encoding(UTF-8)", $fileName)
-		or die "Can't open $fileName: $!";
-	my @stat = stat TEMPCREATEFILE;
-	close(TEMPCREATEFILE);
+	open(my $TEMPCREATEFILE, ">:encoding(UTF-8)", $fileName) or die "Can't open $fileName: $!";
+	my @stat = stat $TEMPCREATEFILE;
+	close($TEMPCREATEFILE);
 
-	# if the owner of the file is running this script (e.g. when the file is
-	# first created) set the permissions and group correctly
+	# If the owner of the file is running this script (e.g. when the file is
+	# first created) set the permissions and group correctly.
 	if ($< == $stat[4]) {
 		my $tmp = chmod($permission, $fileName)
 			or warn "Can't do chmod($permission, $fileName): $!";
 		chown(-1, $numgid, $fileName)
 			or warn "Can't do chown($numgid, $fileName): $!";
 	}
+
+	return;
 }
 
-=item createDirectory($dirName, $permission, $numgid)
+=head2 createDirectory
+
+Usage: C<createDirectory($dirName, $permission, $numgid)>
 
 Creates a directory with the given name, permission bits, and group ID.
 
@@ -198,8 +209,8 @@ Creates a directory with the given name, permission bits, and group ID.
 sub createDirectory {
 	my ($dirName, $permission, $numgid) = @_;
 
-	$permission = (defined($permission)) ? $permission : '0770';
-	# FIXME -- find out where the permission is supposed to be defined
+	$permission //= oct(770);
+
 	my $errors = '';
 	mkdir($dirName, $permission)
 		or $errors .= "Can't do mkdir($dirName, $permission): $!\n" . caller(3);
@@ -209,6 +220,7 @@ sub createDirectory {
 		chown(-1, $numgid, $dirName)
 			or $errors .= "Can't do chown(-1,$numgid,$dirName): $!\n" . caller(3);
 	}
+
 	if ($errors) {
 		warn $errors;
 		return 0;
@@ -242,9 +254,12 @@ sub path_is_subdir {
 	return 1;
 }
 
-=item path_is_readable_subdir($path)
+=head2 path_is_readable_subdir
 
-Checks to see if the given path is a sub directory of the directory the caller says we are allowed to read from.
+Usage: C<path_is_readable_subdir($path)>
+
+Checks to see if the given path is a sub directory of the directory the caller
+says we are allowed to read from.
 
 =cut
 
@@ -252,49 +267,38 @@ sub path_is_readable_subdir {
 	return path_is_subdir(shift, $pg_envir->{directories}{permitted_read_dir}, 1);
 }
 
+=head2 pg_tmp_dir
+
+Returns the temporary directory set in the WeBWorK::PG::Environment.
+
+=cut
+
 sub pg_tmp_dir {
 	return $pg_envir->{directories}{tmp};
 }
 
-=item curlCommand
+=head2 externalCommand
 
-	curl -- path to curl defined in site.conf
+Usage: C<externalCommand($command)>
 
-=cut
-
-sub curlCommand {
-	return $pg_envir->{externalPrograms}{curl};
-}
-
-=item copyCommand
-
-	copyCommand -- path to cp defined in site.conf
-
-=cut
-
-sub copyCommand {
-	return $pg_envir->{externalPrograms}{cp};
-}
-
-=item externalCommand
-
-	returns the path to a requested external command that is defined in site.conf
+Returns the path to a requested external command that is defined in the
+C<WeBWorK::PG::Environment>.
 
 =cut
 
 sub externalCommand {
-	return $pg_envir->{externalPrograms}{ $_[0] };
+	my $cmd = shift;
+	return $pg_envir->{externalPrograms}{$cmd};
 }
 
-#
-# isolate the call to the sage server in case we have to jazz it up
-#
+# Isolate the call to the sage server in case we have to jazz it up.
 sub query_sage_server {
 	my ($python, $url, $accepted_tos, $setSeed, $webworkfunc, $debug, $curlCommand) = @_;
-#	my $sagecall = 	qq{$curlCommand -i -k -sS -L --http1.1 --data-urlencode "accepted_tos=${accepted_tos}"}.
-#	                qq{ --data-urlencode 'user_expressions={"WEBWORK":"_webwork_safe_json(WEBWORK)"}' --data-urlencode "code=${setSeed}${webworkfunc}$python" $url};
-	my $sagecall = qq{$curlCommand -i -k -sS -L  --data-urlencode "accepted_tos=${accepted_tos}"}
-		. qq{ --data-urlencode 'user_expressions={"WEBWORK":"_webwork_safe_json(WEBWORK)"}' --data-urlencode "code=${setSeed}${webworkfunc}$python" $url};
+	my $sagecall =
+		qq{$curlCommand -i -k -sS -L }
+		. qq{--data-urlencode "accepted_tos=${accepted_tos}" }
+		. qq{--data-urlencode 'user_expressions={"WEBWORK":"_webwork_safe_json(WEBWORK)"}' }
+		. qq{--data-urlencode "code=${setSeed}${webworkfunc}$python" $url};
 
 	my $output = `$sagecall`;
 	if ($debug) {
@@ -303,7 +307,8 @@ sub query_sage_server {
 		warn "\n\nRETURN from sage call \n",             $output,   "\n\n";
 		warn "\n\n END SAGE CALL";
 	}
-	# has something been returned?
+
+	# Has something been returned?
 	# $continue: 	HTTP/1.1 100 (Continue)
 	# $header: 		HTTP/1.1 200 OK
 	# 				Content-Length: 1625
@@ -331,47 +336,54 @@ sub query_sage_server {
 	#   content
 
 	my ($continue, $header, @content) = split("\r\n\r\n", $output);
-	#my $content = join("\r\n\r\n",@content); # handle case where there were blank lines in the content
 	my @lines = split("\r\n\r\n", $output);
 	$continue = 0;
 	my $header_ok = 0;
 	while (@lines) {
 		my $header_block = shift(@lines);
 		warn "checking for header:  $header_block" if $debug;
-		next unless $header_block =~ /\S/;                #skip empty lines;
+		next unless $header_block =~ /\S/;                # skip empty lines;
 		next if ($header_block =~ m!HTTP[ 12/.]+100!);    # skip continue line
 		if ($header_block =~ m!HTTP[ 12/.]+200!) {        # 200 return is ok
 			$header_ok = 1;
 			last;
 		}
 	}
-	my $content = join("|||\n|||", @lines);    #headers have been removed.
-		#warn "output list is ", $content; # join("|||\n|||",($continue, $header, $content));
-		#warn "header_ok is $header_ok";
+	my $content = join("|||\n|||", @lines);               # headers have been removed.
 	my $result;
-	if ($header_ok) {    #success put any extraneous splits back together
+	if ($header_ok) {
+		# Success! Put any extraneous splits back together.
 		$result = join("\r\n\r\n", @lines);
 	} else {
-		warn "ERROR in contacting sage server. Did you accept the terms of service by
-		      setting {accepted_tos=>'true'} in the askSage options?\n $content\n";
+		warn "ERROR in contacting sage server. Did you accept the terms of service by "
+			. "setting { accepted_tos => 'true' } in the askSage options?\n$content\n";
 		$result = undef;
 	}
-	$result;
+
+	return $result;
 }
 
+=head2 AskSage
+
+Usage: C<AskSage($python, $args)>
+
+Executes a sage cell server query via curl and returns the result.
+
+=cut
+
 sub AskSage {
-	#
-	# to send values back in a hash, add them to the python WEBWORK dictionary
-	#
-	chomp(my $python = shift);
-	my $args         = shift @_;
+	my ($python, $args) = @_;
+	chomp($python);
+
+	# To send values back in a hash, add them to the python WEBWORK dictionary.
 	my $url          = $args->{url} || 'https://sagecell.sagemath.org/service';
 	my $seed         = $args->{seed};
-	my $accepted_tos = $args->{accepted_tos} || 'false';    # force author to accept terms of service explicitly :-)
+	my $accepted_tos = $args->{accepted_tos} || 'false';    # Force author to accept terms of service explicitly.
 	my $debug        = $args->{debug}        || 0;
 	my $setSeed      = $seed ? "set_random_seed($seed)\n" : '';
 	my $curlCommand  = $args->{curlCommand};
-	my $webworkfunc  = <<END;
+
+	my $webworkfunc = <<END;
 WEBWORK={}
 
 def _webwork_safe_json(o):
@@ -399,7 +411,7 @@ def _webwork_safe_json(o):
     return json.dumps(o, default=default)
 END
 
-	my $ret = { success => 0 };    # we want to export more than one piece of information
+	my $ret = { success => 0 };    # We want to export more than one piece of information.
 	eval {
 		my $output = query_sage_server($python, $url, $accepted_tos, $setSeed, $webworkfunc, $debug, $curlCommand);
 
@@ -415,16 +427,15 @@ END
 			my $warning_string = "decoded contents\n ";
 			foreach my $key (keys %$decoded) { $warning_string .= "$key=" . $decoded->{$key} . ", "; }
 			$warning_string .= ' end decoded contents';
-			#warn "\n$warning_string" if $debug;
 			warn " decoded contents \n", PGUtil::pretty_print($decoded, 'text'), "end decoded contents" if $debug;
 		}
-		# was there a Sage/python syntax Error
-		# is the returned something text from stdout (deprecated)
-		# have objects been returned in a WEBWORK variable?
+		# Was there a Sage/python syntax error?
+		# Is the returned something text from stdout? (deprecated)
+		# Have objects been returned in a WEBWORK variable?
 		my $success = 0;
 		$success = $decoded->{success} if defined $decoded and $decoded->{success};
 		warn "success  is $success" if $debug;
-		# the decoding process seems to change the string "true" to "1" sometimes -- we could enforce this
+		# The decoding process seems to change the string "true" to "1" sometimes -- we could enforce this
 		$success = 1 if defined $success and $success eq 'true';
 		$success = 1 if $decoded->{execute_reply}->{status} eq 'ok';
 		warn "now success  is $success because status was ok" if $debug;
@@ -433,37 +444,39 @@ END
 			my $sage_WEBWORK_data          = $decoded->{execute_reply}{user_expressions}{WEBWORK}{data}{'text/plain'};
 			warn "sage_WEBWORK_data $sage_WEBWORK_data" if $debug;
 			if (not_null($sage_WEBWORK_data)) {
-				$WEBWORK_variable_non_empty =    #another hack because '{}' is sometimes returned
+				$WEBWORK_variable_non_empty =    # another hack because '{}' is sometimes returned
 					($sage_WEBWORK_data ne "{}" and $sage_WEBWORK_data ne "'{}'") ? 1 : 0;
 			}    # {} indicates that WEBWORK was not used to pass or return a variable from sage.
 
 			warn "WEBWORK variable has content" if $debug and $WEBWORK_variable_non_empty;
-			$sage_WEBWORK_data =~ s/^'//;    #FIXME -- for now strip off the surrounding single quotes '.
+			$sage_WEBWORK_data =~ s/^'//;    # FIXME: For now strip off the surrounding single quotes.
 			$sage_WEBWORK_data =~ s/'$//;
 			warn "sage_WEBWORK_data: ", PGUtil::pretty_print($sage_WEBWORK_data)
 				if $debug and $WEBWORK_variable_non_empty;
 
 			if ($WEBWORK_variable_non_empty) {
-				# have specific WEBWORK variables been defined?
+				# Have specific WEBWORK variables been defined?
 				$ret->{webwork} = decode_json($sage_WEBWORK_data);
 				$ret->{success} = 1;
 				$ret->{stdout}  = $decoded->{stdout};
-			} elsif (not_null($decoded->{stdout})) {    # no WEBWORK content, but stdout exists
-														# old style text output via stdout (deprecated)
-				$ret = $decoded->{stdout};              # only standard out is returned
+			} elsif (not_null($decoded->{stdout})) {
+				# No WEBWORK content, but stdout exists.
+				# Old style text output via stdout (deprecated)
+				$ret = $decoded->{stdout};    # only standard out is returned
 				warn "no content in WEBWORK variable. Returning stdout", $ret if $debug;
 			} else {
 				die "Error receiving JSON output from sage: \n$output\n ";
 			}
-		} elsif ($success == 0) {    # this might be a syntax error
-			$ret->{error_message} =
-				$decoded->{execute_reply};    # this is a hash.  # need a better pretty print method
+		} elsif ($success == 0) {
+			# This might be a syntax error.
+			$ret->{error_message} = $decoded->{execute_reply};    # This is a hash.  Need a better pretty print method.
 			warn("IO.pm: Perhaps there was syntax error.", join(" ", %{ $decoded->{execute_reply} }));
 		} else {
 			die "IO.pm: Unknown error in asking Sage to do something: success = $success output = \n$output\n";
 		}
 
 	};    # end eval{} for trapping errors in sage call
+
 	if ($@) {
 		warn "IO.pm: ERROR trapped during JSON call to sage:\n $@ ";
 		if (ref($ret) =~ /HASH/) {
@@ -472,11 +485,8 @@ END
 			$ret = undef;
 		}
 	}
+
 	return $ret;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -37,20 +37,14 @@ WeBWorK::PG::IO - Functions used by WeBWorK::PG::Translator for file IO.
 
 =cut
 
-our @EXPORT = qw(
+our @EXPORT_OK = qw(
 	includePGtext
 	read_whole_problem_file
 	read_whole_file
 	convertPath
 	fileFromPath
 	directoryFromPath
-	createDirectory
 );
-
-=head1 SYNOPSIS
-
- use WeBWorK::PG::IO;
- my %functions_to_share = %WeBWorK::PG::IO::SHARE;
 
 =head1 DESCRIPTION
 

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -34,6 +34,7 @@ use utf8;
 use Encode qw(encode decode);
 use JSON qw(decode_json);
 use File::Spec::Functions qw(canonpath);
+use File::Find qw(finddepth);
 
 use PGUtil qw(not_null);
 use WeBWorK::PG::Environment;
@@ -227,6 +228,26 @@ sub createDirectory {
 	} else {
 		return 1;
 	}
+}
+
+=head2 remove_tree
+
+Usage: C<remove_tree($dir)>
+
+Remove a directory and its contents.
+
+=cut
+
+sub remove_tree {
+	my $dir = shift;
+
+	finddepth sub {
+		if (!-l && -d _) {
+			rmdir($File::Find::name) or warn "Unable to remove directory $File::Find::name: $!";
+		} else {
+			unlink($File::Find::name) or warn "Unable to delete file $File::Find::name: $!";
+		}
+	}, $dir;
 }
 
 # This is needed for the subroutine below.  It is copied from WeBWorK::Utils.

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -302,7 +302,7 @@ sub initialize {
 	my $safe_cmpt = $self->{safe};
 
 	$safe_cmpt->share_from('WeBWorK::PG::Translator', \@Translator_shared_subroutine_array);
-	$safe_cmpt->share_from('WeBWorK::PG::IO',         \@WeBWorK::PG::IO::EXPORT);
+	$safe_cmpt->share_from('WeBWorK::PG::IO',         \@WeBWorK::PG::IO::EXPORT_OK);
 
 	no strict;
 	local (%envir) = %{ $self->{envir} };

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -255,7 +255,6 @@ sub new {
 
     &be_strict
     &read_whole_problem_file
-    &convertPath
     &surePathToTmpFile
     &fileFromPath
     &directoryFromPath
@@ -275,7 +274,6 @@ template.
 The macros shared with the safe compartment are
 
     '&read_whole_problem_file'
-    '&convertPath'
     '&surePathToTmpFile'
     '&fileFromPath'
     '&directoryFromPath'


### PR DESCRIPTION
`rm` and `mv` were used in the `LaTeXImage.pm` module.  Removing the `mv` usage was easy.  The `move` method from the `File::Copy` module can be used without being shared to the safe compartment.  The `rm` method is trickier since its usage was a recursive directory removal.  You can't use the `remove_tree` method of the `File::Path` module as that requires sharing the `File::Spec` module to the safe compartment.  That is not a good idea.  So instead a `remove_tree` method is implemented in `WeBWorK::PG::IO` using `File::Find` (which works without being shared to the safe compartment).

The unused `copyCommand` method has been removed.  The last usage of the `curlCommand` method was replaced with the `externalCommand` method, and the `curlCommand` method removed.  Those commands can still be used via the more general `externalCommand` method, although the `cp` external command shouldn't be used anymore.
    
There is also some general clean up of the `WeBWorK::PG::IO` module.  The no-op `convertPath` method has been removed.  The POD has been cleaned up.  All methods that can be used by other modules are now document (in some cases poorly though -- like the AskSage method).  There were some syntax errors and perlcritic issues fixed in the code.

The `LaTeXImage.pm` has some related clean up as well.

Note that this includes pull request #898.