### PR TITLE
Fix a possible undefined value used in string comparison.

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2429,7 +2429,7 @@ sub knowlLink {
 	MODES(
 		TeX  => "{\\bf \\underline{$display_text}}",
 		HTML => qq!<a href="#" class="knowl" $properties>$display_text</a>!,
-		PTX  => ($options{type} eq 'help')
+		PTX  => ($options{type} && $options{type} eq 'help')
 		? ''
 		: '<url ' . ($options{url} ? 'href="' . $options{url} . '"' : '') . ' >' . $display_text . '</url>',
 	);


### PR DESCRIPTION
This was missed in #1044.  The knowLink type option may not be defined. In fact it is only defined for solutions, hints, and helpLinks. The knowlLink method can be called directly, and may not have the type defined.  This causes a warning (even if the display mode is not PTX).