### PR TITLE
Warn if a macro file has a POD directive on the first line but don't fail.

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1266,6 +1266,13 @@ sub PG_macro_file_eval {
 
 	local $SIG{__DIE__} = 'DEFAULT';
 
+	if ($string =~ /^=/) {
+		$string = "\n$string";
+		warn "The first line of a macro must not contain a POD directive at $filePath line 1.\n"
+			. "A new line will be added, but this will result in errors and warnings from "
+			. "this file being reported on the incorrect line number.\n";
+	}
+
 	my ($out, $errors) =
 		PG_macro_file_eval_helper('package main; be_strict();'
 			. 'BEGIN { my $eval = __FILE__; $main::envir{__files__}{$eval} = "'


### PR DESCRIPTION
This adds a new line to the beginning of the code for a macro file that starts with `=` which will usually mean an invalid POD directive on the first line of the file (and is invalid in any case for the first character of a Perl file).

In that case a warning is also shown.  This warning will only be shown if the view_problem_debugging_info flag is set (this corresponds to the webwork2 permission that ta's and above have).

This is to address issue #961.