### PR TITLE
add an alternative 'such that' pipe

### DIFF
--- a/macros/contexts/contextInequalitySetBuilder.pl
+++ b/macros/contexts/contextInequalitySetBuilder.pl
@@ -155,7 +155,8 @@ sub UseVerticalSuchThat {
 				type          => "bin",
 				string        => " | ",
 				TeX           => ' \mid ',
-				class         => "InequalitySetBuilder::BOP::suchthat"
+				class         => "InequalitySetBuilder::BOP::suchthat",
+				alternatives  => ["\x{2223}"]
 			},
 			"_suchthat" => { alias => "|", hidden => 1 },
 		);


### PR DESCRIPTION
This is pretty niche, but a student managed to copy-paste a special unicode vertical "such that" character from somewhere when entering an answer like `{x | x < 1}`. So this adds that character to be recognized as an alternative to the keyboard pipe character. Only in the `InequalitySetBuilder` context when `UseVerticalSuchThat` (as opposed to a colon) is in use.