### PR TITLE
don't escape dollar for string method in PTX mode

### DIFF
--- a/macros/contexts/contextCurrency.pl
+++ b/macros/contexts/contextCurrency.pl
@@ -250,7 +250,7 @@ sub new {
 			precedence    => 10,
 			associativity => $associativity,
 			type          => "unary",
-			string        => (($main::displayMode eq 'TeX') ? Currency::quoteTeX($symbol) : $symbol),
+			string        => ($main::displayMode eq 'TeX' ? Currency::quoteTeX($symbol) : $symbol),
 			TeX           => Currency::quoteTeX($symbol),
 			class         => 'Currency::UOP::currency'
 		},

--- a/macros/contexts/contextCurrency.pl
+++ b/macros/contexts/contextCurrency.pl
@@ -250,13 +250,9 @@ sub new {
 			precedence    => 10,
 			associativity => $associativity,
 			type          => "unary",
-			string        => (
-				($main::displayMode eq 'TeX' or $main::displayMode eq 'PTX')
-				? Currency::quoteTeX($symbol)
-				: $symbol
-			),
-			TeX   => Currency::quoteTeX($symbol),
-			class => 'Currency::UOP::currency'
+			string        => (($main::displayMode eq 'TeX') ? Currency::quoteTeX($symbol) : $symbol),
+			TeX           => Currency::quoteTeX($symbol),
+			class         => 'Currency::UOP::currency'
 		},
 	);
 	$context->{parser}{Number}  = "Currency::Number";


### PR DESCRIPTION
This is a minor thing I noticed. For `PTX` output, as long as we are not in math mode, the dollar sign should not be escaped. So the `string` method here should not escape the dollar sign for PTX output.