### PR TITLE
handle nested braces in alignment specification

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1282,10 +1282,10 @@ sub ParseAlignment {
 	$alignment =~ s/\R//g;
 
 	# first we parse things like *{20}{...} to expand them
-	my $pattern = qr/\*\{(\d+)\}\{(.*?)\}/;
+	my $pattern = qr/\*\{(\d+)\}(\{((?:(?>[^\{\}]+)|(?2))*)\})/;
 	while ($alignment =~ /$pattern/) {
 		my @captured    = ($alignment =~ /$pattern/);
-		my $replaceWith = $captured[1] x $captured[0];
+		my $replaceWith = $captured[2] x $captured[0];
 		$alignment =~ s/$pattern/$replaceWith/;
 	}
 


### PR DESCRIPTION
This fixes a bug with niceTables. Without this commit, if you specify an alignment string like `*{3}{p{2in}}` somewhere in a niceTables table, it will break. The regex treats this: `{p{2in}` as a matched brace pair with `p{2in` as the contents.

This commit changes the regex to balance the braces.

Try this example:

```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl));
BEGIN_PGML
[# [. Cell .]  [. Cell .]  [. Cell .] #]*{align => '*{3}{p{2in}}'}
END_PGML
ENDDOCUMENT();
```
