### PR TITLE
constrain images to 100% width

### DIFF
--- a/htdocs/js/ImageView/imageview.scss
+++ b/htdocs/js/ImageView/imageview.scss
@@ -1,4 +1,6 @@
 .image-view-elt {
+	max-width: 100%;
+
 	&:hover {
 		cursor: pointer;
 	}


### PR DESCRIPTION
Consider this example problem:

```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl PGtikz.pl));

$image = createTikZImage();
$image->BEGIN_TIKZ
\fill[color=blue] (0,0) -| (1,1) -| cycle;
END_TIKZ

BEGIN_PGML
[#
    [. Text Cell .]
    [. [@image(insertGraph($image), width=>600)@]* .]*
#]{align => 'p{2.5in}p{2.5in}',}

END_PGML
ENDDOCUMENT();
```

The table tries to constrain the second column to be 2.5 in wide. But the image command wants to make the image 600px wide, more than 2.5in. The `600` wins, and the image is presented badly overflowing.

The author could reduce the `600`, but should they have to? Should they have to play with that number until the image just fits? Even if they cut the `width=>600` that still does leads to a default of `200` being used, which is not good either. I think the author should be able to declare the column to be 2.5in wide, and then pass the image a clearly larger size like `600` and it should just shrink down to fit.

So this PR adds inline styling to the `img` element, with `max-width:100%;`. Normally I would not want to use inline styling, but it seems appropriate here. The surrounding table certainly has inline styling for the "2.5in" width, so you'd want the cap on the image width to be styled inline as well. In case the overall HTML gets separated from the CSS files.

I cannot think of a situation where `max-width:100%;` would cause harm, but I'm aware that I could be overlooking something.