### PR TITLE
Remove the `usePolling` chokidar option in generate-assets.js.

### DIFF
--- a/htdocs/generate-assets.js
+++ b/htdocs/generate-assets.js
@@ -198,8 +198,6 @@ if (argv.watchFiles) console.log('\x1b[32mEstablishing watches and performing in
 chokidar.watch(['js'], {
 	ignored: /\.min\.(js|css)$/,
 	cwd: __dirname, // Make sure all paths are given relative to the htdocs directory.
-	usePolling: true, // Needed to get changes to symlinks.
-	interval: 500,
 	awaitWriteFinish: { stabilityThreshold: 500 },
 	persistent: argv.watchFiles ? true : false
 })


### PR DESCRIPTION
With node version 20 the `usePolling` option is resulting in high cpu usage.

Interestingly enough, the PG generate-assets.js script is the one that actually has high cpu usage with this option, not the webwork2 generate-assets.js script.  Something to do with links not actually existing?

This replaces #923 which was accidentally created with the `develop` branch name.