### PR TITLE
Update the LiveGraphics3D.pl macro with modern JavaScript.

### DIFF
--- a/htdocs/js/LiveGraphics/liveGraphics.js
+++ b/htdocs/js/LiveGraphics/liveGraphics.js
@@ -1,913 +1,913 @@
-// liveGraphics.js
-// This is a javascript based replacement for the LiveGraphics3D java library
-// 
-// This program is free software; you can redistribute it and/or modify it under
-// the terms of either: (a) the GNU General Public License as published by the
-// Free Software Foundation; either version 2, or (at your option) any later
-// version, or (b) the "Artistic License" which comes with this package.
-// 
-// This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-// FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
-// Artistic License for more details.
+'use strict';
 
-var LiveGraphics3D = function (container, options) {
-    var my = this;    
-    
-    // define x3d container and scene
-    var x3d = $("<x3d/>").appendTo(container)
-	.css('width',options.width+'px')
-	.css('height',options.height+'px')
-	.css('border','none')
-	.css('overflow','hidden')
-	.attr('swfpath','/webwork2_files/js/vendor/x3dom/x3dom.swf');
-
-    $("<div/>").addClass('sr-only')
-	.text('A manipulable 3d graph.')
-	.prependTo(container);
-
-    // disable mousewheel on container because its used for zoom
-    $(x3d).bind('DOMMouseScroll mousewheel',function(event) {
-	event.preventDefault();
-    });
-
-    var scene = $("<scene/>").appendTo(x3d);
-	
-    // extend options by default values
-    var defaults = {
-	width : 200,
-	height : 200,
-	// Controls if axis are shown or not
-	showAxes : false,
-	// If the axis are shown determines if a full cube is drawn or just
-	// the three axis lines
-	showAxesCube : true,
-        numTicks : 4,
-	tickSize : .1,
-	tickFontSize : .15,
-	axisKey : ['X','Y','Z'],
-	// Determines if the polygons forming the surface have their edges 
-	// drawn
-	drawMesh : true,
-    };
-
-    var options = $.extend({}, defaults, options);
-
-    //global variables
-    //arrays of colors and thicknesses drawn from input
-    var colors = {};
-    var lineThickness = {};
-
-    //scale elements capturing scale of plotted data
-    var windowScale;
-    var coordMins;
-    var coordMaxs;
-
-    //block indexes are used to associate objects to colors and thicknesses
-    var blockIndex = 0;
-    var surfaceBlockIndex = 0;
-
-    //data from input
-    var surfaceCoords = [];
-    var surfaceIndex = [];
-    var lineCoords = [];
-    var lonePoints = [];
-    var loneLabels = [];
-
-    // This is the color map for shading surfaces based on elevation
-    var colormap = [
-	[0.00000,   0.00000,   0.50000],
-	[0.00000,   0.00000,   0.56349],
-	[0.00000,   0.00000,   0.62698],
-	[0.00000,   0.00000,   0.69048],
-	[0.00000,   0.00000,   0.75397],
-	[0.00000,   0.00000,   0.81746],
-	[0.00000,   0.00000,   0.88095],
-	[0.00000,   0.00000,   0.94444],
-	[0.00000,   0.00794,   1.00000],
-	[0.00000,   0.07143,   1.00000],
-	[0.00000,   0.13492,   1.00000],
-	[0.00000,   0.19841,   1.00000],
-	[0.00000,   0.26190,   1.00000],
-	[0.00000,   0.32540,   1.00000],
-	[0.00000,   0.38889,   1.00000],
-	[0.00000,   0.45238,   1.00000],
-	[0.00000,   0.51587,   1.00000],
-	[0.00000,   0.57937,   1.00000],
-	[0.00000,   0.64286,   1.00000],
-	[0.00000,   0.70635,   1.00000],
-	[0.00000,   0.76984,   1.00000],
-	[0.00000,   0.83333,   1.00000],
-	[0.00000,   0.89683,   1.00000],
-	[0.00000,   0.96032,   1.00000],
-	[0.02381,   1.00000,   0.97619],
-	[0.08730,   1.00000,   0.91270],
-	[0.15079,   1.00000,   0.84921],
-	[0.21429,   1.00000,   0.78571],
-	[0.27778,   1.00000,   0.72222],
-	[0.34127,   1.00000,   0.65873],
-	[0.40476,   1.00000,   0.59524],
-	[0.46825,   1.00000,   0.53175],
-	[0.53175,   1.00000,   0.46825],
-	[0.59524,   1.00000,   0.40476],
-	[0.65873,   1.00000,   0.34127],
-	[0.72222,   1.00000,   0.27778],
-	[0.78571,   1.00000,   0.21429],
-	[0.84921,   1.00000,   0.15079],
-	[0.91270,   1.00000,   0.08730],
-	[0.97619,   1.00000,   0.02381],
-	[1.00000,   0.96032,   0.00000],
-	[1.00000,   0.89683,   0.00000],
-	[1.00000,   0.83333,   0.00000],
-	[1.00000,   0.76984,   0.00000],
-	[1.00000,   0.70635,   0.00000],
-	[1.00000,   0.64286,   0.00000],
-	[1.00000,   0.57937,   0.00000],
-	[1.00000,   0.51587,   0.00000],
-	[1.00000,   0.45238,   0.00000],
-	[1.00000,   0.38889,   0.00000],
-	[1.00000,   0.32540,   0.00000],
-	[1.00000,   0.26190,   0.00000],
-	[1.00000,   0.19841,   0.00000],
-	[1.00000,   0.13492,   0.00000],
-	[1.00000,   0.07143,   0.00000],
-	[1.00000,   0.00794,   0.00000],
-	[0.94444,   0.00000,   0.00000],
-	[0.88095,   0.00000,   0.00000],
-	[0.81746,   0.00000,   0.00000],
-	[0.75397,   0.00000,   0.00000],
-	[0.69048,   0.00000,   0.00000],
-	[0.62698,   0.00000,   0.00000],
-	[0.56349,   0.00000,   0.00000],
-	[0.50000,   0.00000,   0.00000]];
-    
-    // intialization function.  This takes the mathmatica data string
-    // and actually sets up the dom structure for the graph. 
-    // the actual graphing is done automatically by x3dom
-    var initialize = function (datastring) {
-
-	// parse matlab string
-	parseLive3DData(datastring);
-
-	// find extremum for axis and window scale
-	setExtremum();
-		
-	// set up scene veiwpoint to be along the x axis looking to the
-	// origin
-	scene.append($("<transform/>").
-		     attr('rotation',[1,0,0,Math.PI/2])
-		     .append($("<viewpoint/>")
-			     .attr( "fieldofview", .9)
-			     .attr( "position", [2*windowScale,0,0] )
-			     .attr( "orientation", [0,1,0,Math.PI/2])));
-	
-	scene.append($('<background/>').attr('skycolor','1 1 1'));
-	
-	// draw components of scene
-	if (options.showAxes) {
-	    drawAxes();
-	}
-
-	drawSurface();
-	drawLines();
-	drawLonePoints();
-	drawLoneLabels();
-
-    };
-    
-    var parseLive3DData = function(text) {
-	// Set up variables
-	$.each(options.vars, function (name, data) {
-	    eval(name+'='+data);
-	});
-
-	// this parses axes commands.  
-	if (text.match(/Axes\s*->\s*True/)) {
-	    options.showAxes = true;
-	}
-
-	// get some initial global configuration 
-	var labels = text.match(/AxesLabel\s*->\s*\{\s*(\w+),\s*(\w+),\s*(\w+)\s*\}/);
-
-	if (labels) {
-	    options.axisKey = [labels[1],labels[2],labels[3]];
-	}
-
-	// split the input into blocks and parse
-	var blocks = recurseMathematicaBlocks(text);
-
-	parseMathematicaBlocks(blocks);
-
-    };
-    
-    // find max and min of all mesh coordinate points and
-    // the maximum coordinate value for the scale. 
-    var setExtremum = function () {
-	var min = [0,0,0];
-	var max = [0,0,0];
-	
-	surfaceCoords.forEach(function(point) {
-	    for (var i=0; i< 3; i++) {
-		if (point[i] < min[i]) {
-		    min[i] = point[i];
-		} else if (point[i]>max[i]) {
-		    max[i] = point[i];
-		}
-	    }
-	});
-	
-	lineCoords.forEach(function(line) {
-	    for (var i=0; i<2; i++) {
-		for (var j=0; j<3; j++) {
-		    if (line[i][j] < min[j]) {
-			min[j] = line[i][j];
-		    } else if (line[i][j]>max[j]) {
-			max[j] = line[i][j];
-		    }   
-		}
-	    }
-	});
-	coordMins = min;
-	coordMaxs = max;
-	
-	var sum = 0;
-
-	for (var i=0; i< 3; i++) {
-	    sum += max[i]-min[i];
-	}
-	
-	windowScale = sum/3;
-    };
-    
-    var drawLines = function() {
-	if (lineCoords.length==0) {
-	    return;
-	}
-
-	// Add surface to scene as an indexedfaceset
-	
-	var linegroup = $('<group/>');
-
-	lineCoords.forEach(function(line){
-
-	    // lines are cylinders that start centered at the origin 
-	    // along the y axis.  We have to translate and rotate them
-	    // into place
-	    var length = Math.sqrt(Math.pow((line[0][0]-line[1][0]),2)+
-				   Math.pow((line[0][1]-line[1][1]),2)+
-				   Math.pow((line[0][2]-line[1][2]),2));
-	    var rotation = [];
-
-	    if (length == 0) {
-		return;
-	    }
-	    
-	    rotation[0] = (line[1][2]-line[0][2]);
-	    rotation[1] = 0;
-	    rotation[2] = (line[0][0]-line[1][0]);
-	    rotation[3] = Math.acos((line[1][1]-line[0][1])/length);
-
-	    var trans = [0,0,0];
-	    
-	    for (var i=0; i < 3; i++) {
-		trans[i] = (line[1][i] + line[0][i])/2;
-	    }
-
-	    var shape = $("<shape/>").appendTo($("<transform/>")
-					       .attr('translation',trans)
-					       .attr('rotation',rotation)
-					       .appendTo(linegroup));
-	    var color = [0,0,0];
-	    var radius = .005;
-
-	    // line[2] contains the block index
-	    if (line[2] in colors) {
-		color = colors[line[2]];
-	    }
-	    
-	    if (line[2] in lineThickness) {
-		radius = Math.max(lineThickness[line[2]],.005);
-	    }
-
-	    $("<appearance/>").appendTo(shape)
-		.append($("<material/>")
-			.attr('diffusecolor',color));
-	    
-	    shape.append($("<Cylinder/>")
-			 .attr("height", length)
-			 .attr("radius", radius*2));
-	});
-	
-	scene.append(linegroup);
-    }
-    
-    var drawSurface = function() {
-	var coordstr = '';
-	var indexstr = '';
-	var colorstr = '';
-	var colorindstr = '';
-
-	if (surfaceCoords.length == 0) {
-	    return;
-	}
-
-	// build a string with all the surface coodinates
-	surfaceCoords.forEach(function(point) {
-	    coordstr += point[0]+' '+point[1]+' '+point[2]+' ';
-	});
-	
-	// build a string with all the surface indexes
-	// at the same time build a string with color data
-	// and the associated color indexes
-	surfaceIndex.forEach(function(index) {
-	    indexstr += index+' ';
-	    
-	    if (index == -1) {
-		colorindstr += '-1 ';
-		return;
-	    }
-
-	    var cindex = parseInt((surfaceCoords[index][2]-coordMins[2])/(coordMaxs[2]-coordMins[2])*colormap.length);
-	    
-	    if (cindex == colormap.length) {
-		cindex--;
-	    }
-	    
-	    colorindstr += cindex+' ';
-	    
-	});
-	
-	colormap.forEach(function(color) {
-	    for (var i=0; i<3; i++) {
-		color[i] += .2;
-		color[i] = Math.min(color[i],1);
-	    }
-	    
-	    colorstr += color[0]+' '+color[1]+' '+color[2]+' ';
-	});
-	
-	var flatcolor = false;
-	var color = [];
-
-	if (surfaceBlockIndex in colors) {
-	    flatcolor = true;
-	    color = colors[surfaceBlockIndex];
-	}
-
-	// Add surface to scene as an indexedfaceset
-	var shape = $("<shape/>").appendTo(scene);
-	
-	var appearance = $("<appearance/>").appendTo(shape);
-	
-	appearance .append($("<material/>")
-			   .attr("ambientIntensity",'0')
-			   .attr('convex','false')
-			   .attr('creaseangle',Math.PI)
-			   .attr('diffusecolor',color)
-			   .attr("shininess",".015"));
-	
-	var indexedfaceset = $("<indexedfaceset/>")
-	    .attr('coordindex',indexstr)
-	    .attr('solid','false');
-	
-	indexedfaceset.append($("<coordinate/>")
-			      .attr('point',coordstr));
-
-	if (!flatcolor) {
-	    indexedfaceset.attr('colorindex',colorindstr);
-	    indexedfaceset.append($("<color/>")
-				  .attr('color',colorstr));
-	}
-
-	// append the indexed face set to the shape after its assembled.  
-	// otherwise sometimes x3d tries to access the various data before 
-	// its ready
-	indexedfaceset.appendTo(shape);
-
-	if (options.drawMesh) {
-
-	    shape = $("<shape/>").appendTo(scene);
-	
-	    appearance = $("<appearance/>").appendTo(shape);
-	    
-	    appearance .append($("<material/>")
-			       .attr('diffusecolor',[0,0,0]));
-	    
-	    var indexedlineset = $("<indexedlineset/>")
-		.attr('coordindex',indexstr)
-		.attr('solid','true');
-	    
-	    indexedlineset.append($("<coordinate/>")
-				  .attr('point',coordstr));
-	    
-	    indexedlineset.appendTo(shape);
-	}
-
-    }	
-
-    var drawAxes = function() {
-
-	// build x axis and add the ticks. 
-	// all of this is done in two dimensions and then rotated and shifted 
-	// into place
-	var xgroup = $("<group/>").appendTo($("<transform/>")
-					   .appendTo(scene)
-					   .attr('translation',[0,coordMins[1],coordMins[2]]));
-	
-	var xaxis = $("<shape/>").append($("<appearance/>")
-					 .append($("<material/>")
-						 .attr("emissiveColor", 'black')
-						))
-	    .append($("<Polyline2D/>")
-		    .attr("lineSegments", coordMins[0]+' 0 '+coordMaxs[0]+' 0'));
-	xgroup.append(xaxis);
-	
-	$.each(makeAxisTicks(0),function() {
-	    this.appendTo(xgroup)});
-
-	if (options.showAxesCube) {
-	    
-	    var trans = [[0,coordMins[1],coordMaxs[2]],
-			 [0,coordMaxs[1],coordMins[2]],
-			 [0,coordMaxs[1],coordMaxs[2]]];
-
-	    trans.forEach(function (tran) {
-		$("<transform/>").attr('translation',tran)
-		    .appendTo(scene)
-		    .append($("<shape/>").append($("<appearance/>")
-						 .append($("<material/>")
-							 .attr("emissiveColor", 'black')
-							))
-			    .append($("<Polyline2D/>")
-				    .attr("lineSegments", coordMins[0]+' 0 '+coordMaxs[0]+' 0')));
-	    });
-	}
-
-	// build y axis and add the ticks
-	var ygroup = $("<group/>").appendTo($("<transform/>")
-					    .appendTo(scene)
-					    .attr('translation',[coordMins[0],0,coordMins[2]])
-					    .attr('rotation',[0,0,1,Math.PI/2]));
-	
-	var yaxis = $("<shape/>").append($("<appearance/>")
-					 .append($("<material/>")
-						 .attr("emissiveColor", 'black')
-						))
-	    .append($("<Polyline2D/>")
-		    .attr("lineSegments", coordMins[1]+' 0 '+coordMaxs[1]+' 0'));
-	ygroup.append(yaxis);
-
-	$.each(makeAxisTicks(1),function() {
-	    this.appendTo(ygroup)});
-	
-	if (options.showAxesCube) {
-	    
-	    var trans = [[coordMins[0],0,coordMaxs[2]],
-			 [coordMaxs[0],0,coordMins[2]],
-			 [coordMaxs[0],0,coordMaxs[2]]];
-	    
-	    trans.forEach(function (tran) {
-		$("<transform/>").attr('translation',tran)
-		    .attr('rotation',[0,0,1,Math.PI/2])
-		    .appendTo(scene)
-		    .append($("<shape/>").append($("<appearance/>")
-						 .append($("<material/>")
-							 .attr("emissiveColor", 'black')
-							))
-			    .append($("<Polyline2D/>")
-				    .attr("lineSegments", coordMins[1]+' 0 '+coordMaxs[1]+' 0')));
-	    });
-	}
-	
-	// build z axis and add the ticks
-	var zgroup = $("<group/>").appendTo($("<transform/>")
-					   .appendTo(scene)
-					   .attr('translation',[coordMins[0],coordMins[1],0])
-					    .attr('rotation',[0,1,0,-Math.PI/2]));
-	
-	var zaxis = $("<shape/>").append($("<appearance/>")
-					 .append($("<material/>")
-						 .attr("emissiveColor", 'black')
-						 ))
-	    .append($("<Polyline2D/>")
-		    .attr("lineSegments", coordMins[2]+' 0 '+coordMaxs[2]+' 0'));
-
-	zgroup.append(zaxis);
-
-	$.each(makeAxisTicks(2),function() {
-	    this.appendTo(zgroup)});
-
-	if (options.showAxesCube) {
-	    
-	    var trans = [[coordMins[0],coordMaxs[1],0],
-			 [coordMaxs[0],coordMins[1],0],
-			 [coordMaxs[0],coordMaxs[1],0]];
-
-	    trans.forEach(function (tran) {
-		$("<transform/>").attr('translation',tran)
-		    .attr('rotation',[0,1,0,-Math.PI/2])
-		    .appendTo(scene)
-		    .append($("<shape/>").append($("<appearance/>")
-						 .append($("<material/>")
-							 .attr("emissiveColor", 'black')
-							))
-			    .append($("<Polyline2D/>")
-				    .attr("lineSegments", coordMins[2]+' 0 '+coordMaxs[2]+' 0')));
-	    });
-	}
-	
-    }
-    
-    // biuilds the ticks, the tick labels, and the axis label for 
-    // axisindex I
-    var makeAxisTicks = function (I) {
-	var shapes = [];
-
-	for(var i=0; i<options.numTicks-1; i++) {
-	    // coordinate of tick and label
-	    var coord = (coordMaxs[I]-coordMins[I])/options.numTicks*(i+1)+coordMins[I];
-
-	    //ticks are boxes defined by tickSize
-	    var tick = $("<shape/>").append($($("<appearance/>")
-					      .append($("<material/>")
-						      .attr("diffuseColor","black"))));
-	    tick.appendTo($("<transform/>")
-			  .attr('translation',[coord,0,0]));
-
-	    tick.append($("<box/>")
-			.attr('size', options.tickSize+' '
-			      +options.tickSize+' '+
-			      options.tickSize));
-
-	    shapes.push(tick.parent());
-
-	    // labels have two decimal places and always point towards view
-	    var ticklabel = $("<shape/>").append($($("<appearance/>")
-					      .append($("<material/>")
-						      .attr("diffuseColor","black"))));
-	    
-	    ticklabel.appendTo($("<billboard/>")
-			       .attr("axisOfRotation", "0 0 0")
-			       .appendTo($("<transform/>")
-					 .attr('translation',[coord,.1,0])));
-
-	    ticklabel.append($("<text/>")
-			     .attr('string',coord.toFixed(2))
-			     .attr('solid','true')
-			     .append($("<fontstyle/>")
-				     .attr('size',options.tickFontSize*windowScale)
-				     .attr('family', "mono")
-				     .attr('style', 'bold')
-				     .attr('justify', 'MIDDLE')));
-	    
-	    shapes.push(ticklabel.parent().parent());
-
-	}
-	
-	// axis label goes on the end of the axis. 
-	var axislabel = $("<shape/>").append($($("<appearance/>")
-					       .append($("<material/>")
-						       .attr("diffuseColor","black"))));
-	
-	axislabel.appendTo($("<billboard/>")
-			   .attr("axisOfRotation", "0 0 0")
-			   .appendTo($("<transform/>")
-				     .attr('translation',[coordMaxs[I],.1,0])));
-	
-	axislabel.append($("<text/>")
-			 .attr('string',options.axisKey[I])
-			 .attr('solid','true')
-			 .append($("<fontstyle/>")
-				 .attr('size',options.tickFontSize*windowScale)
-				 .attr('family', "mono")
-				 .attr('style', 'bold')
-				 .attr('justify', 'MIDDLE')));
-	
-	shapes.push(axislabel.parent().parent());
-
-	return shapes;
-    }
-	    
-    var drawLonePoints = function () {
-	
-	lonePoints.forEach(function (point) {
-	    
-	    var color = 'black';
-	    if (point.rgb) {
-		color=point.rgb;
-	    }
-	    
-	    // lone points are drawn as spheres so they have mass
-	    var sphere = $("<shape/>").append($($("<appearance/>")
-						.append($("<material/>")
-							.attr("diffuseColor",color))));
-	    sphere.appendTo($("<transform/>")
-			  .attr('translation',point.coords));
-
-	    sphere.append($("<sphere/>")
-			.attr('radius',point.radius*2.25));
-
-	    sphere.parent().appendTo(scene);
-	    
-	});
-	
-    }
-
-    var drawLoneLabels = function () {
-	
-	loneLabels.forEach(function (label) {
-	    
-	    // the text is a billboard that automatically faces the user
-	    var text = $("<shape/>").append($($("<appearance/>")
-					      .append($("<material/>")
-						      .attr("diffuseColor",'black'))));
-	    
-	    text.appendTo($("<billboard/>")
-			  .attr("axisOfRotation", "0 0 0")
-			  .appendTo($("<transform/>")
-				    .attr('translation',label.coords)));
-	    
-	    var size = '.5';
-	    if (label.size) {
-		//mathematica label sizes are fontsizes, where 
-		//the units for x3dom are local coord sizes
-		size = label.size/(1.5*windowScale);
-	    }
-	    
-	    text.append($("<text/>")
-			.attr('string',label.text)
-			.attr('solid','true')
-			.append($("<fontstyle/>")
-				.attr('size',size)
-				.attr('family', "mono")
-				.attr('justify', 'MIDDLE')));
-	    
-	    text.parent().parent().appendTo(scene);
-	    
-	});
-	
-    }
-
-    var parseMathematicaBlocks = function (blocks) {
-
-	blocks.forEach(function(block) {
-	    blockIndex++;
-	    
-	    if (block.match(/^\s*\{/)) {
-		// This is a block inside of a block.
-		// so recurse
-		var subblocks = recurseMathematicaBlocks(block);
-		parseMathematicaBlocks(subblocks);
-
-	    } else if (block.match(/Point/)) {
-		// now find any individual points that need to be plotted
-		// points are defined by short blocks so we dont split into
-		// individual commands
-		var str = block.match(/Point\[\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/);
-		var point = {};
-		
-		if (!str) {
-		    console.log('Error Parsing Point');
-		    return;
-		}
-		
-		point.coords = [parseFloat(str[1]),parseFloat(str[2]),parseFloat(str[3])];
-		
-		str = block.match(/PointSize\[\s*(\d*\.?\d*)\s*\]/);
-		
-		if (str) {
-		    point.radius = parseFloat(str[1]);
-		}
-		
-		str = block.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
-		
-		if (str) {
-		    point.rgb = [parseFloat(str[1]),parseFloat(str[2]),parseFloat(str[3])];
-		}
-		
-		lonePoints.push(point);
-		
-	    } else {
-		// Otherwise its a list of commands that we need to 
-		// process individually
-		var commands = splitMathematicaBlocks(block);
-		
-		commands.forEach(function(command) {
-		    if (command.match(/^\s*\{/)) {
-			// This is a block inside of a block.
-			// so recurse
-			var subblocks = recurseMathematicaBlocks(block);
-			parseMathematicaBlocks(subblocks);
-		    } else if (command.match(/Polygon/)) {
-			if (!surfaceBlockIndex) {
-			    surfaceBlockIndex = blockIndex;
+(() => {
+	// Convenience method for easily constructing nested x3dom elements with code that clearly reveals the structure.
+	const createX3DElement = (type, attributes = null, ...children) => {
+		const element = document.createElement(type);
+		if (attributes) {
+			for (const [attribute, value] of Object.entries(attributes)) {
+				element.setAttribute(attribute, value);
 			}
+		}
+		element.append(...children);
+		return element;
+	};
 
-			var polystring = command.replace(/Polygon\[([^\]]*)\]/,"$1");
-			var pointstrings = recurseMathematicaBlocks(polystring,-1);
-			// for each polygon extract all the points
-			pointstrings.forEach(function(pointstring) {
-			    pointstring = pointstring.replace(/\{([^\{]*)\}/,"$1");
-			    
-			    var splitstring = pointstring.split(',');
-			    var point = [];
-			    
-			    for (var i=0; i < 3; i++) {
-				point[i] = parseFloat(eval(splitstring[i]));
-			    }
-			    
-			    // find the index of the point in surfaceCoords.  If 
-			    // the point is not in surfaceCoords, add it
-			    for (var i=0; i<surfaceCoords.length; i++) {
-				if (surfaceCoords[i][0] == point[0] &&
-				    surfaceCoords[i][1] == point[1] &&
-				    surfaceCoords[i][2] == point[2]) {
-				    surfaceIndex.push(i);
-				    
-				    return;
+	const liveGraphics3D = (container) => {
+		const options = JSON.parse(container.dataset.options);
+
+		// Set default options.
+		options.width = options.width ?? 200;
+		options.height = options.height ?? 200;
+		options.showAxes = options.showAxes ?? false;
+		options.showAxesCube = options.showAxesCube ?? true;
+		options.numTicks = options.numTicks ?? 4;
+		options.tickSize = options.tickSize ?? 0.1;
+		options.tickFontSize = options.tickFontSize ?? 0.15;
+		options.axisKey = options.axisKey ?? ['X', 'Y', 'Z'];
+		options.drawMesh = options.drawMesh ?? true;
+
+		// Define the x3d element and scene.
+		const x3d = createX3DElement('x3d', { width: `${options.width}px`, height: `${options.height}px` });
+		container.append(x3d);
+
+		const screenReaderOnly = document.createElement('span');
+		screenReaderOnly.classList.add('visually-hidden');
+		screenReaderOnly.textContent = 'A manipulable 3d graph.';
+		container.append(screenReaderOnly);
+
+		const scene = createX3DElement('scene');
+		x3d.append(scene);
+
+		// Arrays of colors and thicknesses drawn from input.
+		const colors = {};
+		const lineThickness = {};
+
+		// Scale elements capturing scale of plotted data.
+		let windowScale = 0;
+		let coordMins;
+		let coordMaxs;
+
+		// Block indexes are used to associate objects to colors and thicknesses.
+		let blockIndex = 0;
+		let surfaceBlockIndex = 0;
+
+		// Data from input.
+		const surfaceCoords = [];
+		const surfaceIndex = [];
+		const lineCoords = [];
+		const points = [];
+		const labels = [];
+
+		let variables = '';
+
+		// This is the color map for shading surfaces based on elevation.
+		const colormap = [
+			[0.0, 0.0, 0.5],
+			[0.0, 0.0, 0.56349],
+			[0.0, 0.0, 0.62698],
+			[0.0, 0.0, 0.69048],
+			[0.0, 0.0, 0.75397],
+			[0.0, 0.0, 0.81746],
+			[0.0, 0.0, 0.88095],
+			[0.0, 0.0, 0.94444],
+			[0.0, 0.00794, 1.0],
+			[0.0, 0.07143, 1.0],
+			[0.0, 0.13492, 1.0],
+			[0.0, 0.19841, 1.0],
+			[0.0, 0.2619, 1.0],
+			[0.0, 0.3254, 1.0],
+			[0.0, 0.38889, 1.0],
+			[0.0, 0.45238, 1.0],
+			[0.0, 0.51587, 1.0],
+			[0.0, 0.57937, 1.0],
+			[0.0, 0.64286, 1.0],
+			[0.0, 0.70635, 1.0],
+			[0.0, 0.76984, 1.0],
+			[0.0, 0.83333, 1.0],
+			[0.0, 0.89683, 1.0],
+			[0.0, 0.96032, 1.0],
+			[0.02381, 1.0, 0.97619],
+			[0.0873, 1.0, 0.9127],
+			[0.15079, 1.0, 0.84921],
+			[0.21429, 1.0, 0.78571],
+			[0.27778, 1.0, 0.72222],
+			[0.34127, 1.0, 0.65873],
+			[0.40476, 1.0, 0.59524],
+			[0.46825, 1.0, 0.53175],
+			[0.53175, 1.0, 0.46825],
+			[0.59524, 1.0, 0.40476],
+			[0.65873, 1.0, 0.34127],
+			[0.72222, 1.0, 0.27778],
+			[0.78571, 1.0, 0.21429],
+			[0.84921, 1.0, 0.15079],
+			[0.9127, 1.0, 0.0873],
+			[0.97619, 1.0, 0.02381],
+			[1.0, 0.96032, 0.0],
+			[1.0, 0.89683, 0.0],
+			[1.0, 0.83333, 0.0],
+			[1.0, 0.76984, 0.0],
+			[1.0, 0.70635, 0.0],
+			[1.0, 0.64286, 0.0],
+			[1.0, 0.57937, 0.0],
+			[1.0, 0.51587, 0.0],
+			[1.0, 0.45238, 0.0],
+			[1.0, 0.38889, 0.0],
+			[1.0, 0.3254, 0.0],
+			[1.0, 0.2619, 0.0],
+			[1.0, 0.19841, 0.0],
+			[1.0, 0.13492, 0.0],
+			[1.0, 0.07143, 0.0],
+			[1.0, 0.00794, 0.0],
+			[0.94444, 0.0, 0.0],
+			[0.88095, 0.0, 0.0],
+			[0.81746, 0.0, 0.0],
+			[0.75397, 0.0, 0.0],
+			[0.69048, 0.0, 0.0],
+			[0.62698, 0.0, 0.0],
+			[0.56349, 0.0, 0.0],
+			[0.5, 0.0, 0.0]
+		];
+
+		// Split a list of mathematica commands into blocks.
+		const splitMathematicaBlocks = (text) => {
+			let bracketcount = 0;
+			const blocks = [];
+			let block = '';
+
+			for (let i = 0; i < text.length; ++i) {
+				block += text.charAt(i);
+
+				if (text.charAt(i) === '[') ++bracketcount;
+
+				if (text.charAt(i) === ']') {
+					bracketcount--;
+					if (bracketcount == 0) {
+						++i;
+						blocks.push(block);
+						block = '';
+					}
 				}
-			    }
-			    
-			    surfaceIndex.push(surfaceCoords.length);
-			    surfaceCoords.push(point);
-			    
+			}
+
+			return blocks;
+		};
+
+		// The mathematica code comes in blocks enclosed by braces.  This code makes an array from those blocks.
+		// The largest of them will be the polygon block which defines the surface.
+		const recurseMathematicaBlocks = (text, initialcount) => {
+			let bracketcount = 0;
+			const blocks = [];
+			let block = '';
+
+			if (initialcount) {
+				bracketcount = initialcount;
+			}
+
+			for (let i = 0; i < text.length; ++i) {
+				if (text.charAt(i) === '{') {
+					++bracketcount;
+				}
+
+				if (bracketcount > 0) {
+					block += text.charAt(i);
+				}
+
+				if (text.charAt(i) === '}') {
+					bracketcount--;
+					if (bracketcount == 0) {
+						blocks.push(block.substring(1, block.length - 1));
+						block = '';
+					}
+				}
+			}
+
+			return blocks;
+		};
+
+		const parseMathematicaBlocks = (blocks) => {
+			for (const block of blocks) {
+				++blockIndex;
+
+				if (block.match(/^\s*\{/)) {
+					// This is a block inside of a block.  So recurse.
+					parseMathematicaBlocks(recurseMathematicaBlocks(block));
+				} else if (block.match(/Point/)) {
+					// Find any individual points that need to be plotted.
+					// Points are defined by short blocks so don't split into individual commands.
+					let str = block.match(/Point\[\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/);
+					const point = {};
+
+					if (!str) {
+						console.log('Error Parsing Point');
+						continue;
+					}
+
+					point.coords = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
+
+					str = block.match(/PointSize\[\s*(\d*\.?\d*)\s*\]/);
+
+					if (str) {
+						point.radius = parseFloat(str[1]);
+					}
+
+					str = block.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
+
+					if (str) {
+						point.rgb = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
+					}
+
+					points.push(point);
+				} else {
+					// Otherwise its a list of commands that need to be individually processed.
+					for (const command of splitMathematicaBlocks(block)) {
+						if (command.match(/^\s*\{/)) {
+							// This is a block inside of a block.  So recurse.
+							parseMathematicaBlocks(recurseMathematicaBlocks(block));
+						} else if (command.match(/Polygon/)) {
+							if (!surfaceBlockIndex) surfaceBlockIndex = blockIndex;
+
+							// Extract all points for each polygon.
+							for (const pointstring of recurseMathematicaBlocks(
+								command.replace(/Polygon\[([^\]]*)\]/, '$1'),
+								-1
+							)) {
+								const splitstring = pointstring.replace(/\{([^\{]*)\}/, '$1').split(',');
+								const point = [];
+
+								for (let i = 0; i < 3; ++i) {
+									point[i] = parseFloat(
+										new Function(`'use strict'; { ${variables} return ${splitstring[i]} }`)()
+									);
+								}
+
+								// Find the index of the point in surfaceCoords.
+								// If the point is not in surfaceCoords, then add it.
+								const pointIndex = surfaceCoords.findIndex(
+									(p) => p[0] === point[0] && p[1] === point[1] && p[2] === point[2]
+								);
+
+								if (pointIndex === -1) {
+									surfaceIndex.push(surfaceCoords.length);
+									surfaceCoords.push(point);
+								} else {
+									surfaceIndex.push(pointIndex);
+								}
+							}
+
+							surfaceIndex.push(-1);
+						} else if (command.match(/Line/)) {
+							// Add a line to the line array.
+							const pointstrings = recurseMathematicaBlocks(
+								command.replace(/Line\[([^\]]*)\],/, '$1'),
+								-1
+							);
+
+							const line = [];
+
+							try {
+								for (let i = 0; i < 2; ++i) {
+									pointstrings[i] = pointstrings[i].replace(/\{([^\{]*)\}/, '$1');
+									const splitstring = pointstrings[i].split(',');
+									const point = [];
+
+									for (let j = 0; j < 3; ++j) {
+										point[j] = parseFloat(
+											new Function(`'use strict'; { ${variables} return ${splitstring[j]} }`)()
+										);
+									}
+
+									line.push(point);
+								}
+							} catch (e) {
+								console.log(`Error Parsing Line: ${e}`);
+								continue;
+							}
+
+							line.push(blockIndex);
+							lineCoords.push(line);
+						} else if (command.match(/RGBColor/)) {
+							const str = command.match(
+								/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/
+							);
+
+							colors[blockIndex] = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
+						} else if (command.match(/Thickness/)) {
+							lineThickness[blockIndex] = parseFloat(command.match(/Thickness\[\s*(\d*\.?\d*)\s*\]/)[1]);
+						} else if (command.match(/Text/)) {
+							// Find any individual labels that need to be plotted.
+							const label = {};
+
+							const labelStr = command.match(
+								/\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
+							);
+							if (!labelStr) {
+								console.log('Error Parsing Label');
+								continue;
+							}
+
+							label.coords = [parseFloat(labelStr[1]), parseFloat(labelStr[2]), parseFloat(labelStr[3])];
+
+							const optionsStr = command.match(/StyleForm\[\s*(\w+),\s*FontSize\s*->\s*(\d+)\s*\]/);
+							if (!optionsStr) {
+								console.log('Error Parsing Label');
+								continue;
+							}
+
+							label.text = optionsStr[1];
+							label.fontSize = optionsStr[2];
+
+							labels.push(label);
+						}
+					}
+				}
+			}
+		};
+
+		const parseLive3DData = (text) => {
+			// Set up variables.
+			for (const [name, data] of Object.entries(options.vars)) {
+				variables += `const ${name} = ${data};`;
+			}
+
+			// Parse axes commands.
+			if (text.match(/Axes\s*->\s*True/)) options.showAxes = true;
+
+			const labels = text.match(/AxesLabel\s*->\s*\{\s*(\w+),\s*(\w+),\s*(\w+)\s*\}/);
+			if (labels) options.axisKey = [labels[1], labels[2], labels[3]];
+
+			// Split the input into blocks and parse.
+			parseMathematicaBlocks(recurseMathematicaBlocks(text));
+		};
+
+		// Find the maximum and minimum of all mesh coordinate points and the maximum coordinate value for the scale.
+		const setExtremum = () => {
+			const min = [0, 0, 0];
+			const max = [0, 0, 0];
+
+			for (const point of surfaceCoords) {
+				for (let i = 0; i < 3; ++i) {
+					if (point[i] < min[i]) min[i] = point[i];
+					else if (point[i] > max[i]) max[i] = point[i];
+				}
+			}
+
+			for (const line of lineCoords) {
+				for (let i = 0; i < 2; ++i) {
+					for (let j = 0; j < 3; ++j) {
+						if (line[i][j] < min[j]) {
+							min[j] = line[i][j];
+						} else if (line[i][j] > max[j]) {
+							max[j] = line[i][j];
+						}
+					}
+				}
+			}
+
+			coordMins = min;
+			coordMaxs = max;
+
+			let sum = 0;
+			for (let i = 0; i < 3; ++i) {
+				sum += max[i] - min[i];
+			}
+
+			windowScale = sum / 3;
+		};
+
+		// Build the ticks, tick labels, and axis label for the axis with the given index.
+		const makeAxisTicks = (index) => {
+			const shapes = [];
+
+			for (let i = 0; i < options.numTicks - 1; ++i) {
+				// Coordinate of tick and label
+				const coord = ((coordMaxs[index] - coordMins[index]) / options.numTicks) * (i + 1) + coordMins[index];
+
+				// Ticks are boxes defined by tickSize
+				shapes.push(
+					createX3DElement(
+						'transform',
+						{ translation: [coord, 0, 0] },
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { diffuseColor: 'black' })
+							),
+							createX3DElement('box', {
+								size: `${options.tickSize} ${options.tickSize} ${options.tickSize}`
+							})
+						)
+					)
+				);
+
+				// Labels have two decimal places and always point towards view.
+				shapes.push(
+					createX3DElement(
+						'transform',
+						{ translation: [coord, 0.1, 0] },
+						createX3DElement(
+							'billboard',
+							{ axisOfRotation: '0 0 0' },
+							createX3DElement(
+								'shape',
+								null,
+								createX3DElement(
+									'appearance',
+									null,
+									createX3DElement('material', { diffuseColor: 'black' })
+								),
+								createX3DElement(
+									'text',
+									{ string: coord.toFixed(2), solid: 'true' },
+									createX3DElement('fontstyle', {
+										size: options.tickFontSize * windowScale,
+										family: 'mono',
+										style: 'bold',
+										justify: 'MIDDLE'
+									})
+								)
+							)
+						)
+					)
+				);
+			}
+
+			// Add the axis label to the end of the axis.
+			shapes.push(
+				createX3DElement(
+					'transform',
+					{ translation: [coordMaxs[index], 0.1, 0] },
+					createX3DElement(
+						'billboard',
+						{ axisOfRotation: '0 0 0' },
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { diffuseColor: 'black' })
+							),
+							createX3DElement(
+								'text',
+								{ string: options.axisKey[index], solid: 'true' },
+								createX3DElement('fontstyle', {
+									size: options.tickFontSize * windowScale,
+									family: 'mono',
+									style: 'bold',
+									justify: 'MIDDLE'
+								})
+							)
+						)
+					)
+				)
+			);
+
+			return shapes;
+		};
+
+		const drawAxes = () => {
+			// Build the x axis and add the ticks.
+			scene.append(
+				createX3DElement(
+					'transform',
+					{ translation: [0, coordMins[1], coordMins[2]] },
+					createX3DElement(
+						'group',
+						null,
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { emissiveColor: 'black' })
+							),
+							createX3DElement('Polyline2D', { lineSegments: coordMins[0] + ' 0 ' + coordMaxs[0] + ' 0' })
+						),
+						...makeAxisTicks(0)
+					)
+				)
+			);
+
+			if (options.showAxesCube) {
+				for (const translation of [
+					[0, coordMins[1], coordMaxs[2]],
+					[0, coordMaxs[1], coordMins[2]],
+					[0, coordMaxs[1], coordMaxs[2]]
+				]) {
+					scene.append(
+						createX3DElement(
+							'transform',
+							{ translation },
+							createX3DElement(
+								'shape',
+								null,
+								createX3DElement(
+									'appearance',
+									null,
+									createX3DElement('material', { emissiveColor: 'black' })
+								),
+								createX3DElement('Polyline2D', {
+									lineSegments: coordMins[0] + ' 0 ' + coordMaxs[0] + ' 0'
+								})
+							)
+						)
+					);
+				}
+			}
+
+			// Build the y axis and add the ticks.
+			scene.append(
+				createX3DElement(
+					'transform',
+					{ translation: [coordMins[0], 0, coordMins[2]], rotation: [0, 0, 1, Math.PI / 2] },
+					createX3DElement(
+						'group',
+						null,
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { emissiveColor: 'black' })
+							),
+							createX3DElement('Polyline2D', { lineSegments: coordMins[1] + ' 0 ' + coordMaxs[1] + ' 0' })
+						),
+						...makeAxisTicks(1)
+					)
+				)
+			);
+
+			if (options.showAxesCube) {
+				for (const translation of [
+					[coordMins[0], 0, coordMaxs[2]],
+					[coordMaxs[0], 0, coordMins[2]],
+					[coordMaxs[0], 0, coordMaxs[2]]
+				]) {
+					scene.append(
+						createX3DElement(
+							'transform',
+							{ translation, rotation: [0, 0, 1, Math.PI / 2] },
+							createX3DElement(
+								'shape',
+								null,
+								createX3DElement(
+									'appearance',
+									null,
+									createX3DElement('material', { emissiveColor: 'black' })
+								),
+								createX3DElement('Polyline2D', {
+									lineSegments: coordMins[1] + ' 0 ' + coordMaxs[1] + ' 0'
+								})
+							)
+						)
+					);
+				}
+			}
+
+			// Build the z axis and add the ticks.
+			scene.append(
+				createX3DElement(
+					'transform',
+					{ translation: [coordMins[0], coordMins[1], 0], rotation: [0, 1, 0, -Math.PI / 2] },
+					createX3DElement(
+						'group',
+						null,
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { emissiveColor: 'black' })
+							),
+							createX3DElement('Polyline2D', { lineSegments: coordMins[2] + ' 0 ' + coordMaxs[2] + ' 0' })
+						),
+						...makeAxisTicks(2)
+					)
+				)
+			);
+
+			if (options.showAxesCube) {
+				for (const translation of [
+					[coordMins[0], coordMaxs[1], 0],
+					[coordMaxs[0], coordMins[1], 0],
+					[coordMaxs[0], coordMaxs[1], 0]
+				]) {
+					scene.append(
+						createX3DElement(
+							'transform',
+							{ translation, rotation: [0, 1, 0, -Math.PI / 2] },
+							createX3DElement(
+								'shape',
+								null,
+								createX3DElement(
+									'appearance',
+									null,
+									createX3DElement('material', { emissiveColor: 'black' })
+								),
+								createX3DElement('Polyline2D', {
+									lineSegments: coordMins[2] + ' 0 ' + coordMaxs[2] + ' 0'
+								})
+							)
+						)
+					);
+				}
+			}
+		};
+
+		const drawSurface = () => {
+			if (surfaceCoords.length == 0) return;
+
+			let coordstr = '';
+			let indexstr = '';
+			let colorstr = '';
+			let colorindstr = '';
+
+			// Build a string with all the surface coodinates.
+			for (const point of surfaceCoords) {
+				coordstr += point.join(' ') + ' ';
+			}
+
+			// Build a string with all the surface indexes.  At the same time build
+			// a string with color data and the associated color indexes.
+			for (const index of surfaceIndex) {
+				indexstr += index + ' ';
+
+				if (index == -1) {
+					colorindstr += '-1 ';
+					continue;
+				}
+
+				let cindex = parseInt(
+					((surfaceCoords[index][2] - coordMins[2]) / (coordMaxs[2] - coordMins[2])) * colormap.length
+				);
+
+				if (cindex == colormap.length) {
+					--cindex;
+				}
+
+				colorindstr += cindex + ' ';
+			}
+
+			for (const color of colormap) {
+				for (let i = 0; i < 3; ++i) {
+					color[i] += 0.2;
+					color[i] = Math.min(color[i], 1);
+				}
+
+				colorstr += color[0] + ' ' + color[1] + ' ' + color[2] + ' ';
+			}
+
+			let flatcolor = false;
+			let color = [];
+
+			if (surfaceBlockIndex in colors) {
+				flatcolor = true;
+				color = colors[surfaceBlockIndex];
+			}
+
+			// Add surface to scene as an indexedfaceset
+			const surface = createX3DElement(
+				'shape',
+				null,
+				createX3DElement(
+					'appearance',
+					null,
+					createX3DElement('material', {
+						ambientIntensity: '0',
+						convex: 'false',
+						creaseangle: Math.PI,
+						diffusecolor: color,
+						shininess: '.015'
+					})
+				)
+			);
+
+			const indexedfaceset = createX3DElement(
+				'indexedfaceset',
+				{ coordindex: indexstr, solid: 'false' },
+				createX3DElement('coordinate', { point: coordstr })
+			);
+
+			if (!flatcolor) {
+				indexedfaceset.setAttribute('colorindex', colorindstr);
+				indexedfaceset.append(createX3DElement('color', { color: colorstr }));
+			}
+
+			// Append the indexed face set to the shape after it is assembled.
+			// Otherwise sometimes x3d tries to access the various data before its ready.
+			surface.append(indexedfaceset);
+
+			scene.append(surface);
+
+			if (options.drawMesh) {
+				scene.append(
+					createX3DElement(
+						'shape',
+						null,
+						createX3DElement('appearance', null, createX3DElement('material', { diffusecolor: [0, 0, 0] })),
+						createX3DElement(
+							'indexedlineset',
+							{ coordindex: indexstr, solid: 'true' },
+							createX3DElement('coordinate', { point: coordstr })
+						)
+					)
+				);
+			}
+		};
+
+		const drawLines = () => {
+			if (lineCoords.length == 0) return;
+
+			const lineGroup = createX3DElement('group');
+
+			for (const line of lineCoords) {
+				// Lines are cylinders that start centered at the origin along the y axis.
+				// They need to be translated and rotated into place.
+				const length = Math.sqrt(
+					Math.pow(line[0][0] - line[1][0], 2) +
+						Math.pow(line[0][1] - line[1][1], 2) +
+						Math.pow(line[0][2] - line[1][2], 2)
+				);
+				if (length == 0) continue;
+
+				const rotation = [];
+				rotation[0] = line[1][2] - line[0][2];
+				rotation[1] = 0;
+				rotation[2] = line[0][0] - line[1][0];
+				rotation[3] = Math.acos((line[1][1] - line[0][1]) / length);
+
+				const translation = [0, 0, 0];
+
+				for (let i = 0; i < 3; ++i) {
+					translation[i] = (line[1][i] + line[0][i]) / 2;
+				}
+
+				let color = [0, 0, 0];
+				let radius = 0.005;
+
+				if (line[2] in colors) color = colors[line[2]];
+				if (line[2] in lineThickness) radius = Math.max(lineThickness[line[2]], 0.005);
+
+				lineGroup.append(
+					createX3DElement(
+						'transform',
+						{ translation, rotation },
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement('appearance', null, createX3DElement('material', { diffusecolor: color })),
+							createX3DElement('Cylinder', { height: length, radius: radius * 2 })
+						)
+					)
+				);
+			}
+
+			scene.append(lineGroup);
+		};
+
+		const drawPoints = () => {
+			for (const point of points) {
+				// Points are drawn as spheres.
+				scene.append(
+					createX3DElement(
+						'transform',
+						{ translation: point.coords },
+						createX3DElement(
+							'shape',
+							null,
+							createX3DElement(
+								'appearance',
+								null,
+								createX3DElement('material', { diffuseColor: point.rgb ?? 'black' })
+							),
+							createX3DElement('sphere', { radius: point.radius * 2.25 })
+						)
+					)
+				);
+			}
+		};
+
+		const drawLabels = () => {
+			for (const label of labels) {
+				// The text is a billboard that automatically faces the user.
+				scene.append(
+					createX3DElement(
+						'transform',
+						{ translation: label.coords },
+						createX3DElement(
+							'billboard',
+							{ axisOfRotation: '0 0 0' },
+							createX3DElement(
+								'shape',
+								null,
+								createX3DElement(
+									'appearance',
+									null,
+									createX3DElement('material', { diffuseColor: 'black' })
+								),
+								createX3DElement(
+									'text',
+									{ string: label.text, solid: 'true' },
+									createX3DElement('fontstyle', {
+										// Mathematica label sizes are fontsizes, where
+										// the units for x3dom are local coordinate sizes.
+										size: label.size ? label.size / (1.5 * windowScale) : '.5',
+										family: 'mono',
+										justify: 'MIDDLE'
+									})
+								)
+							)
+						)
+					)
+				);
+			}
+		};
+
+		// Intialization function.  This takes the mathmatica data string and actually sets up the
+		// dom structure for the graph.  The actual graphing is done automatically by x3dom.
+		const initialize = (datastring) => {
+			// Parse matlab string.
+			parseLive3DData(datastring);
+
+			// Find extremum for axis and window scale.
+			setExtremum();
+
+			// Set up scene veiwpoint to be along the x axis looking to the origin.
+			scene.append(
+				createX3DElement(
+					'transform',
+					{ rotation: [1, 0, 0, Math.PI / 2] },
+					createX3DElement('viewpoint', {
+						fieldofview: 0.9,
+						position: [2 * windowScale, 0, 0],
+						orientation: [0, 1, 0, Math.PI / 2]
+					})
+				)
+			);
+
+			scene.append(createX3DElement('background', { skycolor: '1 1 1' }));
+
+			// Draw components of scene
+			if (options.showAxes) drawAxes();
+			drawSurface();
+			drawLines();
+			drawPoints();
+			drawLabels();
+		};
+
+		// This section of code is run whenever the object is created.  It obtains the data either from direct input, a
+		// zip file, or a data file.  Then it calls intialize with the data string.
+
+		if (options.input) {
+			initialize(options.input);
+		} else if (options.archive) {
+			// If an archive file is provided then retrieve that file.
+			// The file name is the file inside the archive that contains the data.
+			JSZipUtils.getBinaryContent(options.archive, (error, data) => {
+				if (error) {
+					console.log(error);
+					container.innerHTML = 'Failed to get input archive';
+				}
+
+				JSZip.loadAsync(data).then((zip) => {
+					zip.file(options.file)
+						.async('string')
+						.then((string) => initialize(string));
+				});
 			});
-			
-			surfaceIndex.push(-1);
-		       
-		    } else if (command.match(/Line/)) {
-			//Add a line to the line array
-			
-			var str = command.replace(/Line\[([^\]]*)\],/,"$1");
-			
-			var pointstrings = recurseMathematicaBlocks(str,-1);
-			
-			var line = [];
-			
-			for (var i=0; i<2; i++) {
-			    pointstrings[i] = pointstrings[i].replace(/\{([^\{]*)\}/,"$1");
-			    var splitstring = pointstrings[i].split(',');
-			    var point = [];
-			    
-			    for (var j=0; j<3; j++) {
-				point[j] = parseFloat(eval(splitstring[j]));
-			    }
-			    
-			    if (point) {
-				line.push(point);
-			    } else {
-				console.log('Error Parsing Line');
-				return;
-			    }
-			}
-
-			line.push(blockIndex);
-
-			lineCoords.push(line);
-
-		    } else if (command.match(/RGBColor/)) {
-			var str = command.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
-
-			colors[blockIndex] = [parseFloat(str[1]),parseFloat(str[2]),parseFloat(str[3])];
-
-		    } else if (command.match(/Thickness/)) {
-			var str = command.match(/Thickness\[\s*(\d*\.?\d*)\s*\]/);
-
-			lineThickness[blockIndex] = parseFloat(str[1]);
-			
-		    } else if (command.match(/Text/)) {
-			// now find any individual labels that need to be plotted
-			var str = command.match(/\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/);
-			var label = {};
-			
-			if (!str) {
-			    console.log('Error Parsing Label');
-			    return;
-			}
-			
-			label.coords = [parseFloat(str[1]),parseFloat(str[2]),parseFloat(str[3])];
-			str = command.match(/StyleForm\[\s*(\w+),\s*FontSize\s*->\s*(\d+)\s*\]/);
-			
-			if (!str) {
-			    console.log('Error Parsing Label');
-			    return;
-			}
-			
-			label.text = str[1];
-			label.fontSize = str[2];
-			
-			loneLabels.push(label);
-			
-		    }
-		});
-			   	
-	    }
-	});
-    }
-    
-    var splitMathematicaBlocks = function (text) {
-	// This splits a list of mathematica commands on the commas
-	
-	var bracketcount = 0;
-	var blocks = [];
-	var block = '';
-	
-	for (var i=0; i < text.length; i++) {
-
-	    block += text.charAt(i);
-	    
-	    if (text.charAt(i) === '[') {
-		bracketcount++;
-	    }
-
-	    if (text.charAt(i) == ']') {
-		bracketcount--;
-		if (bracketcount == 0) {
-		    i++;
-		    blocks.push(block);
-		    block = '';
+		} else if (options.file) {
+			fetch(options.file)
+				.then((response) => (response.ok ? response.text() : response))
+				.then((data) => initialize(data))
+				.catch((error) => {
+					console.log(error);
+					container.innerHTML = 'Failed to get input file';
+				});
+		} else {
+			container.innerHTML = 'No input data provided';
 		}
+	};
 
-	    }
-	}
+	// Deal with live graphics 3d elements that are already on the page.
+	document.querySelectorAll('.live-graphics-3d-container').forEach(liveGraphics3D);
 
