### PR TITLE
Close a feedback popover when escape is pressed.

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -18,6 +18,12 @@
 			});
 		}
 
+		const escapeClose = (e) => {
+			if (e.key === 'Escape') feedbackPopover.hide();
+		};
+
+		feedbackBtn.addEventListener('keydown', escapeClose);
+
 		feedbackBtn.addEventListener('shown.bs.popover', () => {
 			// Execute javascript in the answer preview.
 			feedbackPopover.tip?.querySelectorAll('script').forEach((origScript) => {
@@ -27,6 +33,8 @@
 				origScript.parentNode.replaceChild(newScript, origScript);
 				setTimeout(() => feedbackPopover.update());
 			});
+
+			feedbackPopover.tip?.addEventListener('keydown', escapeClose);
 
 			const moveToFront = () => {
 				if (feedbackPopover.tip) feedbackPopover.tip.style.zIndex = 18;


### PR DESCRIPTION
This only works if either the button or the popover is focused, and only closes that popover, not all popovers that are open on the page.  If the button or popover is not focused, then escape will not close it.

This is to address https://github.com/openwebwork/webwork2/issues/2362 (which was closed). This is a variant of what I think was desired in that issue that I think I could tolerate.  I don't want a global key handler for the page that closes all popovers when escape is pressed. There are several issues with global key handlers like that.  They can interfere with other things on the page for one thing. They often end up resulting in unintended consequenses.