### PR TITLE
Restructure how answer names are associated with answer evaluators.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -446,9 +446,8 @@ sub ans_matrix {
 	my $named_extension = pgRef('NAMED_ANS_ARRAY_EXTENSION');
 	my $named_ans_rule  = pgRef('NAMED_ANS_RULE');
 	my $HTML            = "";
-	my $ename           = $name;
-	$name             = pgCall('NEW_ANS_NAME') if ($name eq '');
-	$ename            = "${answerPrefix}_${name}";
+	pgCall('RECORD_IMPLICIT_ANS_NAME', $name = pgCall('NEW_ANS_NAME')) unless $name;
+	my $ename = "${answerPrefix}_${name}";
 	$self->{ans_name} = $ename;
 	$self->{ans_rows} = $rows;
 	$self->{ans_cols} = $cols;

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1402,7 +1402,15 @@ sub Answer {
 			}
 			$rule = $ans->$method(@options);
 			$rule = PGML::LaTeX($rule);
-			if (!(ref($ans) eq 'parser::MultiAnswer' && $ans->{part} > 1)) {
+			my $isMultiAnswer = ref($ans) eq 'parser::MultiAnswer';
+			if ($isMultiAnswer) {
+				$ans->{pgml_cmp} = { cmp => [ $ans->cmp(%{ $item->{cmp_options} }) ] } unless defined $ans->{pgml_cmp};
+				if ($ans->{namedRules}) {
+					main::NAMED_ANS(shift(@{ $ans->{pgml_cmp}{cmp} }), shift(@{ $ans->{pgml_cmp}{cmp} }));
+				} else {
+					main::ANS(shift(@{ $ans->{pgml_cmp}{cmp} })) if @{ $ans->{pgml_cmp}{cmp} };
+				}
+			} else {
 				my @cmp =
 					ref($item->{answer}) eq 'AnswerEvaluator' ? $item->{answer} : $ans->cmp(%{ $item->{cmp_options} });
 				if (defined($item->{name})) {

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -187,83 +187,101 @@ EndOfFile
 
 =head2  Answer blank macros:
 
-These produce answer blanks of various sizes or pop up lists or radio answer buttons.
-The names for the answer blanks are
-generated implicitly.
+These produce answer blanks of various sizes or pop up lists or radio answer
+buttons. The names for the answer blanks are generated and implicitly
+associated with answer evaluators via the C<ANS> method.
 
-    ans_rule( width )
-    tex_ans_rule( width )
-    ans_radio_buttons(value1 => label1, value2, label2 => value3, label3 => ...)
-    pop_up_list(@list)   # list consists of (value => label,  PR => "Product rule", ...)
-    pop_up_list([@list]) # list consists of values
+    ans_rule(width)
+    ans_radio_buttons(value1 => name1, value2, name2 => value3, name3 => ...)
+    pop_up_list(@list)      # list consists of (value => label, PR => "Product rule", ...)
+    pop_up_list([@list])    # list consists of values
 
 In the last case, one can use C<pop_up_list(['?', 'yes', 'no'])> to produce a
 pop-up list containing the three strings listed, and then use str_cmp to check
 the answer.
 
-To indicate the checked position of radio buttons put a '%' in front of the value: C<ans_radio_buttons(1, 'Yes', '%2', 'No')>
-will have 'No' checked.  C<tex_ans_rule> works inside math equations in C<HTML_tth> mode.  It does not work in C<Latex2HTML> mode since this mode produces gif pictures.
+To indicate the checked position of radio buttons put a '%' in front of the
+value: C<ans_radio_buttons(1, 'Yes', '%2', 'No')> will have 'No' checked.
 
-The following method is defined in F<PG.pl> for entering the answer evaluators corresponding
-to answer rules with automatically generated names.  The answer evaluators are matched with the
-answer rules in the order in which they appear on the page.
+The following method is defined in F<PG.pl> for entering the answer evaluators
+corresponding to answer rules with automatically generated names. The answer
+evaluators are matched with the answer rules in the order in which they appear
+on the page.
 
     ANS(ans_evaluator1, ans_evaluator2, ...);
 
-These are more primitive macros which produce answer blanks for specialized cases when complete
-control over the matching of answers blanks and answer evaluators is desired.
-The names of the answer blanks must be generated manually, and it is best if they do NOT begin
-with the default answer prefix (currently AnSwEr).
-
-    labeled_ans_rule(name, width)  # an alias for NAMED_ANS_RULE where width defaults to 20 if omitted.
+These are more primitive macros which produce answer blanks for specialized
+cases when complete control over the matching of answers blanks and answer
+evaluators is desired.  The names of the answer blanks must be generated
+manually, and it is best if they do NOT begin with the default answer prefix
+(currently AnSwEr).
 
     NAMED_ANS_RULE(name, width)
-    NAMED_ANS_BOX(name, rows, cols)
-    NAMED_ANS_RADIO(name, value, label)
-    NAMED_ANS_RADIO_EXTENSION(name, value, label)
-    NAMED_ANS_RADIO_BUTTONS(name, value1, label1, value2, label2, ...)
-    check_box('-name' => answer5, '-value' => 'statement3', '-label' => 'I loved this course!')
-    NAMED_POP_UP_LIST($name, @list) # list consists of (value => tag,  PR => "Product rule", ...)
-    NAMED_POP_UP_LIST($name, [@list]) # list consists of a list of values (and each tag will be set to the corresponding value)
+    labeled_ans_rule(name, width)    # alias for NAMED_ANS_RULE
+	NAMED_ANS_BOX(name, rows, cols)
+    NAMED_ANS_RADIO(name, value, name)
+    NAMED_ANS_RADIO_EXTENSION(name, value, name)
+    NAMED_ANS_RADIO_BUTTONS(name, value1, name1, value2, name2, ...)
+    NAMED_POP_UP_LIST($name, @list)     # list consists of (value => tag, PR => "Product rule", ...)
+    NAMED_POP_UP_LIST($name, [@list])   # list consists of a list of values
+                                        # (and each tag will be set to the corresponding value)
 
-(Name is the name of the variable, value is the value given to the variable when this option is selected,
-and label is the text printed next to the button or check box.    Check box variables can have multiple values.)
+(Name is the name of the input, value is the value given to the input when
+this option is selected, and label is the text printed next to the button or
+check box. Check box variables can have multiple values.)
 
-NAMED_ANS_RADIO_BUTTONS creates a sequence of NAMED_ANS_RADIO and NAMED_ANS_RADIO_EXTENSION  items which
-are  output either as an array or, in scalar context, as the array glued together with spaces.  It is
-usually easier to use this than to manually construct the radio buttons by hand.  However, sometimes
- extra flexibility is desiredin which case:
+NAMED_ANS_RADIO_BUTTONS creates a sequence of NAMED_ANS_RADIO and
+NAMED_ANS_RADIO_EXTENSION items which are output either as an array or, in
+scalar context, as the array glued together with spaces. It is usually easier
+to use this than to manually construct the radio buttons by hand. However,
+sometimes extra flexibility is desiredin which case:
 
-When entering radio buttons using the "NAMED" format, you should use NAMED_ANS_RADIO button for the first button
-and then use NAMED_ANS_RADIO_EXTENSION for the remaining buttons.  NAMED_ANS_RADIO requires a matching answer evalutor,
-while NAMED_ANS_RADIO_EXTENSION does not. The name used for NAMED_ANS_RADIO_EXTENSION should match the name
-used for NAMED_ANS_RADIO (and the associated answer evaluator).
+When entering radio buttons using the "NAMED" format, you should use
+NAMED_ANS_RADIO button for the first button and then use
+NAMED_ANS_RADIO_EXTENSION for the remaining buttons. NAMED_ANS_RADIO requires a
+matching answer evalutor, while NAMED_ANS_RADIO_EXTENSION does not. The name
+used for NAMED_ANS_RADIO_EXTENSION should match the name used for
+NAMED_ANS_RADIO (and the associated answer evaluator).
 
-The following method is defined in  F<PG.pl> for entering the answer evaluators corresponding
-to answer rules with automatically generated names.  The answer evaluators are matched with the
-answer rules in the order in which they appear on the page.
+The following method is defined for entering the answer evaluators corresponding
+to answer rules. The answer evaluators are matched with the answer rules in the
+order in which they appear on the page.
 
     NAMED_ANS(name1 => ans_evaluator1, name2 => ans_evaluator2, ...);
 
-These auxiliary macros are defined in PG.pl
+Auxiliary macros defined in PG.pl:
 
-    NEW_ANS_NAME(        );   # produces a new anonymous answer blank name  by appending a number to the prefix (AnSwEr)
-                              # and registers this name as an implicitly labeled answer
-                              # Its use is paired with each answer evaluator being entered using ANS()
+=over
 
-    ANS_NUM_TO_NAME(number);  # prepends the prefix (AnSwEr) to the number, but does nothing else.
+=item NEW_ANS_NAME()
 
-    RECORD_ANS_NAME( name );  # records the order in which the answer blank  is rendered
-                              # This is called by all of the constructs above, but must
-                              # be called explicitly if an input blank is constructed explictly
-                              # using HTML code.
+Produces a new anonymous answer blank name by appending a number to the prefix
+(AnSwEr).
 
-These are legacy macros:
+=item ANS_NUM_TO_NAME(number)
 
-    ANS_RULE( number, width );                       # equivalent to NAMED_ANS_RULE( NEW_ANS_NAME(  ), width)
-    ANS_BOX( question_number, height, width );       # equivalent to NAMED_ANS_BOX( NEW_ANS_NAME(  ), height, width)
-    ANS_RADIO( question_number, value, tag );        # equivalent to NAMED_ANS_RADIO( NEW_ANS_NAME( ), value, tag)
-    ANS_RADIO_OPTION( question_number, value, tag ); # equivalent to NAMED_ANS_RADIO_EXTENSION( ANS_NUM_TO_NAME(number), value, tag)
+Prepends the prefix (AnSwEr) to the number, but does nothing else.
+
+=item RECORD_ANS_NAME(name)
+
+Records the order in which the answer blank is rendered. All answer rules must
+be recorded by this method. All named answer rule methods in this macro do this.
+Most answer rules created elsewhere call a named answer rule method in this
+macro to handle this.
+
+=item RECORD_IMPLICIT_ANS_NAME(name)
+
+Records answer names which are to be implicitly associated with an answer This
+is called by the internal answer rule methods, but must be called for all answer
+rules constructed elsewhere as well. After this is called C<RECORD_ANS_NAME>
+must be called as well. Usually the appropriate named answer rule method should
+be called which will do this.
+
+=back
+
+Deprecated macro (still used by many problems):
+
+    ANS_RULE(number, width);    # equivalent to ans_rule(width) -- number is ignored
 
 =cut
 
@@ -395,9 +413,11 @@ sub NAMED_ANS_RULE_EXTENSION {
 	);
 }
 
-sub ANS_RULE {    #deprecated
+# Deprecated
+sub ANS_RULE {
 	my ($number, $col) = @_;
-	my $name = NEW_ANS_NAME($number);
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
 	return NAMED_ANS_RULE($name, $col);
 }
 
@@ -429,12 +449,6 @@ sub NAMED_ANS_BOX {
 			. tag('input', type => 'hidden', name => "previous_$name", value => $answer_value),
 		PTX => '<var name="' . "$name" . '" height="' . "$row" . '" width="' . "$col" . '" />',
 	);
-}
-
-sub ANS_BOX {    #deprecated
-	my ($number, $row, $col) = @_;
-	my $name = NEW_ANS_NAME();
-	return NAMED_ANS_BOX($name, $row, $col);
 }
 
 sub NAMED_ANS_RADIO {
@@ -518,32 +532,9 @@ sub NAMED_ANS_RADIO_BUTTONS {
 	return wantarray ? @out : join(" ", @out);
 }
 
-sub ANS_RADIO {
-	my ($number, $value, $tag) = @_;
-	return NAMED_ANS_RADIO(NEW_ANS_NAME(), $value, $tag);
-}
-
-sub ANS_RADIO_OPTION {
-	my ($number, $value, $tag) = @_;
-	return NAMED_ANS_RADIO_EXTENSION(ANS_NUM_TO_NAME($number), $value, $tag);
-}
-
-sub ANS_RADIO_BUTTONS {
-	my ($number, $value, $tag, @buttons) = @_;
-
-	my @out;
-	push(@out, ANS_RADIO($number, $value, $tag));
-	while (@buttons) {
-		$value = shift @buttons;
-		$tag   = shift @buttons;
-		push(@out, ANS_RADIO_OPTION($number, $value, $tag));
-	}
-	return wantarray ? @out : join(" ", @out);
-}
-
 ##############################################
 #   generate_aria_label( $name )
-#   takes the name of an ANS_RULE or ANS_BOX and generates an appropriate
+#   takes the name of an ANS_RULE and generates an appropriate
 #   aria label for screen readers
 ##############################################
 
@@ -645,7 +636,6 @@ sub NAMED_ANS_CHECKBOX {
 		),
 		PTX => "<li>$tag</li>\n",
 	);
-
 }
 
 sub NAMED_ANS_CHECKBOX_OPTION {
@@ -697,43 +687,16 @@ sub NAMED_ANS_CHECKBOX_BUTTONS {
 	return wantarray ? @out : join(" ", @out);
 }
 
-sub ANS_CHECKBOX {
-	my ($number, $value, $tag) = @_;
-	return NAMED_ANS_CHECKBOX(NEW_ANS_NAME(), $value, $tag);
-}
-
-sub ANS_CHECKBOX_OPTION {
-	my ($number, $value, $tag) = @_;
-	return NAMED_ANS_CHECKBOX_OPTION(ANS_NUM_TO_NAME($number), $value, $tag);
-}
-
-sub ANS_CHECKBOX_BUTTONS {
-	my ($number, $value, $tag, @buttons) = @_;
-
-	my @out;
-	push(@out, ANS_CHECKBOX($number, $value, $tag));
-
-	while (@buttons) {
-		$value = shift @buttons;
-		$tag   = shift @buttons;
-		push(@out, ANS_CHECKBOX_OPTION($number, $value, $tag));
-	}
-
-	return wantarray ? @out : join(" ", @out);
-}
-
 sub ans_rule {
-	my $len = shift || 20;
-	return NAMED_ANS_RULE(NEW_ANS_NAME(), $len);
-}
-
-sub ans_rule_extension {
-	my $len = shift || 20;
-	return NAMED_ANS_RULE(NEW_ANS_NAME(), $len);
+	my $len  = shift;
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
+	return NAMED_ANS_RULE($name, $len || 20);
 }
 
 sub ans_radio_buttons {
-	my $name          = NEW_ANS_NAME();
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
 	my @radio_buttons = NAMED_ANS_RADIO_BUTTONS($name, @_);
 
 	if ($displayMode eq 'TeX') {
@@ -754,7 +717,8 @@ sub ans_radio_buttons {
 }
 
 sub ans_checkbox {
-	my $name       = NEW_ANS_NAME();
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
 	my @checkboxes = NAMED_ANS_CHECKBOX_BUTTONS($name, @_);
 
 	if ($displayMode eq 'TeX') {
@@ -774,63 +738,11 @@ sub ans_checkbox {
 	return wantarray ? @checkboxes : join(" ", @checkboxes);
 }
 
-# define a version of ans_rule which will work inside TeX math mode or display math mode -- at least for tth mode.
-# This is great for displayed fractions.
-sub tex_ans_rule {
-	my $len = shift || 20;
-	# Call NAMED_ANS_RULE before MODES.  Otherwise three answer rules will be created.
-	my $answer_rule = NAMED_ANS_RULE(NEW_ANS_NAME(), $len);
-	return MODES(
-		'TeX'       => $answer_rule,
-		'HTML_tth'  => '\\begin{rawhtml} ' . $answer_rule . '\\end{rawhtml}',
-		'HTML_dpng' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
-		'HTML'      => $answer_rule,
-		'PTX'       => 'Answer boxes cannot be placed inside typeset equations',
-	);
-}
-
-sub tex_ans_rule_extension {
-	my $len = shift || 20;
-	# Call NAMED_ANS_RULE before MODES.  Otherwise three answer rules will be created.
-	my $answer_rule = NAMED_ANS_RULE(NEW_ANS_NAME($$r_ans_rule_count), $len);
-	return MODES(
-		'TeX'       => $answer_rule,
-		'HTML_tth'  => '\\begin{rawhtml} ' . $answer_rule . '\\end{rawhtml}',
-		'HTML_dpng' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
-		'HTML'      => $answer_rule,
-		'PTX'       => 'Answer boxes cannot be placed inside typeset equations',
-	);
-}
-
-sub NAMED_TEX_ANS_RULE {
-	my ($name, $len) = @_;
-	# Call NAMED_ANS_RULE before MODES.  Otherwise three answer rules will be created.
-	my $answer_rule = NAMED_ANS_RULE($name, $len || 20);
-	return MODES(
-		'TeX'       => $answer_rule,
-		'HTML_tth'  => '\\begin{rawhtml} ' . $answer_rule . '\\end{rawhtml}',
-		'HTML_dpng' => '\\fbox{Answer boxes cannot be placed inside typeset equations}',
-		'HTML'      => $answer_rule,
-		'PTX'       => 'Answer boxes cannot be placed inside typeset equations',
-	);
-}
-
-sub NAMED_TEX_ANS_RULE_EXTENSION {
-	my ($name, $len) = @_;
-	# Call NAMED_ANS_RULE before MODES.  Otherwise three answer rules will be created.
-	my $answer_rule = NAMED_ANS_RULE_EXTENSION($name, $len || 20);
-	return MODES(
-		'TeX'       => $answer_rule,
-		'HTML_tth'  => '\\begin{rawhtml} ' . $answer_rule . '\\end{rawhtml}',
-		'HTML_dpng' => '\fbox{Answer boxes cannot be placed inside typeset equations}',
-		'HTML'      => $answer_rule,
-		'PTX'       => 'Answer boxes cannot be placed inside typeset equations',
-	);
-}
-
 sub ans_box {
 	my ($row, $col) = @_;
-	return NAMED_ANS_BOX(NEW_ANS_NAME(), $row || 5, $col || 80);
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
+	return NAMED_ANS_BOX($name, $row || 5, $col || 80);
 }
 
 # this is legacy code; use ans_checkbox instead
@@ -879,7 +791,9 @@ sub NAMED_POP_UP_LIST {
 
 sub pop_up_list {
 	my @list = @_;
-	return NAMED_POP_UP_LIST(NEW_ANS_NAME(), @list);
+	my $name = NEW_ANS_NAME();
+	RECORD_IMPLICIT_ANS_NAME($name);
+	return NAMED_POP_UP_LIST($name, @list);
 }
 
 =head2  answer_matrix
@@ -983,45 +897,26 @@ sub ans_array {
 	$col ||= 20;
 
 	my $ans_label = NEW_ANS_NAME();
-	my $num       = ans_rule_count();
-	my @array;
+	RECORD_IMPLICIT_ANS_NAME($ans_label);
+
 	$main::vecnum = -1;
 	CLEAR_RESPONSES($ans_label);
 
+	my @array;
 	for (my $i = 0; $i < $n; $i += 1) {
-		$array[0][$i] =
-			NAMED_ANS_ARRAY_EXTENSION(NEW_ANS_ARRAY_NAME_EXTENSION($num, 0, $i), $col, ans_label => $ans_label);
+		my $name = NEW_ANS_ARRAY_NAME_EXTENSION(0, $i);
+		$array[0][$i] = NAMED_ANS_ARRAY_EXTENSION($name, $col, ans_label => $ans_label);
 	}
 
 	for (my $j = 1; $j < $m; $j += 1) {
 		for (my $i = 0; $i < $n; $i += 1) {
-			$array[$j][$i] =
-				NAMED_ANS_ARRAY_EXTENSION(NEW_ANS_ARRAY_NAME_EXTENSION($num, $j, $i), $col, ans_label => $ans_label);
+			my $name = NEW_ANS_ARRAY_NAME_EXTENSION($j, $i);
+			$array[$j][$i] = NAMED_ANS_ARRAY_EXTENSION($name, $col, ans_label => $ans_label);
 		}
 	}
 	my $ra_local_display_matrix = PG_restricted_eval(q!\&main::display_matrix!);
-	return &$ra_local_display_matrix(\@array, @options);
-}
 
-sub ans_array_extension {
-	my ($m, $n, $col, @options) = @_;
-	$col ||= 20;
-
-	my $num = ans_rule_count();    # hack -- ans_rule_count is updated after being used
-	my @array;
-	my $ans_label = $main::PG->new_label($num);
-
-	for (my $j = 0; $j < $m; $j += 1) {
-		for (my $i = 0; $i < $n; $i += 1) {
-			$array[$j][$i] = NAMED_ANS_ARRAY_EXTENSION(
-				NEW_ANS_ARRAY_NAME_EXTENSION($num, $j, $i), $col,
-				answer_group_name => $ans_label,
-				@options
-			);
-		}
-	}
-	my $ra_local_display_matrix = PG_restricted_eval(q!\&main::display_matrix!);
-	return &$ra_local_display_matrix(\@array, @options);
+	return $ra_local_display_matrix->(\@array, @options);
 }
 
 # end answer blank macros

--- a/macros/core/PGessaymacros.pl
+++ b/macros/core/PGessaymacros.pl
@@ -158,7 +158,8 @@ sub essay_box {
 	$row ||= 8;
 	$col ||= 75;
 	my $name = NEW_ANS_NAME();
-	return NAMED_ESSAY_BOX($name, $row, $col);
+	main::RECORD_IMPLICIT_ANS_NAME($name);
+	NAMED_ESSAY_BOX($name, $row, $col);
 
 }
 

--- a/macros/core/compoundProblem5.pl
+++ b/macros/core/compoundProblem5.pl
@@ -313,9 +313,7 @@ sub ans_evaluators {
 	my $self    = shift;
 	my $section = $self->{sections}{ $self->{current_section} };
 	if ($section->{section_answers}) {
-		my $count = $main::PG->{unlabeled_answer_eval_count};    # Pitty that we have to grab this by hand
-		foreach my $evaluator (@_) {
-			my $name = main::ANS_NUM_TO_NAME(++$count);
+		foreach my $name (@{ $main::PG->{unlabeled_answer_name_stack} }) {
 			push(@{ $self->{ans_names} },          $name);
 			push(@{ $section->{section_answers} }, $name);
 		}
@@ -725,4 +723,3 @@ sub PROCESS_SCAFFOLD      { $Scaffold::scaffold->PROCESS_SCAFFOLD(@_) }
 sub INITIALIZE_SCAFFOLD { $Scaffold::scaffold->{oldstyle} = 1 }    # backward compatibility
 
 1;
-

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -1067,7 +1067,7 @@ parser::GraphTool->addTools(
 
 sub ANS_NAME {
 	my $self = shift;
-	$self->{name} = main::NEW_ANS_NAME() unless defined($self->{name});
+	main::RECORD_IMPLICIT_ANS_NAME($self->{name} = main::NEW_ANS_NAME()) unless defined $self->{name};
 	return $self->{name};
 }
 

--- a/macros/math/draggableProof.pl
+++ b/macros/math/draggableProof.pl
@@ -278,7 +278,7 @@ sub new {
 
 sub ANS_NAME {
 	my $self = shift;
-	$self->{answer_name} = main::NEW_ANS_NAME() unless defined $self->{answer_name};
+	main::RECORD_IMPLICIT_ANS_NAME($self->{answer_name} = main::NEW_ANS_NAME()) unless defined $self->{answer_name};
 	return $self->{answer_name};
 }
 

--- a/macros/math/draggableSubsets.pl
+++ b/macros/math/draggableSubsets.pl
@@ -272,7 +272,7 @@ sub type { return 'List' }
 
 sub ANS_NAME {
 	my $self = shift;
-	$self->{answer_name} = main::NEW_ANS_NAME() unless defined $self->{answer_name};
+	main::RECORD_IMPLICIT_ANS_NAME($self->{answer_name} = main::NEW_ANS_NAME()) unless defined $self->{answer_name};
 	return $self->{answer_name};
 }
 

--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -542,7 +542,7 @@ sub CHECKS {
 	my ($self, $extend, $name, $size, %options) = @_;
 
 	my @checks;
-	$name = main::NEW_ANS_NAME() unless $name;
+	main::RECORD_IMPLICIT_ANS_NAME($name = main::NEW_ANS_NAME()) unless $name;
 	my $label = main::generate_aria_label($name);
 
 	for my $i (0 .. $#{ $self->{orderedChoices} }) {

--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -371,6 +371,7 @@ sub ans_rule {
 	my $name = $self->ANS_NAME($self->{part}++);
 	if ($self->{singleResult} && $self->{part} == 1) {
 		my $label = main::generate_aria_label($answerPrefix . $name . "_0");
+		main::RECORD_IMPLICIT_ANS_NAME($name) unless $self->{namedRules};
 		return $data->named_ans_rule($name, $size, @_, aria_label => $label);
 	}
 	if ($self->{singleResult} && $self->{part} > 1) {
@@ -382,6 +383,7 @@ sub ans_rule {
 		# warn "extension rule created: $extension_ans_rule for ", ref($data);
 		return $extension_ans_rule;
 	} else {
+		main::RECORD_IMPLICIT_ANS_NAME($name) unless $self->{namedRules};
 		return $data->named_ans_rule($name, $size, @_);
 	}
 }
@@ -399,6 +401,7 @@ sub ans_array {
 	my $name = $self->ANS_NAME($self->{part}++);
 	if ($self->{singleResult} && $self->{part} == 1) {
 		my $label = main::generate_aria_label($answerPrefix . $name . "_0");
+		main::RECORD_IMPLICIT_ANS_NAME($name) unless $self->{namedRules};
 		return $data->named_ans_array(
 			$name, $size,
 			answer_group_name => $self->{answerNames}{0},
@@ -413,6 +416,7 @@ sub ans_array {
 		);
 		# warn "array extension rule created: $HTML for ", ref($data);
 	} else {
+		main::RECORD_IMPLICIT_ANS_NAME($name) unless $self->{namedRules};
 		$HTML = $data->named_ans_array($name, $size, @_);
 	}
 	$self->{cmp}[ $self->{part} - 1 ] = $data->cmp(@ans_defaults);

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -197,7 +197,7 @@ sub MENU {
 	my @list        = @{ $self->{choices} };
 	my $placeholder = $self->{placeholder};
 	my $menu        = "";
-	$name = main::NEW_ANS_NAME() unless $name;
+	main::RECORD_IMPLICIT_ANS_NAME($name = main::NEW_ANS_NAME()) unless $name;
 	my $answer_value = (defined($main::inputs_ref->{$name}) ? $main::inputs_ref->{$name} : '');
 	my $label        = main::generate_aria_label($name);
 

--- a/macros/parsers/parserRadioButtons.pl
+++ b/macros/parsers/parserRadioButtons.pl
@@ -614,7 +614,7 @@ sub BUTTONS {
 	my $size    = shift;
 	my @choices = @{ $self->{orderedChoices} };
 	my @radio   = ();
-	$name = main::NEW_ANS_NAME() unless $name;
+	main::RECORD_IMPLICIT_ANS_NAME($name = main::NEW_ANS_NAME()) unless $name;
 	my $label = main::generate_aria_label($name);
 
 	foreach my $i (0 .. $#choices) {

--- a/macros/parsers/parserRadioMultiAnswer.pl
+++ b/macros/parsers/parserRadioMultiAnswer.pl
@@ -570,7 +570,8 @@ sub appendMessage {
 sub ANS_NAME {
 	my ($self, $i) = @_;
 	return $self->{answerNames}{$i} if defined $self->{answerNames}{$i};
-	$self->{answerNames}{0}  = main::NEW_ANS_NAME() unless defined $self->{answerNames}{0};
+	main::RECORD_IMPLICIT_ANS_NAME($self->{answerNames}{0} = main::NEW_ANS_NAME())
+		unless defined $self->{answerNames}{0};
 	$self->{answerNames}{$i} = $answerPrefix . $self->{answerNames}{0} . '_' . $i unless $i == 0;
 	return $self->{answerNames}{$i};
 }

--- a/macros/parsers/parserWordCompletion.pl
+++ b/macros/parsers/parserWordCompletion.pl
@@ -70,8 +70,9 @@ sub cmp_defaults { return (shift->SUPER::cmp_defaults(@_), mathQuillOpts => 'dis
 
 sub menu {
 	my ($self, $name, $size) = @_;
-	$name ||= main::NEW_ANS_NAME();
 	$size ||= 20;
+
+	main::RECORD_IMPLICIT_ANS_NAME($name = main::NEW_ANS_NAME()) unless $name;
 
 	my $answer_value = $main::inputs_ref->{$name} // '';
 	$answer_value = [ split("\0", $answer_value) ] if $answer_value =~ /\0/;
@@ -83,7 +84,6 @@ sub menu {
 	$answer_value =~ s/\s+/ /g;
 
 	$name = main::RECORD_ANS_NAME($name, $answer_value);
-	my $previous_name = "previous_$name";
 
 	my $tcol = $size / 2 > 3 ? $size / 2 : 3;
 	$tcol = $tcol < 40 ? $tcol : 40;

--- a/macros/ui/quickMatrixEntry.pl
+++ b/macros/ui/quickMatrixEntry.pl
@@ -42,6 +42,8 @@ sub ans_array {
 	my ($self, $size, @options) = @_;
 
 	my $name = main::NEW_ANS_NAME();
+	main::RECORD_IMPLICIT_ANS_NAME($name);
+
 	my ($rows, $columns) = $self->dimensions;
 
 	return main::tag(
@@ -77,7 +79,7 @@ sub MATRIX_ENTRY_BUTTON {
 		# Given a MathObject matrix.
 		($rows, $columns) = $matrix->dimensions;
 		# This assumes that the quick entry button comes before the matrix answer blanks.
-		$answer_number = $main::PG->{unlabeled_answer_blank_count} + 1;
+		$answer_number = $main::PG->{answer_name_count} + 1;
 	} else {
 		$answer_number = $matrix;
 	}


### PR DESCRIPTION
Before describing the restructuring some terminology needs to be clarified.

Henceforth we will no longer refer to any answer as being "unlabeled". All answers are labeled (or better "named" -- more on that later), and always have been.  Every answer rule method calls a named answer rule method, and `ANS` calls `NAMED_ANS` (previously it called `LABELED_ANS`).  Instead answers are either explicitly named (meaning an author chose the name -- hopefully by calling `NEW_ANS_NAME`), or implicitly named (meaning that the association of the name and evaluator is handled by PG by order of ANS and ans_rule calls).

Also, the term "label" should not be used for this. In HTML this is the "name" attribute on the input, and a "label" is a different thing entirely. As such the deprecation flag on the `NAMED_ANS` method has been removed.  In fact, `NAMED_ANS` is no longer an alias for `LABELED_ANS`.  Instead it is the other way around.  So we should encourage using `named_ans_rule` methods together with `NAMED_ANS`.

Now for the restructuring.  Instead of using a fragile pairing of answer name and answer evaluator counts, two FIFO stacks and a name answer hash are used.  The stacks are basically as described by @dpvc in https://github.com/openwebwork/pg/issues/944#issuecomment-1781881663.

When an `ans_rule` method is called is calls `NEW_ANS_NAME` as before. However, `NEW_ANS_NAME` only increments a counter that is only used to make the answer names unique, and does not record the answer anymore. The `ans_rule` method is now responsible for recording the answer after calling `NEW_ANS_NAME`.  It does this by calling
`RECORD_IMPLICIT_ANS_NAME`.  That method pushes the answer name onto the implicit answer name stack.  Then the named answer rule method (which must be called by the answer rule method) records the answer by calling `RECORD_ANS_NAME`.  That actually adds the answer name to the `PG_ANSWERS_HASH`.  Then when `ANS` is called it shifts the first answer name from the stack and associates that answer name to the given answer evaluator by calling `NAMED_ANS`.

The previous paragraph is assuming that the answer rule method is called before the `ANS` method.  If the `ANS` method is called first, then it pushes the answer evaluator onto the other stack which is the implicit evaluator stack.  Then when the `ans_rule` method is called it shifts the first evaluator from the stack and associates it with the given answer name by calling `NAMED_ANS` when the answer is recorded by the named answer rule method.

In the case that an author provides a name (which should be obtained by calling `NEW_ANS_NAME` to obtain a name that will work in all scenarios in which problems are rendered), then these explicit names and associated evaluators are not added to the above stacks.  Of course this is done as before by calling a name answer rule method and `NAMED_ANS` (or its alias `LABELED_ANS`).  This basically circumvents the stacks and makes the association directly.  If the `NAMED_ANS` method is called first, then the given name and evaluator are added to the explicit named evaluator hash.  Then when the named answer rule method is called with the same answer name it removes the evaluator from the hash and adds it to the PG_ANSWERS_HASH.  This ensures that the order of PG_ANSWERS_HASH is the same as the order that the answer rule methods are called.  Thus the order in the (soon to be removed) attempts table will always be correct.  This order will still matter somewhat without the attempts table in some cases as it is the order that the answer evaluators are called in answer processing.

With this pull request I think that all of the examples described in work).  With this it is very easy to intersperse implicitly and explicitly names answers.  If a `MultiAnswer` object is used, its answers can be mixed with other answers easier.  If PGML is used (tweaked by this pull request as discussed in #944), then you don't even need to use the `namedRules` option to do so and PGML handles the details of getting the order correct.  If PGML is not used, you still need to use `namedRules`, but you don't need to name the other answers that are mixed in.

Of course this is completely compatible with existing problems and there is nothing changed for problem authors in terms of the PG answer rule API.

Now it is truly valid to tell authors to use `NEW_ANS_NAME` to get an answer name to use, and it won't interfere with the association of answer names to answer evaluators.  However, care should be taken to call the `NEW_ANS_NAME` method with the answer rule method it will be used for.  This is because the answer names are used to generate the aria labels for answers.  If the `NEW_ANS_NAME` is called before or after another answer rule method then the answer names will be out of order.  You will have something like AnSwEr0002, AnSwEr0001, AnSwEr0003 for order of the names used, and thus the aria labels will be 'answer 2', 'answer 1', 'answer 3' in the order of the page.

There was also POD clean up in PGcore.pm, and some reordering of the methods therein to make the POD headers work better.

There were also several answer rule methods that are not used anywhere in PG or in the OPL that were removed.  For example all of the `tex` answer rules.