-	return blocks;
-    }
-
-
-
-    var recurseMathematicaBlocks = function (text,initialcount) {
-	// the mathematica code comes in blocks encolsed by {}
-	// this code makes an array of those blocks.  The largest of them will
-	// be the polygon block which defines the surface.  
-	var bracketcount = 0;
-	var blocks = [];
-	var block = '';
-	
-	if (initialcount) {
-	    bracketcount = initialcount;
-	}
-
-	for (var i=0; i < text.length; i++) {
-
-	    if (text.charAt(i) === '{') {
-		bracketcount++;
-	    }
-
-	    if (bracketcount > 0) {
-		block += text.charAt(i);
-	    }
-
-	    if (text.charAt(i) == '}') {
-		bracketcount--;
-		if (bracketcount == 0) {
-		    blocks.push(block.substring(1,block.length-1));
-		    block = '';
-		}
-
-	    }
-	}
-
-	return blocks;
-    }
-
-
-    // This section of code is run whenever the object is created
-    // run intialize with the mathematica string, possibly getting the string
-    // form an ajax call if necessary
-    
-    if (options.input) {
-	initialize(options.input);
-    } else if (options.archive) {
-	// If an archive file is provided then that is the file we get
-	// the file name is then the file we want inside the archive. 
-	JSZipUtils.getBinaryContent(options.archive, function (error, data) {
-	    if (error) {
-		console.log(error);
-		$(container).html('Failed to get input archive');
-	    }
-	    
-		JSZip.loadAsync(data).then((zip) => {
-			zip.file(options.file).async('string').then((string) => initialize(string));
+	// Deal with live graphics 3d elements that are added to the page later.
+	const observer = new MutationObserver((mutationsList) => {
+		mutationsList.forEach((mutation) => {
+			mutation.addedNodes.forEach((node) => {
+				if (node instanceof Element) {
+					if (node.classList.contains('live-graphics-3d-container')) liveGraphics3D(node);
+					else node.querySelectorAll('.live-graphics-3d-container').forEach(liveGraphics3D);
+				}
+			});
 		});
 	});
-
-	    
-    } else if (options.file) {
-	
-	$.ajax({
-	    url : options.file,
-	    dataType : 'text',
-	    async : 'true',
-	    success : function(data) {
-		initialize(data);
-	    },
-	    error : function(x,y,error) {
-		console.log(error);
-		$(container).html('Failed to get input file');
-	    }});
-
-    } else {
-	$(container).html('No input data provided');
-    }
-}
+	observer.observe(document.body, { childList: true, subtree: true });
+})();

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -12,8 +12,7 @@
                 "jszip-utils": "^0.1.0",
                 "mathquill": "github:openwebwork/mathquill#WeBWorK-2.18",
                 "plotly.js-dist-min": "^2.18.2",
-                "sortablejs": "^1.15.0",
-                "x3dom": "^1.8.1"
+                "sortablejs": "^1.15.0"
             },
             "devDependencies": {
                 "autoprefixer": "^10.4.13",
@@ -1625,11 +1624,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/x3dom": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/x3dom/-/x3dom-1.8.1.tgz",
-            "integrity": "sha512-rlKMA0pWkBUqoC75fjSm1rRJhdlnqXcCgEP5MHsspcO5pdkr0J52oO5EmmR1eOCzex5U4qAlyG8aFVoZy8wtfA=="
-        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -2757,11 +2751,6 @@
                 "string-width": "^4.1.0",
                 "strip-ansi": "^6.0.0"
             }
