### PR TITLE
Improved non-recursive version of contFrac in contextFraction.pl.

### DIFF
--- a/t/contexts/fraction.t
+++ b/t/contexts/fraction.t
@@ -21,9 +21,24 @@ import Parser::Legacy;
 
 Context('Fraction');
 
-ok my $a1 = Compute('1/2');
-ok my $a2 = Compute('2/4');
+subtest 'contextFraction: Basic computation and reduction' => sub {
+	ok my $a1 = Compute('1/2'), 'compute 1/2';
+	ok my $a2 = Compute('2/4'), 'compute 2/4';
 
-is $a1->value, $a2->value, 'contextFraction: reduce fractions';
+	is $a1->value, $a2->value, 'comparison (1/2 = 2/4)';
+};
+
+subtest 'contextFraction: Conversion of real to fraction' => sub {
+	my ($result, $direct);
+	for my $num (1 .. 100) {
+		for my $den (1 .. 100) {
+			my $real = Real($num / $den);
+			push(@$result, Fraction($real)->value);
+			push(@$direct, Fraction($num, $den)->value);
+		}
+	}
+
+	is $result, $direct, 'converted real gives correct fraction';
+};
 
 done_testing();


### PR DESCRIPTION
This version uses a loop instead of a recursive function.  Benchmarking shows it is at least twice as fast.  It also should use less memory overhead as it does not store the steps in constructing the continued fraction in arrays.  It only keeps what is needed to continue.  That is the last two values of the convergent numerator and denominator.

A basic unit test is added to check that this does the right thing.  Note that this unit test works with both this branch and the code in develop.  Demonstrating that they both generate the same fractions.

I have had this sitting here since March.  This is a good change, and I don't know why I didn't put it in sooner.