### PR TITLE
Update the quickMatrixEntry.pl macro

### DIFF
--- a/htdocs/js/QuickMatrixEntry/quickmatrixentry.js
+++ b/htdocs/js/QuickMatrixEntry/quickmatrixentry.js
@@ -1,0 +1,132 @@
+/* global bootstrap */
+
+'use strict';
+
+(() => {
+	const setupQuickMatrixEntryBtn = (button) => {
+		button.addEventListener('click', () => {
+			const name = button.name;
+
+			const modal = document.createElement('div');
+			modal.classList.add('modal');
+			modal.tabIndex = -1;
+			modal.setAttribute('aria-labelledby', 'matrix-entry-dialog-title');
+			modal.setAttribute('aria-hidden', 'true');
+
+			const modalDialog = document.createElement('div');
+			modalDialog.classList.add('modal-dialog', 'modal-dialog-centered');
+			const modalContent = document.createElement('div');
+			modalContent.classList.add('modal-content');
+
+			const modalHeader = document.createElement('div');
+			modalHeader.classList.add('modal-header');
+
+			const title = document.createElement('h1');
+			title.classList.add('fs-3', 'm-0');
+			title.id = 'matrix-entry-dialog-title';
+			title.textContent = 'Enter matrix';
+
+			const closeButton = document.createElement('button');
+			closeButton.type = 'button';
+			closeButton.classList.add('btn-close');
+			closeButton.dataset.bsDismiss = 'modal';
+			closeButton.setAttribute('aria-label', 'close');
+
+			modalHeader.append(title, closeButton);
+
+			const modalBody = document.createElement('div');
+			modalBody.classList.add('modal-body');
+			const modalBodyContent = document.createElement('div');
+			modalBody.append(modalBodyContent);
+
+			const textarea = document.createElement('textarea');
+			textarea.classList.add('form-control');
+			textarea.rows = 10;
+			modalBodyContent.append(textarea);
+
+			const modalFooter = document.createElement('div');
+			modalFooter.classList.add('modal-footer');
+
+			const enterButton = document.createElement('button');
+			enterButton.classList.add('btn', 'btn-primary');
+			enterButton.textContent = 'Enter';
+
+			modalFooter.append(enterButton);
+			modalContent.append(modalHeader, modalBody, modalFooter);
+			modalDialog.append(modalContent);
+			modal.append(modalDialog);
+
+			const insert_value = (i, j, entry) => {
+				const input = document.getElementById(i == 0 && j == 0 ? name : `MaTrIx_${name}_${i}_${j}`);
+				if (!input) return;
+				input.value = entry;
+				if (window.answerQuills && window.answerQuills[input.name])
+					answerQuills[input.name].mathField.latex(entry);
+			};
+
+			const extract_value = (i, j) =>
+				document.getElementById(i == 0 && j == 0 ? name : `MaTrIx_${name}_${i}_${j}`)?.value || 0;
+
+			const rows = parseInt(button.dataset.rows);
+			const columns = parseInt(button.dataset.columns);
+
+			// Enter something that indicates how many columns to fill.
+			const entries = [];
+			for (let i = 0; i < rows; ++i) {
+				entries.push([]);
+				for (let j = 0; j < columns; ++j) {
+					entries[entries.length - 1].push(extract_value(i, j));
+				}
+			}
+			textarea.value = entries.map((row) => row.join(' ')).join('\n');
+
+			enterButton.addEventListener('click', () => {
+				// Get the textarea value, and then remove initial and trailing white space, replace commas with a
+				// space, replace end brackets with a new line, and remove start brackets. Then split on new lines.
+				const matrix = [];
+				for (const row of textarea.value
+					.replace(/^\s*|\s*$/, '')
+					.replace(/,/g, ' ')
+					.replace(/\]/g, '\n')
+					.replace(/\[/g, '')
+					.split(/\n/)) {
+					matrix.push(row.replace(/^\s*/, '').split(/\s+/));
+				}
+
+				for (let i = 0; i < matrix.length; ++i) {
+					for (let j = 0; j < matrix[i].length; ++j) {
+						insert_value(i, j, matrix[i][j]);
+					}
+				}
+
+				bsModal.hide();
+			});
+
+			const bsModal = new bootstrap.Modal(modal);
+			bsModal.show();
+			document.querySelector('.modal-backdrop')?.style.setProperty('--bs-backdrop-opacity', '0.2');
+
+			modal.addEventListener('hidden.bs.modal', () => {
+				bsModal.dispose();
+				modal.remove();
+			});
+		});
+	};
+
+	// Deal with uncheckable radios already in the page.
+	document.querySelectorAll('.quick-matrix-entry-btn').forEach(setupQuickMatrixEntryBtn);
+
+	// Deal with radios that are added to the page later.
+	const observer = new MutationObserver((mutationsList) => {
+		for (const mutation of mutationsList) {
+			for (const node of mutation.addedNodes) {
+				if (node instanceof Element) {
+					if (node.classList.contains('quick-matrix-entry-btn')) setupQuickMatrixEntryBtn(node);
+					else node.querySelectorAll('.quick-matrix-entry-btn').forEach(setupQuickMatrixEntryBtn);
+				}
+			}
+		}
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+	window.addEventListener('unload', () => observer.disconnect());
+})();

--- a/macros/ui/quickMatrixEntry.pl
+++ b/macros/ui/quickMatrixEntry.pl
@@ -1,120 +1,146 @@
-#!/usr/bin/perl -w
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
 
-###################################
-# quick matrix entry package
-###################################
+loadMacros('MathObjects.pl');
 
-sub _quickMatrixEntry_init { };    # don't reload this file
-
-sub INITIALIZE_QUICK_MATRIX_ENTRY {
-	main::HEADER_TEXT($quick_entry_javascript);
-	main::TEXT($quick_entry_form);
-	return '';
+sub _quickMatrixEntry_init {
+	ADD_JS_FILE('js/QuickMatrixEntry/quickmatrixentry.js', 0, { defer => undef });
+	return;
 }
 
-# <input class="opener" type='button' name="AnSwEr0002" value="Quick Entry"
-#  rows=5 columns=9>
+sub QuickMatrixEntry { return parser::QuickMatrixEntry->new(@_) }
+
+package parser::QuickMatrixEntry;
+our @ISA = qw(Value::Matrix);
+
+# Allow promotion of Value::Matrix objects.
+sub promote {
+	my ($self, @args) = @_;
+	my $context = Value::isContext($args[0]) ? shift @args : $self->context;
+	my $x       = @args                      ? shift @args : $self;
+	return $self->new($context, $x, @args) if @args || ref($x) eq 'ARRAY';
+	$x = Value::makeValue($x, context => $context);
+	return $x->inContext($context)              if ref($x) eq 'Value::Matrix' || ref($x) eq (ref($self) || $self);
+	return $self->make($context, @{ $x->data }) if Value::classMatch($x, 'Point', 'Vector');
+	Value::Error(q{Can't convert %s to %s}, Value::showClass($x), Value::showClass($self));
+	return;
+}
+
+sub ans_array {
+	my ($self, $size, @options) = @_;
+
+	my $name = main::NEW_ANS_NAME();
+	my ($rows, $columns) = $self->dimensions;
+
+	return main::tag(
+		'div',
+		class => 'my-2',
+		main::tag(
+			'button',
+			class        => 'quick-matrix-entry-btn btn btn-secondary',
+			type         => 'button',
+			name         => $name,
+			data_rows    => $rows,
+			data_columns => $columns,
+			main::maketext('Quick Entry')
+		)
+	) . $self->SUPER::named_ans_array($name, $size, @options, answer_group_name => $name);
+}
+
+sub type  { return 'Matrix'; }
+sub class { return 'Matrix'; }
+
+# Backwards compatibility. This is deprecated and should not be used.
+
+package main;
+
+sub INITIALIZE_QUICK_MATRIX_ENTRY { }
+
 sub MATRIX_ENTRY_BUTTON {
-	my $answer_number = shift;
-	# warn(" input reference is ". ref($answer_number));
-	my ($rows, $columns) = @_;
-	if (ref($answer_number) =~ /Matrix/i) {    # (handed a MathObject matrix)
-		my $matrix = $answer_number;
-		($rows, $columns) = $matrix->dimensions();
+	my ($matrix, $rows, $columns) = @_;
+
+	my $answer_number;
+
+	if (Value::isValue($matrix) && Value::classMatch($matrix, 'Matrix')) {
+		# Given a MathObject matrix.
+		($rows, $columns) = $matrix->dimensions;
+		# This assumes that the quick entry button comes before the matrix answer blanks.
 		$answer_number = $main::PG->{unlabeled_answer_blank_count} + 1;
-		# the +1 assumes that the quick entry button comes before (above) the matrix answer blanks.
+	} else {
+		$answer_number = $matrix;
 	}
-	$rows    = $rows    // 1;
-	$columns = $columns // 5;
-	my $answer_name = "AnSwEr" . sprintf('%04d', $answer_number);
-	# warn("answer number $answer_name rows $rows columns $columns");
-	return qq!
-	$PAR
-		<input class="opener" type='button' name="$answer_name" value="Quick Entry"
-		rows="$rows" columns="$columns">
-	$PAR!;
+
+	$rows    //= 1;
+	$columns //= 5;
+
+	return tag(
+		'div',
+		class => 'my-2',
+		tag(
+			'button',
+			class        => 'quick-matrix-entry-btn btn btn-secondary',
+			type         => 'button',
+			name         => 'AnSwEr' . sprintf('%04d', $answer_number),
+			data_rows    => $rows,
+			data_columns => $columns,
+			maketext('Quick Entry')
+		)
+	);
 }
 
-our $quick_entry_javascript = <<'END_JS';
-<script>
-$(function() {
-        $( "#quick_entry_form" ).dialog({
-            autoOpen: false,
-            });
-        //console.log('startup');
-        var name = $("#quick_entry_form").attr("name");
-        //console.log("name is " + name );
-        var insert_value = function(name, i,j,entry) {
-			var pos = "#MaTrIx_"+name+"_"+i+"_"+j;
-			if (i==0 && j==0 ) {
-				pos= "#"+name;
-			}  //MaTrIx_AnSwEr0007_0_3
-			//console.log($(pos).val());
-			$(pos).val(entry); //instead of 4000
-		}
-		var extract_value = function(name, i,j) {
-			var pos = "#MaTrIx_"+name+"_"+i+"_"+j;
-			if (i==0 && j==0 ) {
-				pos= "#"+name;
-			}  //MaTrIx_AnSwEr0007_0_3
-			//console.log($(pos).val());
-			return $(pos).val() ;
-		}
-    $( ".opener" ).click(function() {
-         //console.log(this.name );
-         name = this.name;
-         rows = $(this).attr("rows");
-         columns = $(this).attr("columns");
-         //console.log("cols = " + columns);
-         // enter something that indicates how many columns to fill
-         entry = '';
-         for(i=0;i<=rows-1;i++) {
-            for(j=0;j<=columns-1; j++) {
-         		entry = entry + extract_value(name,i,j)+' ';
-         	}
-         	entry = entry + '\n';
-         }
-         //console.log("entry " + entry); # prefill the entry area
-         $("textarea#matrix_input").val(entry);
-         $( "#quick_entry_form" ).dialog( "open" );
-
-    });
-    $( "#closer" ).click(function() {
-        //var name="AnSwEr0007";
-        var entry1 = $("textarea#matrix_input").val().replace(/^\s*/,'');
-        //remove initial white space
-        var entry2=entry1;
-        // replace commas with a space
-        // replace ] with a return
-        // replace [ with nothing
-        if (entry1.match(/\[/) ) {
-        	entry2 = entry1.replace(/,/g,' ').replace(/\]/g,'\n').replace(/\[/g,'');
-        }
-        var mat2=entry2.split(/\n\s*/);
-        //var mat2=mat.split(/\n\s*/);
-        var mat3=[];
-        for (i=0; i<mat2.length; i++) {
-        	var mat_tmp = mat2[i].replace(/^\s*/,''); // remove initial white space
-            mat3.push( mat_tmp.split(/\s+/) );
-        }
-        for (i=0; i<mat3.length; i++) {
-            for(j=0; j<mat3[i].length; j++){
-                insert_value(name,i,j,mat3[i][j]);
-            }
-        }
-        $( "#quick_entry_form" ).dialog( "close" );
-      });
-});
-</script>
-END_JS
-
-our $quick_entry_form = <<'END_TEXT';
-<div id="quick_entry_form" name="quick entry" title="Enter matrix">
-  <textarea id="matrix_input" rows="5" columns = "10">
-  </textarea>
-  <button id="closer">enter</button>
-</div>
-END_TEXT
-
-INITIALIZE_QUICK_MATRIX_ENTRY();    # only need the javascript to be entered once.
 1;
+
+__END__
+
+=head1 NAME
+
+quickMatrixEntry.pl - Add a button to MathObject C<Matrix> array answers that
+allows pasting of matrix contents.
+
+=head1 DESCRIPTION
+
+A QuickMatrixEntry object lets you add a "Quick Entry" button to a MathObject
+C<Matrix> array answer.  When the button is clicked it opens a dialog in which
+you can edit the entries of the matrix in a text area.  This allows pasting of
+large matrices from other sources.
+
+A QuickMatrixEntry object is created in much the same way that a MathObject
+C<Matrix> is created.  Set the context to the C<Matrix> context, and call the
+C<QuickMatrixEntry> method with an array of arrays. For example,
+
+    Context('Matrix');
+
+    $matrix = QuickMatrixEntry([
+        [ 1, 2, 3, 4, 5, 6, 7, 8 ],
+        [ 8, 7, 6, 5, 4, 3, 2, 1 ],
+        [ 1, 2, 3, 4, 5, 6, 7, 8 ],
+        [ 8, 7, 6, 5, 4, 3, 2, 1 ],
+        [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+    ]);
+
+Then add the array of answer rules to the problem with
+
+    BEGIN_PGML
+    [_]*{$matrix}{4}
+    END_PGML
+
+Other than the button that is added above the array of answers, the
+C<QuickMatrixEntry> is just a MathObject C<Matrix>, and everything that can be
+done with a MathObject C<Matrix> can also be done with a C<QuickMatrixEntry>.
+However, if not used via C<ans_array> (the starred answer form in PGML) the
+button will not be added and the C<QuickMatrixEntry> object will be nothing more
+than a MathObject C<Matrix>.  This generally should not be done.
+
+=cut


### PR DESCRIPTION
This removes the dependence on jQuery and jquery-ui.

This also adds an ans_rule method for PGML usage.  The POD documentation that was added explains only how to use the macro in this way.

There is deprecated code for backwards compatibility, although I would gladly remove that.  The only known problem that uses this macro is in the pg repository.  It is the file `t/matrix_tableau_tests/tableau_javascript.pg`.  I would also like to delete that file.