### PR TITLE
Clean up the pretty_print method in PGUtil.pm

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -99,7 +99,10 @@ our $PG;
 
 sub not_null { $PG->not_null(@_) }
 
-sub pretty_print { $PG->pretty_print(shift, $main::displayMode) }
+sub pretty_print {
+	my ($input, $level, $print_level) = @_;
+	$PG->pretty_print($input, $level // $main::displayMode, $print_level // 5);
+}
 
 sub encode_pg_and_html { PGcore::encode_pg_and_html(@_) }
 


### PR DESCRIPTION
Currently there are some issues with the method. Undefined variables used in strings cause warnings, and a string containing the word "hash" can cause errors. Furthermore, the formatting of the output is quite bad and uses invalid html (for its HTML display mode).

Also make it possible to override all of the arguments for the `PGUtil.pm` `pretty_print` method when calling the `PG.pl` pretty_print method. Thus you can call `pretty_print(output, 'text', 10)` instead of `$PG->pretty_print(output, 'text', 10)` for this anymore. This is useful in debugging when you want to see deeper into a MathObject object. The method still works the same when the additional arguments aren't passed.

I debated on rearranging the last two arguments, but left them for now. The level is the argument that you would typically want to change. It is less likely that you would want to change the display mode.

Attached is a problem to test this.  This problem does not work for hardcopy on the develop branch, but does with this pull request.  It looks much better in  html with this pull request than without.
[pretty-print.pg.txt](https://github.com/openwebwork/pg/files/12414437/pretty-print.pg.txt)

You can also test this with an admin user in webwork2 using the various checkboxes like "Answer Group Info" and such.