### PR TITLE
Make the MathQuill editor toolbar appear on the right even for right-to-left languages.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.scss
+++ b/htdocs/js/MathQuill/mqeditor.scss
@@ -100,6 +100,7 @@ input[type='text'].codeshard.mq-edit {
 	border-radius: 4px;
 	border: 2px solid darkgray;
 	background-color: white;
+	/*rtl:ignore*/
 	right: 10px;
 	z-index: 1001;
 	overflow-y: auto;


### PR DESCRIPTION
Currenlty if the course language is set to he-IL and the `$perProblemLangAndDirSettingMode` is set to `auto:en:ltr`, then the computations for the toolbar position make the toolbar on the right but way to wide.  This just makes the toolbar appear the same as for left-to-right languages.  That is not strictly correct, but since the toolbar is not currently translated, I am not sure much better can be done at this point.

This addresses issue #988.