### PR TITLE
Remove Unnecessary niceTables Warning

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1365,7 +1365,7 @@ sub ParseAlignment {
 
 			# could parse these further for color identification, etc
 		} else {
-			main::WARN_MESSAGE("Token $token in texalignment could not be parsed");
+			main::WARN_MESSAGE("Token $token in texalignment could not be parsed") unless ($token =~ /^\s*$/);
 		}
 	}
 


### PR DESCRIPTION
Right now, if the texalignment string for niceTables includes any whitespace, warnings are thrown. Furthermore, the warning message is unclear since the token is whitespace: "Token in texalignment could not be parsed" (seemingly with no specific token referenced).

I see no reason to warn about whitespace in these strings, so this PR prevents the unnecessary warning.