### PR TITLE
For PGML escape all characters (\, `, and $) in a line of html output not just the first.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1483,7 +1483,7 @@ sub Escape {
 	$string =~ s/"/&quot;/g;
 
 	# Wrap the characters \, `, and $ in span tags to prevent MathJax from processing them.
-	$string =~ s/([\\`\$]+)/<span class="tex2jax_ignore">$1<\/span>/;
+	$string =~ s/([\\`\$]+)/<span class="tex2jax_ignore">$1<\/span>/g;
 	return $string;
 }
 


### PR DESCRIPTION
All of @somiaj's suggested escape code comments in #1980 contained the `g` flag on the regular expression, but when #878 was actually committed, the code did not.  As a result only the first character on the line will actually be escaped.  This results in rather unexpected MathJax rendering.  For example, if the line contains
```
`x + y = 3` and `x - y = 4`
```
then this is rendered as
```
<span class="text2jax_ignore">`</span>x + y = 3` and `x - y = 4`
```
Which results in `` ` and ` `` being rendered by MathJax.