### PR TITLE
tweaks affecting problems rendered in an iframe with iFrameResizer

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -44,6 +44,8 @@
 				?.querySelector('.popover-header')
 				?.addEventListener('click', () => feedbackPopover.hide());
 
+			if (feedbackPopover.tip) feedbackPopover.tip.dataset.iframeHeight = '1';
+
 			const revealCorrectBtn = feedbackPopover.tip?.querySelector('.reveal-correct-btn');
 			if (revealCorrectBtn && feedbackPopover.correctRevealed) {
 				revealCorrectBtn.nextElementSibling?.classList.remove('d-none');

--- a/htdocs/js/MathQuill/mqeditor.scss
+++ b/htdocs/js/MathQuill/mqeditor.scss
@@ -112,7 +112,9 @@ input[type='text'].codeshard.mq-edit {
 	/*rtl:ignore*/
 	right: 10px;
 	z-index: 1001;
+	overflow-x: hidden;
 	overflow-y: auto;
+	scrollbar-width: thin;
 	opacity: 1;
 	transition: opacity 500ms ease;
 


### PR DESCRIPTION
This pairs with a PR to `webwork2`:  https://github.com/openwebwork/webwork2/pull/2378. This affects how problems behave when they are in an iframe that uses iFrameResizer. With this PR and the one in `webwork2`, the feedback popover should trigger the iframe resizing, but the MathQuill editor should not. And the MQ editor should never have a horizontal scrollbar. And when there is a vertical scrollbar, it should not obscure the buttons too much.