### PR TITLE
Fix the translator content post processing for the PTX display mode.

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1209,8 +1209,8 @@ sub post_process_content {
 		warn "ERRORS from post processing PG text:\n$@\n" if $@;
 	} else {
 		$self->{safe}->share_from('main', [qw(%Mojo::Base:: %Mojo::Collection:: %Mojo::DOM::)]);
-		our $problemDOM = Mojo::DOM->new(${ $self->{PG_PROBLEM_TEXT_REF} });
-		$problemDOM->xml(1) if $self->{rh_pgcore}{displayMode} eq 'PTX';
+		our $problemDOM =
+			Mojo::DOM->new->xml($self->{rh_pgcore}{displayMode} eq 'PTX')->parse(${ $self->{PG_PROBLEM_TEXT_REF} });
 		our $pageHeader = Mojo::DOM->new(${ $self->{PG_HEADER_TEXT_REF} });
 		$self->{safe}->share('$problemDOM', '$pageHeader');
 		$self->{safe}->reval('for (@{ $main::PG->{content_post_processors} }) { $_->($problemDOM, $pageHeader); }', 1);


### PR DESCRIPTION
The `XML` semantics option needs to be activated before the problem text is parsed.

This fixes issue #1048.