### PR TITLE
Fix CheckboxList part answers of a RadioMultiAnswer.

### DIFF
--- a/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.js
+++ b/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.js
@@ -39,12 +39,14 @@
 			// If MathQuill is enabled, then this will be the MathQuill input.
 			const answerInputs = [document.getElementById(`mq-answer-${answerRule}`) ?? input];
 
-			// If this is a radio answer, then save the other radio inputs so they can be also be disabled/enabled
-			// appropriately depending on which radio input in the radio multianswer group is selected.
-			if (input.type && input.type.toLowerCase() == 'radio') {
+			// If this is a radio or checkbox answer, then save the other radio or checkbox inputs so they can be also
+			// be disabled/enabled appropriately depending on which radio input in the radio multianswer group is
+			// selected.
+			const type = input.type?.toLowerCase();
+			if (type && (type === 'radio' || type === 'checkbox')) {
 				answerInputs.push(
-					...Array.from(document.querySelectorAll(`input[type="radio"][name="${answerRule}"]`)).filter(
-						(radio) => radio.id !== answerRule
+					...Array.from(document.querySelectorAll(`input[type="${type}"][name="${answerRule}"]`)).filter(
+						(input) => input.id !== answerRule
 					)
 				);
 			}


### PR DESCRIPTION
If a CheckboxList is one of the answers in a RadioMultiAnswer part, then the checkboxes are not enabled/disabled correctly as the radio buttons are checked.  This fixes that.

This was not implemented previously because there was no MathObject checkbox answer.  Now there is so this is needed.

An example problem is attached.  In that problem with the develop branch if you select various radio buttons in the problem you will see that only the first checkbox is enabled or disabled when the radio button for its part is selected or unselected.  With this pull request all checkboxes are enabled and disabled appropriately.
[rma-with-checkbox-sub.pg.txt](https://github.com/openwebwork/pg/files/12743017/rma-with-checkbox-sub.pg.txt)
