### PR TITLE
PGML tables

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1212,7 +1212,7 @@ sub pushItem {
 		if ($item->{type} eq 'text') {
 			my $text = join('', @{ $item->{stack} });
 			PGML::Warning 'Table row text must be in cells' unless $text =~ m/^\s*$/;
-		} elsif ($item->{type} eq 'table-cell') {
+		} elsif ($item->{type} eq 'table-cell' || $item->{type} eq 'options') {
 			$self->SUPER::pushItem($item);
 		} elsif ($item->{type} eq 'comment') {
 		} else {

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -594,6 +594,7 @@ my $balanceAll = qr/[\{\[\'\"]/;
 		class        => 'PGML::Block::Table',
 		parseAll     => 1,
 		ignoreIndent => 1,
+		allowPar     => 1,
 		terminator   => qr/#\]/,
 		allowStar    => 1,
 		options      => [ qw(


### PR DESCRIPTION
This brings table-making to PGML, starting with work by @dpvc responding to #909, with some amendments I made. It is not ready yet, because options on cells do not work. Options on a cell should work like `[. cell content .]{b => 1}` for example to make the cell bold. But instead the presence of option braces is somehow preventing the cell from even becoming a part of its row. @dpvc , do you see what the issue is there?

```
DOCUMENT();
loadMacros(
    "PGstandard.pl",
    "PGML.pl",
);

BEGIN_PGML
[# [- [. [`x`] .] [. [`x^2`].] -] [- [. [`1`] .] [. [_]{1} .] -] #]

[# [- [. [`x`] .] [. [`x^2`].] -] [- [. [`1`] .] [. [_]{1} .] -] #]{center => 0}

[#
    [-
        [. [`x`] .]
        [. [`x^2`].]
     -]
    [-
        [. [`1`] .]
        [. [_]{1} .]
     -]
#]{align => '|c|c|', horizontalrules => 1}

[#
    [-
        [. [`x`] .]
        [. [`x^2`].]
     -]
    [-
        [. [`1`] .]
        [. [_]{1} .]
     -]
#]{center => 0, align => '|c|c|', horizontalrules => 1}
END_PGML
ENDDOCUMENT();
```

I also need to look into the codemirror syntax highlighting, since a line opening with `#]` is being treated as a heading.

