### PR TITLE
Check for numbers in Compute

### DIFF
--- a/macros/core/Parser.pl
+++ b/macros/core/Parser.pl
@@ -95,6 +95,14 @@ original can be obtained from the C<original_formula> property.
 sub Compute {
 	my $string  = shift;
 	my $formula = Formula($string);
+	if (Value::matchNumber($string)) {
+		my $real = Real($string);
+		warn "Compute() called with ambiguous value: $string\n"
+			. '-- use Real() for scientific notation'
+			. " ($real) or use Formula() for $formula \n"
+			unless ($real == $formula);
+		return $real;
+	}
 	$formula = $formula->{tree}->Compute if $formula->{tree}{canCompute};
 	my $context = $formula->context;
 	my $flags   = Value::contextSet($context, reduceConstants => 0, reduceConstantFunctions => 0, showExtraParens => 0);


### PR DESCRIPTION
## Background

Compute is a convenience for parsing MathObjects. A problem arises when Compute is asked to parse a value that rises above or below the threshold for perl to represent in scientific notation. The string for such values contains 'e', which Compute then parses as Euler's number.

**Recent Examples:**
* #655 
* [normal_prob Forum post](https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8361)

### "Fix"

With this PR, passing a valid scientific notation value to Compute() will (by default) create a `Real` MathObject instead of a `Formula`. However, this new default behavior will also come with a warning about the ambiguous input. The warning instructs authors to decide between Real() and Formula() in choosing an explicit MathObject.

In the code, I used Value::matchNumber to identify arguments to `Compute()` as valid strictly-numerical strings. In such cases, the Formula and Real MathObjects are compared and a warning is triggered whenever there is ambiguity. For all arguments identified as numbers, even if ambiguous, the Real version is returned.

This change to the default behavior will only negatively impact problems that have attempted to parse a linear expression in 'e' (with no whitespace) using Compute(). These problems, if they exist, will now see warnings along with the change in the default behavior.

### Testing

```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl');

$x = Compute(6e+20);

BEGIN_PGML

The answer is [$x]: [__]{$x}

END_PGML

ENDDOCUMENT();
```

Before this PR, the correct answer is '6*e+20'.

With this PR, the correct answer is '6*10^20' and you will see the correct answer is also displayed in scientific notation. You will also receive a warning about the ambiguous value. Changing from `Compute()` to `Real()` or `Formula()` will remove the error message and parse the correct answer accordingly.

### Further Consideration

Note that `[__]{6e+20}` will neither create a warning nor have the correct answer value. I don't think we should consider supporting this use case. In fact, I think we should consider triggering a warning any time PGML encounters an answer that is not a MathObject/AnswerEvaluator.