### PR TITLE
Round 2 of updates to the LiveGraphics3D macros

### DIFF
--- a/htdocs/js/LiveGraphics/liveGraphics.js
+++ b/htdocs/js/LiveGraphics/liveGraphics.js
@@ -1,18 +1,6 @@
 'use strict';
 
 (() => {
-	// Convenience method for easily constructing nested x3dom elements with code that clearly reveals the structure.
-	const createX3DElement = (type, attributes = null, ...children) => {
-		const element = document.createElement(type);
-		if (attributes) {
-			for (const [attribute, value] of Object.entries(attributes)) {
-				element.setAttribute(attribute, value);
-			}
-		}
-		element.append(...children);
-		return element;
-	};
-
 	const liveGraphics3D = (container) => {
 		const options = JSON.parse(container.dataset.options);
 
@@ -22,112 +10,32 @@
 		options.showAxes = options.showAxes ?? false;
 		options.showAxesCube = options.showAxesCube ?? true;
 		options.numTicks = options.numTicks ?? 4;
-		options.tickSize = options.tickSize ?? 0.1;
-		options.tickFontSize = options.tickFontSize ?? 0.15;
-		options.axisKey = options.axisKey ?? ['X', 'Y', 'Z'];
+		options.axisKey = options.axisKey ?? ['x', 'y', 'z'];
 		options.drawMesh = options.drawMesh ?? true;
-
-		// Define the x3d element and scene.
-		const x3d = createX3DElement('x3d', { width: `${options.width}px`, height: `${options.height}px` });
-		container.append(x3d);
 
 		const screenReaderOnly = document.createElement('span');
 		screenReaderOnly.classList.add('visually-hidden');
 		screenReaderOnly.textContent = 'A manipulable 3d graph.';
 		container.append(screenReaderOnly);
 
-		const scene = createX3DElement('scene');
-		x3d.append(scene);
+		// Inital view point and up vector.
+		const eye = { x: 1.25, y: 1.25, z: 1.25 };
+		const up = { x: 0, y: 0, z: 1 };
 
-		// Arrays of colors and thicknesses drawn from input.
+		// Colors and thicknesses drawn from input.
 		const colors = {};
 		const lineThickness = {};
 
-		// Scale elements capturing scale of plotted data.
-		let windowScale = 0;
-		let coordMins;
-		let coordMaxs;
-
 		// Block indexes are used to associate objects to colors and thicknesses.
 		let blockIndex = 0;
-		let surfaceBlockIndex = 0;
 
-		// Data from input.
-		const surfaceCoords = [];
-		const surfaceIndex = [];
-		const lineCoords = [];
+		// Data from input (translated into plotly traces).
+		const surfaces = {};
+		const lines = {};
 		const points = [];
 		const labels = [];
 
 		let variables = '';
-
-		// This is the color map for shading surfaces based on elevation.
-		const colormap = [
-			[0.0, 0.0, 0.5],
-			[0.0, 0.0, 0.56349],
-			[0.0, 0.0, 0.62698],
-			[0.0, 0.0, 0.69048],
-			[0.0, 0.0, 0.75397],
-			[0.0, 0.0, 0.81746],
-			[0.0, 0.0, 0.88095],
-			[0.0, 0.0, 0.94444],
-			[0.0, 0.00794, 1.0],
-			[0.0, 0.07143, 1.0],
-			[0.0, 0.13492, 1.0],
-			[0.0, 0.19841, 1.0],
-			[0.0, 0.2619, 1.0],
-			[0.0, 0.3254, 1.0],
-			[0.0, 0.38889, 1.0],
-			[0.0, 0.45238, 1.0],
-			[0.0, 0.51587, 1.0],
-			[0.0, 0.57937, 1.0],
-			[0.0, 0.64286, 1.0],
-			[0.0, 0.70635, 1.0],
-			[0.0, 0.76984, 1.0],
-			[0.0, 0.83333, 1.0],
-			[0.0, 0.89683, 1.0],
-			[0.0, 0.96032, 1.0],
-			[0.02381, 1.0, 0.97619],
-			[0.0873, 1.0, 0.9127],
-			[0.15079, 1.0, 0.84921],
-			[0.21429, 1.0, 0.78571],
-			[0.27778, 1.0, 0.72222],
-			[0.34127, 1.0, 0.65873],
-			[0.40476, 1.0, 0.59524],
-			[0.46825, 1.0, 0.53175],
-			[0.53175, 1.0, 0.46825],
-			[0.59524, 1.0, 0.40476],
-			[0.65873, 1.0, 0.34127],
-			[0.72222, 1.0, 0.27778],
-			[0.78571, 1.0, 0.21429],
-			[0.84921, 1.0, 0.15079],
-			[0.9127, 1.0, 0.0873],
-			[0.97619, 1.0, 0.02381],
-			[1.0, 0.96032, 0.0],
-			[1.0, 0.89683, 0.0],
-			[1.0, 0.83333, 0.0],
-			[1.0, 0.76984, 0.0],
-			[1.0, 0.70635, 0.0],
-			[1.0, 0.64286, 0.0],
-			[1.0, 0.57937, 0.0],
-			[1.0, 0.51587, 0.0],
-			[1.0, 0.45238, 0.0],
-			[1.0, 0.38889, 0.0],
-			[1.0, 0.3254, 0.0],
-			[1.0, 0.2619, 0.0],
-			[1.0, 0.19841, 0.0],
-			[1.0, 0.13492, 0.0],
-			[1.0, 0.07143, 0.0],
-			[1.0, 0.00794, 0.0],
-			[0.94444, 0.0, 0.0],
-			[0.88095, 0.0, 0.0],
-			[0.81746, 0.0, 0.0],
-			[0.75397, 0.0, 0.0],
-			[0.69048, 0.0, 0.0],
-			[0.62698, 0.0, 0.0],
-			[0.56349, 0.0, 0.0],
-			[0.5, 0.0, 0.0]
-		];
 
 		// Split a list of mathematica commands into blocks.
 		const splitMathematicaBlocks = (text) => {
@@ -141,7 +49,7 @@
 				if (text.charAt(i) === '[') ++bracketcount;
 
 				if (text.charAt(i) === ']') {
-					bracketcount--;
+					--bracketcount;
 					if (bracketcount == 0) {
 						++i;
 						blocks.push(block);
@@ -160,21 +68,15 @@
 			const blocks = [];
 			let block = '';
 
-			if (initialcount) {
-				bracketcount = initialcount;
-			}
+			if (initialcount) bracketcount = initialcount;
 
 			for (let i = 0; i < text.length; ++i) {
-				if (text.charAt(i) === '{') {
-					++bracketcount;
-				}
+				if (text.charAt(i) === '{') ++bracketcount;
 
-				if (bracketcount > 0) {
-					block += text.charAt(i);
-				}
+				if (bracketcount > 0) block += text.charAt(i);
 
 				if (text.charAt(i) === '}') {
-					bracketcount--;
+					--bracketcount;
 					if (bracketcount == 0) {
 						blocks.push(block.substring(1, block.length - 1));
 						block = '';
@@ -193,31 +95,50 @@
 					// This is a block inside of a block.  So recurse.
 					parseMathematicaBlocks(recurseMathematicaBlocks(block));
 				} else if (block.match(/Point/)) {
-					// Find any individual points that need to be plotted.
 					// Points are defined by short blocks so don't split into individual commands.
-					let str = block.match(/Point\[\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/);
-					const point = {};
-
-					if (!str) {
+					let pointStr = block.match(
+						/Point\[\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
+					);
+					if (!pointStr || pointStr.length < 4) {
 						console.log('Error Parsing Point');
 						continue;
 					}
 
-					point.coords = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
+					// Points are implemented as the top and bottom half of a sphere.  Note that using a marker in a
+					// scatter3d trace results in bad clipping since markers are really only two dimensional circles.
+					const point = { type: 'mesh3d', x: [], y: [], z: [], color: 'black', hoverinfo: 'none' };
 
-					str = block.match(/PointSize\[\s*(\d*\.?\d*)\s*\]/);
+					const x = parseFloat(pointStr[1]),
+						y = parseFloat(pointStr[2]),
+						z = parseFloat(pointStr[3]);
 
-					if (str) {
-						point.radius = parseFloat(str[1]);
+					const pointSizeStr = block.match(/PointSize\[\s*(\d*\.?\d*)\s*\]/);
+					const r = pointSizeStr && pointSizeStr.length == 2 ? parseFloat(pointSizeStr[1]) * 2.5 : 0.025;
+
+					const colorStr = block.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
+					if (colorStr) point.color = `rgb(${colorStr[1] * 255},${colorStr[2] * 255},${colorStr[3] * 255})`;
+
+					const samples = 20;
+
+					const phiValues = Array(samples)
+						.fill(0)
+						.map((_v, i) => (i * (Math.PI / 2)) / (samples - 1));
+
+					const thetaValues = Array(samples)
+						.fill(0)
+						.map((_v, i) => (2 * i * Math.PI) / (samples - 1));
+
+					for (const phi of phiValues) {
+						for (const theta of thetaValues) {
+							point.x.push(x + r * Math.cos(theta) * Math.sin(phi));
+							point.y.push(y + r * Math.sin(theta) * Math.sin(phi));
+							point.z.push(z + r * Math.cos(phi));
+						}
 					}
 
-					str = block.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
-
-					if (str) {
-						point.rgb = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
-					}
-
-					points.push(point);
+					// The lower hemisphere is obtained by duplicating the upper hemisphere and negating its z
+					// coordinate relative to the z position of the center.
+					points.push(point, { ...point, z: point.z.map((v) => 2 * z - v) });
 				} else {
 					// Otherwise its a list of commands that need to be individually processed.
 					for (const command of splitMathematicaBlocks(block)) {
@@ -225,97 +146,191 @@
 							// This is a block inside of a block.  So recurse.
 							parseMathematicaBlocks(recurseMathematicaBlocks(block));
 						} else if (command.match(/Polygon/)) {
-							if (!surfaceBlockIndex) surfaceBlockIndex = blockIndex;
-
-							// Extract all points for each polygon.
-							for (const pointstring of recurseMathematicaBlocks(
-								command.replace(/Polygon\[([^\]]*)\]/, '$1'),
-								-1
-							)) {
-								const splitstring = pointstring.replace(/\{([^\{]*)\}/, '$1').split(',');
-								const point = [];
-
-								for (let i = 0; i < 3; ++i) {
-									point[i] = parseFloat(
-										new Function(`'use strict'; { ${variables} return ${splitstring[i]} }`)()
-									);
-								}
-
-								// Find the index of the point in surfaceCoords.
-								// If the point is not in surfaceCoords, then add it.
-								const pointIndex = surfaceCoords.findIndex(
-									(p) => p[0] === point[0] && p[1] === point[1] && p[2] === point[2]
-								);
-
-								if (pointIndex === -1) {
-									surfaceIndex.push(surfaceCoords.length);
-									surfaceCoords.push(point);
-								} else {
-									surfaceIndex.push(pointIndex);
-								}
-							}
-
-							surfaceIndex.push(-1);
-						} else if (command.match(/Line/)) {
-							// Add a line to the line array.
-							const pointstrings = recurseMathematicaBlocks(
-								command.replace(/Line\[([^\]]*)\],/, '$1'),
-								-1
-							);
-
-							const line = [];
-
+							// Extract all points of the polygon.
+							const polygonPoints = [];
 							try {
-								for (let i = 0; i < 2; ++i) {
-									pointstrings[i] = pointstrings[i].replace(/\{([^\{]*)\}/, '$1');
-									const splitstring = pointstrings[i].split(',');
+								const pointStrings = recurseMathematicaBlocks(
+									command.replace(/Polygon\[([^\]]*)\]/, '$1'),
+									-1
+								);
+								if (pointStrings.length < 3) throw 'Polygons must have at least thre points.';
+
+								for (const pointString of pointStrings) {
+									const coordStrings = pointString.replace(/\{([^\{]*)\}/, '$1').split(',');
+									if (coordStrings.length !== 3) throw 'Points must have three coordinates.';
+
 									const point = [];
 
-									for (let j = 0; j < 3; ++j) {
-										point[j] = parseFloat(
-											new Function(`'use strict'; { ${variables} return ${splitstring[j]} }`)()
+									for (const coordString of coordStrings) {
+										point.push(
+											parseFloat(
+												new Function(`'use strict'; { ${variables} return ${coordString} }`)()
+											)
 										);
 									}
 
-									line.push(point);
+									polygonPoints.push(point);
 								}
 							} catch (e) {
-								console.log(`Error Parsing Line: ${e}`);
+								console.log(`Error parsing polygon: ${e}`);
+								continue;
+							}
+							if (!surfaces[blockIndex]) {
+								surfaces[blockIndex] = {
+									surface: {
+										type: 'mesh3d',
+										x: [],
+										y: [],
+										z: [],
+										i: [],
+										j: [],
+										k: [],
+										showscale: false,
+										hoverinfo: 'none'
+									},
+									mesh: {
+										type: 'scatter3d',
+										mode: 'lines',
+										x: [],
+										y: [],
+										z: [],
+										line: { width: 1, color: 'black' },
+										hoverinfo: 'none'
+									}
+								};
+							}
+
+							const polygonIndices = [];
+
+							for (const point of polygonPoints) {
+								// Find the index of the point in the surface x, y, z coordinate arrays.
+								// If the point is not in the arrays, then add it.
+								let pointIndex = 0;
+								for (; pointIndex < surfaces[blockIndex].surface.x.length; ++pointIndex) {
+									if (
+										surfaces[blockIndex].surface.x[pointIndex] === point[0] &&
+										surfaces[blockIndex].surface.y[pointIndex] === point[1] &&
+										surfaces[blockIndex].surface.z[pointIndex] === point[2]
+									)
+										break;
+								}
+
+								if (pointIndex === surfaces[blockIndex].surface.x.length) {
+									surfaces[blockIndex].surface.x.push(point[0]);
+									surfaces[blockIndex].surface.y.push(point[1]);
+									surfaces[blockIndex].surface.z.push(point[2]);
+								}
+
+								surfaces[blockIndex].mesh.x.push(point[0]);
+								surfaces[blockIndex].mesh.y.push(point[1]);
+								surfaces[blockIndex].mesh.z.push(point[2]);
+
+								polygonIndices.push(pointIndex);
+							}
+
+							// Split the polygon into triangle faces, and add the indices of the vertices of these
+							// triangles to the face index arrays.
+							for (let i = 1; i < polygonIndices.length - 1; ++i) {
+								surfaces[blockIndex].surface.i.push(polygonIndices[0]);
+								surfaces[blockIndex].surface.j.push(polygonIndices[i]);
+								surfaces[blockIndex].surface.k.push(polygonIndices[i + 1]);
+							}
+
+							surfaces[blockIndex].mesh.x.push('None');
+							surfaces[blockIndex].mesh.y.push('None');
+							surfaces[blockIndex].mesh.z.push('None');
+						} else if (command.match(/Line/)) {
+							const x = [],
+								y = [],
+								z = [];
+
+							try {
+								const pointStrings = recurseMathematicaBlocks(
+									command.replace(/Line\[([^\]]*)\],/, '$1'),
+									-1
+								);
+								if (pointStrings.length < 2) throw 'Lines must have at least two points.';
+
+								for (const pointString of pointStrings) {
+									const coordStrings = pointString.split(',');
+									if (coordStrings.length !== 3) throw 'Points must have three coordinates.';
+
+									const point = [];
+
+									for (const coordString of coordStrings) {
+										point.push(
+											parseFloat(
+												new Function(`'use strict'; { ${variables} return ${coordString} }`)()
+											)
+										);
+									}
+
+									x.push(point[0]);
+									y.push(point[1]);
+									z.push(point[2]);
+								}
+							} catch (e) {
+								console.log(`Error parsing line: ${e}`);
 								continue;
 							}
 
-							line.push(blockIndex);
-							lineCoords.push(line);
+							x.push('None');
+							y.push('None');
+							z.push('None');
+
+							if (lines[blockIndex]) {
+								lines[blockIndex].x.push(...x);
+								lines[blockIndex].y.push(...y);
+								lines[blockIndex].z.push(...z);
+							} else {
+								lines[blockIndex] = {
+									type: 'scatter3d',
+									mode: 'lines',
+									x,
+									y,
+									z,
+									line: { width: 5 },
+									hoverinfo: 'none'
+								};
+							}
 						} else if (command.match(/RGBColor/)) {
 							const str = command.match(
 								/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/
 							);
-
-							colors[blockIndex] = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
+							if (str && str.length === 4)
+								colors[blockIndex] = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
 						} else if (command.match(/Thickness/)) {
-							lineThickness[blockIndex] = parseFloat(command.match(/Thickness\[\s*(\d*\.?\d*)\s*\]/)[1]);
+							const str = command.match(/Thickness\[\s*(\d*\.?\d*)\s*\]/);
+							if (str && str.length === 2) lineThickness[blockIndex] = parseFloat(str[1]);
 						} else if (command.match(/Text/)) {
-							// Find any individual labels that need to be plotted.
-							const label = {};
-
 							const labelStr = command.match(
 								/\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
 							);
-							if (!labelStr) {
+							if (!labelStr || labelStr.length !== 4) {
 								console.log('Error Parsing Label');
 								continue;
 							}
 
-							label.coords = [parseFloat(labelStr[1]), parseFloat(labelStr[2]), parseFloat(labelStr[3])];
+							const label = {
+								type: 'scatter3d',
+								mode: 'text',
+								textfont: { color: 'black', size: 12, family: 'mono' },
+								textposition: 'top center',
+								hoverinfo: 'none'
+							};
+
+							label.x = [parseFloat(labelStr[1])];
+							label.y = [parseFloat(labelStr[2])];
+							label.z = [parseFloat(labelStr[3])];
 
 							const optionsStr = command.match(/StyleForm\[\s*(\w+),\s*FontSize\s*->\s*(\d+)\s*\]/);
-							if (!optionsStr) {
-								console.log('Error Parsing Label');
+							if (!optionsStr || optionsStr.length < 3) {
+								console.log('Error parsing label.');
 								continue;
 							}
 
-							label.text = optionsStr[1];
-							label.fontSize = optionsStr[2];
+							label.text = [optionsStr[1]];
+							label.textfont.size = optionsStr[2];
 
 							labels.push(label);
 						}
@@ -334,532 +349,99 @@
 			if (text.match(/Axes\s*->\s*True/)) options.showAxes = true;
 
 			const labels = text.match(/AxesLabel\s*->\s*\{\s*(\w+),\s*(\w+),\s*(\w+)\s*\}/);
-			if (labels) options.axisKey = [labels[1], labels[2], labels[3]];
+			if (labels && labels.length === 4) options.axisKey = [labels[1], labels[2], labels[3]];
+
+			const viewPoint = text.match(
+				/ViewPoint\s*->\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
+			);
+			if (viewPoint && viewPoint.length === 4) {
+				eye.x = parseFloat(viewPoint[1]);
+				eye.y = parseFloat(viewPoint[2]);
+				eye.z = parseFloat(viewPoint[3]);
+			}
+
+			const viewVertical = text.match(
+				/ViewVertical\s*->\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
+			);
+			if (viewVertical && viewVertical.length === 4) {
+				up.x = parseFloat(viewVertical[1]);
+				up.y = parseFloat(viewVertical[2]);
+				up.z = parseFloat(viewVertical[3]);
+			}
 
 			// Split the input into blocks and parse.
 			parseMathematicaBlocks(recurseMathematicaBlocks(text));
 		};
 
-		// Find the maximum and minimum of all mesh coordinate points and the maximum coordinate value for the scale.
-		const setExtremum = () => {
-			const min = [0, 0, 0];
-			const max = [0, 0, 0];
-
-			for (const point of surfaceCoords) {
-				for (let i = 0; i < 3; ++i) {
-					if (point[i] < min[i]) min[i] = point[i];
-					else if (point[i] > max[i]) max[i] = point[i];
-				}
-			}
-
-			for (const line of lineCoords) {
-				for (let i = 0; i < 2; ++i) {
-					for (let j = 0; j < 3; ++j) {
-						if (line[i][j] < min[j]) {
-							min[j] = line[i][j];
-						} else if (line[i][j] > max[j]) {
-							max[j] = line[i][j];
-						}
-					}
-				}
-			}
-
-			coordMins = min;
-			coordMaxs = max;
-
-			let sum = 0;
-			for (let i = 0; i < 3; ++i) {
-				sum += max[i] - min[i];
-			}
-
-			windowScale = sum / 3;
-		};
-
-		// Build the ticks, tick labels, and axis label for the axis with the given index.
-		const makeAxisTicks = (index) => {
-			const shapes = [];
-
-			for (let i = 0; i < options.numTicks - 1; ++i) {
-				// Coordinate of tick and label
-				const coord = ((coordMaxs[index] - coordMins[index]) / options.numTicks) * (i + 1) + coordMins[index];
-
-				// Ticks are boxes defined by tickSize
-				shapes.push(
-					createX3DElement(
-						'transform',
-						{ translation: [coord, 0, 0] },
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { diffuseColor: 'black' })
-							),
-							createX3DElement('box', {
-								size: `${options.tickSize} ${options.tickSize} ${options.tickSize}`
-							})
-						)
-					)
-				);
-
-				// Labels have two decimal places and always point towards view.
-				shapes.push(
-					createX3DElement(
-						'transform',
-						{ translation: [coord, 0.1, 0] },
-						createX3DElement(
-							'billboard',
-							{ axisOfRotation: '0 0 0' },
-							createX3DElement(
-								'shape',
-								null,
-								createX3DElement(
-									'appearance',
-									null,
-									createX3DElement('material', { diffuseColor: 'black' })
-								),
-								createX3DElement(
-									'text',
-									{ string: coord.toFixed(2), solid: 'true' },
-									createX3DElement('fontstyle', {
-										size: options.tickFontSize * windowScale,
-										family: 'mono',
-										style: 'bold',
-										justify: 'MIDDLE'
-									})
-								)
-							)
-						)
-					)
-				);
-			}
-
-			// Add the axis label to the end of the axis.
-			shapes.push(
-				createX3DElement(
-					'transform',
-					{ translation: [coordMaxs[index], 0.1, 0] },
-					createX3DElement(
-						'billboard',
-						{ axisOfRotation: '0 0 0' },
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { diffuseColor: 'black' })
-							),
-							createX3DElement(
-								'text',
-								{ string: options.axisKey[index], solid: 'true' },
-								createX3DElement('fontstyle', {
-									size: options.tickFontSize * windowScale,
-									family: 'mono',
-									style: 'bold',
-									justify: 'MIDDLE'
-								})
-							)
-						)
-					)
-				)
-			);
-
-			return shapes;
-		};
-
-		const drawAxes = () => {
-			// Build the x axis and add the ticks.
-			scene.append(
-				createX3DElement(
-					'transform',
-					{ translation: [0, coordMins[1], coordMins[2]] },
-					createX3DElement(
-						'group',
-						null,
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { emissiveColor: 'black' })
-							),
-							createX3DElement('Polyline2D', { lineSegments: coordMins[0] + ' 0 ' + coordMaxs[0] + ' 0' })
-						),
-						...makeAxisTicks(0)
-					)
-				)
-			);
-
-			if (options.showAxesCube) {
-				for (const translation of [
-					[0, coordMins[1], coordMaxs[2]],
-					[0, coordMaxs[1], coordMins[2]],
-					[0, coordMaxs[1], coordMaxs[2]]
-				]) {
-					scene.append(
-						createX3DElement(
-							'transform',
-							{ translation },
-							createX3DElement(
-								'shape',
-								null,
-								createX3DElement(
-									'appearance',
-									null,
-									createX3DElement('material', { emissiveColor: 'black' })
-								),
-								createX3DElement('Polyline2D', {
-									lineSegments: coordMins[0] + ' 0 ' + coordMaxs[0] + ' 0'
-								})
-							)
-						)
-					);
-				}
-			}
-
-			// Build the y axis and add the ticks.
-			scene.append(
-				createX3DElement(
-					'transform',
-					{ translation: [coordMins[0], 0, coordMins[2]], rotation: [0, 0, 1, Math.PI / 2] },
-					createX3DElement(
-						'group',
-						null,
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { emissiveColor: 'black' })
-							),
-							createX3DElement('Polyline2D', { lineSegments: coordMins[1] + ' 0 ' + coordMaxs[1] + ' 0' })
-						),
-						...makeAxisTicks(1)
-					)
-				)
-			);
-
-			if (options.showAxesCube) {
-				for (const translation of [
-					[coordMins[0], 0, coordMaxs[2]],
-					[coordMaxs[0], 0, coordMins[2]],
-					[coordMaxs[0], 0, coordMaxs[2]]
-				]) {
-					scene.append(
-						createX3DElement(
-							'transform',
-							{ translation, rotation: [0, 0, 1, Math.PI / 2] },
-							createX3DElement(
-								'shape',
-								null,
-								createX3DElement(
-									'appearance',
-									null,
-									createX3DElement('material', { emissiveColor: 'black' })
-								),
-								createX3DElement('Polyline2D', {
-									lineSegments: coordMins[1] + ' 0 ' + coordMaxs[1] + ' 0'
-								})
-							)
-						)
-					);
-				}
-			}
-
-			// Build the z axis and add the ticks.
-			scene.append(
-				createX3DElement(
-					'transform',
-					{ translation: [coordMins[0], coordMins[1], 0], rotation: [0, 1, 0, -Math.PI / 2] },
-					createX3DElement(
-						'group',
-						null,
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { emissiveColor: 'black' })
-							),
-							createX3DElement('Polyline2D', { lineSegments: coordMins[2] + ' 0 ' + coordMaxs[2] + ' 0' })
-						),
-						...makeAxisTicks(2)
-					)
-				)
-			);
-
-			if (options.showAxesCube) {
-				for (const translation of [
-					[coordMins[0], coordMaxs[1], 0],
-					[coordMaxs[0], coordMins[1], 0],
-					[coordMaxs[0], coordMaxs[1], 0]
-				]) {
-					scene.append(
-						createX3DElement(
-							'transform',
-							{ translation, rotation: [0, 1, 0, -Math.PI / 2] },
-							createX3DElement(
-								'shape',
-								null,
-								createX3DElement(
-									'appearance',
-									null,
-									createX3DElement('material', { emissiveColor: 'black' })
-								),
-								createX3DElement('Polyline2D', {
-									lineSegments: coordMins[2] + ' 0 ' + coordMaxs[2] + ' 0'
-								})
-							)
-						)
-					);
-				}
-			}
-		};
-
-		const drawSurface = () => {
-			if (surfaceCoords.length == 0) return;
-
-			let coordstr = '';
-			let indexstr = '';
-			let colorstr = '';
-			let colorindstr = '';
-
-			// Build a string with all the surface coodinates.
-			for (const point of surfaceCoords) {
-				coordstr += point.join(' ') + ' ';
-			}
-
-			// Build a string with all the surface indexes.  At the same time build
-			// a string with color data and the associated color indexes.
-			for (const index of surfaceIndex) {
-				indexstr += index + ' ';
-
-				if (index == -1) {
-					colorindstr += '-1 ';
-					continue;
-				}
-
-				let cindex = parseInt(
-					((surfaceCoords[index][2] - coordMins[2]) / (coordMaxs[2] - coordMins[2])) * colormap.length
-				);
-
-				if (cindex == colormap.length) {
-					--cindex;
-				}
-
-				colorindstr += cindex + ' ';
-			}
-
-			for (const color of colormap) {
-				for (let i = 0; i < 3; ++i) {
-					color[i] += 0.2;
-					color[i] = Math.min(color[i], 1);
-				}
-
-				colorstr += color[0] + ' ' + color[1] + ' ' + color[2] + ' ';
-			}
-
-			let flatcolor = false;
-			let color = [];
-
-			if (surfaceBlockIndex in colors) {
-				flatcolor = true;
-				color = colors[surfaceBlockIndex];
-			}
-
-			// Add surface to scene as an indexedfaceset
-			const surface = createX3DElement(
-				'shape',
-				null,
-				createX3DElement(
-					'appearance',
-					null,
-					createX3DElement('material', {
-						ambientIntensity: '0',
-						convex: 'false',
-						creaseangle: Math.PI,
-						diffusecolor: color,
-						shininess: '.015'
-					})
-				)
-			);
-
-			const indexedfaceset = createX3DElement(
-				'indexedfaceset',
-				{ coordindex: indexstr, solid: 'false' },
-				createX3DElement('coordinate', { point: coordstr })
-			);
-
-			if (!flatcolor) {
-				indexedfaceset.setAttribute('colorindex', colorindstr);
-				indexedfaceset.append(createX3DElement('color', { color: colorstr }));
-			}
-
-			// Append the indexed face set to the shape after it is assembled.
-			// Otherwise sometimes x3d tries to access the various data before its ready.
-			surface.append(indexedfaceset);
-
-			scene.append(surface);
-
-			if (options.drawMesh) {
-				scene.append(
-					createX3DElement(
-						'shape',
-						null,
-						createX3DElement('appearance', null, createX3DElement('material', { diffusecolor: [0, 0, 0] })),
-						createX3DElement(
-							'indexedlineset',
-							{ coordindex: indexstr, solid: 'true' },
-							createX3DElement('coordinate', { point: coordstr })
-						)
-					)
-				);
-			}
-		};
-
-		const drawLines = () => {
-			if (lineCoords.length == 0) return;
-
-			const lineGroup = createX3DElement('group');
-
-			for (const line of lineCoords) {
-				// Lines are cylinders that start centered at the origin along the y axis.
-				// They need to be translated and rotated into place.
-				const length = Math.sqrt(
-					Math.pow(line[0][0] - line[1][0], 2) +
-						Math.pow(line[0][1] - line[1][1], 2) +
-						Math.pow(line[0][2] - line[1][2], 2)
-				);
-				if (length == 0) continue;
-
-				const rotation = [];
-				rotation[0] = line[1][2] - line[0][2];
-				rotation[1] = 0;
-				rotation[2] = line[0][0] - line[1][0];
-				rotation[3] = Math.acos((line[1][1] - line[0][1]) / length);
-
-				const translation = [0, 0, 0];
-
-				for (let i = 0; i < 3; ++i) {
-					translation[i] = (line[1][i] + line[0][i]) / 2;
-				}
-
-				let color = [0, 0, 0];
-				let radius = 0.005;
-
-				if (line[2] in colors) color = colors[line[2]];
-				if (line[2] in lineThickness) radius = Math.max(lineThickness[line[2]], 0.005);
-
-				lineGroup.append(
-					createX3DElement(
-						'transform',
-						{ translation, rotation },
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement('appearance', null, createX3DElement('material', { diffusecolor: color })),
-							createX3DElement('Cylinder', { height: length, radius: radius * 2 })
-						)
-					)
-				);
-			}
-
-			scene.append(lineGroup);
-		};
-
-		const drawPoints = () => {
-			for (const point of points) {
-				// Points are drawn as spheres.
-				scene.append(
-					createX3DElement(
-						'transform',
-						{ translation: point.coords },
-						createX3DElement(
-							'shape',
-							null,
-							createX3DElement(
-								'appearance',
-								null,
-								createX3DElement('material', { diffuseColor: point.rgb ?? 'black' })
-							),
-							createX3DElement('sphere', { radius: point.radius * 2.25 })
-						)
-					)
-				);
-			}
-		};
-
-		const drawLabels = () => {
-			for (const label of labels) {
-				// The text is a billboard that automatically faces the user.
-				scene.append(
-					createX3DElement(
-						'transform',
-						{ translation: label.coords },
-						createX3DElement(
-							'billboard',
-							{ axisOfRotation: '0 0 0' },
-							createX3DElement(
-								'shape',
-								null,
-								createX3DElement(
-									'appearance',
-									null,
-									createX3DElement('material', { diffuseColor: 'black' })
-								),
-								createX3DElement(
-									'text',
-									{ string: label.text, solid: 'true' },
-									createX3DElement('fontstyle', {
-										// Mathematica label sizes are fontsizes, where
-										// the units for x3dom are local coordinate sizes.
-										size: label.size ? label.size / (1.5 * windowScale) : '.5',
-										family: 'mono',
-										justify: 'MIDDLE'
-									})
-								)
-							)
-						)
-					)
-				);
-			}
-		};
-
-		// Intialization function.  This takes the mathmatica data string and actually sets up the
-		// dom structure for the graph.  The actual graphing is done automatically by x3dom.
+		// Parse the data string and translate it into plotly traces.
 		const initialize = (datastring) => {
-			// Parse matlab string.
+			// Parse LiveGraphics3D string.
 			parseLive3DData(datastring);
 
-			// Find extremum for axis and window scale.
-			setExtremum();
+			const traces = [];
 
-			// Set up scene veiwpoint to be along the x axis looking to the origin.
-			scene.append(
-				createX3DElement(
-					'transform',
-					{ rotation: [1, 0, 0, Math.PI / 2] },
-					createX3DElement('viewpoint', {
-						fieldofview: 0.9,
-						position: [2 * windowScale, 0, 0],
-						orientation: [0, 1, 0, Math.PI / 2]
-					})
-				)
+			for (const [blockIndex, surface] of Object.entries(surfaces)) {
+				if (blockIndex in colors) {
+					surface.surface.color = `rgb(${colors[blockIndex][0] * 255},${colors[blockIndex][1] * 255},${
+						colors[blockIndex][2] * 255
+					})`;
+				} else {
+					surface.surface.intensity = surface.surface.z;
+					surface.surface.colorscale = 'RdBu';
+				}
+
+				traces.push(surface.surface);
+				if (options.drawMesh) traces.push(surface.mesh);
+			}
+
+			for (const [blockIndex, line] of Object.entries(lines)) {
+				if (blockIndex in colors)
+					line.line.color = `rgb(${colors[blockIndex][0] * 255},${colors[blockIndex][1] * 255},${
+						colors[blockIndex][2] * 255
+					})`;
+
+				if (blockIndex in lineThickness) {
+					line.line.width = Math.max(lineThickness[blockIndex], 0.005) * 400;
+				}
+
+				traces.push(line);
+			}
+
+			traces.push(...points, ...labels);
+
+			Plotly.newPlot(
+				container,
+				traces,
+				{
+					width: options.width,
+					height: options.height,
+					margin: { l: 5, r: 5, b: 5, t: 5 },
+					showlegend: false,
+					paper_bgcolor: 'white',
+					scene: {
+						xaxis: {
+							visible: options.showAxes,
+							title: options.axisKey[0],
+							nticks: options.numTicks + 2,
+							showspikes: false
+						},
+						yaxis: {
+							visible: options.showAxes,
+							title: options.axisKey[1],
+							nticks: options.numTicks + 2,
+							showspikes: false
+						},
+						zaxis: {
+							visible: options.showAxes,
+							title: options.axisKey[2],
+							nticks: options.numTicks + 2,
+							showspikes: false
+						},
+						camera: { eye, up }
+					}
+				},
+				{ displaylogo: false }
 			);
-
-			scene.append(createX3DElement('background', { skycolor: '1 1 1' }));
-
-			// Draw components of scene
-			if (options.showAxes) drawAxes();
-			drawSurface();
-			drawLines();
-			drawPoints();
-			drawLabels();
 		};
 
 		// This section of code is run whenever the object is created.  It obtains the data either from direct input, a

--- a/htdocs/js/LiveGraphics/liveGraphics.js
+++ b/htdocs/js/LiveGraphics/liveGraphics.js
@@ -4,437 +4,494 @@
 	const liveGraphics3D = (container) => {
 		const options = JSON.parse(container.dataset.options);
 
-		// Set default options.
-		options.width = options.width ?? 200;
-		options.height = options.height ?? 200;
-		options.showAxes = options.showAxes ?? false;
-		options.showAxesCube = options.showAxesCube ?? true;
-		options.numTicks = options.numTicks ?? 4;
-		options.axisKey = options.axisKey ?? ['x', 'y', 'z'];
-		options.drawMesh = options.drawMesh ?? true;
+		const width = options.width || 200;
+		const height = options.height || 200;
+
+		const maxTicks = options.maxTicks instanceof Array ? options.maxTicks : Array(3).fill(options.maxTicks ?? 6);
+		while (maxTicks.length < 3) maxTicks.push(6);
 
 		const screenReaderOnly = document.createElement('span');
 		screenReaderOnly.classList.add('visually-hidden');
 		screenReaderOnly.textContent = 'A manipulable 3d graph.';
 		container.append(screenReaderOnly);
 
+		// General options that can be overriden by settings in the input data.
+		let lighting = true;
+		let showAxes = false;
+		let axesLabels = ['x', 'y', 'z'];
+
 		// Inital view point and up vector.
 		const eye = { x: 1.25, y: 1.25, z: 1.25 };
 		const up = { x: 0, y: 0, z: 1 };
 
-		// Colors and thicknesses drawn from input.
-		const colors = {};
-		const lineThickness = {};
+		// Initial graphics state. This is pushed onto the state stack when a block at depth 0 is executed. At each
+		// successive block depth this state is copied and pushed onto the state stack.  The options in the state apply
+		// to all graphics primitives in that block.  The state can be changed within a block by the RGBColor,
+		// Thickness, and GrayLevel commands. All graphics primitives in the block after the change are affected. Also
+		// note that if these are called inside an EdgeForm command, then the edge options are changed instead.
+		const initialState = {
+			color: null,
+			lineThickness: null,
+			edgeColor: 'black',
+			edgeThickness: 0.001,
+			pointSize: 0.01,
+			edgeForm: false,
+			drawEdges: true
+		};
+		const state = [];
 
-		// Block indexes are used to associate objects to colors and thicknesses.
+		// The block index is used to group parts of surfaces, lines, and edges in the same block.
 		let blockIndex = 0;
 
 		// Data from input (translated into plotly traces).
 		const surfaces = {};
+		const edges = {};
 		const lines = {};
 		const points = [];
 		const labels = [];
 
 		let variables = '';
 
-		// Split a list of mathematica commands into blocks.
-		const splitMathematicaBlocks = (text) => {
-			let bracketcount = 0;
-			const blocks = [];
-			let block = '';
+		const executeCommand = (command) => {
+			const currentState = state.slice(-1)[0];
 
-			for (let i = 0; i < text.length; ++i) {
-				block += text.charAt(i);
+			if (command.id === 'Point') {
+				if (command.blocks.length !== 1 || command.blocks[0].length < 3) {
+					console.log('Error parsing point: A point must have three coordinates.');
+					return;
+				}
 
-				if (text.charAt(i) === '[') ++bracketcount;
+				// Points are implemented as the top and bottom half of a sphere.  Note that using a marker in a
+				// scatter3d trace results in bad clipping since markers are really only two dimensional circles.
+				const point = { type: 'mesh3d', x: [], y: [], z: [], color: 'black', hoverinfo: 'none' };
 
-				if (text.charAt(i) === ']') {
-					--bracketcount;
-					if (bracketcount == 0) {
-						++i;
-						blocks.push(block);
-						block = '';
+				const x = command.blocks[0][0],
+					y = command.blocks[0][1],
+					z = command.blocks[0][2];
+
+				const r = currentState.pointSize * 2.5;
+
+				point.color = `rgb(${currentState.color[0] * 255},${currentState.color[1] * 255},${
+					currentState.color[2] * 255
+				})`;
+
+				const samples = 20;
+
+				const phiValues = Array(samples)
+					.fill(0)
+					.map((_v, i) => (i * (Math.PI / 2)) / (samples - 1));
+
+				const thetaValues = Array(samples)
+					.fill(0)
+					.map((_v, i) => (2 * i * Math.PI) / (samples - 1));
+
+				for (const phi of phiValues) {
+					for (const theta of thetaValues) {
+						point.x.push(x + r * Math.cos(theta) * Math.sin(phi));
+						point.y.push(y + r * Math.sin(theta) * Math.sin(phi));
+						point.z.push(z + r * Math.cos(phi));
 					}
 				}
-			}
 
-			return blocks;
-		};
+				// The lower hemisphere is obtained by duplicating the upper hemisphere and negating its z
+				// coordinate relative to the z position of the center.
+				points.push(point, { ...point, z: point.z.map((v) => 2 * z - v) });
+			} else if (command.id === 'Polygon') {
+				if (command.blocks.length !== 1 || command.blocks[0].length < 3) {
+					console.log('Error parsing polygon: Polygons must have at least three points.');
+					return;
+				}
 
-		// The mathematica code comes in blocks enclosed by braces.  This code makes an array from those blocks.
-		// The largest of them will be the polygon block which defines the surface.
-		const recurseMathematicaBlocks = (text, initialcount) => {
-			let bracketcount = 0;
-			const blocks = [];
-			let block = '';
+				if (!surfaces[blockIndex]) {
+					surfaces[blockIndex] = {
+						type: 'mesh3d',
+						x: [],
+						y: [],
+						z: [],
+						i: [],
+						j: [],
+						k: [],
+						showscale: false,
+						hoverinfo: 'none'
+					};
 
-			if (initialcount) bracketcount = initialcount;
+					if (!lighting) {
+						// Set the ambient lighting to the max, and disable all others.  Ambient lighting is needed
+						// unless you just want a black blob for the surface.
+						surfaces[blockIndex].lighting = {
+							ambient: 1,
+							diffuse: 0,
+							fresnel: 0,
+							roughness: 0,
+							specular: 0
+						};
+					}
 
-			for (let i = 0; i < text.length; ++i) {
-				if (text.charAt(i) === '{') ++bracketcount;
-
-				if (bracketcount > 0) block += text.charAt(i);
-
-				if (text.charAt(i) === '}') {
-					--bracketcount;
-					if (bracketcount == 0) {
-						blocks.push(block.substring(1, block.length - 1));
-						block = '';
+					if (currentState.color instanceof Array) {
+						surfaces[blockIndex].color = `rgb(${currentState.color[0] * 255},${
+							currentState.color[1] * 255
+						},${currentState.color[2] * 255})`;
+					} else {
+						surfaces[blockIndex].intensity = surfaces[blockIndex].z;
+						surfaces[blockIndex].colorscale = 'RdBu';
 					}
 				}
-			}
 
-			return blocks;
-		};
+				if (currentState.drawEdges && !edges[blockIndex]) {
+					edges[blockIndex] = {
+						type: 'scatter3d',
+						mode: 'lines',
+						x: [],
+						y: [],
+						z: [],
+						line: { width: currentState.edgeThickness * 1000, color: 'black' },
+						hoverinfo: 'none'
+					};
 
-		const parseMathematicaBlocks = (blocks) => {
-			for (const block of blocks) {
-				++blockIndex;
+					if (currentState.edgeColor instanceof Array) {
+						edges[blockIndex].line.color = `rgb(${currentState.edgeColor[0] * 255},${
+							currentState.edgeColor[1] * 255
+						},${currentState.edgeColor[2] * 255})`;
+					}
+				}
 
-				if (block.match(/^\s*\{/)) {
-					// This is a block inside of a block.  So recurse.
-					parseMathematicaBlocks(recurseMathematicaBlocks(block));
-				} else if (block.match(/Point/)) {
-					// Points are defined by short blocks so don't split into individual commands.
-					let pointStr = block.match(
-						/Point\[\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
-					);
-					if (!pointStr || pointStr.length < 4) {
-						console.log('Error Parsing Point');
-						continue;
+				const polygonIndices = [];
+
+				for (const point of command.blocks[0]) {
+					if (point.length !== 3) {
+						console.log('Error parsing polygon: Points must have three coordinates.');
+						return;
 					}
 
-					// Points are implemented as the top and bottom half of a sphere.  Note that using a marker in a
-					// scatter3d trace results in bad clipping since markers are really only two dimensional circles.
-					const point = { type: 'mesh3d', x: [], y: [], z: [], color: 'black', hoverinfo: 'none' };
-
-					const x = parseFloat(pointStr[1]),
-						y = parseFloat(pointStr[2]),
-						z = parseFloat(pointStr[3]);
-
-					const pointSizeStr = block.match(/PointSize\[\s*(\d*\.?\d*)\s*\]/);
-					const r = pointSizeStr && pointSizeStr.length == 2 ? parseFloat(pointSizeStr[1]) * 2.5 : 0.025;
-
-					const colorStr = block.match(/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/);
-					if (colorStr) point.color = `rgb(${colorStr[1] * 255},${colorStr[2] * 255},${colorStr[3] * 255})`;
-
-					const samples = 20;
-
-					const phiValues = Array(samples)
-						.fill(0)
-						.map((_v, i) => (i * (Math.PI / 2)) / (samples - 1));
-
-					const thetaValues = Array(samples)
-						.fill(0)
-						.map((_v, i) => (2 * i * Math.PI) / (samples - 1));
-
-					for (const phi of phiValues) {
-						for (const theta of thetaValues) {
-							point.x.push(x + r * Math.cos(theta) * Math.sin(phi));
-							point.y.push(y + r * Math.sin(theta) * Math.sin(phi));
-							point.z.push(z + r * Math.cos(phi));
+					for (let i = 0; i < point.length; ++i) {
+						try {
+							point[i] = new Function(`'use strict'; { ${variables} return ${point[i]} }`)();
+						} catch (e) {
+							console.log(`Failed to evaluate variable quantity in coordinate of point: ${point[i]}`);
+							return;
 						}
 					}
 
-					// The lower hemisphere is obtained by duplicating the upper hemisphere and negating its z
-					// coordinate relative to the z position of the center.
-					points.push(point, { ...point, z: point.z.map((v) => 2 * z - v) });
+					// Find the index of the point in the surface x, y, z coordinate arrays.
+					// If the point is not in the arrays, then add it.
+					let pointIndex = 0;
+					for (; pointIndex < surfaces[blockIndex].x.length; ++pointIndex) {
+						if (
+							surfaces[blockIndex].x[pointIndex] === point[0] &&
+							surfaces[blockIndex].y[pointIndex] === point[1] &&
+							surfaces[blockIndex].z[pointIndex] === point[2]
+						)
+							break;
+					}
+
+					if (pointIndex === surfaces[blockIndex].x.length) {
+						surfaces[blockIndex].x.push(point[0]);
+						surfaces[blockIndex].y.push(point[1]);
+						surfaces[blockIndex].z.push(point[2]);
+					}
+
+					edges[blockIndex]?.x.push(point[0]);
+					edges[blockIndex]?.y.push(point[1]);
+					edges[blockIndex]?.z.push(point[2]);
+
+					polygonIndices.push(pointIndex);
+				}
+
+				// Split the polygon into triangle faces, and add the indices of the vertices of these
+				// triangles to the face index arrays.
+				for (let i = 1; i < polygonIndices.length - 1; ++i) {
+					surfaces[blockIndex].i.push(polygonIndices[0]);
+					surfaces[blockIndex].j.push(polygonIndices[i]);
+					surfaces[blockIndex].k.push(polygonIndices[i + 1]);
+				}
+
+				edges[blockIndex]?.x.push('None');
+				edges[blockIndex]?.y.push('None');
+				edges[blockIndex]?.z.push('None');
+			} else if (command.id === 'Line') {
+				if (command.blocks.length !== 1 || command.blocks[0].length < 2) {
+					console.log('Error parsing line: Lines must have at least two points.');
+					return;
+				}
+
+				const x = [],
+					y = [],
+					z = [];
+
+				for (const point of command.blocks[0]) {
+					if (point.length !== 3) {
+						console.log('Error parsing line: Points must have three coordinates.');
+						return;
+					}
+
+					for (let i = 0; i < point.length; ++i) {
+						try {
+							point[i] = new Function(`'use strict'; { ${variables} return ${point[i]} }`)();
+						} catch (e) {
+							console.log(`Failed to evaluate variable quantity in coordinate of point: ${point[i]}`);
+							return;
+						}
+					}
+
+					x.push(point[0]);
+					y.push(point[1]);
+					z.push(point[2]);
+				}
+
+				x.push('None');
+				y.push('None');
+				z.push('None');
+
+				if (lines[blockIndex]) {
+					lines[blockIndex].x.push(...x);
+					lines[blockIndex].y.push(...y);
+					lines[blockIndex].z.push(...z);
 				} else {
-					// Otherwise its a list of commands that need to be individually processed.
-					for (const command of splitMathematicaBlocks(block)) {
-						if (command.match(/^\s*\{/)) {
-							// This is a block inside of a block.  So recurse.
-							parseMathematicaBlocks(recurseMathematicaBlocks(block));
-						} else if (command.match(/Polygon/)) {
-							// Extract all points of the polygon.
-							const polygonPoints = [];
-							try {
-								const pointStrings = recurseMathematicaBlocks(
-									command.replace(/Polygon\[([^\]]*)\]/, '$1'),
-									-1
-								);
-								if (pointStrings.length < 3) throw 'Polygons must have at least thre points.';
-
-								for (const pointString of pointStrings) {
-									const coordStrings = pointString.replace(/\{([^\{]*)\}/, '$1').split(',');
-									if (coordStrings.length !== 3) throw 'Points must have three coordinates.';
-
-									const point = [];
-
-									for (const coordString of coordStrings) {
-										point.push(
-											parseFloat(
-												new Function(`'use strict'; { ${variables} return ${coordString} }`)()
-											)
-										);
-									}
-
-									polygonPoints.push(point);
-								}
-							} catch (e) {
-								console.log(`Error parsing polygon: ${e}`);
-								continue;
-							}
-							if (!surfaces[blockIndex]) {
-								surfaces[blockIndex] = {
-									surface: {
-										type: 'mesh3d',
-										x: [],
-										y: [],
-										z: [],
-										i: [],
-										j: [],
-										k: [],
-										showscale: false,
-										hoverinfo: 'none'
-									},
-									mesh: {
-										type: 'scatter3d',
-										mode: 'lines',
-										x: [],
-										y: [],
-										z: [],
-										line: { width: 1, color: 'black' },
-										hoverinfo: 'none'
-									}
-								};
-							}
-
-							const polygonIndices = [];
-
-							for (const point of polygonPoints) {
-								// Find the index of the point in the surface x, y, z coordinate arrays.
-								// If the point is not in the arrays, then add it.
-								let pointIndex = 0;
-								for (; pointIndex < surfaces[blockIndex].surface.x.length; ++pointIndex) {
-									if (
-										surfaces[blockIndex].surface.x[pointIndex] === point[0] &&
-										surfaces[blockIndex].surface.y[pointIndex] === point[1] &&
-										surfaces[blockIndex].surface.z[pointIndex] === point[2]
-									)
-										break;
-								}
-
-								if (pointIndex === surfaces[blockIndex].surface.x.length) {
-									surfaces[blockIndex].surface.x.push(point[0]);
-									surfaces[blockIndex].surface.y.push(point[1]);
-									surfaces[blockIndex].surface.z.push(point[2]);
-								}
-
-								surfaces[blockIndex].mesh.x.push(point[0]);
-								surfaces[blockIndex].mesh.y.push(point[1]);
-								surfaces[blockIndex].mesh.z.push(point[2]);
-
-								polygonIndices.push(pointIndex);
-							}
-
-							// Split the polygon into triangle faces, and add the indices of the vertices of these
-							// triangles to the face index arrays.
-							for (let i = 1; i < polygonIndices.length - 1; ++i) {
-								surfaces[blockIndex].surface.i.push(polygonIndices[0]);
-								surfaces[blockIndex].surface.j.push(polygonIndices[i]);
-								surfaces[blockIndex].surface.k.push(polygonIndices[i + 1]);
-							}
-
-							surfaces[blockIndex].mesh.x.push('None');
-							surfaces[blockIndex].mesh.y.push('None');
-							surfaces[blockIndex].mesh.z.push('None');
-						} else if (command.match(/Line/)) {
-							const x = [],
-								y = [],
-								z = [];
-
-							try {
-								const pointStrings = recurseMathematicaBlocks(
-									command.replace(/Line\[([^\]]*)\],/, '$1'),
-									-1
-								);
-								if (pointStrings.length < 2) throw 'Lines must have at least two points.';
-
-								for (const pointString of pointStrings) {
-									const coordStrings = pointString.split(',');
-									if (coordStrings.length !== 3) throw 'Points must have three coordinates.';
-
-									const point = [];
-
-									for (const coordString of coordStrings) {
-										point.push(
-											parseFloat(
-												new Function(`'use strict'; { ${variables} return ${coordString} }`)()
-											)
-										);
-									}
-
-									x.push(point[0]);
-									y.push(point[1]);
-									z.push(point[2]);
-								}
-							} catch (e) {
-								console.log(`Error parsing line: ${e}`);
-								continue;
-							}
-
-							x.push('None');
-							y.push('None');
-							z.push('None');
-
-							if (lines[blockIndex]) {
-								lines[blockIndex].x.push(...x);
-								lines[blockIndex].y.push(...y);
-								lines[blockIndex].z.push(...z);
-							} else {
-								lines[blockIndex] = {
-									type: 'scatter3d',
-									mode: 'lines',
-									x,
-									y,
-									z,
-									line: { width: 5 },
-									hoverinfo: 'none'
-								};
-							}
-						} else if (command.match(/RGBColor/)) {
-							const str = command.match(
-								/RGBColor\[\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*,\s*(\d*\.?\d*)\s*\]/
-							);
-							if (str && str.length === 4)
-								colors[blockIndex] = [parseFloat(str[1]), parseFloat(str[2]), parseFloat(str[3])];
-						} else if (command.match(/Thickness/)) {
-							const str = command.match(/Thickness\[\s*(\d*\.?\d*)\s*\]/);
-							if (str && str.length === 2) lineThickness[blockIndex] = parseFloat(str[1]);
-						} else if (command.match(/Text/)) {
-							const labelStr = command.match(
-								/\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
-							);
-							if (!labelStr || labelStr.length !== 4) {
-								console.log('Error Parsing Label');
-								continue;
-							}
-
-							const label = {
-								type: 'scatter3d',
-								mode: 'text',
-								textfont: { color: 'black', size: 12, family: 'mono' },
-								textposition: 'top center',
-								hoverinfo: 'none'
-							};
-
-							label.x = [parseFloat(labelStr[1])];
-							label.y = [parseFloat(labelStr[2])];
-							label.z = [parseFloat(labelStr[3])];
-
-							const optionsStr = command.match(/StyleForm\[\s*(\w+),\s*FontSize\s*->\s*(\d+)\s*\]/);
-							if (!optionsStr || optionsStr.length < 3) {
-								console.log('Error parsing label.');
-								continue;
-							}
-
-							label.text = [optionsStr[1]];
-							label.textfont.size = optionsStr[2];
-
-							labels.push(label);
-						}
-					}
+					lines[blockIndex] = {
+						type: 'scatter3d',
+						mode: 'lines',
+						x,
+						y,
+						z,
+						line: { width: 5 },
+						hoverinfo: 'none'
+					};
 				}
+
+				if (currentState.color instanceof Array) {
+					lines[blockIndex].line.color = `rgb(${currentState.color[0] * 255},${currentState.color[1] * 255},${
+						currentState.color[2] * 255
+					})`;
+				}
+
+				if (currentState.lineThickness !== null)
+					lines[blockIndex].line.width = Math.max(currentState.lineThickness, 0.005) * 400;
+			} else if (command.id === 'EdgeForm') {
+				if (!command.blocks.length) currentState.drawEdges = false;
+				else currentState.drawEdges = true;
+
+				currentState.edgeForm = true;
+				executeBlocks(command.blocks);
+				currentState.edgeForm = false;
+			} else if (command.id === 'RGBColor') {
+				if (command.blocks.length === 3) {
+					if (currentState.edgeForm) currentState.edgeColor = command.blocks;
+					else currentState.color = command.blocks;
+				}
+			} else if (command.id === 'GrayLevel') {
+				if (command.blocks.length === 1) {
+					if (currentState.edgeForm)
+						currentState.edgeColor = [command.blocks[0], command.blocks[0], command.blocks[0]];
+					else currentState.color = [command.blocks[0], command.blocks[0], command.blocks[0]];
+				}
+			} else if (command.id === 'Thickness') {
+				if (command.blocks.length === 1) {
+					if (currentState.edgeForm) currentState.edgeThickness = command.blocks[0];
+					else currentState.lineThickness = command.blocks[0];
+				}
+			} else if (command.id === 'PointSize') {
+				if (command.blocks.length === 1) currentState.pointSize = command.blocks[0];
+			} else if (command.id === 'Text') {
+				if (command.blocks.length < 2 || command.blocks[1].length !== 3) {
+					console.log('Error parsing label: Missing arguments.');
+					return;
+				}
+
+				const label = {
+					type: 'scatter3d',
+					mode: 'text',
+					textfont: { color: 'black', size: 12, family: 'mono' },
+					textposition: 'top center',
+					hoverinfo: 'none'
+				};
+
+				label.x = [command.blocks[1][0]];
+				label.y = [command.blocks[1][1]];
+				label.z = [command.blocks[1][2]];
+
+				if (command.blocks[0].id !== 'StyleForm' || command.blocks[0].blocks.length !== 1) {
+					console.log('Error parsing label: No text provided.');
+					return;
+				}
+
+				label.text = command.blocks[0].blocks[0];
+				if (command.blocks[0].attributes.FontSize) label.textfont.size = command.blocks[0].attributes.FontSize;
+
+				labels.push(label);
 			}
 		};
 
-		const parseLive3DData = (text) => {
+		const executeBlocks = (blocks) => {
+			if (!state.slice(-1)[0]?.edgeForm) {
+				if (state.length) state.push(Object.assign({}, state.slice(-1)[0]));
+				else state.push(initialState);
+				++blockIndex;
+			}
+
+			for (const block of blocks) {
+				if (block instanceof Array) {
+					for (const subBlock of block) {
+						if (subBlock instanceof Array) executeBlocks(subBlock);
+						else executeCommand(subBlock);
+					}
+				} else executeCommand(block);
+			}
+
+			if (!state.slice(-1)[0].edgeForm) state.pop();
+		};
+
+		const parseLive3DData = (data) => {
 			// Set up variables.
 			for (const [name, data] of Object.entries(options.vars)) {
 				variables += `const ${name} = ${data};`;
 			}
 
-			// Parse axes commands.
-			if (text.match(/Axes\s*->\s*True/)) options.showAxes = true;
+			if (data.attributes.Axes === true) showAxes = true;
 
-			const labels = text.match(/AxesLabel\s*->\s*\{\s*(\w+),\s*(\w+),\s*(\w+)\s*\}/);
-			if (labels && labels.length === 4) options.axisKey = [labels[1], labels[2], labels[3]];
+			if (data.attributes.AxesLabel instanceof Array && data.attributes.AxesLabel.length === 3)
+				axesLabels = data.attributes.AxesLabel;
 
-			const viewPoint = text.match(
-				/ViewPoint\s*->\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
-			);
-			if (viewPoint && viewPoint.length === 4) {
-				eye.x = parseFloat(viewPoint[1]);
-				eye.y = parseFloat(viewPoint[2]);
-				eye.z = parseFloat(viewPoint[3]);
+			if (data.attributes.ViewPoint instanceof Array && data.attributes.ViewPoint.length === 3) {
+				eye.x = data.attributes.ViewPoint[0];
+				eye.y = data.attributes.ViewPoint[1];
+				eye.z = data.attributes.ViewPoint[2];
 			}
 
-			const viewVertical = text.match(
-				/ViewVertical\s*->\s*\{\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*,\s*(-?\d*\.?\d*)\s*\}/
-			);
-			if (viewVertical && viewVertical.length === 4) {
-				up.x = parseFloat(viewVertical[1]);
-				up.y = parseFloat(viewVertical[2]);
-				up.z = parseFloat(viewVertical[3]);
+			if (data.attributes.ViewVertical instanceof Array && data.attributes.ViewVertical.length === 3) {
+				up.x = data.attributes.ViewVertical[0];
+				up.y = data.attributes.ViewVertical[1];
+				up.z = data.attributes.ViewVertical[2];
 			}
 
-			// Split the input into blocks and parse.
-			parseMathematicaBlocks(recurseMathematicaBlocks(text));
+			if ('Lighting' in data.attributes) lighting = data.attributes.Lighting;
+
+			executeBlocks(data.blocks);
+		};
+
+		const parseArray = (stream, parent, delim = '[') => {
+			let delimCount = 1;
+			let block = [];
+
+			const oppDelim = delim === '[' ? ']' : delim === '{' ? '}' : '\n';
+
+			while (stream.length && stream[0] !== delim) stream.shift();
+			stream.shift();
+
+			while (stream.length) {
+				if (stream[0].match(/^\s/)) {
+					stream.shift();
+					continue;
+				}
+
+				const char = stream.shift();
+
+				if (char === oppDelim) {
+					--delimCount;
+					if (delimCount == 0) break;
+				}
+
+				block.push(char);
+
+				if (char === delim) ++delimCount;
+			}
+
+			const array = [];
+
+			while (block.length) {
+				const element = extractNext(block, parent);
+				if (typeof element !== 'undefined') array.push(element);
+				if (block.length && block[0] === ',') block.shift();
+			}
+
+			return array;
+		};
+
+		const extractNext = (stream, parent = {}) => {
+			if (!stream.length) return;
+
+			// Block
+			if (stream[0] === '{') return parseArray(stream, parent, '{');
+
+			let identifier = '';
+			while (stream.length && stream[0].match(/^[A-Za-z]/)) identifier += stream.shift();
+
+			if (identifier) {
+				while (stream.length && stream[0].match(/^[A-Za-z0-9]/)) identifier += stream.shift();
+
+				// Attribute
+				if (stream.length && stream[0] === '-' && stream[1] === '>') {
+					stream.shift();
+					stream.shift();
+					const value = extractNext(stream, parent);
+					if (!parent.attributes) parent.attributes = {};
+					parent.attributes[identifier] = value;
+					return;
+				}
+
+				// Command
+				if (stream.length && stream[0] === '[') {
+					const command = { id: identifier };
+					command.blocks = parseArray(stream, command);
+					return command;
+				}
+			}
+
+			// The last case is that of a scalar argument for a command or attribute.  So accumulate everything
+			// up to the next comma or the end of the stream if that comes first.
+			while (stream.length && stream[0] !== ',') identifier += stream.shift();
+
+			if (identifier.toLowerCase() === 'true') return true;
+			if (identifier.toLowerCase() === 'false') return false;
+
+			if (/^[+-]?\d+\.?\d*$/.test(identifier)) return parseFloat(identifier);
+
+			return identifier;
+		};
+
+		const parseLive3DString = (text) => {
+			const stream = text.replaceAll(/\s*/g, '').split('');
+			return extractNext(stream);
 		};
 
 		// Parse the data string and translate it into plotly traces.
 		const initialize = (datastring) => {
-			// Parse LiveGraphics3D string.
-			parseLive3DData(datastring);
-
-			const traces = [];
-
-			for (const [blockIndex, surface] of Object.entries(surfaces)) {
-				if (blockIndex in colors) {
-					surface.surface.color = `rgb(${colors[blockIndex][0] * 255},${colors[blockIndex][1] * 255},${
-						colors[blockIndex][2] * 255
-					})`;
-				} else {
-					surface.surface.intensity = surface.surface.z;
-					surface.surface.colorscale = 'RdBu';
-				}
-
-				traces.push(surface.surface);
-				if (options.drawMesh) traces.push(surface.mesh);
+			try {
+				// Parse LiveGraphics3D string into a javascript object.
+				const data = parseLive3DString(datastring);
+				if (!data || data.id !== 'Graphics3D') throw 'Unable to parse live graphics 3d data string.';
+				// Evaluate data.
+				parseLive3DData(data);
+			} catch (e) {
+				console.log(e);
+				return;
 			}
-
-			for (const [blockIndex, line] of Object.entries(lines)) {
-				if (blockIndex in colors)
-					line.line.color = `rgb(${colors[blockIndex][0] * 255},${colors[blockIndex][1] * 255},${
-						colors[blockIndex][2] * 255
-					})`;
-
-				if (blockIndex in lineThickness) {
-					line.line.width = Math.max(lineThickness[blockIndex], 0.005) * 400;
-				}
-
-				traces.push(line);
-			}
-
-			traces.push(...points, ...labels);
 
 			Plotly.newPlot(
 				container,
-				traces,
+				[...Object.values(surfaces), ...Object.values(edges), ...Object.values(lines), ...points, ...labels],
 				{
-					width: options.width,
-					height: options.height,
+					width,
+					height,
 					margin: { l: 5, r: 5, b: 5, t: 5 },
 					showlegend: false,
 					paper_bgcolor: 'white',
 					scene: {
 						xaxis: {
-							visible: options.showAxes,
-							title: options.axisKey[0],
-							nticks: options.numTicks + 2,
+							visible: showAxes,
+							title: axesLabels[0],
+							nticks: maxTicks[0],
 							showspikes: false
 						},
 						yaxis: {
-							visible: options.showAxes,
-							title: options.axisKey[1],
-							nticks: options.numTicks + 2,
+							visible: showAxes,
+							title: axesLabels[1],
+							nticks: maxTicks[1],
 							showspikes: false
 						},
 						zaxis: {
-							visible: options.showAxes,
-							title: options.axisKey[2],
-							nticks: options.numTicks + 2,
+							visible: showAxes,
+							title: axesLabels[2],
+							nticks: maxTicks[2],
 							showspikes: false
 						},
 						camera: { eye, up }

--- a/htdocs/js/LiveGraphics/liveGraphics.js
+++ b/htdocs/js/LiveGraphics/liveGraphics.js
@@ -378,11 +378,6 @@
 			stream.shift();
 
 			while (stream.length) {
-				if (stream[0].match(/^\s/)) {
-					stream.shift();
-					continue;
-				}
-
 				const char = stream.shift();
 
 				if (char === oppDelim) {

--- a/macros/graph/LiveGraphics3D.pl
+++ b/macros/graph/LiveGraphics3D.pl
@@ -61,6 +61,12 @@ String containing Graphics3D data to be displayed by the applet.
 
 Width and height of applet.
 
+=item * C<< max_ticks => n >>
+
+Maximum number of ticks to show on the C<x>, C<y>, and C<z> axes.  This can be
+given as a single positive integer, or can be a reference to an array of three
+positive integers.
+
 =item * C<< vars => [vars] >>
 
 Hash of variables to pass as independent variables to the applet, together with
@@ -121,6 +127,7 @@ sub LiveGraphics3D {
 		scale      => 1,
 		tex_size   => 500,
 		tex_center => 0,
+		max_ticks  => 6,
 		@_
 	);
 
@@ -148,12 +155,13 @@ sub LiveGraphics3D {
 			class        => 'live-graphics-3d-container',
 			style        => "width:${w}px;height:${h}px;border:1px solid black;",
 			data_options => JSON->new->encode({
-				width   => $w - 2,
-				height  => $h - 2,
-				file    => $options{file} // '',
-				input   => ($options{input} // '') =~ s/\n//gr,
-				archive => $options{archive} // '',
-				vars    => \%vars
+				width    => $w - 2,
+				height   => $h - 2,
+				maxTicks => $options{max_ticks},
+				file     => $options{file} // '',
+				input    => ($options{input} // '') =~ s/\n//gr,
+				archive  => $options{archive} // '',
+				vars     => \%vars
 			})
 		);
 	}

--- a/macros/graph/LiveGraphics3D.pl
+++ b/macros/graph/LiveGraphics3D.pl
@@ -76,10 +76,6 @@ their initial values, e.g., C<< vars => [ a => 1, b => 1 ] >>.
 
 The background color to use (default is white).
 
-=item * C<< scale => n >>
-
-Scaling factor for applet (default is 1).
-
 =item * C<< image => file >>
 
 A file containing an image to use in TeX mode.
@@ -118,13 +114,13 @@ sub _LiveGraphics3D_init {
 	ADD_JS_FILE('node_modules/jszip/dist/jszip.min.js',             0, { defer => undef });
 	ADD_JS_FILE('node_modules/jszip-utils/dist/jszip-utils.min.js', 0, { defer => undef });
 	ADD_JS_FILE('js/LiveGraphics/liveGraphics.js',                  0, { defer => undef });
+	return;
 }
 
 sub LiveGraphics3D {
 	my %options = (
 		size       => [ 250, 250 ],
 		background => '#FFFFFF',
-		scale      => 1,
 		tex_size   => 500,
 		tex_center => 0,
 		max_ticks  => 6,
@@ -169,14 +165,14 @@ sub LiveGraphics3D {
 
 # Syntactic sugar to make it easier to pass files and data to LiveGraphics3D.
 sub Live3Dfile {
-	my $file = shift;
-	LiveGraphics3D(file => $file, @_);
+	my ($file, %options) = @_;
+	return LiveGraphics3D(file => $file, %options);
 }
 
 # Syntactic sugar to make it easier to pass raw Graohics3D data to LiveGraphics3D.
 sub Live3Ddata {
-	my $data = shift;
-	LiveGraphics3D(input => $data, @_);
+	my ($data, %options) = @_;
+	return LiveGraphics3D(input => $data, %options);
 }
 
 # A message you can use for a caption under a graph.

--- a/macros/graph/LiveGraphics3D.pl
+++ b/macros/graph/LiveGraphics3D.pl
@@ -19,13 +19,17 @@ LiveGraphics3D.pl - provides the ability to have an interactive 3D plot.
 
 =head1 DESCRIPTION
 
-Macros for handling interactive 3D graphics via the LiveGraphics3D Java applet.
-The applet needs to be in the course html directory.  (If it is in the system
-html area, you will need to change the default below or supply the jar option
-explicitly).
+Macros for handling interactive 3D graphics.
 
-The LiveGraphics3D applet displays a Mathematica Graphics3D object that is
-stored in a .m file (or a compressed one).  Use Mathematica to create one.
+This parses LiveGraphics3D data into L<Plotly|https://plotly.com/javascript>
+traces. See L<https://www-users.cse.umn.edu/~rogness/lg3d/mma_syntax.html> for
+information about the Mathematica syntax of the LiveGraphics3D format. Note that
+not all of the syntax is supported by this macro. Instead of creating this data
+directly, it is recommended to use one of the other LiveGraphics PG macros that
+generate this data. See L<LiveGraphicsCylindricalPlot3D.pl>,
+L<LiveGraphicsParametricCurve3D.pl>, L<LiveGraphicsParametricSurface3D.pl>,
+L<LiveGraphicsRectangularPlot3D.pl>, L<LiveGraphicsVectorField2D.pl>, and
+L<LiveGraphicsVectorField3D.pl>.
 
 =head1 METHODS
 
@@ -104,11 +108,10 @@ also be given.
 =cut
 
 sub _LiveGraphics3D_init {
-	ADD_CSS_FILE('https://www.x3dom.org/download/1.8.3/x3dom.css', 1);
-	ADD_JS_FILE('https://www.x3dom.org/download/1.8.3/x3dom-full.js', 1);
-	ADD_JS_FILE('node_modules/jszip/dist/jszip.min.js',               0, { defer => undef });
-	ADD_JS_FILE('node_modules/jszip-utils/dist/jszip-utils.min.js',   0, { defer => undef });
-	ADD_JS_FILE('js/LiveGraphics/liveGraphics.js',                    0, { defer => undef });
+	ADD_JS_FILE('node_modules/plotly.js-dist-min/plotly.min.js',    0, { defer => undef });
+	ADD_JS_FILE('node_modules/jszip/dist/jszip.min.js',             0, { defer => undef });
+	ADD_JS_FILE('node_modules/jszip-utils/dist/jszip-utils.min.js', 0, { defer => undef });
+	ADD_JS_FILE('js/LiveGraphics/liveGraphics.js',                  0, { defer => undef });
 }
 
 sub LiveGraphics3D {
@@ -143,14 +146,14 @@ sub LiveGraphics3D {
 		return tag(
 			'div',
 			class        => 'live-graphics-3d-container',
-			style        => "width:fit-content;height:fit-content;border:1px solid black;",
+			style        => "width:${w}px;height:${h}px;border:1px solid black;",
 			data_options => JSON->new->encode({
-				width   => $w,
-				height  => $h,
+				width   => $w - 2,
+				height  => $h - 2,
 				file    => $options{file} // '',
 				input   => ($options{input} // '') =~ s/\n//gr,
 				archive => $options{archive} // '',
-				vars    => \%vars,
+				vars    => \%vars
 			})
 		);
 	}

--- a/macros/graph/LiveGraphicsCylindricalPlot3D.pl
+++ b/macros/graph/LiveGraphicsCylindricalPlot3D.pl
@@ -15,81 +15,133 @@
 
 =head1 NAME
 
-LiveGraphicsCylindricalPlot3D.pl - provide an interactive plot on a rectangular cylinder.
+LiveGraphicsCylindricalPlot3D.pl - provide an interactive plot on a rectangular
+cylinder.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsCylindricalPlot3D.pl> provides a macros for creating an
-interactive plot of a function of two variables C<z = f(r,t)>
-(where C<r> is the radius and C<t=theta >is the angle) via the C<LiveGraphics3D>
-javascript applet.  The routine CC<ylindricalPlot3D()> takes a C<MathObject> Formula
-of two variables defined over an annular domain and some plot options
-as input and returns a string of plot data that can be displayed
-using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
+This macro provides the C<CylindricalPlot3D> method for creating an interactive
+plot of a function of two variables C<z = f(r, t)> (where C<r> is the radius and
+C<t> is the angle) via the C<LiveGraphics3D> JavaScript applet.  The method
+takes a C<MathObject> Formula of two variables defined over an annular domain
+and some plot options as input and returns a string of plot data that can be
+displayed using the C<Live3Ddata> routine of the L<LiveGraphics3D.pl> macro.
 
-=head1 USAGE
+=head1 METHODS
 
-    CylindricalPlot3D(options)
+=head2 CylindricalPlot3D
 
-Options are:
+Usage: C<CylindricalPlot3D(%options)>
 
-    function => $f,        $f is a MathObjects Formula
-                           For example, in the setup section define
+The available options are as follows.
 
-                           Context("Numeric");
-                           Context()->variables->add(r=>"Real",t=>"Real");
-                           $a = random(1,3,1);
-                           $f = Formula("$a*r + t"); # use double quotes!
+=over
 
-                           before calling CylindricalPlot3D()
+=item C<< function => $f >>
 
-    rvar => "r",           independent variable name, default "r"
-    tvar => "t",           independent variable name, default "t"
+C<$f> is a MathObject Formula. For example, in the setup section define
 
-    rmin =>  0,            domain for rvar
-    rmax =>  3,
+    Context()->variables->are(r => 'Real', t => 'Real');
+    $a = random(1, 3);
+    $f = Formula("$a * r + t");    # Use double quotes!
 
-    tmin => -3,            domain for tvar
-    tmax =>  3,
+before calling C<CylindricalPlot3D>.
 
-    rsamples => 20,        deltar = (rmax - rmin) / rsamples
-    tsamples => 20,        deltat = (tmax - tmin) / tsamples
+=item C<< rvar => 'r' >>
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+Radial independent variable name, default 'r'. This must correspond to the
+radial variable used in the C<function>.
 
-    xaxislabel => "X",     Capital letters may be easier to read
-    yaxislabel => "Y",
-    zaxislabel => "Z",
+=item C<< tvar => 't' >>
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+Angular independent variable name, default 't'. This must correspond to the
+angular variable used in the C<function>.
 
+=item C<< rmin => -3 >>
+
+Lower bound for the domain of the radial variable.
+
+=item C<< rmax => 3 >>
+
+Upper bound for the domain of the radial variable.
+
+=item C<< tmin => -3 >>
+
+Lower bound for the domain of the angular variable.
+
+=item C<< tmax => 3 >>
+
+Upper bound for the domain of the angular variable.
+
+=item C<< rsamples => 20 >>
+
+The number of sample values for the radial variable in the interval from C<rmin>
+to C<rmax> to use.
+
+=item C<< tsamples => 20 >>
+
+The number of sample values for the angular variable in the interval from
+C<tmin> to C<tmax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the dependent variable.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
 
 =cut
 
-sub _LiveGraphicsCylindricalPlot3D_init { };    # don't reload this file
+sub _LiveGraphicsCylindricalPlot3D_init { }
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-#############################################
-#  Begin CylindricalPlot3D
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub CylindricalPlot3D {
-
-#############################################
-	#
-	#  Set default options
-	#
-
+	# Set default options.
 	my %options = (
-		function   => Formula("1"),
-		rvar       => "r",
-		tvar       => "t",
+		function   => Formula('1'),
+		rvar       => 'r',
+		tvar       => 't',
 		rmin       => 0.001,
 		rmax       => 3,
 		tmin       => 0,
@@ -97,119 +149,70 @@ sub CylindricalPlot3D {
 		rsamples   => 20,
 		tsamples   => 20,
 		axesframed => 1,
-		xaxislabel => "X",
-		yaxislabel => "Y",
-		zaxislabel => "Z",
+		xaxislabel => 'x',
+		yaxislabel => 'y',
+		zaxislabel => 'z',
 		outputtype => 4,
 		@_
 	);
 
-	my $fsubroutine;
-	$options{function}->perlFunction('fsubroutine', [ "$options{rvar}", "$options{tvar}" ]);
+	$options{function}->perlFunction('fsubroutine', [ $options{rvar}, $options{tvar} ]);
 
-######################################################
-	#
-	#  Generate a plotdata array, which has two indices
-	#
-
-	my $rsamples1 = $options{rsamples} - 1;
-	my $tsamples1 = $options{tsamples} - 1;
+	# Generate a plotdata array, which has two indices.
 
 	my $dr = ($options{rmax} - $options{rmin}) / $options{rsamples};
 	my $dt = ($options{tmax} - $options{tmin}) / $options{tsamples};
 
-	my $r;
-	my $t;
+	my (@x, @y, @z);
 
-	my $x;
-	my $y;
-	my $z;
-
-	foreach my $i (0 .. $options{tsamples}) {
-		$t[$i] = $options{tmin} + $i * $dt;
-		foreach my $j (0 .. $options{rsamples}) {
-			$r[$j]     = $options{rmin} + $j * $dr;
-			$x[$i][$j] = $r[$j] * cos($t[$i]);
-			$y[$i][$j] = $r[$j] * sin($t[$i]);
-			$z[$i][$j] = sprintf("%.3f", fsubroutine($r[$j], $t[$i])->value);
-			$x[$i][$j] = sprintf("%.3f", $x[$i][$j]);
-			$y[$i][$j] = sprintf("%.3f", $y[$i][$j]);
+	for my $i (0 .. $options{tsamples}) {
+		my $t = $options{tmin} + $i * $dt;
+		for my $j (0 .. $options{rsamples}) {
+			my $r = $options{rmin} + $j * $dr;
+			$x[$i][$j] = $r * cos($t);
+			$y[$i][$j] = $r * sin($t);
+			$z[$i][$j] = sprintf('%.3f', fsubroutine($r, $t)->value);
+			$x[$i][$j] = sprintf('%.3f', $x[$i][$j]);
+			$y[$i][$j] = sprintf('%.3f', $y[$i][$j]);
 		}
 	}
 
-###########################################################################
-	#
-	#  Generate a plotstring from the plotdata.
-	#
-	#  The plotstring is a list of polygons that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstring, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstring
-	#
+	# Generate a plotstring from the plotdata.  This is a list of polygons that LiveGraphics3D reads as input.
+	# For more information on the format of the plotstring, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
 
-	my $plotstructure = "{";
-
-	foreach my $i (0 .. $tsamples1) {
-		foreach my $j (0 .. $rsamples1) {
-
-			$plotstructure =
-				$plotstructure
-				. "Polygon[{"
-				. "{$x[$i][$j],$y[$i][$j],$z[$i][$j]},"
-				. "{$x[$i+1][$j],$y[$i+1][$j],$z[$i+1][$j]},"
-				. "{$x[$i+1][$j+1],$y[$i+1][$j+1],$z[$i+1][$j+1]},"
-				. "{$x[$i][$j+1],$y[$i][$j+1],$z[$i][$j+1]}" . "}]";
-
-			if (($i < $tsamples1) || ($j < $rsamples1)) {
-				$plotstructure = $plotstructure . ",";
-			}
-
+	# Generate the polygons in the plotstring.
+	my @polygons;
+	for my $i (0 .. $options{tsamples} - 1) {
+		for my $j (0 .. $options{rsamples} - 1) {
+			push(@polygons,
+				'Polygon[{'
+					. "{$x[$i][$j],$y[$i][$j],$z[$i][$j]},"
+					. "{$x[$i+1][$j],$y[$i+1][$j],$z[$i+1][$j]},"
+					. "{$x[$i+1][$j+1],$y[$i+1][$j+1],$z[$i+1][$j+1]},"
+					. "{$x[$i][$j+1],$y[$i][$j+1],$z[$i][$j+1]}"
+					. '}]');
 		}
 	}
 
-	$plotstructure = $plotstructure . "}";
+	my $plotstructure = '{' . join(',', @polygons) . '}';
 
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
-	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	my $plotoptions =
+		$options{outputtype} > 1 && $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End CylindricalPlot3D
-#####################################################
-#####################################################
+}
 
 1;

--- a/macros/graph/LiveGraphicsCylindricalPlot3D.pl
+++ b/macros/graph/LiveGraphicsCylindricalPlot3D.pl
@@ -182,7 +182,7 @@ sub CylindricalPlot3D {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
+	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
 		$plotoptions =
 			$plotoptions
 			. "Axes->True,AxesLabel->"

--- a/macros/graph/LiveGraphicsParametricCurve3D.pl
+++ b/macros/graph/LiveGraphicsParametricCurve3D.pl
@@ -170,7 +170,7 @@ sub ParametricCurve3D {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
+	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
 		$plotoptions =
 			$plotoptions
 			. "Axes->True,AxesLabel->"

--- a/macros/graph/LiveGraphicsParametricCurve3D.pl
+++ b/macros/graph/LiveGraphicsParametricCurve3D.pl
@@ -19,185 +19,179 @@ LiveGraphicsParametricCurve3D.pl - provide an interactive 3D parametric curve.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsParametricCurve3D.pl> provides a macros for creating an
-interactive plot of a vector field via the C<LiveGraphics3D> Javascript applet.
-The routine C<ParametricCurve3D()> takes three C<MathObject> Formulas of
-3 variables as input and returns a string of plot data that can be
-displayed using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
+This macro provides the C<ParametricCurve3D> method for creating an interactive
+plot of a vector field via the C<LiveGraphics3D> JavaScript applet.  The method
+takes three C<MathObject> Formulas in one variable as input and returns a string
+of plot data that can be displayed using the C<Live3Ddata> routine of the
+L<LiveGraphics3D.pl> macro.
 
-=head1 USAGE
+=head1 METHODS
 
-    ParametricCurve3D(options);
+=head2 ParametricCurve3D
 
-Options are:
+Usage: C<ParametricCurve3D(%options)>
 
-    Fx => Formula("t*cos(t)"),  F = < Fx, Fy, Fz > where Fx, Fy, Fz are each
-    Fy => Formula("t*sin(t)"),  functions of tvar
-    Fz => Formula("t"),
+The available options are as follows.
 
-    tvar => "t",           independent variable name, default "t"
-    tmin => -3,            domain for tvar
-    tmax =>  3,
-    tsamples => 3,         deltat = (tmax - tmin) / tsamples
+=over
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+=item C<< Fx => Formula('t * cos(t)') >>
 
-    xaxislabel => "X",     Capital letters may be easier to read
-    yaxislabel => "Y",
-    zaxislabel => "Z",
+Parametric function for the C<x>-coordinate.
 
-    orientation => 0,      do not show any orientation arrows
-                => 1,      show only one arrow in the middle
-                => 2,      make the curve entirely of arrows
+=item C<< Fy => Formula('t * sin(t)') >>
 
-    curvecolor => "RGBColor[1.0,0.0,0.0]",
-    curvethickness => 0.001,
+Parametric function for the C<y>-coordinate.
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+=item C<< Fz => Formula('t') >>
+
+Parametric function for the C<z>-coordinate.
+
+=item C<< tvar => 't' >>
+
+Parameter name, default 't'. This must correspond to the parameter used in
+C<Fx>, C<Fy>, and C<Fz>.
+
+=item C<< tmin => -3 >>
+
+Lower bound for the domain of the parameter.
+
+=item C<< tmax => 3 >>
+
+Upper bound for the domain of the parameter.
+
+=item C<< tsamples => 3 >>
+
+The number of sample values for the parameter in the interval from C<tmin> to
+C<tmax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the dependent variable.
+
+=item C<< curvecolor => 'RGBColor[1.0, 0.0, 0.0]' >>
+
+The color of the curve.
+
+=item C<< curvethickness => 0.001 >>
+
+The curve thickness.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
 
 =cut
 
-sub _LiveGraphicsParametricCurve3D_init { };    # don't reload this file
+sub _LiveGraphicsParametricCurve3D_init { }
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-###########################################
-###########################################
-#  Begin ParametricCurve3D
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub ParametricCurve3D {
-
-###########################################
-	#
-	#  Set default options
-	#
-
+	# Set default options.
 	my %options = (
-		Fx             => Formula("1"),
-		Fy             => Formula("1"),
-		Fz             => Formula("1"),
+		Fx             => Formula('1'),
+		Fy             => Formula('1'),
+		Fz             => Formula('1'),
 		tvar           => 't',
 		tmin           => -3,
 		tmax           => 3,
 		tsamples       => 20,
 		orientation    => 0,
 		axesframed     => 1,
-		xaxislabel     => "X",
-		yaxislabel     => "Y",
-		zaxislabel     => "Z",
-		curvecolor     => "RGBColor[1.0,0.0,0.0]",
+		xaxislabel     => 'x',
+		yaxislabel     => 'y',
+		zaxislabel     => 'z',
+		curvecolor     => 'RGBColor[1.0,0.0,0.0]',
 		curvethickness => 0.001,
 		outputtype     => 4,
 		@_
 	);
 
-	my $Fxsubroutine;
-	my $Fysubroutine;
-	my $Fzsubroutine;
+	$options{Fx}->perlFunction('Fxsubroutine', [ $options{tvar} ]);
+	$options{Fy}->perlFunction('Fysubroutine', [ $options{tvar} ]);
+	$options{Fz}->perlFunction('Fzsubroutine', [ $options{tvar} ]);
 
-	$options{Fx}->perlFunction('Fxsubroutine', ["$options{tvar}"]);
-	$options{Fy}->perlFunction('Fysubroutine', ["$options{tvar}"]);
-	$options{Fz}->perlFunction('Fzsubroutine', ["$options{tvar}"]);
-
-######################################################
-	#
-	#  Generate plot data
-	#
+	# Generate plot data.
 
 	my $dt = ($options{tmax} - $options{tmin}) / $options{tsamples};
 
-	my $t;
+	my (@Fx, @Fy, @Fz);
 
 	#  The curve data
-	foreach my $i (0 .. $options{tsamples}) {
-		$t[$i] = $options{tmin} + $i * $dt;
-
-		$FX[$i] = sprintf("%.3f", (Fxsubroutine($t[$i])->value));
-		$FY[$i] = sprintf("%.3f", (Fysubroutine($t[$i])->value));
-		$FZ[$i] = sprintf("%.3f", (Fzsubroutine($t[$i])->value));
-
+	for my $i (0 .. $options{tsamples}) {
+		my $t = $options{tmin} + $i * $dt;
+		$Fx[$i] = sprintf('%.3f', Fxsubroutine($t)->value);
+		$Fy[$i] = sprintf('%.3f', Fysubroutine($t)->value);
+		$Fz[$i] = sprintf('%.3f', Fzsubroutine($t)->value);
 	}
 
-	if ($options{orientation} > 0) {
-		#
-		#  The arrow head data
-		#
-		my $tmidindex = sprintf("%.0f", $options{tsamples} / 2);
+	# Generate plotstructure from the plotdata.  This is a list of lines that LiveGraphics3D reads as input.  For more
+	# information on the format of the plotstructure, see http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html.
 
+	# Generate the line segments in the plotstructure.
+	my @lines;
+	for my $i (0 .. $options{tsamples} - 1) {
+		push(@lines, "Line[{{$Fx[$i],$Fy[$i],$Fz[$i]},{$Fx[$i+1],$Fy[$i+1],$Fz[$i+1]}}]");
 	}
 
-###########################################################################
-	#
-	#  Generate plotstructure from the plotdata.
-	#
-	#  The plotstucture is a list of arrows (made of lines) that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstructure, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the line segments in the plotstructure
-	#
+	my $plotstructure = "{$options{curvecolor},Thickness[$options{curvethickness}]," . join(',', @lines) . '}';
 
-	my $plotstructure = "{$options{curvecolor},Thickness[$options{curvethickness}],";
-
-	my $tsamples1 = $options{tsamples} - 1;
-
-	foreach my $i (0 .. $tsamples1) {
-
-		$plotstructure =
-			$plotstructure . "Line[{" . "{$FX[$i],$FY[$i],$FZ[$i]}," . "{$FX[$i+1],$FY[$i+1],$FZ[$i+1]}" . "}]";
-
-		if ($i < $tsamples1) { $plotstructure = $plotstructure . "," }
-
-	}
-
-	$plotstructure = $plotstructure . "}";
-
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
-	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	my $plotoptions =
+		$options{outputtype} > 1 && $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End ParametricCurve3D
-##############################################
-##############################################
+}
 
 1;

--- a/macros/graph/LiveGraphicsParametricSurface3D.pl
+++ b/macros/graph/LiveGraphicsParametricSurface3D.pl
@@ -15,83 +15,164 @@
 
 =head1 NAME
 
-LiveGraphicsParametricSurface3D.pl - provide an interactive plot of a parametric surface.
+LiveGraphicsParametricSurface3D.pl - provide an interactive plot of a parametric
+surface.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsParametricSurface3D.pl> provides a macro for creating an
-interactive plot of a parametric surface via the C<LiveGraphics3D> Javascript applet.
-The routine C<ParametricSurface3D()> takes three C<MathObject> Formulas of
-2 variables as input and returns a string of plot data that can be
-displayed using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
+This macro provides the C<ParametricSurface3D> method for creating an
+interactive plot of a parametric surface via the C<LiveGraphics3D> JavaScript
+applet.  The method takes three C<MathObject> Formulas in two variables as input
+and returns a string of plot data that can be displayed using the C<Live3Ddata>
+routine of the L<LiveGraphics3D.pl> macro.
 
-=head1 USAGE
+=head1 Methods
 
-    ParametricSurface3D(options);
+=head2 ParametricSurface3D
 
-Options are:
+Usage: C<ParametricSurface3D(%options)>
 
-    Fx => Formula("cos(u)*cos(v)"),  x-coordinate function
-    Fy => Formula("sin(u)*cos(v)"),  y-coordinate function
-    Fz => Formula("sin(v)"),         z-coordinate function
-                                     F(u,v) = < Fx, Fy, Fz >
-                                     = < Fx(u,v), Fy(u,v), Fz(u,v) >
+The available options are as follows.
 
-    uvar => "u",           parameter name, default "u"
-    vvar => "v",           parameter name, default "v"
+=over
 
-    umin => -3,            domain for uvar
-    umax =>  3,
+=item C<< Fx => Formula('cos(u) * cos(v)') >>
 
-    vmin => -3,            domain for vvar
-    vmax =>  3,
+Parametric function for the C<x>-coordinate.
 
-    usamples => 3,         deltau = (umax - umin) / usamples
-    vsamples => 3,         deltav = (vmax - vmin) / vsamples
+=item C<< Fy => Formula('sin(u) * cos(v)') >>
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+Parametric function for the C<y>-coordinate.
 
-    xaxislabel => "X",     Capital letters may be easier to read
-    yaxislabel => "Y",
-    zaxislabel => "Z",
+=item C<< Fz => Formula('sin(v)') >>
 
-    edges => 0,            1 displays edges of polygons, 0 hides them
-    edgecolor => "RGBColor[0.2,0.2,0.2]",
-    edgethickness => "Thickness[0.001]",
+Parametric function for the C<z>-coordinate.
 
-    mesh => 0,             1 displays open mesh, 0 displays filled polygons
-    meshcolor => "RGBColor[0.7,0.7,0.7]",   three values between 0 and 1
-    meshthickness => 0.001,
+=item C<< uvar => 'u' >>
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+The first parameter, default 'u'. This must correspond to the first parameter
+used in C<Fx>, C<Fy>, and C<Fz>.
+
+=item C<< vvar => 'v' >>
+
+The second parameter, default 'v'. This must correspond to the second parameter
+used in C<Fx>, C<Fy>, and C<Fz>.
+
+=item C<< umin => -3 >>
+
+Lower bound for the domain of the first parameter.
+
+=item C<< umax => 3 >>
+
+Upper bound for the domain of the first parameter.
+
+=item C<< vmin => -3 >>
+
+Lower bound for the domain of the second parameter.
+
+=item C<< vmax => 3 >>
+
+Upper bound for the domain of the second parameter.
+
+=item C<< usamples => 3 >>
+
+The number of sample values for the first parameter in the interval from C<umin>
+to C<umax> to use.
+
+=item C<< vsamples => 3 >>
+
+The number of sample values for the second parameter in the interval from
+C<vmin> to C<vmax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the dependent variable.
+
+=item C<< edges => 1 >>
+
+If set to 1, then the edges of the polygons are shown. If set to 0, then the
+edges are not shown. This is 1 by default.
+
+=item C<< edgecolor => 'RGBColor[0.2, 0.2, 0.2]' >>
+
+The color of the edges if C<edges> is 1.
+
+=item C<< edgethickness => 'Thickness[0.001]' >>
+
+The thickness of the edges if C<edges> is 1.
+
+=item C<< mesh => 0 >>
+
+If set to 1, then the the edge mesh is shown and the polygons for the surface
+are not filled.  If set to 0, then the polygons for the surface are filled.  The
+edge mesh can also be shown in this case by setting C<edges> to 1. This is 0 by
+default.
+
+=item C<< meshcolor => 'RGBColor[0.7, 0.7, 0.7]' >>
+
+The red, green, and blue colors each from 0 to 1 to be combined to form the
+color of the mesh.  If this is set and C<mesh> is 1, then this will be the color
+of the mesh edges.
+
+=item C<< meshthickness => 0.001 >>
+
+The thickness of the mesh edges if C<mesh> is 1.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
 
 =cut
 
-sub _LiveGraphicsParametricSurface3D_init { };    # don't reload this file
+sub _LiveGraphicsParametricSurface3D_init { }
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-###########################################
-###########################################
-#  Begin ParametricSurface3D
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub ParametricSurface3D {
-
-###########################################
-	#
-	#  Set default options
-	#
-
+	# Set default options.
 	my %options = (
-		Fx            => Formula("1"),
-		Fy            => Formula("1"),
-		Fz            => Formula("1"),
+		Fx            => Formula('1'),
+		Fy            => Formula('1'),
+		Fz            => Formula('1'),
 		uvar          => 'u',
 		vvar          => 'v',
 		umin          => -3,
@@ -101,166 +182,103 @@ sub ParametricSurface3D {
 		usamples      => 20,
 		vsamples      => 20,
 		axesframed    => 1,
-		xaxislabel    => "X",
-		yaxislabel    => "Y",
-		zaxislabel    => "Z",
-		edges         => 0,
-		edgecolor     => "RGBColor[0.2,0.2,0.2]",
-		edgethickness => "Thickness[0.001]",
+		xaxislabel    => 'x',
+		yaxislabel    => 'y',
+		zaxislabel    => 'z',
+		edges         => 1,
+		edgecolor     => 'RGBColor[0.2,0.2,0.2]',
+		edgethickness => 'Thickness[0.001]',
 		mesh          => 0,
-		meshcolor     => "RGBColor[0.7,0.7,0.7]",
+		meshcolor     => 'RGBColor[0.7,0.7,0.7]',
 		meshthickness => 0.001,
 		outputtype    => 4,
 		@_
 	);
 
-	my $Fxsubroutine;
-	my $Fysubroutine;
-	my $Fzsubroutine;
+	$options{Fx}->perlFunction('Fxsubroutine', [ $options{uvar}, $options{vvar} ]);
+	$options{Fy}->perlFunction('Fysubroutine', [ $options{uvar}, $options{vvar} ]);
+	$options{Fz}->perlFunction('Fzsubroutine', [ $options{uvar}, $options{vvar} ]);
 
-	$options{Fx}->perlFunction('Fxsubroutine', [ "$options{uvar}", "$options{vvar}" ]);
-	$options{Fy}->perlFunction('Fysubroutine', [ "$options{uvar}", "$options{vvar}" ]);
-	$options{Fz}->perlFunction('Fzsubroutine', [ "$options{uvar}", "$options{vvar}" ]);
-
-######################################################
-	#
-	#  Generate plot data
-	#
+	# Generate plot data.
 
 	my $du = ($options{umax} - $options{umin}) / $options{usamples};
 	my $dv = ($options{vmax} - $options{vmin}) / $options{vsamples};
 
-	my $u;
-	my $v;
+	my (@Fx, @Fy, @Fz);
 
-	foreach my $i (0 .. $options{usamples}) {
-		$u[$i] = $options{umin} + $i * $du;
-		foreach my $j (0 .. $options{vsamples}) {
-			$v[$j] = $options{vmin} + $j * $dv;
-
-			$FX[$i][$j] = sprintf("%.3f", (Fxsubroutine($u[$i], $v[$j])->value));
-			$FY[$i][$j] = sprintf("%.3f", (Fysubroutine($u[$i], $v[$j])->value));
-			$FZ[$i][$j] = sprintf("%.3f", (Fzsubroutine($u[$i], $v[$j])->value));
-
-			$u[$i] = sprintf("%.3f", $u[$i]);
-			$v[$j] = sprintf("%.3f", $v[$j]);
+	for my $i (0 .. $options{usamples}) {
+		my $u = $options{umin} + $i * $du;
+		for my $j (0 .. $options{vsamples}) {
+			my $v = $options{vmin} + $j * $dv;
+			$Fx[$i][$j] = sprintf('%.3f', Fxsubroutine($u, $v)->value);
+			$Fy[$i][$j] = sprintf('%.3f', Fysubroutine($u, $v)->value);
+			$Fz[$i][$j] = sprintf('%.3f', Fzsubroutine($u, $v)->value);
 		}
 	}
 
-###########################################################################
-	#
-	#  Generate plotstructure from the plotdata.
-	#
-	#  The plotstucture is a list of arrows (made of lines) that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstructure, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstructure
-	#
+	# Generate plotstructure from the plotdata.  This is a list of arrows (made of lines) that LiveGraphics3D reads as
+	# input.  For more information on the format of the plotstructure, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
 
-	my $plotstructure = "{";
+	my $plotstructure = '{';
 
 	if ($options{edges} == 0 && $options{mesh} == 0) {
-		$plotstructure = $plotstructure . "EdgeForm[],";
+		$plotstructure .= 'EdgeForm[],';
 	} elsif ($options{edges} == 1 && $options{mesh} == 0) {
-		$plotstructure = $plotstructure . "EdgeForm[{$options{edgecolor},$options{edgethickness}}],";
+		$plotstructure .= "EdgeForm[{$options{edgecolor},$options{edgethickness}}],";
 	}
 
 	if ($options{mesh} == 1) {
-		$plotstructure = $plotstructure . "$options{meshcolor},Thickness[$options{meshthickness}],";
+		$plotstructure .= "$options{meshcolor},Thickness[$options{meshthickness}],";
 	}
 
-	my $usamples1 = $options{usamples} - 1;
-	my $vsamples1 = $options{vsamples} - 1;
-
+	# Generate the polygons or lines in the plotstructure.
+	my @objects;
 	if ($options{mesh} == 0) {
-
-		foreach my $i (0 .. $usamples1) {
-			foreach my $j (0 .. $vsamples1) {
-
-				$plotstructure =
-					$plotstructure
-					. "Polygon[{"
-					. "{$FX[$i][$j],$FY[$i][$j],$FZ[$i][$j]},"
-					. "{$FX[$i+1][$j],$FY[$i+1][$j],$FZ[$i+1][$j]},"
-					. "{$FX[$i+1][$j+1],$FY[$i+1][$j+1],$FZ[$i+1][$j+1]},"
-					. "{$FX[$i][$j+1],$FY[$i][$j+1],$FZ[$i][$j+1]}" . "}]";
-
-				if (($i < $usamples1) || ($j < $vsamples1)) {
-					$plotstructure = $plotstructure . ",";
-				}
-
+		for my $i (0 .. $options{usamples} - 1) {
+			for my $j (0 .. $options{vsamples} - 1) {
+				push(@objects,
+					'Polygon[{'
+						. "{$Fx[$i][$j],$Fy[$i][$j],$Fz[$i][$j]},"
+						. "{$Fx[$i+1][$j],$Fy[$i+1][$j],$Fz[$i+1][$j]},"
+						. "{$Fx[$i+1][$j+1],$Fy[$i+1][$j+1],$Fz[$i+1][$j+1]},"
+						. "{$Fx[$i][$j+1],$Fy[$i][$j+1],$Fz[$i][$j+1]}"
+						. '}]');
 			}
 		}
-
-		# end mesh == 0
 	} else {
-		# begin mesh == 1
-
-		foreach my $i (0 .. $usamples1) {
-			foreach my $j (0 .. $vsamples1) {
-
-				#  this could be made more efficient
-				$plotstructure =
-					$plotstructure
-					. "Line[{"
-					. "{$FX[$i][$j],$FY[$i][$j],$FZ[$i][$j]},"
-					. "{$FX[$i+1][$j],$FY[$i+1][$j],$FZ[$i+1][$j]},"
-					. "{$FX[$i+1][$j+1],$FY[$i+1][$j+1],$FZ[$i+1][$j+1]},"
-					. "{$FX[$i][$j+1],$FY[$i][$j+1],$FZ[$i][$j+1]},"
-					. "{$FX[$i][$j],$FY[$i][$j],$FZ[$i][$j]}" . "}]";
-
-				if (($i < $usamples1) || ($j < $vsamples1)) {
-					$plotstructure = $plotstructure . ",";
-				}
-
+		for my $i (0 .. $options{usamples} - 1) {
+			for my $j (0 .. $options{vsamples} - 1) {
+				push(@objects,
+					'Line[{'
+						. "{$Fx[$i][$j],$Fy[$i][$j],$Fz[$i][$j]},"
+						. "{$Fx[$i+1][$j],$Fy[$i+1][$j],$Fz[$i+1][$j]},"
+						. "{$Fx[$i+1][$j+1],$Fy[$i+1][$j+1],$Fz[$i+1][$j+1]},"
+						. "{$Fx[$i][$j+1],$Fy[$i][$j+1],$Fz[$i][$j+1]},"
+						. "{$Fx[$i][$j],$Fy[$i][$j],$Fz[$i][$j]}"
+						. '}]');
 			}
 		}
-
-	}    # end mesh == 1
-
-	$plotstructure = $plotstructure . "}";
-
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
 	}
 
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	$plotstructure .= join(',', @objects) . '}';
+
+	my $plotoptions =
+		$options{outputtype} > 1 && $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End ParametricSurface3D
-##############################################
-##############################################
+}
 
 1;

--- a/macros/graph/LiveGraphicsParametricSurface3D.pl
+++ b/macros/graph/LiveGraphicsParametricSurface3D.pl
@@ -233,7 +233,7 @@ sub ParametricSurface3D {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
+	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
 		$plotoptions =
 			$plotoptions
 			. "Axes->True,AxesLabel->"

--- a/macros/graph/LiveGraphicsRectangularPlot3D.pl
+++ b/macros/graph/LiveGraphicsRectangularPlot3D.pl
@@ -236,7 +236,7 @@ sub RectangularPlot3DRectangularDomain {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
+	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
 		$plotoptions =
 			$plotoptions
 			. "Axes->True,AxesLabel->"

--- a/macros/graph/LiveGraphicsRectangularPlot3D.pl
+++ b/macros/graph/LiveGraphicsRectangularPlot3D.pl
@@ -19,98 +19,211 @@ LiveGraphicsRectangularPlot3D.pl - provide an interactive 3D rectangular plot.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsRectangularPlot3D.pl> provides two macros for creating an
-interactive plot of a function of two variables C<z = f(x,y)> in
-Rectangular (Cartesian) coordinates via the C<LiveGraphics3D> Javascript applet.
-The routine C<RectangularDomainPlot3D()> takes a MathObject Formula of
-two variables defined over a rectangular domain and some plot options
-as input and returns a string of plot data that can be displayed
-using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
-The routine C<AnnularDomainPlot3D> works similarly for a function
-C<z = f(x,y)> over an annular domain specified in polar by
-C<S<< rmin < r < rmax >>> and C<S<< tmin < theta < tmax >>>.
+This macro provides two methods for creating an interactive plot of a function
+of two variables C<z = f(x, y)> in rectangular (Cartesian) coordinates via the
+C<LiveGraphics3D> JavaScript applet.  The routine
+L</RectangularPlot3DRectangularDomain> takes a C<MathObject> Formula of two
+variables defined over a rectangular domain and some plot options as input and
+returns a string of plot data that can be displayed using the C<Live3Ddata>
+routine of the L<LiveGraphics3D.pl> macro.  The routine
+L</RectangularPlot3DAnnularDomain> works similarly for a function C<z = f(x, y)>
+over an annular domain specified in polar coordinates by C<< rmin < r < rmax >>
+and C<< tmin < theta < tmax >> (polar coordinates are converted to rectangular
+for evaluation of the function).
 
-=head1 USAGE
+=head1 METHODS
+
+=head2 RectangularPlot3DRectangularDomain
+
+Usage: C<RectangularPlot3DRectangularDomain(%options)>
+
+The available options are as follows.
 
 =over
 
-=item C<RectangularPlot3DRectangularDomain(options)>
+=item C<< function => $f >>
 
-Options are:
+C<$f> is a MathObject Formula. For example, in the setup section define
 
-    function => $f,        $f is a MathObjects Formula
-                           For example, in the setup section define
+    Context()->variables->are(x => 'Real', y => 'Real');
+    $a = random(1, 3);
+    $f = Formula("$a * x^2 - 2 * y");    # Use double quotes!
 
-                           Context("Numeric");
-                           Context()->variables->add(s=>"Real",t=>"Real");
-                           $a = random(1,3,1);
-                           $f = Formula("$a*s^2-2*t"); # use double quotes!
+before calling C<RectangularPlot3DRectangularDomain>.
 
-                           before calling RectangularPlot3DRectangularDomain()
+=item C<< xvar => 'x' >>
 
-    xvar => "s",           independent variable name, default "x"
-    yvar => "t",           independent variable name, default "y"
+First independent variable name, default 'x'. This must correspond to the first
+variable used in the C<function>.
 
-    xmin => -3,            domain for xvar
-    xmax =>  3,
+=item C<< yvar => 'y' >>
 
-    ymin => -3,            domain for yvar
-    ymax =>  3,
+Second independent variable name, default 'y'. This must correspond to the
+second variable used in the C<function>.
 
-    xsamples => 20,        deltax = (xmax - xmin) / xsamples
-    ysamples => 20,        deltay = (ymax - ymin) / ysamples
+=item C<< xmin => -3 >>
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+Lower bound for the domain of the first independent variable.
 
-    xaxislabel => "S",     Capital letters may be easier to read
-    yaxislabel => "T",
-    zaxislabel => "Z",
+=item C<< xmax => 3 >>
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+Upper bound for the domain of the first independent variable.
 
-=item C<RectangularPlot3DAnnularDomain(options)>
+=item C<< ymin => -3 >>
 
-Options are:
+Lower bound for the domain of the second independent variable.
 
+=item C<< ymax => 3 >>
 
-    function => $f,        $f is a MathObjects Formula
-                           For example, in the setup section define
+Upper bound for the domain of the second independent variable.
 
-                           Context("Numeric");
-                           Context()->variables->add(y=>"Real",r=>"Real",t=>"Real");
-                           $a = random(1,3,1);
-                           $f = Formula("$a*e^(- x^2 - y^2)"); # use double quotes!
+=item C<< xsamples => 20 >>
 
-                           before calling RectangularPlot3DAnnularDomain()
+The number of sample values for the first independent variable in the interval
+from C<xmin> to C<xmax> to use.
 
-    xvar => "x",           independent variable name, default "x"
-    yvar => "y",           independent variable name, default "y"
+=item C<< ysamples => 20 >>
 
-    rvar => "r",           independent variable name, default "r"
-    tvar => "t",           independent variable name, default "t" (for theta)
+The number of sample values for the second independent variable in the interval
+from C<ymin> to C<ymax> to use.
 
-    rmin => -3,            domain for rvar
-    rmax =>  3,
+=item C<< axesframed => 1 >>
 
-    tmin => -3,            domain for tvar
-    tmax =>  3,
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
 
-    rsamples => 20,        deltar = (rmax - rmin) / rsamples
-    tsamples => 20,        deltat = (tmax - tmin) / tsamples
+=item C<< xaxislabel => 'x' >>
 
-   axesframed => 1,       1 displays framed axes, 0 hides framed axes
+Label for the axis corresponding to the first independent variable.
 
-    xaxislabel => "X",     Capital letters may be easier to read
-    yaxislabel => "Y",
-    zaxislabel => "Z",
+=item C<< yaxislabel => 'y' >>
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the dependent variable.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
+
+=head2 RectangularPlot3DAnnularDomain
+
+Usage: C<RectangularPlot3DAnnularDomain(%options)>
+
+The available options are as follows.
+
+=over
+
+=item C<< function => $f >>
+
+C<$f> is a MathObject Formula. For example, in the setup section define
+
+    Context()->variables->are(x => 'Real', y => 'Real');
+    $a = random(1, 3);
+    $f = Formula("$a * e^(-x^2 - y^2)");    # Use double quotes!
+
+before calling C<RectangularPlot3DRectangularDomain>.
+
+=item C<< xvar => 'x' >>
+
+First independent variable name, default 'x'. This must correspond to the first
+variable used in the C<function>.
+
+=item C<< yvar => 'y' >>
+
+Second independent variable name, default 'y'. This must correspond to the
+second variable used in the C<function>.
+
+=item C<< rmin => -3 >>
+
+Lower bound for the domain of radial coordinate.
+
+=item C<< rmax => 3 >>
+
+Upper bound for the domain of radial coordinate.
+
+=item C<< tmin => -3 >>
+
+Lower bound for the domain of angular coordinate.
+
+=item C<< tmax => 3 >>
+
+Upper bound for the domain of angular coordinate.
+
+=item C<< rsamples => 20 >>
+
+The number of radial values in the interval from C<rmin> to C<rmax> to use.
+
+=item C<< tsamples => 20 >>
+
+The number of angular values in the interval from C<tmin> to C<tmax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the frames axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the dependent variable.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
 
 =back
 
@@ -118,24 +231,15 @@ Options are:
 
 sub _LiveGraphicsRectangularPlot3D_init { };    # don't reload this file
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-###########################################
-###########################################
-#  Begin RectangularPlot3DRectangularDomain
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub RectangularPlot3DRectangularDomain {
-
-###########################################
-	#
-	#  Set default options
-	#
-
+	# Set default options
 	my %options = (
-		function   => Formula("1"),
+		function   => Formula('1'),
 		xvar       => 'x',
 		yvar       => 'y',
 		xmin       => -3,
@@ -145,144 +249,76 @@ sub RectangularPlot3DRectangularDomain {
 		xsamples   => 20,
 		ysamples   => 20,
 		axesframed => 1,
-		xaxislabel => "X",
-		yaxislabel => "Y",
-		zaxislabel => "Z",
+		xaxislabel => 'x',
+		yaxislabel => 'y',
+		zaxislabel => 'z',
 		outputtype => 4,
 		@_
 	);
 
-############################################
-	#
-	#  Reset to Context("Numeric") just to be
-	#  sure that everything will work properly.
-	#
+	$options{function}->perlFunction('fsubroutine', [ $options{xvar}, $options{yvar} ]);
 
-	#Context("Numeric");
-	#Context()->variables->are($options{xvar}=>"Real",$options{yvar}=>"Real");
-
-	my $fsubroutine;
-	$options{function}->perlFunction('fsubroutine', [ "$options{xvar}", "$options{yvar}" ]);
-
-######################################################
-	#
-	#  Generate a plotdata array, which has two indices
-	#
-
-	my $xsamples1 = $options{xsamples} - 1;
-	my $ysamples1 = $options{ysamples} - 1;
+	# Generate a plotdata array, which has two indices.
 
 	my $dx = ($options{xmax} - $options{xmin}) / $options{xsamples};
 	my $dy = ($options{ymax} - $options{ymin}) / $options{ysamples};
 
-	my $x;
-	my $y;
+	my (@x, @y, @z);
 
-	my $z;
-
-	foreach my $i (0 .. $options{xsamples}) {
+	for my $i (0 .. $options{xsamples}) {
 		$x[$i] = $options{xmin} + $i * $dx;
-		foreach my $j (0 .. $options{ysamples}) {
-			$y[$j] = $options{ymin} + $j * $dy;
-			# Use sprintf to round to three decimal places
-			$z[$i][$j] = sprintf("%.3f", fsubroutine($x[$i], $y[$j])->value);
-			$y[$j] = sprintf("%.3f", $y[$j]);
+		for my $j (0 .. $options{ysamples}) {
+			$y[$j]     = $options{ymin} + $j * $dy;
+			$z[$i][$j] = sprintf('%.3f', fsubroutine($x[$i], $y[$j])->value);
+			$y[$j]     = sprintf('%.3f', $y[$j]);
 		}
-		$x[$i] = sprintf("%.3f", $x[$i]);
+		$x[$i] = sprintf('%.3f', $x[$i]);
 	}
 
-###########################################################################
-	#
-	#  Generate a plotstring from the plotdata.
-	#
-	#  The plotstring is a list of polygons
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstring, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstring
-	#
+	# Generate a plotstring from the plotdata. This is a list of polygons LiveGraphics3D reads as input.
+	# For more information on the format of the plotstring, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html.
 
-	my $plotstructure = "{";
-
-	foreach my $i (0 .. $xsamples1) {
-		foreach my $j (0 .. $ysamples1) {
-
-			$plotstructure =
-				$plotstructure
-				. "Polygon[{"
-				. "{$x[$i],$y[$j],$z[$i][$j]},"
-				. "{$x[$i+1],$y[$j],$z[$i+1][$j]},"
-				. "{$x[$i+1],$y[$j+1],$z[$i+1][$j+1]},"
-				. "{$x[$i],$y[$j+1],$z[$i][$j+1]}" . "}]";
-
-			if (($i < $xsamples1) || ($j < $ysamples1)) {
-				$plotstructure = $plotstructure . ",";
-			}
-
+	# Generate the polygons in the plotstring.
+	my @polygons;
+	for my $i (0 .. $options{xsamples} - 1) {
+		for my $j (0 .. $options{ysamples} - 1) {
+			push(@polygons,
+				'Polygon[{'
+					. "{$x[$i],$y[$j],$z[$i][$j]},"
+					. "{$x[$i+1],$y[$j],$z[$i+1][$j]},"
+					. "{$x[$i+1],$y[$j+1],$z[$i+1][$j+1]},"
+					. "{$x[$i],$y[$j+1],$z[$i][$j+1]}"
+					. '}]');
 		}
 	}
+	my $plotstructure = '{' . join(',', @polygons) . '}';
 
-	$plotstructure = $plotstructure . "}";
-
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
-	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	my $plotoptions =
+		$options{outputtype} > 1 && $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
 
-}    #  End RectangularPlot3DRectangularDomain
-##############################################
-##############################################
-
-#############################################
-#############################################
-#  Begin RectangularPlot3DAnnularDomain
+}
 
 sub RectangularPlot3DAnnularDomain {
-
-#############################################
-	#
-	#  Set default options
-	#
-
+	# Set default options.
 	my %options = (
-		function   => Formula("1"),
-		xvar       => "x",
-		yvar       => "y",
-		rvar       => "r",
-		tvar       => "t",
+		function   => Formula('1'),
+		xvar       => 'x',
+		yvar       => 'y',
 		rmin       => 0.001,
 		rmax       => 3,
 		tmin       => 0,
@@ -290,134 +326,71 @@ sub RectangularPlot3DAnnularDomain {
 		rsamples   => 20,
 		tsamples   => 20,
 		axesframed => 1,
-		xaxislabel => "X",
-		yaxislabel => "Y",
-		zaxislabel => "Z",
+		xaxislabel => 'x',
+		yaxislabel => 'y',
+		zaxislabel => 'z',
 		outputtype => 4,
 		@_
 	);
 
-############################################
-	#
-	#  Reset to Context("Numeric") just to be
-	#  sure that everything will work properly.
-	#
+	$options{function}->perlFunction('fsubroutine', [ $options{xvar}, $options{yvar} ]);
 
-	#Context("Numeric");
-	#Context()->variables->are(
-	#$options{xvar}=>"Real",
-	#$options{yvar}=>"Real",
-	#$options{rvar}=>"Real",
-	#$options{tvar}=>"Real"
-	#);
+	# Generate a plotdata array which has two indices.
 
-	my $fsubroutine;
-	$options{function}->perlFunction('fsubroutine', [ "$options{xvar}", "$options{yvar}" ]);
-
-######################################################
-	#
-	#  Generate a plotdata array, which has two indices
-	#
-
-	my $rsamples1 = $options{rsamples} - 1;
-	my $tsamples1 = $options{tsamples} - 1;
+	my ($rsamples1, $tsamples1) = ($options{rsamples} - 1, $options{tsamples} - 1);
 
 	my $dr = ($options{rmax} - $options{rmin}) / $options{rsamples};
 	my $dt = ($options{tmax} - $options{tmin}) / $options{tsamples};
 
-	my $t;
-	my $r;
+	my (@x, @y, @z);
 
-	my $x;
-	my $y;
-
-	my $z;
-
-	foreach my $i (0 .. $options{tsamples}) {
-		$t[$i] = $options{tmin} + $i * $dt;
-		foreach my $j (0 .. $options{rsamples}) {
-			$r[$j]     = $options{rmin} + $j * $dr;
-			$x[$i][$j] = $r[$j] * cos($t[$i]);
-			$y[$i][$j] = $r[$j] * sin($t[$i]);
-			$z[$i][$j] = sprintf("%.3f", fsubroutine($x[$i][$j], $y[$i][$j])->value);
-			$x[$i][$j] = sprintf("%.3f", $x[$i][$j]);
-			$y[$i][$j] = sprintf("%.3f", $y[$i][$j]);
+	for my $i (0 .. $options{tsamples}) {
+		my $t = $options{tmin} + $i * $dt;
+		for my $j (0 .. $options{rsamples}) {
+			my $r = $options{rmin} + $j * $dr;
+			$x[$i][$j] = $r * cos($t);
+			$y[$i][$j] = $r * sin($t);
+			$z[$i][$j] = sprintf('%.3f', fsubroutine($x[$i][$j], $y[$i][$j])->value);
+			$x[$i][$j] = sprintf('%.3f', $x[$i][$j]);
+			$y[$i][$j] = sprintf('%.3f', $y[$i][$j]);
 		}
 	}
 
-###########################################################################
-	#
-	#  Generate a plotstring from the plotdata.
-	#
-	#  The plotstring is a list of polygons that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstring, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstring
-	#
+	# Generate a plotstring from the plotdata.  This is a list of polygons that LiveGraphics3D reads as input.
+	# For more information on the format of the plotstring, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html.
 
-	my $plotstructure = "{";
-
-	foreach my $i (0 .. $tsamples1) {
-		foreach my $j (0 .. $rsamples1) {
-
-			$plotstructure =
-				$plotstructure
-				. "Polygon[{"
-				. "{$x[$i][$j],$y[$i][$j],$z[$i][$j]},"
-				. "{$x[$i+1][$j],$y[$i+1][$j],$z[$i+1][$j]},"
-				. "{$x[$i+1][$j+1],$y[$i+1][$j+1],$z[$i+1][$j+1]},"
-				. "{$x[$i][$j+1],$y[$i][$j+1],$z[$i][$j+1]}" . "}]";
-
-			if (($i < $tsamples1) || ($j < $rsamples1)) {
-				$plotstructure = $plotstructure . ",";
-			}
-
+	# Generate the polygons in the plotstring.
+	my @polygons;
+	for my $i (0 .. $tsamples1) {
+		for my $j (0 .. $rsamples1) {
+			push(@polygons,
+				'Polygon[{'
+					. "{$x[$i][$j],$y[$i][$j],$z[$i][$j]},"
+					. "{$x[$i+1][$j],$y[$i+1][$j],$z[$i+1][$j]},"
+					. "{$x[$i+1][$j+1],$y[$i+1][$j+1],$z[$i+1][$j+1]},"
+					. "{$x[$i][$j+1],$y[$i][$j+1],$z[$i][$j+1]}"
+					. '}]');
 		}
 	}
+	my $plotstructure = '{' . join(',', @polygons) . '}';
 
-	$plotstructure = $plotstructure . "}";
-
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
-	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	my $plotoptions =
+		$options{outputtype} > 1 || $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End RectangularPlot3DAnnularDomain
-#####################################################
-#####################################################
+}
 
 1;

--- a/macros/graph/LiveGraphicsVectorField2D.pl
+++ b/macros/graph/LiveGraphicsVectorField2D.pl
@@ -187,17 +187,16 @@ sub VectorField2D {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
-
+	if ($options{outputtype} > 1) {
 		$plotoptions =
 			$plotoptions
 			. "PlotRange->{{$options{xmin},$options{xmax}},{$options{ymin},$options{ymax}},{-0.1,0.1}},"
 			. "ViewPoint->{0,0,1000},"
 			. "ViewVertical->{0,1,0},"
 			. "Lighting->False,"
-			. "AxesLabel->{$options{xaxislabel},$options{yaxislabel},Z},"
-			.    #; # .
-			"Axes->{True,True,False}";
+			. ($options{axesframed} == 1
+				? "AxesLabel->{$options{xaxislabel},$options{yaxislabel},Z},Axes->{True,True,False}"
+				: '');
 
 	}
 

--- a/macros/graph/LiveGraphicsVectorField2D.pl
+++ b/macros/graph/LiveGraphicsVectorField2D.pl
@@ -19,70 +19,132 @@ LiveGraphicsVectorField2D.pl - provide an interactive plot of a 2D vector field.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsVectorField2D.pl> provides a macros for creating an
-interactive plot of a vector field via the C<LiveGraphics3D> Javascript applet.
-The routine C<VectorField2D()> takes two C<MathObject> Formulas of
-2 variables as input and returns a string of plot data that can be
-displayed using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
+This macro provides a method for creating an interactive plot of a vector field
+via the C<LiveGraphics3D> JavaScript applet.  The method takes two C<MathObject>
+Formulas of two variables as input and returns a string of plot data that can be
+displayed using the C<Live3Ddata> routine of the L<LiveGraphics3D.pl> macro.
 
-=head1 USAGE
+=head1 METHODS
 
-    VectorField2D(options);
+=head2 VectorField2D
 
-Options are:
+Usage: C<VectorField2D(%options)>
 
-    Fx => Formula("y"),    F = < Fx, Fy, Fz > where Fx, Fy, Fz are each
-    Fy => Formula("-x"),   functions of 3 variables
+The available options are as follows.
 
-    xvar => "r",           independent variable name, default "x"
-    yvar => "s",           independent variable name, default "y"
+=over
 
-    xmin => -3,            domain for xvar
-    xmax =>  3,
+=item C<< Fx => Formula('y') >>
 
-    ymin => -3,            domain for yvar
-    ymax =>  3,
+Function for the C<x>-coordinate.
 
-    xsamples => 3,         deltax = (xmax - xmin) / xsamples
-    ysamples => 3,         deltay = (ymax - ymin) / ysamples
+=item C<< Fy => Formula('-x') >>
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+Function for the C<y>-coordinate.
 
-    xaxislabel => "R",     Capital letters may be easier to read
-    yaxislabel => "S",
+=item C<< xvar => 'x' >>
 
-    vectorcolor => "RGBColor[1.0,0.0,0.0]",
-    vectorscale => 0.2,
-    vectorthickness => 0.001,
+First independent variable name, default 'x'. This must correspond to the first
+variable used in the C<Fx> and C<Fy>.
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+=item C<< yvar => 'y' >>
+
+Second independent variable name, default 'y'. This must correspond to the
+second variable used in the C<Fx> and C<Fz>.
+
+=item C<< xmin => -3 >>
+
+Lower bound for the domain of the first independent variable.
+
+=item C<< xmax => 3 >>
+
+Upper bound for the domain of the first independent variable.
+
+=item C<< ymin => -3 >>
+
+Lower bound for the domain of the second independent variable.
+
+=item C<< ymax => 3 >>
+
+Upper bound for the domain of the second independent variable.
+
+=item C<< xsamples => 20 >>
+
+The number of sample values for the first independent variable in the interval
+from C<xmin> to C<xmax> to use.
+
+=item C<< ysamples => 20 >>
+
+The number of sample values for the second independent variable in the interval
+from C<ymin> to C<ymax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< vectorcolor => 'RGBColor[0.0, 0.0, 1.0]' >>
+
+Color of vectors shown in the slope field.
+
+=item C<< vectorscale => 0.2 >>
+
+Multiplier that determines the lentgh of vectors shown in the slope field.
+
+=item C<< vectorthickness => 0.001 >>
+
+Thickness (or width) of the line segments used to construct the vectors shown in
+the slope field.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
 
 =cut
 
-sub _LiveGraphicsVectorField2D_init { };    # don't reload this file
+sub _LiveGraphicsVectorField2D_init { }
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-###########################################
-###########################################
-#  Begin VectorField2D
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub VectorField2D {
-
-###########################################
-	#
-	#  Set default options
-	#
-
+	# Set default options
 	my %options = (
-		Fx              => Formula("1"),
-		Fy              => Formula("1"),
+		Fx              => Formula('1'),
+		Fy              => Formula('1'),
 		xvar            => 'x',
 		yvar            => 'y',
 		xmin            => -3,
@@ -92,135 +154,92 @@ sub VectorField2D {
 		xsamples        => 20,
 		ysamples        => 20,
 		axesframed      => 1,
-		xaxislabel      => "X",
-		yaxislabel      => "Y",
-		vectorcolor     => "RGBColor[1.0,0.0,0.0]",
+		xaxislabel      => 'x',
+		yaxislabel      => 'y',
+		vectorcolor     => 'RGBColor[0.0,0.0,1.0]',
 		vectorscale     => 0.2,
 		vectorthickness => 0.001,
 		outputtype      => 4,
 		@_
 	);
 
-	my $Fxsubroutine;
-	my $Fysubroutine;
+	$options{Fx}->perlFunction('Fxsubroutine', [ $options{xvar}, $options{yvar} ]);
+	$options{Fy}->perlFunction('Fysubroutine', [ $options{xvar}, $options{yvar} ]);
 
-	$options{Fx}->perlFunction('Fxsubroutine', [ "$options{xvar}", "$options{yvar}" ]);
-	$options{Fy}->perlFunction('Fysubroutine', [ "$options{xvar}", "$options{yvar}" ]);
-
-######################################################
-	#
-	#  Generate plot data
-	#
+	# Generate plot data
 
 	my $dx = ($options{xmax} - $options{xmin}) / $options{xsamples};
 	my $dy = ($options{ymax} - $options{ymin}) / $options{ysamples};
 
-	my $xtail;
-	my $ytail;
+	my (@xtail, @ytail, @xtip, @ytip, @xleftbarb, @xrightbarb, @yleftbarb, @yrightbarb);
 
-	foreach my $i (0 .. $options{xsamples}) {
+	for my $i (0 .. $options{xsamples}) {
 		$xtail[$i] = $options{xmin} + $i * $dx;
-		foreach my $j (0 .. $options{ysamples}) {
+		for my $j (0 .. $options{ysamples}) {
 			$ytail[$j] = $options{ymin} + $j * $dy;
 
-			$FX[$i][$j] = sprintf("%.3f", $options{vectorscale} * (Fxsubroutine($xtail[$i], $ytail[$j])->value));
-			$FY[$i][$j] = sprintf("%.3f", $options{vectorscale} * (Fysubroutine($xtail[$i], $ytail[$j])->value));
+			my $Fx = sprintf('%.3f', $options{vectorscale} * Fxsubroutine($xtail[$i], $ytail[$j])->value);
+			my $Fy = sprintf('%.3f', $options{vectorscale} * Fysubroutine($xtail[$i], $ytail[$j])->value);
 
-			$xtail[$i] = sprintf("%.3f", $xtail[$i]);
-			$ytail[$j] = sprintf("%.3f", $ytail[$j]);
+			$xtail[$i] = sprintf('%.3f', $xtail[$i]);
+			$ytail[$j] = sprintf('%.3f', $ytail[$j]);
 
-			$xtip[$i][$j] = $xtail[$i] + sprintf("%.3f", $FX[$i][$j]);
-			$ytip[$i][$j] = $ytail[$j] + sprintf("%.3f", $FY[$i][$j]);
+			$xtip[$i][$j] = $xtail[$i] + sprintf('%.3f', $Fx);
+			$ytip[$i][$j] = $ytail[$j] + sprintf('%.3f', $Fy);
 
-			$xleftbarb[$i][$j] = sprintf("%.3f", $xtail[$i] + 0.8 * $FX[$i][$j] - 0.2 * $FY[$i][$j]);
-			$yleftbarb[$i][$j] = sprintf("%.3f", $ytail[$j] + 0.8 * $FY[$i][$j] + 0.2 * $FX[$i][$j]);
+			$xleftbarb[$i][$j] = sprintf('%.3f', $xtail[$i] + 0.8 * $Fx - 0.2 * $Fy);
+			$yleftbarb[$i][$j] = sprintf('%.3f', $ytail[$j] + 0.8 * $Fy + 0.2 * $Fx);
 
-			$xrightbarb[$i][$j] = sprintf("%.3f", $xtail[$i] + 0.8 * $FX[$i][$j] + 0.2 * $FY[$i][$j]);
-			$yrightbarb[$i][$j] = sprintf("%.3f", $ytail[$j] + 0.8 * $FY[$i][$j] - 0.2 * $FX[$i][$j]);
+			$xrightbarb[$i][$j] = sprintf('%.3f', $xtail[$i] + 0.8 * $Fx + 0.2 * $Fy);
+			$yrightbarb[$i][$j] = sprintf('%.3f', $ytail[$j] + 0.8 * $Fy - 0.2 * $Fx);
 		}
 	}
 
-###########################################################################
-	#
-	#  Generate plotstructure from the plotdata.
-	#
-	#  The plotstucture is a list of arrows (made of lines) that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstructure, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstructure
-	#
+	# Generate plotstructure from the plotdata.  This is a list of arrows (made of lines) that LiveGraphics3D reads as
+	# input.  For more information on the format of the plotstructure, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html.
 
-	my $plotstructure = "{{{{$options{vectorcolor},EdgeForm[],Thickness[$options{vectorthickness}],";
+	# Generate the lines in the plotstructure.
+	my @lines;
 
-	foreach my $i (0 .. $options{xsamples}) {
-		foreach my $j (0 .. $options{ysamples}) {
-
-			$plotstructure =
-				$plotstructure
-				. "Line[{"
-				. "{$xtail[$i],$ytail[$j],0},"
-				. "{$xtip[$i][$j],$ytip[$i][$j],0}" . "}],"
-				. "Line[{"
-				. "{$xleftbarb[$i][$j],$yleftbarb[$i][$j],0},"
-				. "{$xtip[$i][$j],$ytip[$i][$j],0},"
-				. "{$xrightbarb[$i][$j],$yrightbarb[$i][$j],0}" . "}]";
-
-			if (($i < $options{xsamples}) || ($j < $options{ysamples})) {
-				$plotstructure = $plotstructure . ",";
-			}
-
+	for my $i (0 .. $options{xsamples}) {
+		for my $j (0 .. $options{ysamples}) {
+			push(@lines,
+				'Line[{'
+					. "{$xtail[$i],$ytail[$j],0},"
+					. "{$xtip[$i][$j],$ytip[$i][$j],0}"
+					. '}],Line[{'
+					. "{$xleftbarb[$i][$j],$yleftbarb[$i][$j],0},"
+					. "{$xtip[$i][$j],$ytip[$i][$j],0},"
+					. "{$xrightbarb[$i][$j],$yrightbarb[$i][$j],0}"
+					. '}]');
 		}
 	}
 
-	$plotstructure = $plotstructure . "}}}}";
+	my $plotstructure = "{{{{$options{vectorcolor},Thickness[$options{vectorthickness}]," . join(',', @lines) . '}}}}';
 
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
+	my $plotoptions = '';
 	if ($options{outputtype} > 1) {
 		$plotoptions =
 			$plotoptions
 			. "PlotRange->{{$options{xmin},$options{xmax}},{$options{ymin},$options{ymax}},{-0.1,0.1}},"
-			. "ViewPoint->{0,0,1000},"
-			. "ViewVertical->{0,1,0},"
-			. "Lighting->False,"
+			. 'ViewPoint->{0,0,2},ViewVertical->{0,1,0},Lighting->False,'
 			. ($options{axesframed} == 1
 				? "AxesLabel->{$options{xaxislabel},$options{yaxislabel},Z},Axes->{True,True,False}"
 				: '');
-
 	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End VectorField2D
-##############################################
-##############################################
+}
 
 1;

--- a/macros/graph/LiveGraphicsVectorField3D.pl
+++ b/macros/graph/LiveGraphicsVectorField3D.pl
@@ -234,7 +234,7 @@ sub VectorField3D {
 
 	my $plotoptions = "";
 
-	if (($options{outputtype} > 1) || ($options{axesframed} == 1)) {
+	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
 		$plotoptions =
 			$plotoptions
 			. "Axes->True,AxesLabel->"

--- a/macros/graph/LiveGraphicsVectorField3D.pl
+++ b/macros/graph/LiveGraphicsVectorField3D.pl
@@ -19,81 +19,160 @@ LiveGraphicsVectorField3D.pl - provide an interactive plot of a 3D vector field.
 
 =head1 DESCRIPTION
 
-C<LiveGraphicsVectorField3D.pl> provides a macros for creating an
-interactive plot of a vector field via the C<LiveGraphics3D> Javascript applet.
-The routine C<VectorField3D()> takes three C<MathObject> Formulas of
-3 variables as input and returns a string of plot data that can be
-displayed using the C<Live3Ddata()> routine of the C<LiveGraphics3D.pl> macro.
+This macro provides a method for creating an interactive plot of a vector field
+via the C<LiveGraphics3D> JavaScript applet.  The method takes three
+C<MathObject> Formulas of three variables as input and returns a string of plot
+data that can be displayed using the C<Live3Ddata> routine of the
+L<LiveGraphics3D.pl> macro.
 
-=head1 USAGE
+=head1 METHODS
 
-    VectorField3D(options);
+=head2 VectorField3D
 
-Options are:
+Usage: C<VectorField3D(%options)>
 
-    Fx => Formula("y"),    F = < Fx, Fy, Fz > where Fx, Fy, Fz are each
-    Fy => Formula("-x"),   functions of 3 variables
-    Fz => Formula("z"),
+The available options are as follows.
 
-    xvar => "r",           independent variable name, default "x"
-    yvar => "s",           independent variable name, default "y"
-    zvar => "t",           independent variable name, default "z"
+=over
 
-    xmin => -3,            domain for xvar
-    xmax =>  3,
+=item C<< Fx => Formula('y') >>
 
-    ymin => -3,            domain for yvar
-    ymax =>  3,
+Function for the C<x>-coordinate.
 
-    zmin => -3,            domain for zvar
-    zmax =>  3,
+=item C<< Fy => Formula('-x') >>
 
-    xsamples => 3,         deltax = (xmax - xmin) / xsamples
-    ysamples => 3,         deltay = (ymax - ymin) / ysamples
-    zsamples => 3,         deltaz = (zmax - zmin) / zsamples
+Function for the C<y>-coordinate.
 
-    axesframed => 1,       1 displays framed axes, 0 hides framed axes
+=item C<< Fz => Formula('x + y + z') >>
 
-    xaxislabel => "R",     Capital letters may be easier to read
-    yaxislabel => "S",
-    zaxislabel => "T",
+Function for the C<z>-coordinate.
 
-    vectorcolor => "RGBColor[0.0,0.0,1.0]",
-    vectorscale => 0.2,
-    vectorthickness => 0.001,
+=item C<< xvar => 'x' >>
 
-    outputtype => 1,       return string of only polygons (or mesh)
-                  2,       return string of only plotoptions
-                  3,       return string of polygons (or mesh) and plotoptions
-                  4,       return complete plot
+First independent variable name, default 'x'. This must correspond to the first
+variable used in the C<Fx>, C<Fy>, and C<Fz>.
 
+=item C<< yvar => 'y' >>
 
+Second independent variable name, default 'y'. This must correspond to the
+second variable used in the C<Fx>, C<Fy>, and C<Fz>.
 
+=item C<< zvar => 'z' >>
+
+Third independent variable name, default 'z'. This must correspond to the
+third variable used in the C<Fx>, C<Fy>, and C<Fz>.
+
+=item C<< xmin => -3 >>
+
+Lower bound for the domain of the first independent variable.
+
+=item C<< xmax => 3 >>
+
+Upper bound for the domain of the first independent variable.
+
+=item C<< ymin => -3 >>
+
+Lower bound for the domain of the second independent variable.
+
+=item C<< ymax => 3 >>
+
+Upper bound for the domain of the second independent variable.
+
+=item C<< zmin => -3 >>
+
+Lower bound for the domain of the third independent variable.
+
+=item C<< zmax => 3 >>
+
+Upper bound for the domain of the third independent variable.
+
+=item C<< xsamples => 20 >>
+
+The number of sample values for the first independent variable in the interval
+from C<xmin> to C<xmax> to use.
+
+=item C<< ysamples => 20 >>
+
+The number of sample values for the second independent variable in the interval
+from C<ymin> to C<ymax> to use.
+
+=item C<< zsamples => 20 >>
+
+The number of sample values for the third independent variable in the interval
+from C<zmin> to C<zmax> to use.
+
+=item C<< axesframed => 1 >>
+
+If set to 1 then the framed axes are displayed.  If set to 0, the the framed
+axes are not shown. This is 1 by default.
+
+=item C<< xaxislabel => 'x' >>
+
+Label for the axis corresponding to the first independent variable.
+
+=item C<< yaxislabel => 'y' >>
+
+Label for the axis corresponding to the second independent variable.
+
+=item C<< zaxislabel => 'z' >>
+
+Label for the axis corresponding to the third independent variable.
+
+=item C<< vectorcolor => 'RGBColor[0.0, 0.0, 1.0]' >>
+
+Color of vectors shown in the slope field.
+
+=item C<< vectorscale => 0.2 >>
+
+Multiplier that determines the lentgh of vectors shown in the slope field.
+
+=item C<< vectorthickness => 0.001 >>
+
+Thickness (or width) of the line segments used to construct the vectors shown in
+the slope field.
+
+=item C<< outputtype => 1 >>
+
+This determines what is contained in the string that the method returns. The
+values of 1 through 4 are accepted, and have the following meaning.
+
+=over
+
+=item 1.
+
+Return a string of only polygons (or edge mesh).
+
+=item 2.
+
+Return a string of only plot options.
+
+=item 3.
+
+Return a string of polygons (or edge mesh) and plot options.
+
+=item 4.
+
+Return the complete plot to be passed directly to the C<Live3DData> method.
+
+=back
+
+=back
 
 =cut
 
-sub _LiveGraphicsVectorField3D_init { };    # don't reload this file
+sub _LiveGraphicsVectorField3D_init { }
 
-loadMacros("MathObjects.pl", "LiveGraphics3D.pl");
+loadMacros('MathObjects.pl', 'LiveGraphics3D.pl');
 
-$beginplot = "Graphics3D[";
-$endplot   = "]";
-
-###########################################
-###########################################
-#  Begin VectorField3D
+$main::beginplot = 'Graphics3D[';
+$main::endplot   = ']';
 
 sub VectorField3D {
-
-###########################################
-	#
-	#  Set default options
-	#
-
+	# Set default options.
 	my %options = (
-		Fx              => Formula("1"),
-		Fy              => Formula("1"),
-		Fz              => Formula("1"),
+		Fx              => Formula('1'),
+		Fy              => Formula('1'),
+		Fz              => Formula('1'),
 		xvar            => 'x',
 		yvar            => 'y',
 		zvar            => 'z',
@@ -107,10 +186,10 @@ sub VectorField3D {
 		ysamples        => 20,
 		zsamples        => 20,
 		axesframed      => 1,
-		xaxislabel      => "X",
-		yaxislabel      => "Y",
-		zaxislabel      => "Z",
-		vectorcolor     => "RGBColor[0.0,0.0,1.0]",
+		xaxislabel      => 'x',
+		yaxislabel      => 'y',
+		zaxislabel      => 'z',
+		vectorcolor     => 'RGBColor[0.0,0.0,1.0]',
 		vectorscale     => 0.2,
 		vectorthickness => 0.001,
 		xavoid          => 1000000,
@@ -120,148 +199,96 @@ sub VectorField3D {
 		@_
 	);
 
-	my $Fxsubroutine;
-	my $Fysubroutine;
-	my $Fzsubroutine;
+	$options{Fx}->perlFunction('Fxsubroutine', [ $options{xvar}, $options{yvar}, $options{zvar} ]);
+	$options{Fy}->perlFunction('Fysubroutine', [ $options{xvar}, $options{yvar}, $options{zvar} ]);
+	$options{Fz}->perlFunction('Fzsubroutine', [ $options{xvar}, $options{yvar}, $options{zvar} ]);
 
-	$options{Fx}->perlFunction('Fxsubroutine', [ "$options{xvar}", "$options{yvar}", "$options{zvar}" ]);
-	$options{Fy}->perlFunction('Fysubroutine', [ "$options{xvar}", "$options{yvar}", "$options{zvar}" ]);
-	$options{Fz}->perlFunction('Fzsubroutine', [ "$options{xvar}", "$options{yvar}", "$options{zvar}" ]);
-
-######################################################
-	#
-	#  Generate plot data
-	#
+	# Generate plot data.
 
 	my $dx = ($options{xmax} - $options{xmin}) / $options{xsamples};
 	my $dy = ($options{ymax} - $options{ymin}) / $options{ysamples};
 	my $dz = ($options{zmax} - $options{zmin}) / $options{zsamples};
 
-	my $xtail;
-	my $ytail;
-	my $ztail;
+	my (@xtail, @ytail, @ztail, @xtip, @ytip, @ztip, @xleftbarb, @xrightbarb, @yleftbarb, @yrightbarb, @zbarb);
 
-	foreach my $i (0 .. $options{xsamples}) {
+	for my $i (0 .. $options{xsamples}) {
 		$xtail[$i] = $options{xmin} + $i * $dx;
-		foreach my $j (0 .. $options{ysamples}) {
+		for my $j (0 .. $options{ysamples}) {
 			$ytail[$j] = $options{ymin} + $j * $dy;
-			foreach my $k (0 .. $options{zsamples}) {
+			for my $k (0 .. $options{zsamples}) {
 				$ztail[$k] = $options{zmin} + $k * $dz;
 
-				if ($xtail[$i] == $options{xavoid} && $ytail[$j] == $options{yavoid} && $ztail[$k] == $options{zavoid})
+				my ($Fx, $Fy, $Fz) = (0, 0, 0);
+
+				if ($xtail[$i] != $options{xavoid} || $ytail[$j] != $options{yavoid} || $ztail[$k] != $options{zavoid})
 				{
-
-					$FX[$i][$j][$k] = 0;
-					$FY[$i][$j][$k] = 0;
-					$FZ[$i][$j][$k] = 0;
-
-				} else {
-
-					$FX[$i][$j][$k] = sprintf("%.3f",
-						$options{vectorscale} * (Fxsubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value));
-					$FY[$i][$j][$k] = sprintf("%.3f",
-						$options{vectorscale} * (Fysubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value));
-					$FZ[$i][$j][$k] = sprintf("%.3f",
-						$options{vectorscale} * (Fzsubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value));
-
+					$Fx = sprintf('%.3f',
+						$options{vectorscale} * Fxsubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value);
+					$Fy = sprintf('%.3f',
+						$options{vectorscale} * Fysubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value);
+					$Fz = sprintf('%.3f',
+						$options{vectorscale} * Fzsubroutine($xtail[$i], $ytail[$j], $ztail[$k])->value);
 				}
 
-				$xtail[$i] = sprintf("%.3f", $xtail[$i]);
-				$ytail[$j] = sprintf("%.3f", $ytail[$j]);
-				$ztail[$k] = sprintf("%.3f", $ztail[$k]);
+				$xtail[$i] = sprintf('%.3f', $xtail[$i]);
+				$ytail[$j] = sprintf('%.3f', $ytail[$j]);
+				$ztail[$k] = sprintf('%.3f', $ztail[$k]);
 
-				$xtip[$i][$j][$k] = $xtail[$i] + sprintf("%.3f", $FX[$i][$j][$k]);
-				$ytip[$i][$j][$k] = $ytail[$j] + sprintf("%.3f", $FY[$i][$j][$k]);
-				$ztip[$i][$j][$k] = $ztail[$k] + sprintf("%.3f", $FZ[$i][$j][$k]);
+				$xtip[$i][$j][$k] = $xtail[$i] + sprintf('%.3f', $Fx);
+				$ytip[$i][$j][$k] = $ytail[$j] + sprintf('%.3f', $Fy);
+				$ztip[$i][$j][$k] = $ztail[$k] + sprintf('%.3f', $Fz);
 
-				$xleftbarb[$i][$j][$k] = sprintf("%.3f", $xtail[$i] + 0.8 * $FX[$i][$j][$k] - 0.2 * $FY[$i][$j][$k]);
-				$yleftbarb[$i][$j][$k] = sprintf("%.3f", $ytail[$j] + 0.8 * $FY[$i][$j][$k] + 0.2 * $FX[$i][$j][$k]);
+				$xleftbarb[$i][$j][$k] = sprintf('%.3f', $xtail[$i] + 0.8 * $Fx - 0.2 * $Fy);
+				$yleftbarb[$i][$j][$k] = sprintf('%.3f', $ytail[$j] + 0.8 * $Fy + 0.2 * $Fx);
 
-				$xrightbarb[$i][$j][$k] = sprintf("%.3f", $xtail[$i] + 0.8 * $FX[$i][$j][$k] + 0.2 * $FY[$i][$j][$k]);
-				$yrightbarb[$i][$j][$k] = sprintf("%.3f", $ytail[$j] + 0.8 * $FY[$i][$j][$k] - 0.2 * $FX[$i][$j][$k]);
+				$xrightbarb[$i][$j][$k] = sprintf('%.3f', $xtail[$i] + 0.8 * $Fx + 0.2 * $Fy);
+				$yrightbarb[$i][$j][$k] = sprintf('%.3f', $ytail[$j] + 0.8 * $Fy - 0.2 * $Fx);
 
-				$zbarb[$i][$j][$k] = sprintf("%.3f", $ztail[$k] + 0.8 * $FZ[$i][$j][$k]);
-
+				$zbarb[$i][$j][$k] = sprintf("%.3f", $ztail[$k] + 0.8 * $Fz);
 			}
 		}
 	}
 
-###########################################################################
-	#
-	#  Generate plotstructure from the plotdata.
-	#
-	#  The plotstucture is a list of arrows (made of lines) that
-	#  LiveGraphics3D reads as input.
-	#
-	#  For more information on the format of the plotstructure, see
-	#  http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html
-	#  http://www.vis.uni-stuttgart.de/~kraus/LiveGraphics3D/documentation.html
-	#
-###########################################
-	#
-	#  Generate the polygons in the plotstructure
-	#
+	# Generate plotstructure from the plotdata.  This is a list of arrows (made of lines) that LiveGraphics3D reads as
+	# input.  For more information on the format of the plotstructure, see
+	# http://www.math.umn.edu/~rogness/lg3d/page_NoMathematica.html.
 
-	my $plotstructure = "{{{{$options{vectorcolor},Thickness[$options{vectorthickness}],";
-
-	foreach my $i (0 .. $options{xsamples}) {
-		foreach my $j (0 .. $options{ysamples}) {
-			foreach my $k (0 .. $options{zsamples}) {
-
-				$plotstructure =
-					$plotstructure
-					. "Line[{"
-					. "{$xtail[$i],$ytail[$j],$ztail[$k]},"
-					. "{$xtip[$i][$j][$k],$ytip[$i][$j][$k],$ztip[$i][$j][$k]}" . "}],"
-					. "Line[{"
-					. "{$xleftbarb[$i][$j][$k],$yleftbarb[$i][$j][$k],$zbarb[$i][$j][$k]},"
-					. "{$xtip[$i][$j][$k],$ytip[$i][$j][$k],$ztip[$i][$j][$k]},"
-					. "{$xrightbarb[$i][$j][$k],$yrightbarb[$i][$j][$k],$zbarb[$i][$j][$k]}" . "}]";
-
-				if (($i < $options{xsamples}) || ($j < $options{ysamples}) || ($k < $options{zsamples})) {
-					$plotstructure = $plotstructure . ",";
-				}
+	# Generate the lines in the plotstructure.
+	my @lines;
+	for my $i (0 .. $options{xsamples}) {
+		for my $j (0 .. $options{ysamples}) {
+			for my $k (0 .. $options{zsamples}) {
+				push(@lines,
+					'Line[{'
+						. "{$xtail[$i],$ytail[$j],$ztail[$k]},"
+						. "{$xtip[$i][$j][$k],$ytip[$i][$j][$k],$ztip[$i][$j][$k]}"
+						. '}],Line[{'
+						. "{$xleftbarb[$i][$j][$k],$yleftbarb[$i][$j][$k],$zbarb[$i][$j][$k]},"
+						. "{$xtip[$i][$j][$k],$ytip[$i][$j][$k],$ztip[$i][$j][$k]},"
+						. "{$xrightbarb[$i][$j][$k],$yrightbarb[$i][$j][$k],$zbarb[$i][$j][$k]}"
+						. '}]');
 			}
 		}
 	}
 
-	$plotstructure = $plotstructure . "}}}}";
+	my $plotstructure = "{{{{$options{vectorcolor},Thickness[$options{vectorthickness}]," . join(',', @lines) . '}}}}';
 
-##############################################
-	#
-	#  Add plot options to the plotoptions string
-	#
-
-	my $plotoptions = "";
-
-	if ($options{outputtype} > 1 && $options{axesframed} == 1) {
-		$plotoptions =
-			$plotoptions
-			. "Axes->True,AxesLabel->"
-			. "{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}";
-	}
-
-####################################################
-	#
-	#  Return only the plotstring    (if outputtype=>1),
-	#  or only plotoptions           (if outputtype=>2),
-	#  or plotstring, plotoptions    (if outputtype=>2),
-	#  or the entire plot (default)  (if outputtype=>4)
+	my $plotoptions =
+		$options{outputtype} > 1 && $options{axesframed} == 1
+		? "Axes->True,AxesLabel->{$options{xaxislabel},$options{yaxislabel},$options{zaxislabel}}"
+		: '';
 
 	if ($options{outputtype} == 1) {
 		return $plotstructure;
 	} elsif ($options{outputtype} == 2) {
 		return $plotoptions;
 	} elsif ($options{outputtype} == 3) {
-		return "{" . $plotstructure . "," . $plotoptions . "}";
+		return "{$plotstructure,$plotoptions}";
 	} elsif ($options{outputtype} == 4) {
-		return $beginplot . $plotstructure . "," . $plotoptions . $endplot;
+		return "${main::beginplot}${plotstructure},${plotoptions}${main::endplot}";
 	} else {
-		return "Invalid outputtype (outputtype should be a number 1 through 4).";
+		return 'Invalid outputtype (outputtype should be a number 1 through 4).';
 	}
-
-}    #  End VectorField3D
-##############################################
-##############################################
+}
 
 1;


### PR DESCRIPTION
This does three primary things.

First, this switches from using `x3dom` for graphing to using `plotly`.

Second, the parsing of the LiveGraphics3D data has been re-imagined.  The new parsing is more like how the documentation (that I could find) seems to intend it to be done.  At least as I interpret the documentation.   This allows for implementing a few more things from the LiveGraphics3D data that are used by the other LiveGraphics3D macros that were previously not implemented.  More could be done with this as well.

Third, the other LiveGraphics3D macros have been cleaned up, and the POD improved.

Note that the `LiveGraphicsVectorField2D.pl` macro has been updated, but it really doesn't work very well.  It works better than it did before though.  I don't know of any problems that use this macro, so it probably isn't to big of a deal.  To be honest, I don't understand why this macro was created.  It really doesn't make sense to use a 3 dimensional tool such as  LiveGraphics3D to graph 2 dimensional objects.  However, plotly also supports 2 dimensional graphs, and so (with a little javascript ugliness) the macro could be made to work and actually produce a 2 dimensional graph for this macro.