### PR TITLE
Tweaks to the `cmp_defaults` for `parserCheckboxList.pl`

### DIFF
--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -461,6 +461,9 @@ sub cmp_defaults {
 		$self->SUPER::cmp_defaults(%options),
 		entry_type        => 'choice',
 		list_type         => 'selection',
+		showHints         => 0,
+		showLengthHints   => 0,
+		partialCredit     => 0,
 		requireParenMatch => 0,
 		implicitList      => 0,
 		correct_choices   => $self->data


### PR DESCRIPTION
This adds `showHints => 0`, `showLengthHints => 0`, and `partialCredit => 0` to the `cmp_defaults` for `CheckboxList` answers.

For now this adds all of them, but that can be changed as the discussion evolves.  See issue #971.