### PR TITLE
Add display "inline" to the feedback popover.

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -214,7 +214,7 @@
 	--bs-popover-body-padding-y: 0;
 	--bs-popover-max-width: 600px;
 	--bs-popover-zindex: 18;
-	display: inline;
+	position: absolute;
 	min-width: 200px;
 
 	.popover-header {

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -214,6 +214,8 @@
 	--bs-popover-body-padding-y: 0;
 	--bs-popover-max-width: 600px;
 	--bs-popover-zindex: 18;
+	display: inline;
+	min-width: 200px;
 
 	.popover-header {
 		text-align: center;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -298,8 +298,8 @@ sub NAMED_ANS_RULE {
 		TeX => "{\\answerRule[$name]{$tcol}}",
 		# Note: codeshard is used in the css to identify input elements that come from pg.
 		HTML => tag(
-			'span',
-			class => 'text-nowrap',
+			'div',
+			class => 'text-nowrap d-inline',
 			tag(
 				'input',
 				type           => 'text',
@@ -414,8 +414,8 @@ sub NAMED_ANS_BOX {
 	return MODES(
 		TeX  => qq!\\vskip $height in \\hrulefill\\quad !,
 		HTML => tag(
-			'span',
-			class => 'text-nowrap',
+			'div',
+			class => 'text-nowrap d-inline',
 			tag(
 				'textarea',
 				name       => $name,
@@ -855,8 +855,8 @@ sub NAMED_POP_UP_LIST {
 		|| $displayMode eq 'HTML_tth')
 	{
 		return tag(
-			'span',
-			class => 'text-nowrap',
+			'div',
+			class => 'text-nowrap d-inline',
 			tag(
 				'select',
 				class => 'pg-select',
@@ -1359,7 +1359,7 @@ sub PAR {
 	MODES(
 		TeX        => '\\vskip\\baselineskip ',
 		Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}',
-		HTML       => '<P>',
+		HTML       => '<div style="margin-top:1em"></div>',
 		PTX        => "\n\n"
 	);
 }

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -23,11 +23,11 @@ is(
 	qq{<div class="PGML">\n}
 		. qq{Enter a value for <script type="math/tex">\\pi</script>.\n}
 		. qq{<div style="margin-top:1em"></div>\n}
-		. qq{<span class="text-nowrap">}
+		. qq{<div class="text-nowrap d-inline">}
 		. qq{<input aria-label="answer 1 " autocapitalize="off" autocomplete="off" class="codeshard" }
 		. qq{dir="auto" id="AnSwEr0001" name="AnSwEr0001" size="5" spellcheck="false" type="text" value="3.14159">}
 		. qq{<input id="MaThQuIlL_AnSwEr0001" name="MaThQuIlL_AnSwEr0001" type="hidden" value="">}
-		. qq{</span>}
+		. qq{</div>}
 		. qq{<input name="previous_AnSwEr0001" type="hidden" value="3.14159">\n}
 		. qq{</div>\n},
 	'body_text has correct content'


### PR DESCRIPTION
When a feedback button is clicked the feedback popover is injected into the DOM in its parent element.  A bootstrap popover is constructed with `div`s.  As such if the input the feedback button is associated with has content after it in the same line, the injected display block `div` causes the line to break.

This adds `display:inline` to the popover to prevent the line break.

Unfortunately, this does result in invalid html, but it works.  The only fix that I can think of is to change the `span`s added around the inputs into `div`s that also have `display:inline` set.  To fix problems that do not use PGML and use `$PAR` for line breaks, the `$PAR` definition would need to be changed from being a `p` tag to being a `div` with a margin (same as PGML does).

I also added a minimum width to the popover.  Since the popover is in the parent element of the feedback button, bootstrap tries to make the width fit into the width of the parent element.  So if that is narrow, then so is the popover.