### PR TITLE
Alternate to #946 and probably better (slightly) approach.

### DIFF
--- a/macros/core/Parser.pl
+++ b/macros/core/Parser.pl
@@ -97,11 +97,12 @@ sub Compute {
 	my $formula = Formula($string);
 	if (Value::matchNumber($string)) {
 		my $real = Real($string);
-		warn "Compute() called with ambiguous value: $string\n"
-			. '-- use Real() for scientific notation'
-			. " ($real) or use Formula() for $formula \n"
-			unless ($real == $formula);
-		return $real;
+		unless ($real == $formula) {
+			warn "Compute() called with ambiguous value: $string\n"
+				. '-- use Real() for scientific notation'
+				. " ($real) or use Formula() for $formula \n";
+			return $real;
+		}
 	}
 	$formula = $formula->{tree}->Compute if $formula->{tree}{canCompute};
 	my $context = $formula->context;

--- a/macros/core/Parser.pl
+++ b/macros/core/Parser.pl
@@ -93,17 +93,16 @@ original can be obtained from the C<original_formula> property.
 # ^uses Formula
 # ^uses Value::contextSet
 sub Compute {
-	my $string  = shift;
-	my $formula = Formula($string);
-	if (Value::matchNumber($string)) {
-		my $real = Real($string);
-		unless ($real == $formula) {
-			warn "Compute() called with ambiguous value: $string\n"
-				. '-- use Real() for scientific notation'
-				. " ($real) or use Formula() for $formula \n";
-			return $real;
-		}
+	my $string = shift;
+	if ($string =~ m/^\s*-?(?:\d+(?:\.\d*)?|\.\d+)(?:e[-+]\d+)\s*$/
+		&& Value::matchNumber($string)
+		&& ($string ^ $string) eq '0')
+	{
+		warn "Compute() called with ambiguous value: $string\n"
+			. "-- use Real() for scientific notation or Formula() for Euler's number e\n";
+		$string = uc($string);
 	}
+	my $formula = Formula($string);
 	$formula = $formula->{tree}->Compute if $formula->{tree}{canCompute};
 	my $context = $formula->context;
 	my $flags   = Value::contextSet($context, reduceConstants => 0, reduceConstantFunctions => 0, showExtraParens => 0);


### PR DESCRIPTION
Investigating things closer what I see is that the `Real` call added in #935 is not honoring the current context.  In the problem where the issue is being seen, that context happens to be a variant of the `Fraction-NoDecimals` context.  The `Real` call that was added in #935 is not creating a fraction in that context when it should.

This alternate approach only returns the result of the `Real` call in the case that an ambiguous value is detected.  Otherwise it continues on the the rest of the compute method the way that it did before #935 was added.