### PR TITLE
initial PGML version of niceTables

### DIFF
--- a/macros/ui/PGMLTables.pl
+++ b/macros/ui/PGMLTables.pl
@@ -1,0 +1,59 @@
+sub _PGMLTables_init {
+	main::PG_restricted_eval('sub PGMLTable { PGMLTables::PGMLTable(@_) }');
+}
+
+loadMacros('PGML.pl');
+
+package PGMLTables;
+
+sub wrapTeX { return '[`' . shift . '`]' }
+
+sub arrayString {
+	my $array = shift;
+	for (@$array) {s/'/\\'/g}
+	return "['" . join("','", @$array) . "']";
+}
+
+sub PGMLopts {
+	my $opts = shift;
+	for (keys %$opts) {
+		if (ref($opts->{$_}) eq 'ARRAY') {
+			$opts->{$_} = arrayString($opts->{$_});
+		} else {
+			$opts->{$_} =~ s/'/\\'/g;
+			$opts->{$_} = "'$opts->{$_}'";
+		}
+	}
+	return '{' . join(', ', map {"$_ => $opts->{$_}"} keys %$opts) . '}';
+}
+
+sub wrapCell {
+	my $cell = shift;
+	my $opts;
+	if (ref $cell eq 'ARRAY') {
+		my $data = shift @$cell;
+		$opts = {@$cell};
+		$cell = $data;
+	}
+	my $string = "[.$cell.]";
+	$string .= PGMLopts($opts) if $opts;
+	return $string;
+}
+
+sub convertRow {
+	my $row = shift;
+	return join('', map { wrapCell($_) } @$row) . '* ';
+}
+
+sub PGMLTable {
+	my $rows  = shift;
+	my %opts  = @_;
+	my $table = '[#' . join(' ', map { convertRow($_) } @$rows) . '#]';
+	if ($opts{layout}) {
+		$table .= '*';
+		delete $opts{layout};
+	}
+	$table .= PGMLopts(\%opts) if %opts;
+	return $table;
+}
+


### PR DESCRIPTION
With the recent updates to support tables natively in PGML (thanks @Alex-Jordan!), I'm finally able to get MultiAnswer PopUps going inside a table (e.g. columns in a truth table).

I wrote up some helper functions to take the (soon to be) old-school niceTable arguments and create a PGML table from them. This PR is the collection of those helper functions wrapped up into a single `PGMLTable()`object. 

I tested this code out on all of the examples from our niceTables documentation, and it's mostly successful. There are a few unsupported arguments (`tex` and `midrules`, I'm looking at you), which we might consider supporting in the PGML tables code?

A new option is added, `layout => 1` puts the table into LayoutTable spacing (the starred version of PGML tables).

This is just a draft PR for now, of course documentation is still needed here.