### PR TITLE
add elementary, permutation, and zero matrix constructors

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -473,12 +473,14 @@ sub transpose {
 
 #
 #  Get an identity matrix of the requested size
+#  Value::Matrix->I(n)
+#  $A->I    # n is the number of rows of $A
 #
 sub I {
 	my $self    = shift;
 	my $d       = shift;
 	my $context = shift || $self->context;
-	$d = ($self->dimensions)[0] if !defined $d && ref($self) && $self->isSquare;
+	$d = ($self->dimensions)[0] if !defined $d && ref($self);
 	Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                 unless $d =~ m/^[1-9]\d*$/;
 	my @M    = ();
@@ -492,13 +494,20 @@ sub I {
 
 #
 #  Get an elementary matrix of the requested size and type
-#  E(n,[i,j])   nxn, swap rows i and j
-#  E(n,[i,j],k) nxn, replace row i with row i added to k times row j
-#  E(n,[i],k)   nxn, scale row i by k
+#  Value::Matrix->E(n,[i,j])   nxn, swap rows i and j
+#  Value::Matrix->E(n,[i,j],k) nxn, replace row i with row i added to k times row j
+#  Value::Matrix->E(n,[i],k)   nxn, scale row i by k
+#  $A->E([i,j])      # n is the number of rows of $A
+#  $A->E([i,j],k)    # n is the number of rows of $A
+#  $A->E([i],k)      # n is the number of rows of $A
 #
 sub E {
 	my ($self, $d, $rows, $k, $context) = @_;
-	$context = $self->context unless $context;
+	if (ref $d eq 'ARRAY') {
+		($rows, $k, $context) = ($d, $rows, $k);
+		$d = ($self->dimensions)[0] if ref($self);
+	}
+	$context = $self->context                                             unless $context;
 	Value::Error("You must provide a dimension for an Elementary matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                  unless $d =~ m/^[1-9]\d*$/;
 	my @ij = @{$rows};
@@ -534,9 +543,15 @@ sub E {
 #  Get a permutation matrix of the requested size
 #  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3i,
 #  and  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows of I_6
+#  Value::Matrix->P(n,(cycles))
+#  $A->P((cycles))     # n is the number of rows of $A
 #
 sub P {
 	my ($self, $d, @cycles) = @_;
+	if (ref $d eq 'ARRAY') {
+		unshift(@cycles, $d);
+		$d = ($self->dimensions)[0] if ref($self);
+	}
 	my $context = $self->context;
 	$d = ($self->dimensions)[0] if !defined $d && ref($self) && $self->isSquare;
 	Value::Error("You must provide a dimension for a Permutation matrix") unless defined $d;
@@ -571,6 +586,9 @@ sub P {
 
 #
 #  Get an all zero matrix of the requested size
+#  Value::Matrix->Zero(m,n)
+#  Value::Matrix->Zero(n)
+#  $A->Zero    # n is the number of rows of $A
 #
 sub Zero {
 	my ($self, $m, $n, $context) = @_;

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -482,13 +482,10 @@ sub I {
 	Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                 unless $d =~ m/^[1-9]\d*$/;
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
-		$row[$i] = 1;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	for my $i (0 .. $d - 1) {
+		push(@M, $self->make($context, map { $REAL->new(($_ == $i) ? 1 : 0) } 0 .. $d - 1));
 	}
 	return $self->make($context, @M);
 }
@@ -510,17 +507,16 @@ sub E {
 		"If only one row is specified for an Elementary matrix, then a number to scale by must also be specified")
 		if (@ij == 1 && !defined $k);
 	for (@ij) {
-		Value::Error("Row numbers must be integers between 1 and $d")
+		Value::Error("Row indices must be integers between 1 and $d")
 			unless ($_ =~ m/^[1-9]\d*$/ && $_ >= 1 && $_ <= $d);
 	}
 	@ij = map { $_ - 1 } (@ij);
 
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
+	for my $i (0 .. $d - 1) {
+		my @row = (0) x $d;
 		$row[$i] = 1;
 		if (@ij == 1) {
 			$row[$i] = $k if ($i == $ij[0]);
@@ -536,8 +532,8 @@ sub E {
 
 #
 #  Get a permutation matrix of the requested size
-#  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3
-#  And  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows if I_6
+#  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3i,
+#  and  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows of I_6
 #
 sub P {
 	my ($self, $d, @cycles) = @_;
@@ -555,19 +551,17 @@ sub P {
 		Value::Error("A permutation cycle should not repeat an index") unless (@$c == keys %cycle_hash);
 	}
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
-		$row[$i] = 1;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	# Make an identity matrix
+	for my $i (0 .. $d - 1) {
+		push(@M, $self->make($context, map { $REAL->new(($_ == $i) ? 1 : 0) } 0 .. $d - 1));
 	}
 
+	# Then apply the permutation cycles to it
 	for my $c (@cycles) {
-		my $n = @$c;
 		my $swap;
-		for my $i (0 .. $n - 1, 0) {
+		for my $i (0 .. $#$c, 0) {
 			($swap, $M[ $c->[$i] - 1 ]) = ($M[ $c->[$i] - 1 ], $swap);
 		}
 	}
@@ -587,12 +581,10 @@ sub Zero {
 	Value::Error("You must provide dimensions for the Zero matrix") unless defined $m          && defined $n;
 	Value::Error("Dimension must be a positive integer")            unless $m =~ m/^[1-9]\d*$/ && $n =~ m/^[1-9]\d*$/;
 	my @M    = ();
-	my @Z    = split('', 0 x $n);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $m - 1) {
-		my @row = @Z;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	for my $i (0 .. $m - 1) {
+		push(@M, $self->make($context, map { $REAL->new(0) } 0 .. $n - 1));
 	}
 	return $self->make($context, @M);
 }


### PR DESCRIPTION
The Matrix class already has an identity matrix constructor. For example: `Value:Matrix->I(4)`. Or if `$A` is already a 4x4 matrix, then `$A->I` will do the same.

This PR adds a few more constructors for special matrices, so you can just ask for them rather than have to build them element by element in a problem. I would like feedback on whether or not it is OK to put these directly into the Matrix class, instead of into some linear algebra macro file.

* Elementary scalar matrix:  `Value:Matrix->E(4, [2], 3)` makes a 4x4 matrix such that left multiplication with a 4xn matrix scales the 2nd row by 3.
* Elementary row swap matrix:  `Value:Matrix->E(4, [2,3])` makes a 4x4 matrix such that left multiplication with a 4xn matrix swaps the 2nd and third rows.
* Elementary row replacement matrix:  `Value:Matrix->E(4, [2,3], 5)` makes a 4x4 matrix such that left multiplication with a 4xn matrix replaces the 2nd row with the 2nd row added to 5 times the 3rd row.
* Permutation matrix: `Value:Matrix->P(4, [1,2,3])` makes a 4x4 matrix corresponding to the cycle (123).
* Permutation matrix: `Value:Matrix->P(4, [1,2,3], [1,4], ...)` makes a 4x4 matrix corresponding to the product of the given cycles.
* Zero matrix: `Value:Matrix->Zero(4, 5)` makes a 4x5 matrix of all zeros.
* Zero matrix: `Value:Matrix->Zero(4)` makes a 4x4 matrix of all zeros.


All of the constructors can be called as a method from an existing matrix like `$A`. However in most cases you still must supply all the arguments. The exception is with a zero matrix, where `$A->Zero` will give you a zero matrix with the same dimensions as `$A`.