-        },
-        "x3dom": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/x3dom/-/x3dom-1.8.1.tgz",
-            "integrity": "sha512-rlKMA0pWkBUqoC75fjSm1rRJhdlnqXcCgEP5MHsspcO5pdkr0J52oO5EmmR1eOCzex5U4qAlyG8aFVoZy8wtfA=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -16,8 +16,7 @@
         "jszip-utils": "^0.1.0",
         "mathquill": "github:openwebwork/mathquill#WeBWorK-2.18",
         "plotly.js-dist-min": "^2.18.2",
-        "sortablejs": "^1.15.0",
-        "x3dom": "^1.8.1"
+        "sortablejs": "^1.15.0"
     },
     "devDependencies": {
         "autoprefixer": "^10.4.13",

--- a/macros/graph/LiveGraphics3D.pl
+++ b/macros/graph/LiveGraphics3D.pl
@@ -19,193 +19,159 @@ LiveGraphics3D.pl - provides the ability to have an interactive 3D plot.
 
 =head1 DESCRIPTION
 
+Macros for handling interactive 3D graphics via the LiveGraphics3D Java applet.
+The applet needs to be in the course html directory.  (If it is in the system
+html area, you will need to change the default below or supply the jar option
+explicitly).
 
-Macros for handling interactive 3D graphics via the LiveGraphics3D
-Java applet.  The applet needs to be in the course html directory.
-(If it is in the system html area, you will need to change the
-default below or supply the jar option explicitly).
+The LiveGraphics3D applet displays a Mathematica Graphics3D object that is
+stored in a .m file (or a compressed one).  Use Mathematica to create one.
 
-The LiveGraphics3D applet displays a mathematica Graphics3D object
-that is stored in a .m file (or a compressed one).  Use Mathematica
-to create one.  (In the future, I plan to write a perl class that
-will create these for you on the fly. -- DPVC)
+=head1 METHODS
 
-The main routines are
+The following methods are provided.
+
+=head2 LiveGraphics3D
+
+Usage: C<LiveGraphics3D(options)>
+
+The following options can be given.
 
 =over
 
-=item * C<Live3Dfile>
+=item * C<< file => name >>
 
-load a data file
+Name of the C<.m> file to load.
 
-=item * C<Live3Ddata>
+=item * C<< archive => name >>
 
-load raw Graphics3D data
+Name of a C<.zip> file to load.  If this is set, then the C<file> option must
+also be given, and must be set to the name of the file in the zip archive that
+contains the data.
 
-=item * C<LiveGraphics3D(options)>
+=item * C<< input => 3Ddata >>
 
-Options are from:
+String containing Graphics3D data to be displayed by the applet.
 
-    file => name           name of .m file to load
+=item * C<< size => [w, h] >>
 
-    archive => name        name of a .zip file to load
+Width and height of applet.
 
-    input => 3Ddata        string containing Graphics3D data to
-                           be displayed by the applet
+=item * C<< vars => [vars] >>
 
-    size => [w,h]          width and height of applet
+Hash of variables to pass as independent variables to the applet, together with
+their initial values, e.g., C<< vars => [ a => 1, b => 1 ] >>.
 
-    vars => [vars]         hash of variables to pass as independent
-                           variables to the applet, togther with
-                           their initial values
-                             e.g., vars => [a=>1,b=>1]
+=item * C<< background => "#RRGGBB" >>
 
-    depend => [list]       list of dependent variables to pass to
-                           the applet with their replacement strings
-                           (see LiveGraphics3D documentation)
+The background color to use (default is white).
 
-    background=>"#RRGGBB"  the background color to use (default is white)
+=item * C<< scale => n >>
 
-    scale => n             scaling factor for applet (default is 1.)
+Scaling factor for applet (default is 1).
 
-    image => file          a file containing an image to use in TeX mode
-                           or when Java is disabled
+=item * C<< image => file >>
 
-    tex_size => ratio      a scaling factor for the TeX image (as a portion
-                           of the line width).
-                           1000 is 100%, 500 is 50%, etc.
+A file containing an image to use in TeX mode.
 
-    tex_center => 0 or 1   center the image in TeX mode or not
+=item * C<< tex_size => ratio >>
 
-    Live3D => [params]     hash of additional parameters to pass to
-                           the Live3D applet.
-                           e.g. Live3D => [VISIBLE_FACES => "FRONT"]
+A scaling factor for the TeX image (as a portion of the line width).  1000 is
+100%, 500 is 50%, etc.
+
+=item * C<< tex_center => 0 or 1 >>
+
+Whether to center the image in TeX mode.
 
 =back
+
+=head2 Live3Dfile
+
+Usage: C<< Live3Dfile($file, options) >>
+
+Load a data file.  This just calls C<LiveGraphics3D> with the C<file> option set
+to C<$file>.  All other options supported by C<LiveGraphics3D> can also be
+given.
+
+=head2 Live3Ddata
+
+Usage: C<< Live3Ddata($input, options) >>
+
+Load raw Graphics3D data.  This just calls C<LiveGraphics3D> with the C<input>
+option set to C<$input>.  All other options supported by C<LiveGraphics3D> can
+also be given.
 
 =cut
 
 sub _LiveGraphics3D_init {
-	ADD_JS_FILE('node_modules/x3dom/x3dom.js');
-	ADD_JS_FILE('node_modules/jszip/dist/jszip.min.js');
-	ADD_JS_FILE('node_modules/jszip-utils/dist/jszip-utils.min.js');
-	ADD_JS_FILE('js/LiveGraphics/liveGraphics.js');
-	ADD_CSS_FILE('node_modules/x3dom/x3dom.css');
+	ADD_CSS_FILE('https://www.x3dom.org/download/1.8.3/x3dom.css', 1);
+	ADD_JS_FILE('https://www.x3dom.org/download/1.8.3/x3dom-full.js', 1);
+	ADD_JS_FILE('node_modules/jszip/dist/jszip.min.js',               0, { defer => undef });
+	ADD_JS_FILE('node_modules/jszip-utils/dist/jszip-utils.min.js',   0, { defer => undef });
+	ADD_JS_FILE('js/LiveGraphics/liveGraphics.js',                    0, { defer => undef });
 }
 
 sub LiveGraphics3D {
 	my %options = (
 		size       => [ 250, 250 ],
-		background => "#FFFFFF",
-		scale      => 1.,
+		background => '#FFFFFF',
+		scale      => 1,
 		tex_size   => 500,
 		tex_center => 0,
 		@_
 	);
-	my $out = "";
-	my $p;
-	my %pval;
-	my $ratio = $options{tex_size} * (.001);
 
 	if ($main::displayMode eq "TeX") {
-		#
-		#  In TeX mode, include the image, if there is one, or
-		#   else give the user a message about using it on line
-		#
+		# In TeX mode, include the image, if there is one, or
+		# else give the user a message about using it on line.
 		if ($options{image}) {
-			$out = "\\includegraphics[width=$ratio\\linewidth]{$options{image}}";
+			my $ratio = $options{tex_size} * 0.001;
+			my $out   = "\\includegraphics[width=$ratio\\linewidth]{$options{image}}";
 			$out = "\\centerline{$out}" if $options{tex_center};
 			$out .= "\n";
+			return $out;
 		} else {
-			$out = "\\vbox{
-         \\hbox{[ This image is created by}
-         \\hbox{\\quad an interactive applet;}
-         \\hbox{you must view it on line ]}
-      }";
+			return "[ This image is created by an interactive applet. You must view it on line. ]\n";
 		}
-		# In html mode check to see if we use javascript or not
 	} else {
 		my ($w, $h) = @{ $options{size} };
-		$out .= $bHTML if ($main::displayMode eq "Latex2HTML");
-		#
-		#  Put the js in a table
-		#
-		$out .= qq{\n<TABLE BORDER="1" CELLSPACING="2" CELLPADDING="0">\n<TR>};
-		$out .= qq{<TD WIDTH="$w" HEIGHT="$h" ALIGN="CENTER">};
 
-		$archive_input = $options{archive} // '';
-		$file_input    = $options{file}    // '';
-		$direct_input  = $options{input}   // '';
+		# Include independent variables.
+		my %vars;
+		%vars = @{ $options{vars} } if $options{vars};
 
-		$direct_input =~ s/\n//g;
-
-		#
-		#  include any independent variables
-		#
-		$ind_vars = '{}';
-
-		if ($options{vars}) {
-			$ind_vars = "{";
-			%vars     = @{ $options{vars} };
-
-			foreach $var (keys %vars) {
-				$ind_vars .= "\"$var\":\"" . $vars{$var} . "\",";
-			}
-
-			$ind_vars .= "}";
-		}
-
-		$out .= <<EOS;
-    <script>
-    var thisTD = jQuery('script:last').parent();
-    var options = { width : $w,
-		    height : $h,
-		    file : '$file_input',
-		    input : '$direct_input',
-		    archive : '$archive_input',
-		    vars : $ind_vars,
-    };
-
-    if (typeof LiveGraphics3D !== 'undefined') {
-        var graph = new LiveGraphics3D(thisTD[0],options);
-    }
-
-    </script>
-EOS
-
-		$out .= "</TD></TD>\n</TABLE>\n";
-		$out .= $eHTML if ($main::displayMode eq "Latex2HTML");
-		# otherwise use the applet
+		return tag(
+			'div',
+			class        => 'live-graphics-3d-container',
+			style        => "width:fit-content;height:fit-content;border:1px solid black;",
+			data_options => JSON->new->encode({
+				width   => $w,
+				height  => $h,
+				file    => $options{file} // '',
+				input   => ($options{input} // '') =~ s/\n//gr,
+				archive => $options{archive} // '',
+				vars    => \%vars,
+			})
+		);
 	}
-
-	return $out;
 }
 
-#
-#  Syntactic sugar to make it easier to pass files and data to
-#  LiveGraphics3D.
-#
+# Syntactic sugar to make it easier to pass files and data to LiveGraphics3D.
 sub Live3Dfile {
 	my $file = shift;
 	LiveGraphics3D(file => $file, @_);
 }
 
-#
-#  Syntactic sugar to make it easier to pass raw Graohics3D data
-#  to LiveGraphics3D.
-#
+# Syntactic sugar to make it easier to pass raw Graohics3D data to LiveGraphics3D.
 sub Live3Ddata {
 	my $data = shift;
 	LiveGraphics3D(input => $data, @_);
 }
 
-#
-#  A message you can use for a caption under a graph
-#
-$LIVEMESSAGE = MODES(
-	TeX        => '',
-	Latex2HTML => $BCENTER . "Drag the surface to rotate it" . $ECENTER,
-	HTML       => $BCENTER . "Drag the surface to rotate it" . $ECENTER
+# A message you can use for a caption under a graph.
+$main::LIVEMESSAGE = MODES(
+	TeX  => '',
+	HTML => $BCENTER . "Drag the surface to rotate it" . $ECENTER
 );
 
 1;


### PR DESCRIPTION
This removes the dependence on jQuery and updates the JavaScript and macro.

Unfortunately, the npm installed version of x3dom does not include the x3dom-full.js file, and the live graphics macro uses x3dom elements (like Polyline2D) which are not supported by the basic x3dom.js file. So that library can not be installed via npm. So instead the x3dom files are served from the www.x3dom.org site.  Another option would be to go back to the old school approach of including the files in the repository directly.  Note that the npm package that we were using is made available by a third party. The main thing that you will notice from switching to using the x3dom-full.js file is that now the cube containing the 3D graph will be visible again (that uses the Polyline2D).

Also the version of x3dom is upgraded to 1.8.3.

Also, the underlying html injected by Perl in macro is different. Instead of using a table with a single row and cell, a div is used. That table actually worked quite poorly in many cases, and certainly was not the right thing to use.  Furthermore, there is no injected script element.  Instead the options are passed via data attributes on that div.