### PR TITLE
enforce MA checkTypes for each evaluator

### DIFF
--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -234,6 +234,13 @@ sub cmp {
 			});
 		}
 	}
+	# showing type warnings will prevent the custom checker
+	# from being called, regardless of the checkTypes setting
+	if (!$self->{checkTypes}) {
+		foreach my $cmp (@{ $self->{cmp} }) {
+			$cmp->ans_hash(showTypeWarnings => 0);
+		}
+	}
 	my @cmp = ();
 	if ($self->{singleResult}) {
 		push(@cmp, $self->ANS_NAME(0)) if $self->{namedRules};
@@ -372,7 +379,7 @@ sub entry_cmp {
 }
 
 #
-#  Call the correct answser's checker to check for syntax and type errors.
+#  Call the correct answer's checker to check for syntax and type errors.
 #  If this is the last one, perform the user's checker routine as well
 #  Return the individual answer (our answer hash is discarded).
 #
@@ -424,7 +431,7 @@ sub perform_check {
 	$rh_ans->{isPreview} = $inputs->{previewAnswers}
 		|| ($inputs_{action} && $inputs->{action} =~ m/^Preview/);
 
-	Parser::Context->current(undef, $context);                                 # change to multi-answser's context
+	Parser::Context->current(undef, $context);                                 # change to multi-answer's context
 	my $flags = Value::contextSet($context, $self->cmp_contextFlags($ans));    # save old context flags
 	$context->{answerHash} = $rh_ans;                                          # attach the answerHash
 	my @result = Value::cmp_compare([@correct], [@student], $self, $rh_ans);


### PR DESCRIPTION
## MultiAnswer and Type Checking

When using MultiAnswer, the `checkTypes` setting is effectively ignored. See attached file for MWE.

What happens is that when the user response is parsed, MathObjects do type checking by default and add a feedback message. The presence of this feedback message stops the evaluator from calling the custom checker in the MultiAnswer object. Culprit: L417 below.

https://github.com/openwebwork/pg/blob/e1313567a81dc3b9b6a70b8a45817b3804171c09/macros/parsers/parserMultiAnswer.pl#L414-L422

## Fix(es?)

This PR stifles the type warnings by setting `showTypeWarnings` to false (only when `checkTypes` is false, of course) within each individual evaluator/AnswerHash that the MultiAnswer contains. 

Another possible solution would be to modify L417 as follows:
``` perl
return if ($self->{checkTypes} && $ans->{ans_message}) || !defined($ans->{student_value});
```

This second solution has the benefit of retaining the default type-checking message, but I wonder about situations where `ans_message` might be defined for reasons other than type-checking failures. Does anyone know of potential edge-cases here?

This PR takes (what I believe to be) the safer route. 