### PR TITLE
[Hotfix] Ensure a false score is saved as 0 in AnswerHash.

### DIFF
--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -252,7 +252,7 @@ sub input {    #$rh_ans->input('foo') is a synonym for $rh_ans->{student_ans}='f
 sub score {
 	my $self  = shift;
 	my $score = shift;
-	$self->{score} = $score if defined($score);
+	$self->{score} = $score || 0 if defined($score);
 	$self->{score};
 }
 

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1696,7 +1696,7 @@ sub cmp_list_compare {
 	#
 	#  Check for empty lists
 	#
-	if (scalar(@correct) == 0) { $ans->score($m == 0); return }
+	if (scalar(@correct) == 0) { $ans->score($m == 0 ? 1 : 0); return }
 
 	#
 	#  Loop through student answers looking for correct ones


### PR DESCRIPTION
  Somewhere in the Rendering.pm path, a boolean false score gets
  converted into an empty string, which can no longer be used in some
  numerical comparisons, as discussed in openwebwork/webwork2#2300.

  This fixes the case mentioned in the issue, and sets false values to 0
  when setting the score in the AnswerHash to catch other possible cases.

This is a hotfix of #992.