### PR TITLE
num and den methods for Fraction objects

### DIFF
--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -196,6 +196,10 @@ C<reduceFractions> is set to 0.  The C<reduce()> method will reduce a
 fraction to lowest terms, and the C<isReduced()> method returns true when
 the fraction is reduced and false otherwise.
 
+Fraction objects also have the C<num> and C<den> methods to return the
+numerator and denominator. Note that these will be the unreduced numerator
+and denominator when the C<reduceFractions> is set to 0.
+
 If you wish to convert a fraction to its numeric (real number) form,
 use the C<Real()> constructor to coerce it to a real.  E.g.,
 
@@ -907,6 +911,14 @@ sub isReduced {
 	my $self = shift;
 	my (($a, $b), ($c, $d)) = ($self->value, $self->reduce->value);
 	return $a == $c && $b == $d;
+}
+
+sub num {
+	return (shift->value)[0];
+}
+
+sub den {
+	return (shift->value)[1];
 }
 
 ##################################################


### PR DESCRIPTION
This adds `num` and `den` methods for a Fraction object as a slightly more convenient and much more readable way to access a fraction's parts compared with how I usually do it.

Ex:
```
Context("Fraction");
$f = Fraction(15,20);

TEXT("The denominator is ", $f->den, " and the numerator is ", "$f->num);
```