### PR TITLE
Fix a bug for custom GraphTool tools that derive from a built in tool.

### DIFF
--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -2080,7 +2080,7 @@ window.graphTool = (containerId, options) => {
 
 					handleKeyEvent(e) {
 						if ('handleKeyEvent' in toolObject) toolObject.handleKeyEvent.call(this, gt, e);
-						if (parentTool) super.handleKeyEvent();
+						if (parentTool) super.handleKeyEvent(e);
 					}
 
 					activate() {


### PR DESCRIPTION
The handleKeyEvent method needs to pass the event on to the super class in case the super class uses it (it usually will).

This does not affect any of the built in tools, so there is nothing to test for this pull request.  It is just the way it should be in case someone wants to use this as it was intended.