### PR TITLE
Accessibility tweak for the MathQuill toolbar.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -332,10 +332,11 @@
 				button.classList.add('symbol-button', 'btn', 'btn-dark');
 				button.dataset.latex = buttonData.latex;
 				button.dataset.bsToggle = 'tooltip';
-				button.dataset.bsTitle = buttonData.tooltip;
+				button.title = buttonData.tooltip;
 				const icon = document.createElement('span');
 				icon.id = `icon-${buttonData.id}-${answerQuill.id}`;
 				icon.textContent = buttonData.icon;
+				icon.setAttribute('aria-hidden', 'true');
 				button.append(icon);
 				answerQuill.toolbar.append(button);
 

--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -342,13 +342,7 @@
 
 				MQ.StaticMath(icon, { mouseEvents: false });
 
-				answerQuill.toolbar.tooltips.push(
-					new bootstrap.Tooltip(button, {
-						placement: 'left',
-						trigger: 'hover',
-						delay: { show: 500, hide: 0 }
-					})
-				);
+				answerQuill.toolbar.tooltips.push(new bootstrap.Tooltip(button, { placement: 'left' }));
 
 				button.addEventListener('click', () => {
 					answerQuill.mathField.cmd(button.dataset.latex);


### PR DESCRIPTION
This adds the `aria-hidden` attribute to the span containing the static MathQuill element in the toolbar buttons, and changes the `data-bs-title` attribute of the button itself to a `title`. I don't know if the latter change makes much difference since bootstrap will move the title from the button to the tooltip in any case.  But adding `aria-hidden` will prevent the contents of the span from being read by screen readers.  The title of the tooltip or button should be read instead.

Maybe this will work to address https://github.com/openwebwork/mathquill/issues/24?