### PR TITLE
Small tweak to #935 to safe guard internal Compute calls.

### DIFF
--- a/macros/core/Parser.pl
+++ b/macros/core/Parser.pl
@@ -95,7 +95,7 @@ original can be obtained from the C<original_formula> property.
 sub Compute {
 	my $string  = shift;
 	my $formula = Formula($string);
-	if (Value::matchNumber($string)) {
+	if (!ref($string) && Value::matchNumber($string)) {
 		my $real = Real($string);
 		warn "Compute() called with ambiguous value: $string\n"
 			. '-- use Real() for scientific notation'


### PR DESCRIPTION
There are cases where Compute is called internally on non string objects.  Those calls can pass through the new check for ambiguous number forms add in #935, and that can cause issues.

This protects against that by only performing the new check on `$string`s that are not objects already.

I am seeing issues with a problem that uses the
contextLimitedPolynomial.pl macro where this is corrupting the formula tree.  I am working on creating a minimal example that demonstrates the issue, but it is a bit difficult as this is in a problem that does some complicated parsing of the formula tree to extract the terms from a formula created in the with that macro.  This is further complicated as the problem also modifies the context to make the coefficients of the polynomial be fractions in the `Fraction-NoDecimals` context of contextFraction.pl.

In any case, I am certain that there is no reason to perform this check on anything that is not a scalar value, and that this fixes the issue while still achieving the desired result of pull request #935.