### PR TITLE
Add line breaks back to answer messages.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1318,8 +1318,10 @@ sub ENDDOCUMENT {
 											)
 											. (
 												($rh_envir->{showMessages} && $ansHash->{ans_message})
-												? feedbackLine(maketext('Message'), $ansHash->{ans_message},
-													'feedback-message')
+												? feedbackLine(
+													maketext('Message'), $ansHash->{ans_message} =~ s/\n/<br>/gr,
+													'feedback-message'
+												)
 												: ''
 											);
 										}


### PR DESCRIPTION
I missed this in the original conversion from the previous attempts table.  It used to convert new lines to `<br>` tags.  This adds that to the new feedback mechanism.