### PR TITLE
Matrix boolean

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -473,12 +473,14 @@ sub transpose {
 
 #
 #  Get an identity matrix of the requested size
+#  Value::Matrix->I(n)
+#  $A->I    # n is the number of rows of $A
 #
 sub I {
 	my $self    = shift;
 	my $d       = shift;
 	my $context = shift || $self->context;
-	$d = ($self->dimensions)[0] if !defined $d && ref($self) && $self->isSquare;
+	$d = ($self->dimensions)[0] if !defined $d && ref($self);
 	Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                 unless $d =~ m/^[1-9]\d*$/;
 	my @M    = ();
@@ -492,13 +494,20 @@ sub I {
 
 #
 #  Get an elementary matrix of the requested size and type
-#  E(n,[i,j])   nxn, swap rows i and j
-#  E(n,[i,j],k) nxn, replace row i with row i added to k times row j
-#  E(n,[i],k)   nxn, scale row i by k
+#  Value::Matrix->E(n,[i,j])   nxn, swap rows i and j
+#  Value::Matrix->E(n,[i,j],k) nxn, replace row i with row i added to k times row j
+#  Value::Matrix->E(n,[i],k)   nxn, scale row i by k
+#  $A->E([i,j])      # n is the number of rows of $A
+#  $A->E([i,j],k)    # n is the number of rows of $A
+#  $A->E([i],k)      # n is the number of rows of $A
 #
 sub E {
 	my ($self, $d, $rows, $k, $context) = @_;
-	$context = $self->context unless $context;
+	if (ref $d eq 'ARRAY') {
+		($rows, $k, $context) = ($d, $rows, $k);
+		$d = ($self->dimensions)[0] if ref($self);
+	}
+	$context = $self->context                                             unless $context;
 	Value::Error("You must provide a dimension for an Elementary matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                  unless $d =~ m/^[1-9]\d*$/;
 	my @ij = @{$rows};
@@ -534,9 +543,15 @@ sub E {
 #  Get a permutation matrix of the requested size
 #  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3i,
 #  and  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows of I_6
+#  Value::Matrix->P(n,(cycles))
+#  $A->P((cycles))     # n is the number of rows of $A
 #
 sub P {
 	my ($self, $d, @cycles) = @_;
+	if (ref $d eq 'ARRAY') {
+		unshift(@cycles, $d);
+		$d = ($self->dimensions)[0] if ref($self);
+	}
 	my $context = $self->context;
 	$d = ($self->dimensions)[0] if !defined $d && ref($self) && $self->isSquare;
 	Value::Error("You must provide a dimension for a Permutation matrix") unless defined $d;
@@ -571,6 +586,9 @@ sub P {
 
 #
 #  Get an all zero matrix of the requested size
+#  Value::Matrix->Zero(m,n)
+#  Value::Matrix->Zero(n)
+#  $A->Zero    # n is the number of rows of $A
 #
 sub Zero {
 	my ($self, $m, $n, $context) = @_;

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -482,13 +482,10 @@ sub I {
 	Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                 unless $d =~ m/^[1-9]\d*$/;
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
-		$row[$i] = 1;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	for my $i (0 .. $d - 1) {
+		push(@M, $self->make($context, map { $REAL->new(($_ == $i) ? 1 : 0) } 0 .. $d - 1));
 	}
 	return $self->make($context, @M);
 }
@@ -510,17 +507,16 @@ sub E {
 		"If only one row is specified for an Elementary matrix, then a number to scale by must also be specified")
 		if (@ij == 1 && !defined $k);
 	for (@ij) {
-		Value::Error("Row numbers must be integers between 1 and $d")
+		Value::Error("Row indices must be integers between 1 and $d")
 			unless ($_ =~ m/^[1-9]\d*$/ && $_ >= 1 && $_ <= $d);
 	}
 	@ij = map { $_ - 1 } (@ij);
 
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
+	for my $i (0 .. $d - 1) {
+		my @row = (0) x $d;
 		$row[$i] = 1;
 		if (@ij == 1) {
 			$row[$i] = $k if ($i == $ij[0]);
@@ -536,8 +532,8 @@ sub E {
 
 #
 #  Get a permutation matrix of the requested size
-#  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3
-#  And  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows if I_6
+#  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3i,
+#  and  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows of I_6
 #
 sub P {
 	my ($self, $d, @cycles) = @_;
@@ -555,19 +551,17 @@ sub P {
 		Value::Error("A permutation cycle should not repeat an index") unless (@$c == keys %cycle_hash);
 	}
 	my @M    = ();
-	my @Z    = split('', 0 x $d);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $d - 1) {
-		my @row = @Z;
-		$row[$i] = 1;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	# Make an identity matrix
+	for my $i (0 .. $d - 1) {
+		push(@M, $self->make($context, map { $REAL->new(($_ == $i) ? 1 : 0) } 0 .. $d - 1));
 	}
 
+	# Then apply the permutation cycles to it
 	for my $c (@cycles) {
-		my $n = @$c;
 		my $swap;
-		for my $i (0 .. $n - 1, 0) {
+		for my $i (0 .. $#$c, 0) {
 			($swap, $M[ $c->[$i] - 1 ]) = ($M[ $c->[$i] - 1 ], $swap);
 		}
 	}
@@ -587,12 +581,10 @@ sub Zero {
 	Value::Error("You must provide dimensions for the Zero matrix") unless defined $m          && defined $n;
 	Value::Error("Dimension must be a positive integer")            unless $m =~ m/^[1-9]\d*$/ && $n =~ m/^[1-9]\d*$/;
 	my @M    = ();
-	my @Z    = split('', 0 x $n);
 	my $REAL = $context->Package('Real');
 
-	foreach my $i (0 .. $m - 1) {
-		my @row = @Z;
-		push(@M, $self->make($context, map { $REAL->new($_) } @row));
+	for my $i (0 .. $m - 1) {
+		push(@M, $self->make($context, map { $REAL->new(0) } 0 .. $n - 1));
 	}
 	return $self->make($context, @M);
 }

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -301,7 +301,7 @@ sub isUpperTriangular {
 	return 1 if scalar(@d) == 1;
 	return 0 if scalar(@d) > 2;
 	for my $i (2 .. $d[0]) {
-		for my $j (1 .. min($i - 1, $d[1])) {
+		for my $j (1 .. ($i - 1 < $d[1] ? $i - 1 : $d[1])) {
 			return 0 unless $self->element($i, $j) == 0;
 		}
 	}

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -291,6 +291,119 @@ sub isZero {
 	return 1;
 }
 
+#
+#  See if the matrix is triangular, diagonal, symmetric, orthogonal
+#
+
+sub isUpperTriangular {
+	my $self = shift;
+	my @d    = $self->dimensions;
+	return 1 if scalar(@d) == 1;
+	return 0 if scalar(@d) > 2;
+	for my $i (2 .. $d[0]) {
+		for my $j (1 .. min($i - 1, $d[1])) {
+			return 0 unless $self->element($i, $j) == 0;
+		}
+	}
+	return 1;
+}
+
+sub isLowerTriangular {
+	my $self = shift;
+	my @d    = $self->dimensions;
+	if (scalar(@d) == 1) {
+		for ((@{ $self->{data} })[ 1 .. $#{ $self->{data} } ]) {
+			return 0 unless $_ == 0;
+		}
+	}
+	return 0 if scalar(@d) > 2;
+	for my $i (1 .. $d[0] - 1) {
+		for my $j ($i + 1 .. $d[1]) {
+			return 0 unless $self->element($i, $j) == 0;
+		}
+	}
+	return 1;
+}
+
+sub isDiagonal {
+	my $self = shift;
+	return $self->isSquare && $self->isUpperTriangular && $self->isLowerTriangular;
+}
+
+sub isSymmetric {
+	my $self = shift;
+	return 0 unless $self->isSquare;
+	my $d = ($self->dimensions)[0];
+	return 1 if $d == 1;
+	for my $i (1 .. $d - 1) {
+		for my $j ($i + 1 .. $d) {
+			return 0 unless $self->element($i, $j) == $self->element($j, $i);
+		}
+	}
+	return 1;
+}
+
+sub isOrthogonal {
+	my $self = shift;
+	return 0 unless $self->isSquare;
+	my @d = $self->dimensions;
+	if (scalar(@d) == 1) {
+		return 0 unless ($self->{data}->[0] == 1 || $self->{data}->[0] == -1);
+	}
+	my $M = $self * $self->transpose;
+	return $M->isOne;
+}
+
+#
+#  See if the matrix is in (reduced) row echelon form
+#
+
+sub isREF {
+	my $self = shift;
+	my @d    = $self->dimensions;
+	return 1 if scalar(@d) == 1;
+	return 0 if scalar(@d) > 2;
+	my $k = 0;
+	for my $i (1 .. $d[0]) {
+		for my $j (1 .. $d[1]) {
+			if ($j <= $k) {
+				return 0 unless $self->element($i, $j) == 0;
+			} elsif ($self->element($i, $j) != 0) {
+				$k = $j;
+				last;
+			} elsif ($j == $d[1]) {
+				$k = $d[1] + 1;
+			}
+		}
+	}
+	return 1;
+}
+
+sub isRREF {
+	my $self = shift;
+	my @d    = $self->dimensions;
+	return 1 if scalar(@d) == 1;
+	return 0 if scalar(@d) > 2;
+	my $k = 0;
+	for my $i (1 .. $d[0]) {
+		for my $j (1 .. $d[1]) {
+			if ($j <= $k) {
+				return 0 unless $self->element($i, $j) == 0;
+			} elsif ($self->element($i, $j) != 0) {
+				return 0 unless $self->element($i, $j) == 1;
+				for my $m (1 .. $i - 1) {
+					return 0 unless $self->element($m, $j) == 0;
+				}
+				$k = $j;
+				last;
+			} elsif ($j == $d[1]) {
+				$k = $d[1] + 1;
+			}
+		}
+	}
+	return 1;
+}
+
 sub _isNumber {
 	my $n = shift;
 	return Value::isNumber($n) || Value::classMatch($n, 'Fraction');


### PR DESCRIPTION
This builds on #1012, adding some boolean methods: `isUpperTriangular`, `isLowerTriangular`, `isDiagonal`, `isSymmetric`, `isREF`, `isRREF`, and `isOrthogonal`. In some places, the code could have been shorter and more elegant, but I tried to lean toward efficiency. For example, `isSymmetric` could have simply asked if `$self == $self->transpose`, but I suspect what is here is a little faster.

These will help with custom answer checkers in a linear algebra course. For example asking a student to orthogonally diagonalize a matrix. 