### PR TITLE
Prevent scaffolds from revealing when an answer is correct when feedback is not permitted.

### DIFF
--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -627,8 +627,12 @@ sub add_container {
 				Mojo::DOM->new_tag(
 					'div',
 					class => 'accordion-header'
-						. ($iscorrect ? ' iscorrect' : ' iswrong')
-						. ($canopen   ? ' canopen'   : ' cannotopen'),
+						. (
+							$iscorrect && ($main::envir{showFeedback} || $main::envir{forceShowAttemptResults})
+							? ' iscorrect'
+							: ' iswrong'
+						)
+						. ($canopen ? ' canopen' : ' cannotopen'),
 					id => "$label-header",
 					sub {
 						Mojo::DOM->new_tag(


### PR DESCRIPTION
This uses the new `showFeedback` and `forceShowAttemptResults` environment variables.  If those are both false, then the status of the answers in the scaffold should not be revealed by adding the `iscorrect` class.

This means that when an answer preview occurs, scaffolds will still open if all answers within it are correct, but the scaffold will not get the green color.  Instead it will be yellow always until the answers are submitted.

This is most important for tests.  In tests all parts of a scaffold are already open, and if a preview (or page change) occurs, it should not reveal that the answers are correct.  That should not occur until the test is graded.

In general this is the correct thing.  Scaffolds are currently giving feedback when feedback is not permitted.  This fixes that.