### PR TITLE
move feedback message to top of feedback card

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -220,13 +220,8 @@
 	.popover-header {
 		text-align: center;
 		cursor: pointer;
-	}
-
-	&.preview {
-		.popover-header {
-			--bs-popover-header-bg: var(--bs-info);
-			--bs-popover-header-color: white;
-		}
+		--bs-popover-header-bg: var(--bs-info);
+		--bs-popover-header-color: white;
 	}
 
 	&.correct {

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -222,6 +222,13 @@
 		cursor: pointer;
 	}
 
+	&.preview {
+		.popover-header {
+			--bs-popover-header-bg: var(--bs-info);
+			--bs-popover-header-color: white;
+		}
+	}
+
 	&.correct {
 		.popover-header {
 			--bs-popover-header-bg: var(--bs-success);

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -219,13 +219,13 @@
 
 	.popover-header {
 		text-align: center;
+		cursor: pointer;
 	}
 
 	&.correct {
 		.popover-header {
 			--bs-popover-header-bg: var(--bs-success);
 			--bs-popover-header-color: white;
-			cursor: pointer;
 		}
 	}
 

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -277,6 +277,9 @@
 
 				&.feedback-message {
 					background-color: #ede275;
+					&:not(:last-child) {
+						border-bottom: 1px solid black;
+					}
 				}
 			}
 		}

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -280,6 +280,10 @@
 					&:not(:last-child) {
 						border-bottom: 1px solid black;
 					}
