### PR TITLE
Add PG's own localization.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,7 @@ jobs:
             libhtml-parser-perl \
             libjson-perl \
             libjson-xs-perl \
+            liblocale-maketext-lexicon-perl \
             libtest2-suite-perl \
             libtie-ixhash-perl \
             libuuid-tiny-perl \

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-conf/pg_config.yml
+*~
+*.swp
 *.bak
+
+conf/pg_config.yml
 cover_db/
 
 htdocs/node_modules

--- a/bin/update-localization-files
+++ b/bin/update-localization-files
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+function print_help_exit
+{
+	printf "Usage: %s [options]\n" $(basename $0) >&2
+	printf " Update the pg.pot and language .po files with translation strings from the code.\n" >&2
+	printf "  options:\n" >&2
+	printf "    -p|--po-update  Update po files as well.  By default only the pg.pot file is updated.\n" >&2
+	printf "    -l|--langauge   Update the only given language in addition to updating the pg.pot file.\n" >&2
+	printf "    -h|--help       Show this help.\n" >&2
+	exit 1
+}
+
+TEMP=$(getopt -a -o pl:h -l po-update,language:,help -n "$(basename $0)" -- "$@")
+
+eval set -- "$TEMP"
+
+UPDATE_PO=false
+LANGUAGE=""
+
+while [ ! "$1" = "--" ]
+do
+	case "$1" in
+		-p|--po-update)
+			UPDATE_PO=true
+			shift 1
+			;;
+		-l|--language)
+			LANGUAGE=$2
+			shift 2
+			;;
+		-h|--help)
+			print_help_exit
+			;;
+		*)
+			echo "Internal error!"
+			exit 1
+			;;
+	esac
+done
+
+if [ -z "$PG_ROOT" ]; then
+    echo >&2 "You need to set the PG_ROOT environment variable.  Aborting."
+    exit 1
+fi
+
+command -v xgettext.pl >/dev/null 2>&1 || {
+    echo >&2 "xgettext.pl needs to be installed.  It is inlcuded in the perl package Locale::Maketext::Extract. Aborting.";
+    exit 1;
+}
+
+LOCDIR=$PG_ROOT/lib/WeBWorK/PG/Localize
+
+cd $LOCDIR
+
+echo "Updating $LOCDIR/pg.pot"
+
+xgettext.pl -o pg.pot -D $PG_ROOT/lib -D $PG_ROOT/macros
+
+if $UPDATE_PO; then
+	find $LOCDIR -name '*.po' -exec bash -c "echo \"Updating {}\"; msgmerge -qUN {} pg.pot" \;
+elif [[ $LANGUAGE != "" && -e "$LANGUAGE.po" ]]; then
+	echo "Updating $LOCDIR/$LANGUAGE.po"
+	msgmerge -qUN $LANGUAGE.po pg.pot
+fi

--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -247,6 +247,7 @@ modules:
   - [PGresponsegroup]
   - ['Tie::IxHash']
   - ['Locale::Maketext']
+  - ['WeBWorK::PG::Localize']
   - [JSON]
   - ['Class::Tiny']
   - ['IO::Handle']

