### PR TITLE
Don't wrap the TeX for a PGML tag block in braces.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1822,7 +1822,7 @@ sub Tag {
 	} elsif ($item->{tex}) {
 		($tex_begin, $tex_end) = ("\\begin{$item->{tex}}", "\\end{$item->{tex}}");
 	}
-	return '{' . ($tex_begin // '') . $self->string($item) . ($tex_end // '') . '}';
+	return ($tex_begin // '') . $self->string($item) . ($tex_end // '');
 }
 
 ######################################################################


### PR DESCRIPTION
It turns out this can be quite limiting.  For example, I was trying to used a `tabbing` environment, and the rows in that environment being wrapped in braces won't work.  So if braces are needed, the author must add them.