### PR TITLE
remove workaround for MathView double star operator

### DIFF
--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -278,7 +278,7 @@
 
 		// Regenerate the preview in the math viewer whenever the input value changes.
 		regenPreview() {
-			let text = this.inputTextBox.value.replace(/\*\*/g, '^');
+			let text = this.inputTextBox.value;
 
 			if (this.renderingMode === 'LATEX') this.mviewer.textContent = `\\(${text}\\)`;
 			else this.mviewer.textContent = `\`${text}\``;


### PR DESCRIPTION
In MathView js, there is this place (which this PR removes) where `**` gets replaced with `^`. This is unnecessary since the AsciiMath portion of the MathJax config is already handling `**` as if it were a `^`.

Furthermore, this is actually harmful, since it prevents a user from using the AsciiMath `***` to make a `⋆`.

So this PR removes that replacement.