### PR TITLE
Forgotten amendment to #921.

### DIFF
--- a/lib/PGUtil.pm
+++ b/lib/PGUtil.pm
@@ -67,13 +67,6 @@ The default is "html".
 The C<$level> parameter is the cut off for the depth into objects to show.  The
 default is 5.
 
-WARNING: This is not the C<pretty_print> method that is directly available in
-problems.  The C<pretty_print> method that is directly available in problems is
-defined in L<PG.pl>, and the usage of that method is C<pretty_print($rh_hash_input)>.
-Note that it does not accept the second two parameters of this method.  That
-method calls the C<pretty_print> method defined in L<PGcore.pm> which in turn
-calls this method.
-
 =cut
 
 sub pretty_print {

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -100,8 +100,8 @@ our $PG;
 sub not_null { $PG->not_null(@_) }
 
 sub pretty_print {
-	my ($input, $level, $print_level) = @_;
-	$PG->pretty_print($input, $level // $main::displayMode, $print_level // 5);
+	my ($input, $display_mode, $print_level) = @_;
+	$PG->pretty_print($input, $display_mode // $main::displayMode, $print_level // 5);
 }
 
 sub encode_pg_and_html { PGcore::encode_pg_and_html(@_) }


### PR DESCRIPTION
This was mentioned by @drdrew42 a couple of weeks ago, and I forgot to do it.  The argument name of the `pretty_print` method was incorrect. Although it doesn't affect the usage it is misleading as to what it does.

Also remove the warning I added in PGUtil.pm that is no longer pertinent with the addition of the two arguments to the method in PG.pl.