### PR TITLE
Update JSXGraph to version 1.7.0.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "jsxgraph": "^1.6.2",
+                "jsxgraph": "^1.7.0",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
                 "mathquill": "github:openwebwork/mathquill#WeBWorK-2.18",
@@ -734,9 +734,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/jsxgraph": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.6.2.tgz",
-            "integrity": "sha512-ufnzAjSOYojklySpTqq50lF5AJXqyyqxarFfSaO3GsrmgCBbtKSk9X9cJHIuPrAlVttjA6Iy0Cm5y8c+zO9CUw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.7.0.tgz",
+            "integrity": "sha512-Rzj7P3jmdXcefRoDpdOv54bA7WZ4co6x01NpWU5P1U33D28z1626zuLh1ZXh5nB7Fv6DCn4wT/yXrv3sreT4ww==",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -2151,9 +2151,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "jsxgraph": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.6.2.tgz",
-            "integrity": "sha512-ufnzAjSOYojklySpTqq50lF5AJXqyyqxarFfSaO3GsrmgCBbtKSk9X9cJHIuPrAlVttjA6Iy0Cm5y8c+zO9CUw=="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.7.0.tgz",
+            "integrity": "sha512-Rzj7P3jmdXcefRoDpdOv54bA7WZ4co6x01NpWU5P1U33D28z1626zuLh1ZXh5nB7Fv6DCn4wT/yXrv3sreT4ww=="
         },
         "jszip": {
             "version": "3.10.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -11,7 +11,7 @@
         "prepare": "npm run generate-assets"
     },
     "dependencies": {
-        "jsxgraph": "^1.6.2",
+        "jsxgraph": "^1.7.0",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",
         "mathquill": "github:openwebwork/mathquill#WeBWorK-2.18",


### PR DESCRIPTION
This fixes the issue observed in #1014.  Although there is another issue with a console.log statement that seems to have accidentally left in this JSXGraph release.  This console.log message occurs anytime the coordinate hints change.  So for problems that use the `showCoordinateHints => 0` option, this message doesn't appear!  This has been fixed in their main branch, so hopefully they release a patch fix soon that includes this fix. Hopefully before our next release.