### PR TITLE
Add a PGML tag block.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1658,6 +1658,15 @@ sub Tag {
 		PGML::Warning qq{The tag "$tag" is not allowed};
 		return $self->string($item);
 	}
+	if ($tag eq 'span') {
+		for my $subblock (@{ $item->{stack} }) {
+			if ($subblock->{type} =~ /^(indent|align|par|list|bullet|answer|heading|rule|code|pre|verbatim|table|tag)$/)
+			{
+				PGML::Warning qq{A "span" tag may not contain a $subblock->{type}};
+				return $self->string($item);
+			}
+		}
+	}
 	return main::tag($tag, @attributes, $self->string($item));
 }
 

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1652,7 +1652,7 @@ sub Math {
 
 sub Tag {
 	my ($self, $item) = @_;
-	my %whitelist  = (a => 1, div => 1, span => 1);
+	my %whitelist  = (div => 1, span => 1);
 	my @attributes = ref($item->{html}) eq 'ARRAY' ? @{ $item->{html} }           : $item->{html};
 	my $tag        = @attributes % 2               ? (shift @attributes // 'div') : 'div';
 	unless ($whitelist{$tag}) {

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -692,7 +692,6 @@ my $balanceAll = qr/[\{\[\'\"]/;
 	"[<" => {
 		type        => 'tag',
 		parseAll    => 1,
-		allowPar    => 1,
 		isContainer => 1,
 		terminator  => qr/>\]/,
 		options     => [qw(html tex ptx)]


### PR DESCRIPTION
The syntax for a tag block is

```
[^ contents ^]{
    tag => 'tag name',
    attributes => { class => 'my-class', ... },
    tex_begin => 'tex start code',
    tex_end => 'tex end code'
}
```

or equivalently

`[^ contents ^]{'tag name'}{{ class => 'my-class', ... }}{'tex start code'}{'tex end code'}`

using the short form for passing options.

All of the options are optional (with the tag name defaulting to a 'div').  So you can do `[^ hello ^]`, and that will render a `div` whose contents are "hello".  The `attibutes` option should be a reference to a hash containing any HTML attributes you want the tag to have.

The contents of a tag are PGML.  So you can do

```
[^
    [#
        [. [`x`] .] [. [`y`] .]*
        [. [^ [`1`] ^]{'span'}{{ style => 'color:blue' }} .] [. [`2`] .]*
    #]
^]
```

The above example also shows that a tag can be used in the cell of a niceTable.

Note that tag blocks can also contain other tag blocks.

The `tex_begin` and `tex_end` options are only used when the displayMode
is "TeX".   The content will be wrapped in the values of those options
in that case.  For example,

```
[^ My blue equation is [`x + y = 3`] ^]{'div'}{{ style => 'color:blue' }}{'\color{blue}'}
```

Note that when displayMode is "TeX", the contents (including the values of `tex_begin` and `tex_end`) are always wrapped in grouping braces.  So you don't have to provide grouping (as would be needed for the color statement in the above example or any content after it would also be blue).

Note that the quotes on the tag name, tex_begin, and tex_end options are needed.

One of the main reasons for this new PGML block is to provide an easier way for a problem author to specify where the feedback for a MultiAnswer object with singleResult set should go.  This is demonstrated in the following example:

```
DOCUMENT();
loadMacros('PGstandard.pl', 'PGML.pl', 'parserMultiAnswer.pl');

$multians = MultiAnswer(1, 4, 9)->with(
    singleResult => 1,
    checker      => sub {
        my ($correct, $student, $self, $ans) = @_;
        my $score = 0;
        for (0 .. $#$student) {
            $score += 1 if $correct->[$_] == $student->[$_];
        }
        return $score / @$correct;
    }
);

BEGIN_PGML
[^
    [#
        [. [`x`] .] [. [`x^2`] .]*{ headerrow => 1 }
        [. [`1`] .] [. [_]{$multians} .]*
        [. [`2`] .] [. [_]{$multians} .]*
        [. [`3`] .] [. [_]{$multians} .]
    #]{ valign => 'middle', padding => [ 0.5, 0.5 ] }
^]{'div'}{{ class => 'mx-auto ww-feedback-container ww-fb-align-middle' }}
END_PGML

ENDDOCUMENT();
```

Note that currently the contents of a tag block are rendered as if the tag block was not there for the "PTX" displayMode.