### PR TITLE
new context flag to require constant entries

### DIFF
--- a/lib/Parser/List/Matrix.pm
+++ b/lib/Parser/List/Matrix.pm
@@ -24,6 +24,8 @@ sub _check {
 		$self->{equation}->Error("Entries in a Matrix must be Numbers or Lists of Numbers")
 			unless ($x->type =~ m/Number|Matrix/);
 	}
+	$self->{equation}->Error("Entries of a Matrix must be constant")
+		if ($self->context->flag("requireConstantMatrices") && !($self->{isConstant}));
 }
 
 #

--- a/lib/Parser/List/Point.pm
+++ b/lib/Parser/List/Point.pm
@@ -20,6 +20,8 @@ sub _check {
 			$self->{equation}->Error([ "Coordinates of Points must be Numbers, not %s", $type ]);
 		}
 	}
+	$self->{equation}->Error("Coordinates of a Point must be constant")
+		if ($self->context->flag("requireConstantPoints") && !($self->{isConstant}));
 }
 
 #########################################################################

--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -22,6 +22,9 @@ sub _check {
 			$type = (($type =~ m/^[aeiou]/i) ? "an " : "a ") . $type;
 			$self->{equation}->Error([ "Coordinates of Vectors must be Numbers, not %s", $type ]);
 		}
+		if ($self->context->flag("requireConstantEntries") && !($x->{isConstant})) {
+			$self->{equation}->Error("Coordinates of Vectors must be constant");
+		}
 	}
 }
 

--- a/lib/Parser/List/Vector.pm
+++ b/lib/Parser/List/Vector.pm
@@ -22,10 +22,9 @@ sub _check {
 			$type = (($type =~ m/^[aeiou]/i) ? "an " : "a ") . $type;
 			$self->{equation}->Error([ "Coordinates of Vectors must be Numbers, not %s", $type ]);
 		}
-		if ($self->context->flag("requireConstantEntries") && !($x->{isConstant})) {
-			$self->{equation}->Error("Coordinates of Vectors must be constant");
-		}
 	}
+	$self->{equation}->Error("Coordinates of a Vector must be constant")
+		if ($self->context->flag("requireConstantVectors") && !($self->{isConstant}));
 }
 
 sub ijk {


### PR DESCRIPTION
This makes it so that you can set a context flag `requireConstantEntries`, and if so, vectors cannot have variables in their entries. But for example something like `t <1, 2, 3>` is still legal. This allows me to write a problem that requires students to "factor out" a parameter from vector answers.

I want to check with @dpvc that this is an OK way to do this. If so I will extend this PR to do the same thing for Matrix objects. And I'll add a default value of `0` to `Default.pm`.