### PR TITLE
avoid an error from misuse of 'AnSwEr'

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -543,7 +543,7 @@ sub generate_aria_label {
 	my $label = '';
 
 	# if we dont have an AnSwEr type name then we do the best we can
-	if ($name !~ /AnSwEr/) {
+	if ($name !~ /AnSwEr\d+/) {
 		return maketext('answer') . ' ' . $name;
 	}
 


### PR DESCRIPTION
Line 557 assumes that if `AnSwEr` is a substring of the answer name, that it is followed by some digits. But the test at line 546 does not look for digits following `AnSwEr`. So if for some reason a problem author manually creates an answer name like `MyAnSwEr`, then there will be an error message.

This just changes the check at line 546 to look for some trailing digits. If they are not there, the subroutine exits early.

No one should be manually creating answers that have `AnSwEr`  as a substring. But sometimes problem authors who are newbies and looking at code somewhere to mimic might end up doing this. This PR addresses one issue if that happens. I note there would be more issues, since other things here assume that the presence of `AnSwEr` means it was an auto-generated answer name. But that's a different matter.