### PR TITLE
Add `strict` to modules shared to the PG safe zone in pg_config.dist.yml

### DIFF
--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -254,3 +254,4 @@ modules:
   - ['Rserve']
   - [DragNDrop]
   - ['Types::Serialiser']
+  - [strict]

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -128,7 +128,7 @@ BEGIN {
 
 			# The first item is the main package.
 			$module =~ s/\.pm$//;
-			eval "package Main; require $module; import $module;";
+			eval "package main; require $module; import $module;";
 			warn "Failed to evaluate module $module: $@" if $@;
 			push @$ra_included_modules, "\%${module}::";
 
@@ -194,7 +194,7 @@ sub evaluate_modules {
 		# Ensure that the name is in fact a base name.
 		s/\.pm$//;
 
-		eval "package Main; require $_; import $_";
+		eval "package main; require $_; import $_";
 		warn "Failed to evaluate module $_: $@" if $@;
 
 		# Record this in the appropriate place.


### PR DESCRIPTION
Versions of Perl prior to 5.34 need this.  Otherwise warnings are issue by the `BEGIN { strict->import }` approach now used in place of the old `BEGIN { be_strict() }` approach.

Note that this is not used by webwork2, but the standalone renderer will need this (if anyone runs that with an older perl version).  So the standalone renderer will also need to update its distributed pg_config.yml file.

Also change `Main` to `main` in the translator.  I can't resist fixing this any longer.  The proper namespace is `main`.  This is also used inconsistently in `Translator.pm`.  Other than these two instances `main` is used everywhere else.

This is related to (but not needed to fix) the issue brought up in https://github.com/openwebwork/pg/pull/968#issuecomment-1910760107.