--- a/cpanfile
+++ b/cpanfile
@@ -17,6 +17,7 @@ on runtime => sub {
 	requires 'JSON';
 	requires 'JSON::XS';
 	requires 'Locale::Maketext';
+	requires 'Locale::Maketext::Lexicon';
 	requires 'Tie::IxHash';
 	requires 'Types::Serialiser';
 	requires 'UUID::Tiny';

--- a/docker/pg.Dockerfile
+++ b/docker/pg.Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
 		libhtml-parser-perl \
 		libjson-perl \
 		libjson-xs-perl \
+		liblocale-maketext-lexicon-perl \
 		libtest2-suite-perl \
 		libtie-ixhash-perl \
 		libuuid-tiny-perl \

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -125,9 +125,7 @@ sub initialize {
 		WARNING_messages => $self->{WARNING_messages},
 		DEBUG_messages   => $self->{DEBUG_messages},
 	);
-	#$self->{maketext} =  WeBWorK::Localize::getLoc($self->{envir}->{language});
-	$self->{maketext} = $self->{envir}->{language_subroutine};
-	#$self->debug_message("PG alias created", $self->{PG_alias} );
+	$self->{maketext}      = $self->{envir}{language_subroutine};
 	$self->{PG_loadMacros} = new PGloadfiles($self->{envir});
 	$self->{flags}         = {
 		showPartialCorrectAnswers => 1,

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -24,6 +24,7 @@ use WeBWorK::PG::Environment;
 use WeBWorK::PG::Translator;
 use WeBWorK::PG::RestrictedClosureClass;
 use WeBWorK::PG::Constants;
+use WeBWorK::PG::Localize;
 
 use constant DISPLAY_MODES => {
 	# display name   # mode name
@@ -260,8 +261,8 @@ sub defineProblemEnvironment ($pg_envir, $options = {}, $image_generator = undef
 		mathViewLocale => $options->{mathViewLocale} // $pg_envir->{options}{mathViewLocale},
 
 		# Internationalization
-		language            => $options->{language}            // 'en',
-		language_subroutine => $options->{language_subroutine} // sub (@args) { return $args[0]; },
+		language            => $options->{language} // 'en',
+		language_subroutine => WeBWorK::PG::Localize::getLoc($options->{language} // 'en'),
 
 		# Directories and URLs
 		pgMacrosDir       => "$pg_envir->{directories}{root}/macros",

--- a/lib/WeBWorK/PG/Localize.pm
+++ b/lib/WeBWorK/PG/Localize.pm
@@ -1,0 +1,284 @@
+package WeBWorK::PG::Localize;
+use parent 'Locale::Maketext';
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Locale::Maketext::Lexicon;
+
+Locale::Maketext::Lexicon->import({
+	'i-default' => ['Auto'],
+	'*'         => [ Gettext => File::Spec->catfile("$ENV{PG_ROOT}/lib/WeBWorK/PG/Localize", '*.[pm]o') ],
+	_decode     => 1,
+	_encoding   => undef,
+});
+*tense = sub { \$_[1] . ((\$_[2] eq 'present') ? 'ing' : 'ed') };
+
+# This subroutine is used to pass a language handle into the safe
+# compartment so that maketext can be used in problems and macros.
+sub getLoc {
+	my $lang = shift;
+	my $lh   = WeBWorK::PG::Localize->get_handle($lang);
+	return sub { $lh->maketext(@_) };
+}
+
+sub getLangHandle {
+	my $lang = shift;
+	return WeBWorK::PG::Localize->get_handle($lang);
+}
+
+# This is like [quant] but it doesn't write the number.
+#  usage: [quant,_1,<singular>,<plural>,<optional zero>]
+sub plural {
+	my ($handle, $num, @forms) = @_;
+
+	return ''        if @forms == 0;
+	return $forms[2] if @forms > 2 && $num == 0;
+
+	# Normal case:
+	return $handle->numerate($num, @forms);
+}
+
+# This is like [quant] but it also has a negative case. (The one usage in the code interprets this as unlimited.)
+#  usage: [negquant,_1,<negative case>,<singular>,<plural>,<optional zero>]
+sub negquant {
+	my ($handle, $num, @forms) = @_;
+
+	return $num if @forms == 0;
+
+	my $negcase = shift @forms;
+	return $negcase if $num < 0;
+
+	return $forms[2] if @forms > 2 && $num == 0;
+	return $handle->numf($num) . ' ' . $handle->numerate($num, @forms);
+}
+
+our %Lexicon = ('_AUTO' => 1);
+
+# Override the Locale::Maketext::_compile method. The only real difference is that this override
+# method does not call "use strict" in the code eval. Thus it can be used in the safe zone.
+sub _compile {
+	my ($handle, $string_to_compile) = @_;
+
+	# The while regex is more expensive than this check on strings that don't need a compile.
+	# This op causes a ~2% speed hit for strings that need compile and a 250% speed improvement
+	# on strings that don't need compiling.
+	return \"$string_to_compile" if $string_to_compile !~ m/[\[~\]]/ms;
+
+	my @code;
+	my (@c)        = ('');    # "chunks" -- scratch.
+	my $call_count = 0;
+	my $big_pile   = '';
+	{
+		my $in_group = 0;     # start out outside a group
+		my ($m, @params);     # scratch
+
+		while (
+			$string_to_compile =~    # Iterate over chunks.
+			m/(
+				[^\~\[\]]+  # non-~[] stuff (Capture everything else here)
+				|
+				~.          # ~[, ~], ~~, ~other
+				|
+				\[          # [ presumably opening a group
+				|
+				\]          # ] presumably closing a group
+				|
+				~           # terminal ~ ?
+				|
+				$
+			)/xgs
+			)
+		{
+			if ($1 eq '[' || $1 eq '') {
+				# Whether this is "[" or end, force processing of any preceding literal.
+				if ($in_group) {
+					if ($1 eq '') {
+						$handle->_die_pointing($string_to_compile, 'Unterminated bracket group');
+					} else {
+						$handle->_die_pointing($string_to_compile, 'You can\'t nest bracket groups');
+					}
+				} else {
+					$in_group = 1 if ($1 ne '');
+
+					die "How come \@c is empty?? in <$string_to_compile>" unless @c;    # sanity
+					if (length $c[-1]) {
+						# Now actually processing the preceding literal
+						$big_pile .= $c[-1];
+						if (
+							$Locale::Maketext::USE_LITERALS && (
+								(ord('A') == 65)
+								? $c[-1] !~ m/[^\x20-\x7E]/s
+								# ASCII very safe chars
+								: $c[-1] !~ m/[^ !"\#\$%&'()*+,\-.\/0-9:;<=>?\@A-Z[\\\]^_`a-z{|}~\x07]/s
+								# EBCDIC very safe chars
+							)
+							)
+						{
+							# Normal case -- all very safe chars
+							$c[-1] =~ s/'/\\'/g;
+							push @code, q{ '} . $c[-1] . "',\n";
+							$c[-1] = '';    # reuse this slot
+						} else {
+							$c[-1] =~ s/\\\\/\\/g;
+							push @code, ' $c[' . $#c . "],\n";
+							push @c,    '';                      # new chunk
+						}
+					}
+					# else just ignore the empty string.
+				}
+
+			} elsif ($1 eq ']') {
+				# Close group -- go back in-band
+				if ($in_group) {
+					$in_group = 0;
+
+					# And now process the group...
+
+					if (!length($c[-1]) || $c[-1] =~ m/^\s+$/s) {
+						$c[-1] = '';    # Reset out chunk
+						next;
+					}
+
+					($m, @params) = split(/,/, $c[-1], -1);
+
+					# A bit of a hack -- we've turned "~,"'s into DELs, so turn them into real commas here.
+					if (ord('A') == 65) {
+						# ASCII, etc
+						for ($m, @params) {tr/\x7F/,/}
+					} else {
+						# EBCDIC (1047, 0037, POSIX-BC)
+						for ($m, @params) {tr/\x07/,/}
+					}
+
+					# Special-case handling of some method names:
+					if ($m eq '_*' || $m =~ m/^_(-?\d+)$/s) {
+						# Treat [_1,...] as [,_1,...], etc.
+						unshift @params, $m;
+						$m = '';
+					} elsif ($m eq '*') {
+						$m = 'quant';    # "*" for "times": "4 cars" is 4 times "cars"
+					} elsif ($m eq '#') {
+						$m = 'numf';     # "#" for "number": [#,_1] for "the number _1"
+					}
+
+					# Most common case: a simple, legal-looking method name.
+					if ($m eq '') {
+						# 0-length method name means to just interpolate:
+						push @code, ' (';
+					} elsif ($m =~ /^\w+$/s
+						&& !$handle->{'blacklist'}{$m}
+						&& (!defined $handle->{'whitelist'} || $handle->{'whitelist'}{$m}))
+					{
+						# Exclude anything fancy and restrict to the whitelist/blacklist.
+						push @code, ' $_[0]->' . $m . '(';
+					} else {
+						# TODO: Implement something? Or just too icky to consider?
+						$handle->_die_pointing(
+							$string_to_compile,
+							"Can't use \"$m\" as a method name in bracket group",
+							2 + length($c[-1])
+						);
+					}
+
+					pop @c;    # we don't need that chunk anymore
+					++$call_count;
+
+					for my $p (@params) {
+						if ($p eq '_*') {
+							# Meaning: all parameters except $_[0]
+							$code[-1] .= ' @_[1 .. $#_], ';
+							# and yes, that does the right thing for all @_ < 3
+						} elsif ($p =~ m/^_(-?\d+)$/s) {
+							# _3 meaning $_[3]
+							$code[-1] .= '$_[' . (0 + $1) . '], ';
+						} elsif (
+							$Locale::Maketext::USE_LITERALS && (
+								(ord('A') == 65)
+								? $p !~ m/[^\x20-\x7E]/s
+								# ASCII very safe chars
+								: $p !~ m/[^ !"\#\$%&'()*+,\-.\/0-9:;<=>?\@A-Z[\\\]^_`a-z{|}~\x07]/s
+								# EBCDIC very safe chars
+							)
+							)
+						{
+							# Normal case: a literal containing only safe characters
+							$p =~ s/'/\\'/g;
+							$code[-1] .= q{'} . $p . q{', };
+						} else {
+							# Stow it on the chunk-stack, and just refer to that.
+							push @c,    $p;
+							push @code, ' $c[' . $#c . '], ';
+						}
+					}
+					$code[-1] .= "),\n";
+
+					push @c, '';
+				} else {
+					$handle->_die_pointing($string_to_compile, q{Unbalanced ']'});
+				}
+
+			} elsif (substr($1, 0, 1) ne '~') {
+				# It's stuff not containing "~" or "[" or "]", i.e., a literal blob.
+				my $text = $1;
+				$text =~ s/\\/\\\\/g;
+				$c[-1] .= $text;
+			} elsif ($1 eq '~~') {
+				$c[-1] .= '~';
+			} elsif ($1 eq '~[') {
+				$c[-1] .= '[';
+			} elsif ($1 eq '~]') {
+				$c[-1] .= ']';
+			} elsif ($1 eq '~,') {
+				if ($in_group) {
+					# This is a hack, based on the assumption that no one will actually
+					# want a DEL inside a bracket group.  Let's hope that's it's true.
+					if (ord('A') == 65) {
+						# ASCII etc
+						$c[-1] .= "\x7F";
+					} else {
+						# EBCDIC (cp 1047, 0037, POSIX-BC)
+						$c[-1] .= "\x07";
+					}
+				} else {
+					$c[-1] .= '~,';
+				}
+			} elsif ($1 eq '~') {
+				# This is possible only at string end, it seems.
+				$c[-1] .= '~';
+			} else {
+				# It's a "~X" where X is not a special character.
+				# Consider it a literal ~ and X.
+				my $text = $1;
+				$text =~ s/\\/\\\\/g;
+				$c[-1] .= $text;
+			}
+		}
+	}
+
+	if ($call_count) {
+		undef $big_pile;    # Well, nevermind that.
+	} else {
+		# It's all literals! So don't bother with the eval. Return a SCALAR reference.
+		return \$big_pile;
+	}
+
+	die q{Last chunk isn't null??} if @c && length $c[-1];    # sanity
+	if (@code == 0) {
+		# Not possible?
+		return \'';
+	} elsif (@code > 1) {
+		# Most cases, presumably!
+		unshift @code, "join '',\n";
+	}
+	unshift @code, "sub {\n";
+	push @code, "}\n";
+
+	my $sub = eval(join '', @code);
+	die "$@ while eval-ling " . join('', @code) if $@;        # Should be impossible.
+
+	return $sub;
+}
+
+1;

--- a/lib/WeBWorK/PG/Localize/cs-CZ.po
+++ b/lib/WeBWorK/PG/Localize/cs-CZ.po
@@ -1,0 +1,161 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Robert Mařík <robert.marik.cz@gmail.com>, 2022-2023
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:00-0500\n"
+"Last-Translator: Robert Mařík <robert.marik.cz@gmail.com>, 2022-2023\n"
+"Language-Team: Czech (Czech Republic) (http://app.transifex.com/webwork/"
+"webwork2/language/cs_CZ/)\n"
+"Language: cs_CZ\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "Nápověda:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "Poznámka:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "Řešení:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Za částečné zodpovězení této úlohy můžete obdržet částečné hodnocení."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/de.po
+++ b/lib/WeBWorK/PG/Localize/de.po
@@ -1,0 +1,165 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Armin Reiser, 2022
+# Armin Reiser, 2022
+# Fabian Gabel, 2022
+# Fabian Gabel, 2022
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Fabian Gabel, 2022\n"
+"Language-Team: German (http://app.transifex.com/webwork/webwork2/language/"
+"de/)\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr "Neue Version dieser Aufgabe anfordern"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "Hinweis: "
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr "Hinweis: "
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "Note:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "Lösung:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr "Lösung: "
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "Dies is eine neu randomisierte Version der Aufgabe."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr "Diese Aufgabe besteht aus mehreren Teilen."
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Für diese Aufgabe können Sie Teilpunkte erhalten."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+"Nach Ablauf der Bearbeitungszeit erhalten Sie eine neue Version dieser "
+"Aufgabe"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Antworten können im nächsten Teil nicht mehr geändert werden!"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr "Antwort"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr "Spalte"
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "Aufgabe"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/el.po
+++ b/lib/WeBWorK/PG/Localize/el.po
@@ -1,0 +1,188 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Antonis Troullakis, 2022
+# Athina Psoma, 2022
+# Chaido Skandyla, 2022
+# Christina Liouliou, 2022
+# Despoina, 2022-2023
+# Dimitra Papantoniou, 2022
+# Efthimiou Afroditi, 2022
+# Efthymia Papadopoulou, 2022
+# Elena Kapna, 2022
+# Elisavet, 2022-2023
+# Evangelos Papadopoulos, 2022
+# Ioannis Souldatos, 2022-2023
+# kalliopi Kiosse, 2022-2023
+# Kleopatra Chatziioannou, 2022
+# Kyriaki Kourouni, 2022-2023
+# Lika, 2022-2023
+# Maria Liakou, 2022
+# Maria Sakelliadi, 2022
+# Nikoleta Tentoglou, 2022
+# Panagiota Kosteli, 2022
+# Salma Chasan, 2022
+# Sofia Mavroudi, 2022
+# Stavroula Tziortzii, 2022
+# Tsiatsiou Katerina, 2022
+# Tzivani Marianna, 2022
+# ΑΛΕΞΑΝΔΡΑ ΣΤΕΦΑΝΙΔΟΥ, 2022
+# Παρασκευάς Παπαβασιλείου, 2022
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Kyriaki Kourouni, 2022-2023\n"
+"Language-Team: Greek (http://app.transifex.com/webwork/webwork2/language/"
+"el/)\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr "Λάθος"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr "Λήψη νέας εκδοχής του προβλήματος"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr "Επιστροφή σε Μέρος 1"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr "Μετάβαση στο επόμενο"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr "Στην έντυπη μορφή εμφανίζεται πάντα η αρχική μορφή του προβλήματος."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "Υπόδειξη:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr "Υπόδειξη:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr "Αν επιστρέψετε αργότερα, ενδέχεται να επανέλθει στην αρχική του μορφή."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "Σημείωση:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr "Ορισμός τυχαίου αριθμού:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "Απάντηση:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr "Λύση:"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr "Υποβάλετε τις απαντήσεις σας ξανά για να συνεχίσετε."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "Αυτή είναι μια νέα (επανατυχαιοποιημένη) έκδοση του προβλήματος."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+"Αυτό το πρόβλημα περιέχει ένα βίντεο που πρέπει να προβληθεί στο διαδίκτυο."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr "Αυτό το πρόβλημα έχει περισσότερα από ένα μέρη."
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr "Σωστό"
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Μπορείτε να κερδίσετε μερική πίστωση σε αυτό το πρόβλημα."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+"Μπορείτε να λάβετε νέα εκδοχή του προβλήματος μετά την ημερομηνία λήξης."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr "Μη δεκτές αλλαγές σε απαντήσεις αν συνεχίσετε στο επόμενο μέρος!"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr "Ο περιηγητής σας δεν υποστηρίζει την ετικέτα βίντεο."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr "Το σκορ σας σε αυτήν την προσπάθεια είναι μόνο για αυτό το μέρος˙"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr "απάντηση"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr "στήλη"
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr "άι"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr "εάν"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr "αλλιώς"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr "μέρος"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "πρόβλημα"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr "σειρά"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr "όταν υποβάλλετε τις απαντήσεις σας"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr "το συνολικό σκορ σας είναι για όλα τα μέρη που συνδυάζονται."

--- a/lib/WeBWorK/PG/Localize/en.po
+++ b/lib/WeBWorK/PG/Localize/en.po
@@ -1,0 +1,160 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Jason Aubrey <aubreyja@gmail.com>\n"
+"Language-Team: English (United States) (http://www.transifex.com/webwork/"
+"webwork2/language/en_US/)\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+# does not need to be translated
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/es.po
+++ b/lib/WeBWorK/PG/Localize/es.po
@@ -1,0 +1,162 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Andrés Forero <aguilulfo@gmail.com>, 2020
+# Enrique Acosta <enriqueacostajaramillo@gmail.com>, 2020
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Enrique Acosta <enriqueacostajaramillo@gmail.com>, 2020\n"
+"Language-Team: Spanish (http://app.transifex.com/webwork/webwork2/language/"
+"es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "Pista:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "Nota:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "Solución:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Puedes obtener una fracción del puntaje total en este problema."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "Problema"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/fr-CA.po
+++ b/lib/WeBWorK/PG/Localize/fr-CA.po
@@ -1,0 +1,170 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Hélène Larue <helene.larue@videotron.ca>, 2017
+# Jonathan Desaulniers <jonathan.desaulniers@cegepmontpetit.ca>, 2018-2019,2021-2022
+# Julie Tremblay <julie.tremblay@bdeb.qc.ca>, 2016-2017
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Jonathan Desaulniers <jonathan.desaulniers@cegepmontpetit."
+"ca>, 2018-2019,2021-2022\n"
+"Language-Team: French (Canada) (http://app.transifex.com/webwork/webwork2/"
+"language/fr_CA/)\n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr "Faux"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr "Obtenir une nouvelle version du problème"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr "Retour à la partie 1"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr "Aller à la partie suivante"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+"Le document sera toujours imprimer avec la version originale du problème."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "Indice :"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr "Indice:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+"Si vous revenez plus tard, le problème pourrait être revenu à sa version "
+"originale."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "Note:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr "Définir la source aléatoire à:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "Solution :"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr "Solution:"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr "Soumettre votre réponse à nouveau pour passer à la partie suivante."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "Voici une nouvelle version (à nouveau randomisée) du problème."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr "Ce problème contient une vidéo qui doit être consultée en ligne."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr "Ce problème comporte plusieurs parties."
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr "Vrai"
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Vous pouvez obtenir une partie des points pour ce problème."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+"Vous pouvez obtenir une nouvelle version du problème après la date de remise."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+"Vous ne pouvez pas modifier vos réponses en passant à la partie suivante!"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr "Votre navigateur ne supporte pas l'environnement vidéo."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+"Votre résultat pour cette tentative correspond à cette partie seulement;"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr "réponse"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr "colonne"
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr "Je"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr "Si"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr "autrement"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr "partie"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "problème"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr "ligne"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr "Quand vous soumettez vos réponses"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr "Votre résultat d'ensemble est pour chacune des parties combinées."

--- a/lib/WeBWorK/PG/Localize/fr.po
+++ b/lib/WeBWorK/PG/Localize/fr.po
@@ -1,0 +1,165 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Jonathan Desaulniers <jonathan.desaulniers@cegepmontpetit.ca>, 2018
+# Michael E Gage <gage@math.rochester.edu>, 2014
+# Michael E Gage <gage@math.rochester.edu>, 2011
+# Sébastien Labbé <slabqc at gmail.com>, Université du Québec à Montréal, 2011
+# Stéphanie Lanthier <lanthier.stephanie@gmail.com>, 2011
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Stéphanie Lanthier <lanthier.stephanie@gmail.com>, 2011\n"
+"Language-Team: French (http://app.transifex.com/webwork/webwork2/language/"
+"fr/)\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Vous pouvez obtenir une partie des points pour ce problème."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/he-IL.po
+++ b/lib/WeBWorK/PG/Localize/he-IL.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Michael Oren Perlstein <michaelore@campus.technion.ac.il>, 2018
+# Nathan Wallach <tani@mathnet.technion.ac.il>, 2018
+# Nathan Wallach <taniwallach@gmail.com>, 2022-2023
+# Ran Kiri <rankiri@campus.technion.ac.il>, 2018
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: Nathan Wallach <taniwallach@gmail.com>, 2022-2023\n"
+"Language-Team: Hebrew (Israel) (http://app.transifex.com/webwork/webwork2/"
+"language/he_IL/)\n"
+"Language: he_IL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr " לא נכון"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr "קבל גרסה חדשה של שאלה זו."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr "חזור לחקל 1"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr "המשך לחלק הבא"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr "בקבצי הדפסה תמיד יודפס הגרסה המקורית של השאלה."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr "רמז:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr "רמז: "
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr "אם תחזור לשאלה בהמשל, ייתכן שהשאלה תחזור לגרסה המקורית."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr "הערה:"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr "החלף את זרע ההגרלות אל:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr "פתרון:"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr "פתרון: "
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr "שלח את התשובות שוב כדי להתקדם לחלק הבא."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr "הנה גרסה חדשה של השאלה."
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr "השאלה מכילה וידיאו שיש לראות באופן מקוון."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr "לשאלה זו יש יותר מחלק אחד."
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr "נכון"
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "ניתן לקבל ניקוד חלקי בשאלה זו"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr "אתה יכול לבקש גרסה שונה של שאלה זו לאחר מועד ההגשה."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr "לא ניתן לשנות תשובות כאשר אתה מתקדם לחלק הבא!"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr "הדפדפן שלך לא תומך ב-video tag."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr "הציון שקבלת בהגשה זו הוא רק לחקל זה;"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr "תשובה"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr "עמודה"
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr "i"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr "if"
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr "אחרת"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr "חלק"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "שאלה"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr "שורה"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr "כאשר אתה מגיש את תשובותיך"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr "הציון הכולל הוא על בסיס כל החלקים."

--- a/lib/WeBWorK/PG/Localize/hu.po
+++ b/lib/WeBWorK/PG/Localize/hu.po
@@ -1,0 +1,160 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# pcsiba <pcsiba@gmail.com>, 2014,2016-2017
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:01-0500\n"
+"Last-Translator: pcsiba <pcsiba@gmail.com>, 2014,2016-2017\n"
+"Language-Team: Hungarian (http://app.transifex.com/webwork/webwork2/language/"
+"hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr "Igaz"
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Ezért a feladatért részpontokat kaphat. "
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr "válasz"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr "oszlop"
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr "feladat"
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr "sor"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/ko.po
+++ b/lib/WeBWorK/PG/Localize/ko.po
@@ -1,0 +1,160 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Ji-Young Ham <jiyoungham1@gmail.com>, 2022
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:02-0500\n"
+"Last-Translator: Ji-Young Ham <jiyoungham1@gmail.com>, 2022\n"
+"Language-Team: Korean (http://app.transifex.com/webwork/webwork2/language/"
+"ko/)\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr "다음 단계로 이동하려면 답변을 다시 제출하십시오."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "이 문제의 부분 점수를 받았습니다."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr "이 문제의 새 버전은 마감일 이후에 받을 수 있습니다."
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr "입력답을 제출할 때에는"
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr "전체 점수는 모든 부분을 합한 것입니다."

--- a/lib/WeBWorK/PG/Localize/pg.pot
+++ b/lib/WeBWorK/PG/Localize/pg.pot
@@ -1,0 +1,146 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2016-03-31 10:14-0400\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186 /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293 /opt/webwork/pg/macros/core/compoundProblem.pl:498 /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518 /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396 /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509 /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610 /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39 /opt/webwork/pg/lib/Value/Vector.pm:303 /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485 /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/ru-RU.po
+++ b/lib/WeBWorK/PG/Localize/ru-RU.po
@@ -1,0 +1,161 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:02-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Russian (Russia) (http://app.transifex.com/webwork/webwork2/"
+"language/ru_RU/)\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Балл за эту задачу может дробиться. "
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/tr.po
+++ b/lib/WeBWorK/PG/Localize/tr.po
@@ -1,0 +1,159 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:02-0500\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: Turkish (http://app.transifex.com/webwork/webwork2/language/"
+"tr/)\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "Bu sorudan kısmi puan alabilirsiniz."
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/zh-CN.po
+++ b/lib/WeBWorK/PG/Localize/zh-CN.po
@@ -1,0 +1,162 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Liping Chen <chenlipi@msu.edu>, 2013
+# Liping Chen <chenlipi@msu.edu>, 2013
+# 李 明昊 <lmh_2017@126.com>, 2020
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:02-0500\n"
+"Last-Translator: Liping Chen <chenlipi@msu.edu>, 2013\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/webwork/webwork2/"
+"language/zh_CN/)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "这一题你可以得到部分成绩"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""

--- a/lib/WeBWorK/PG/Localize/zh-HK.po
+++ b/lib/WeBWorK/PG/Localize/zh-HK.po
@@ -1,0 +1,160 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Liping Chen <chenlipi@msu.edu>, 2013
+msgid ""
+msgstr ""
+"Project-Id-Version: webwork2\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2023-09-16 14:03-0500\n"
+"Last-Translator: Liping Chen <chenlipi@msu.edu>, 2013\n"
+"Language-Team: Chinese (Hong Kong) (http://app.transifex.com/webwork/"
+"webwork2/language/zh_HK/)\n"
+"Language: zh_HK\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:285
+msgid "False"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:186
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:187
+msgid "Get a new version of this problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:483
+msgid "Go back to Part 1"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:293
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:498
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:512
+msgid "Go on to next part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:427
+msgid "Hardcopy will always print the original version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1518
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1519
+msgid "Hint:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1517
+msgid "Hint: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:425
+msgid "If you come back to it later, it may revert to its original version."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:396
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:422
+msgid "Note:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:188
+msgid "Set random seed to:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1509
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1510
+msgid "Solution:"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:1508
+msgid "Solution: "
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:525
+msgid "Submit your answers again to go on to the next part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:423
+msgid "This is a new (re-randomized) version of the problem."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3181
+msgid "This problem contains a video which must be viewed online."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:631
+msgid "This problem has more than one part."
+msgstr ""
+
+#: /opt/webwork/pg/macros/parsers/parserPopUp.pl:284
+msgid "True"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGanswermacros.pl:1616
+msgid "You can earn partial credit on this problem."
+msgstr "这一题你可以得到部分成绩"
+
+#: /opt/webwork/pg/macros/deprecated/problemRandomize.pl:397
+msgid "You can get a new version of this problem after the due date."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:646
+msgid "You may not change your answers when going on to the next part!"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:3174
+msgid "Your browser does not support the video tag."
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:634
+msgid "Your score for this attempt is for this part only;"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:610
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:621
+msgid "answer"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "column"
+msgstr ""
+
+# does not need to be translated
+#. ('j', 'k', '_0')
+#. ('j', 'k')
+#: /opt/webwork/pg/lib/Parser/List/Vector.pm:39
+#: /opt/webwork/pg/lib/Value/Vector.pm:303
+#: /opt/webwork/pg/macros/contexts/contextLimitedVector.pl:95
+msgid "i"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:840
+msgid "if"
+msgstr ""
+
+#: /opt/webwork/pg/macros/contexts/contextPiecewiseFunction.pl:843
+msgid "otherwise"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:627
+msgid "part"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:616
+msgid "problem"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/PGbasicmacros.pl:633
+msgid "row"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:485
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:500
+msgid "when you submit your answers"
+msgstr ""
+
+#: /opt/webwork/pg/macros/core/compoundProblem.pl:638
+msgid "your overall score is for all the parts combined."
+msgstr ""


### PR DESCRIPTION
This separates the webwork2 and PG localizations.  PG now uses its own translation po and pot files and provides its own language handle for maketext.  Only the language is passed in by the caller.

The translations in the PG code have been transferred from webwork2.

Note that this includes the fixes for using `maketext` inside the safe compartment that were in the now closed https://github.com/openwebwork/webwork2/pull/2213.

That is the `_compile` method of `Locale::Maketext` is overridden to remove the `use strict` usage inside of its code eval call. That is the only essential difference between the override method added here and the original method in `Locale::Maketext`.  With this you can use `maketext` interpolation in PG. For example, you can call `maketext('[quant,_1,dog] ate my homework', $num_dogs)`.