### PR TITLE
don't remove excess whitespace from student answers

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -301,14 +301,13 @@ sub NAMED_ANS_RULE {
 		$rh_sticky_answers->{$name} = \@answers;                # Store the rest.
 	}
 
-	$answer_value =~ s/\s+/ /g;                                 # Remove excessive whitespace from student answer.
 	$name = RECORD_ANS_NAME($name, $answer_value);
 	my $previous_name = "previous_$name";
 	$name          = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%$name"          : $name;
 	$previous_name = ($envir{use_opaque_prefix}) ? "%%IDPREFIX%%$previous_name" : $previous_name;
 
-	my $tcol = $col / 2 > 3 ? $col / 2 : 3;                     # get max
-	$tcol = $tcol < 40 ? $tcol : 40;                            # get min
+	my $tcol = $col / 2 > 3 ? $col / 2 : 3;    # get max
+	$tcol = $tcol < 40 ? $tcol : 40;           # get min
 
 	return MODES(
 		TeX => "{\\answerRule[$name]{$tcol}}",


### PR DESCRIPTION
This is motivated by a problem I had for a linear algebra course, where students encrypt a short message. The alphabet in play included a space character. One student's code word (the answer they needed to enter) had space characters that were getting trimmed because of the line here. I can't recall if it was because their answer started with a space or had two consecutive spaces inside.

I can't think of a bad side effect from removing this, although it is possible somewhere something assumes that excess white space has already been removed.