+					&:last-child {
+						border-bottom-left-radius: var(--bs-card-inner-border-radius);
+						border-bottom-right-radius: var(--bs-card-inner-border-radius);
+					}
 				}
 			}
 		}

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1022,7 +1022,7 @@ sub ENDDOCUMENT {
 
 				my %options = (
 					resultTitle      => maketext('Preview'),
-					resultClass      => 'preview',
+					resultClass      => '',
 					btnClass         => 'btn-info',
 					btnAddClass      => 'ms-1',
 					feedbackElements => Mojo::Collection->new,
@@ -1126,10 +1126,11 @@ sub ENDDOCUMENT {
 						if $options{insertElement} && $options{insertElement}->attr->{'data-feedback-insert-method'};
 				}
 
-				# Add the preview/correct/incorrect/partially-correct class and
+				# Add the correct/incorrect/partially-correct class and
 				# aria-described by attribute to the feedback elements.
 				for (@{ $options{feedbackElements} }) {
-					$_->attr(class              => join(' ', $options{resultClass}, $_->attr->{class} || ()));
+					$_->attr(class => join(' ', $options{resultClass}, $_->attr->{class} || ()))
+						if $options{resultClass};
 					$_->attr('aria-describedby' => "ww-feedback-$answerLabel");
 				}
 
@@ -1195,7 +1196,7 @@ sub ENDDOCUMENT {
 							bs_trigger             => 'click',
 							bs_placement           => 'bottom',
 							bs_html                => 'true',
-							bs_custom_class        => join(' ', 'ww-feedback-popover', $options{resultClass}),
+							bs_custom_class        => join(' ', 'ww-feedback-popover', $options{resultClass} || ()),
 							bs_fallback_placements => '[]',
 							bs_content             => Mojo::DOM->new_tag(
 								'div',

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -827,8 +827,8 @@ changes this to "Ungraded" for essay answers.
 =item *
 
 C<resultClass>: This is the CSS class that is added to each answer input in the
-response group. By default it is set to "preview", "correct", "incorrect",
-or "partially-correct" depending on the status of the answer and
+response group. By default it is set to the empty string, "correct",
+"incorrect", or "partially-correct" depending on the status of the answer and
 the type of submission.
 
 =item *

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1153,10 +1153,14 @@ sub ENDDOCUMENT {
 					my ($title, $line, $class) = @_;
 					$class //= '';
 					return '' unless defined $line && $line =~ /\S/;
-					return Mojo::DOM->new_tag(
-						'div',
-						class => 'card-header text-center p-1',
-						sub { Mojo::DOM->new_tag('h4', class => 'card-title fs-6 m-0', $title); }
+					return (
+						$title
+						? Mojo::DOM->new_tag(
+							'div',
+							class => 'card-header text-center p-1',
+							sub { Mojo::DOM->new_tag('h4', class => 'card-title fs-6 m-0', $title); }
+							)
+						: ''
 					) . Mojo::DOM->new_tag('div', class => "card-body text-center $class", sub {$line});
 				}
 
@@ -1202,7 +1206,13 @@ sub ENDDOCUMENT {
 										'div',
 										class => 'card',
 										sub {
-											($rh_envir->{showAttemptAnswers} && $options{showEntered}
+											(
+												$rh_envir->{showMessages} && $ansHash->{ans_message}
+												? feedbackLine('', $ansHash->{ans_message} =~ s/\n/<br>/gr,
+													'feedback-message')
+												: ''
+											)
+											. ($rh_envir->{showAttemptAnswers} && $options{showEntered}
 												? feedbackLine(maketext('You Entered'), $ansHash->{student_ans})
 												: '')
 											. (
@@ -1227,14 +1237,6 @@ sub ENDDOCUMENT {
 														$options{wrapPreviewInTex},
 														$ansHash->{correct_ans}
 													)
-												)
-												: ''
-											)
-											. (
-												($rh_envir->{showMessages} && $ansHash->{ans_message})
-												? feedbackLine(
-													maketext('Message'), $ansHash->{ans_message} =~ s/\n/<br>/gr,
-													'feedback-message'
 												)
 												: ''
 											);

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -827,8 +827,8 @@ changes this to "Ungraded" for essay answers.
 =item *
 
 C<resultClass>: This is the CSS class that is added to each answer input in the
-response group. By default it is set to the empty string, "correct",
-"incorrect", or "partially-correct" depending on the status of the answer and
+response group. By default it is set to "preview", "correct", "incorrect",
+or "partially-correct" depending on the status of the answer and
 the type of submission.
 
 =item *
@@ -1022,7 +1022,7 @@ sub ENDDOCUMENT {
 
 				my %options = (
 					resultTitle      => maketext('Preview'),
-					resultClass      => '',
+					resultClass      => 'preview',
 					btnClass         => 'btn-info',
 					btnAddClass      => 'ms-1',
 					feedbackElements => Mojo::Collection->new,
@@ -1126,11 +1126,10 @@ sub ENDDOCUMENT {
 						if $options{insertElement} && $options{insertElement}->attr->{'data-feedback-insert-method'};
 				}
 
-				# Add the correct/incorrect/partially-correct class and
+				# Add the preview/correct/incorrect/partially-correct class and
 				# aria-described by attribute to the feedback elements.
 				for (@{ $options{feedbackElements} }) {
-					$_->attr(class => join(' ', $options{resultClass}, $_->attr->{class} || ()))
-						if $options{resultClass};
+					$_->attr(class              => join(' ', $options{resultClass}, $_->attr->{class} || ()));
 					$_->attr('aria-describedby' => "ww-feedback-$answerLabel");
 				}
 
@@ -1191,12 +1190,12 @@ sub ENDDOCUMENT {
 						. ($rh_envir->{showMessages} && $ansHash->{ans_message} ? ' with-message' : ''),
 						'aria-label' => $options{resultTitle},
 						data         => {
-							$showResults && $options{resultTitle} ? (bs_title => $options{resultTitle}) : (),
+							bs_title               => $options{resultTitle},
 							bs_toggle              => 'popover',
 							bs_trigger             => 'click',
 							bs_placement           => 'bottom',
 							bs_html                => 'true',
-							bs_custom_class        => join(' ', 'ww-feedback-popover', $options{resultClass} || ()),
+							bs_custom_class        => join(' ', 'ww-feedback-popover', $options{resultClass}),
 							bs_fallback_placements => '[]',
 							bs_content             => Mojo::DOM->new_tag(
 								'div',


### PR DESCRIPTION
This moves the feedback message to the top of the card, as discussed in the #939 thread.

I'm not sure about it yet. Additionally styling adjustments might be in order.