### PR TITLE
use stringify in context Currency

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -938,6 +938,9 @@ sub replaceVariable {
 		if   ($block->{parsed}) { $result = $result->string }
 		else                    { $result = '{' . $result->TeX . '}' }
 	}
+	if (Value::isValue($result)) {
+		$result = ($block->{type} eq 'math' && !$block->{parsed} ? '{' . $result->TeX . '}' : $result->string);
+	}
 	return $result;
 }
 


### PR DESCRIPTION
This has Davide's edits from #886. It works to fix the reported issue. Two side effects have been mentioned:

* Something like `$message = "The cost is $c.";` and then in PGML using `[$message]` would not work without a star.
* Something like `[$c]*` currently works, but would no longer work in hardcopy.