### PR TITLE
Fix an issue with the `student_ans` not being HTML escaped when errors occur.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -337,6 +337,8 @@ sub cmp_error {
 			. protectHTML(substr($string, $s, $e - $s))
 			. '</SPAN>'
 			. protectHTML(substr($string, $e));
+	} else {
+		$ans->{student_ans} = protectHTML($ans->{student_ans});
 	}
 	$self->cmp_Error($ans, $message);
 }


### PR DESCRIPTION
This addresses the issue found in #990.  This issue occurs at least as far back as PG 2.17 (but probably occured before that as well).

If an answer has an error that prevents it from being parsed into a MathObject value, and yet the error `pos` is not set, then the answer is not HTML escaped as it should be.  This can result in the answer in the "You Entered" feedback entry (or the old attempts table "Entered" column) not being displayed correctly.

You can test with the problem
```perl
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl');

Context('Matrix');
$v = Vector(1, 0, 0);

BEGIN_PGML
Enter the vector [`[$v]`]: [_]{$v}
END_PGML

ENDDOCUMENT();
```

If you enter the answer `<x(1,0),0,0>`, then on the develop branch the "You Entered" section of feedback will appear to be empty.  Using the element inspector of the developer tools you will see that it is there. With this pull request it will appear as it should.

Note that in the cases that the answer does parse into a MatHObject value or the error `pos` is set, then the answer is HTML escaped already.