### PR TITLE
for PTX output, skip help links

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2429,7 +2429,9 @@ sub knowlLink {
 	MODES(
 		TeX  => "{\\bf \\underline{$display_text}}",
 		HTML => qq!<a href="#" class="knowl" $properties>$display_text</a>!,
-		PTX  => '<url ' . ($options{url} ? 'href="' . $options{url} . '"' : '') . ' >' . $display_text . '</url>',
+		PTX  => ($options{type} eq 'help')
+		? ''
+		: '<url ' . ($options{url} ? 'href="' . $options{url} . '"' : '') . ' >' . $display_text . '</url>',
 	);
 }
 


### PR DESCRIPTION
The help links (from AnswerFormatHelp.pl) should be omitted from PTX output. That output is meant to be used in static (non-interactive) contexts like PDF or a preview of the exercise before the reader reaches the interactive HTML version. Giving the reader help on input syntax in that context is unnecessary and distracting.

So this change skips over such links for PTX output.

Perhaps the same should be done for TeX? I am fine only doing this for PTX though.