### PR TITLE
set iframeHeight on graphTool popover for iframeResizer

### DIFF
--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -2539,6 +2539,7 @@ window.graphTool = (containerId, options) => {
 		if (!gt.helpEnabled) gt.messageBox.classList.add('gt-disabled-help');
 		gt.messageBox.setAttribute('role', 'region');
 		gt.messageBox.setAttribute('aria-live', 'polite');
+		gt.messageBox.dataset.iframeHeight = '1';
 		gt.graphContainer.append(gt.messageBox);
 		gt.messageBox.addEventListener('keydown', (e) => {
 			if (e.key === 'Escape') gt.confirm.dispose?.(e);


### PR DESCRIPTION
A graphTool help popover might extend low and iframeResizer does not adjust. This fixes that.

Before, except without the "Lorem ipsum".

<img width="574" alt="Screenshot 2024-04-13 at 8 50 11 AM" src="https://github.com/openwebwork/pg/assets/4732672/62bb69ff-f701-49a6-978c-2596aca3a385">

After, except without the "Lorem ipsum".

<img width="560" alt="Screenshot 2024-04-13 at 8 54 08 AM" src="https://github.com/openwebwork/pg/assets/4732672/77b06dc7-8b51-45d6-8f92-14e902908c0b">

The help popover texts are not all that long, and this is probably not an issue for regular WW use (in the limited places where an iframe is in play). But I noticed it in PTX output where the regular buttons below the problem are not within the iframe, so the bottom edge of the iframe can be much closer to the graph. Perhaps with the numberline help, since iirc that can be long. But I did not look at that.
