### PR TITLE
escape pattern for EV3P for perl/latex brace conflict (hotfix)

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2286,11 +2286,12 @@ sub EV3P {
 	my $option_ref = {};
 	$option_ref = shift if ref($_[0]) eq 'HASH';
 	my %options = (
-		processCommands  => 1,
-		processVariables => 1,
-		processParser    => 1,
-		processMath      => 1,
-		fixDollars       => 1,
+		processCommands        => 1,
+		processVariables       => 1,
+		processParser          => 1,
+		processMath            => 1,
+		fixDollars             => 1,
+		escapeBraceBackslashes => 1,
 		%{$option_ref},
 	);
 	my $string = join(" ", @_);
@@ -2298,6 +2299,7 @@ sub EV3P {
 	if ($options{processVariables}) {
 		my $eval_string = $string;
 		$eval_string =~ s/\$(?![a-z\{])/\${DOLLAR}/gi if $options{fixDollars};
+		$eval_string =~ s/\{(?=\\\\[^\\])/\\\{/g      if $options{escapeBraceBackslashes};
 		my ($evaluated_string, $PG_eval_errors, $PG_full_errors) =
 			PG_restricted_eval("<<END_OF_EVALUATION_STRING\n$eval_string\nEND_OF_EVALUATION_STRING\n");
 		if ($PG_eval_errors) {


### PR DESCRIPTION
This is an alternative to #915, as mentioned there. This approach escapes a brace that we are pretty sure is not intended to be part of a perl hash value accessor. I lean toward this approach since it doesn't require macro authors to know about the underlying issue with braces. And if it needs adjusting, it's just in one place.

This is a conservative regex pattern that only escapes the brace if followed by backslash,backslash,not-backslash. It could be a little less conservative. Or a lot less conservative like `s/\{(?!\s*[\$\w])/\\\{/g`, _always_ escaping a brace unless it is followed by a word character or a dollar sign, which could indicate the brace was indeed meant to be part of a hash value accessor.

I'll wait for discussion to see if this goes forward ro needs changing, before opening a `develop` version.