### PR TITLE
reduction rule for m(nx)->(mn)x

### DIFF
--- a/lib/Parser/BOP.pm
+++ b/lib/Parser/BOP.pm
@@ -303,6 +303,32 @@ sub swapOps {
 }
 
 #
+#  Change an association "(a bop b) bop c" to "a bop (b bop c)" or vice versa
+#  argument $dir should be 'left' or 'right'
+#  'left'  for "a bop (b bop c)" to become "(a bop b) bop c"
+#  'right' for "(a bop b) bop c" to become "a bop (b bop c)"
+#  Assumes the calling entity verified it is appropriate to associate
+#
+sub associateOps {
+	my $self = shift;
+	my $dir  = shift;
+	if ($dir eq 'left') {
+		return $self->Item('BOP')->new(
+			$self->{equation}, $self->{bop},
+			$self->Item('BOP')->new($self->{equation}, $self->{bop}, $self->{lop}, $self->{rop}{lop})->reduce,
+			$self->{rop}{rop}
+		)->reduce;
+	} else {
+		return $self->Item('BOP')->new(
+			$self->{equation},
+			$self->{lop}{bop},
+			$self->{lop}{lop},
+			$self->Item('BOP')->new($self->{equation}, $self->{bop}, $self->{lop}{rop}, $self->{rop})
+		)->reduce;
+	}
+}
+
+#
 #  Get the variables from the two operands
 #
 sub getVariables {

--- a/lib/Parser/BOP/multiply.pm
+++ b/lib/Parser/BOP/multiply.pm
@@ -68,6 +68,21 @@ sub _reduce {
 	$self->swapOps
 		if (($self->{rop}->class eq 'Number' && $self->{lop}->class ne 'Number' && $reduce->{'x*n'})
 			|| ($self->{lop}->class eq 'Function' && $self->{rop}->class ne 'Function' && $reduce->{'fn*x'}));
+
+	if ($reduce->{'m*(n*x)'}
+		&& defined $self->{lop}
+		&& defined $self->{rop}{lop}
+		&& defined $self->{rop}{bop}
+		&& $self->{lop}->class eq 'Number'
+		&& $self->{rop}{lop}->class eq 'Number'
+		&& $self->{rop}{bop} eq '*')
+	{
+		my $m = $self->{lop};
+		$self->{lop} = $self->{rop}->copy;
+		$self->{lop}->swapOps;
+		$self->{lop}{lop} = $m;
+		$self->{rop} = $self->{rop}{rop};
+	}
 	return $self;
 }
 
@@ -78,14 +93,15 @@ sub makeNeg {
 	return $self;
 }
 
-$Parser::reduce->{'1*x'}    = 1;
-$Parser::reduce->{'x*1'}    = 1;
-$Parser::reduce->{'0*x'}    = 1;
-$Parser::reduce->{'x*0'}    = 1;
-$Parser::reduce->{'(-x)*y'} = 1;
-$Parser::reduce->{'x*(-y)'} = 1;
-$Parser::reduce->{'x*n'}    = 1;
-$Parser::reduce->{'fn*x'}   = 1;
+$Parser::reduce->{'1*x'}     = 1;
+$Parser::reduce->{'x*1'}     = 1;
+$Parser::reduce->{'0*x'}     = 1;
+$Parser::reduce->{'x*0'}     = 1;
+$Parser::reduce->{'(-x)*y'}  = 1;
+$Parser::reduce->{'x*(-y)'}  = 1;
+$Parser::reduce->{'x*n'}     = 1;
+$Parser::reduce->{'fn*x'}    = 1;
+$Parser::reduce->{'m*(n*x)'} = 1;
 
 sub string {
 	my ($self, $precedence, $showparens, $position, $outerRight) = @_;

--- a/lib/Parser/BOP/multiply.pm
+++ b/lib/Parser/BOP/multiply.pm
@@ -68,21 +68,11 @@ sub _reduce {
 	$self->swapOps
 		if (($self->{rop}->class eq 'Number' && $self->{lop}->class ne 'Number' && $reduce->{'x*n'})
 			|| ($self->{lop}->class eq 'Function' && $self->{rop}->class ne 'Function' && $reduce->{'fn*x'}));
-
-	if ($reduce->{'m*(n*x)'}
-		&& defined $self->{lop}
-		&& defined $self->{rop}{lop}
-		&& defined $self->{rop}{bop}
-		&& $self->{lop}->class eq 'Number'
-		&& $self->{rop}{lop}->class eq 'Number'
-		&& $self->{rop}{bop} eq '*')
-	{
-		my $m = $self->{lop};
-		$self->{lop} = $self->{rop}->copy;
-		$self->{lop}->swapOps;
-		$self->{lop}{lop} = $m;
-		$self->{rop} = $self->{rop}{rop};
-	}
+	$self = $self->associateOps('left')
+		if ($reduce->{'m*(n*x)'}
+			&& $self->{lop}->class eq 'Number'
+			&& $self->{rop}->isa('Parser::BOP::multiply')
+			&& $self->{rop}{lop}->class eq 'Number');
 	return $self;
 }
 


### PR DESCRIPTION
This adds a reduction rule `m*(n*x)` which will change things like `2*(3*expression)` to `(2*3)*expression`. I am not sure that this is the right way to do this, but it works with the testing I have done. 

I think this may address the issue that led to #887, but @drdrew42 should look at that. I think this may be the reduction rule that @dpvc mentioned there.

With:
```
$f = Formula('3x^2');
$df = $f->D->reduce;
$g = Formula('3*2^x');
$dg = $g->D->reduce;

BEGIN_PGML
[`[$df]`]

[`[$dg]`]
END_PGML
```

prior to this commit, you will see something like `3*2x` and `3*0.693147 2^x`. After this commit, you will see `6x` and `2.07944 2^x`.
