### PR TITLE
Fix an issue that makes unanswered CheckboxList answers in a MultiAnswer answered.

### DIFF
--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -470,7 +470,7 @@ sub cmp_defaults {
 # Adjust student preview and answer strings to be the actual choice strings rather than the value strings.
 sub cmp_preprocess {
 	my ($self, $ans) = @_;
-	if (defined $ans->{student_value} && @{ $ans->{student_value}->data }) {
+	if (defined $ans->{student_value} && (grep { defined && /\S/ } @{ $ans->{student_value}->data })) {
 		$ans->{original_student_ans} = join(', ', map { $self->labelText($_) } @{ $ans->{student_value}->data });
 		$ans->{preview_latex_string} = $self->quoteTeX($ans->{original_student_ans});
 		$ans->{student_ans}          = $self->quoteHTML($ans->{original_student_ans});


### PR DESCRIPTION
When a CheckboxList is one of the answers for a MultiAnswer object and `allowBlankAnswers` is 1 for the MultiAnswer object, then for some not quite determined reason the cmp_preprocess method of parserCheckboxList.pl is called at an earlier stage than otherwise, and additionally at that point the answer hash `student_value` is a Value::String whose data array contains one empty element.  As such the the answer strings end up begin set to the last checkbox answer label due to the way that the `labelText` method works.

Note that the checker still works correctly, but what is displayed in the results table is misleading.

Essentially the CheckboxList cmp_preprocess is not correctly detecting when no checkboxes are checked.  This skips setting answer strings in the case that no checkboxes are checked.

A minimal working example is attached.  Test this by checking or submitting answers without answering anything.  With the develop branch it will show that the first answer is not answered, but the second is.  With this pull request it will show both parts unanswered.
[ma-checkbox.pg.txt](https://github.com/openwebwork/pg/files/12739084/ma-checkbox.pg.txt)
