### PR TITLE
allow empty set symbol for empty solution sets

### DIFF
--- a/macros/contexts/contextFiniteSolutionSets.pl
+++ b/macros/contexts/contextFiniteSolutionSets.pl
@@ -103,6 +103,7 @@ sub _contextFiniteSolutionSets_init {
 		"none"              => { alias => 'no real solutions' },
 		"no solution"       => { alias => 'no real solutions' },
 		"no solutions"      => { alias => 'no real solutions' },
+		"\x{2205}"          => { alias => 'no real solutions' },
 		#Hack. Investigate making all of this be a constant.
 		"{}"                        => { alias => 'no real solutions' },
 		"{ }"                       => { alias => 'no real solutions' },


### PR DESCRIPTION
This lets a student enter ∅ directly if they are trying to say that there are no solutions. For now this is just if they happen to know how to get that symbol into the input field.