### PR TITLE
Add a special case to feedback to show correct answers only.

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -40,9 +40,7 @@
 			moveToFront();
 
 			// Make a click on the popover header close the popover.
-			feedbackPopover.tip
-				?.querySelector('.popover-header .btn-close')
-				?.addEventListener('click', () => feedbackPopover.hide());
+			feedbackPopover.tip?.querySelector('.btn-close')?.addEventListener('click', () => feedbackPopover.hide());
 
 			if (feedbackPopover.tip) feedbackPopover.tip.dataset.iframeHeight = '1';
 
@@ -68,6 +66,13 @@
 				});
 			}
 		});
+
+		if (feedbackBtn.dataset.showCorrectOnly) {
+			setTimeout(() => {
+				feedbackBtn.click();
+				setTimeout(() => feedbackPopover.update(), 100);
+			}, 0);
+		}
 	};
 
 	// Setup feedback popovers already on the page.

--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -224,7 +224,6 @@
 	--bs-popover-max-width: 600px;
 	--bs-popover-zindex: 17;
 	position: absolute;
-	min-width: 200px;
 
 	.popover-header {
 		text-align: center;
@@ -260,11 +259,29 @@
 		}
 	}
 
+	&:not(.correct-only) {
+		min-width: 200px;
+
+		.popover-body {
+			.card {
+				border-top-left-radius: 0;
+				border-top-right-radius: 0;
+				--bs-card-spacer-y: 0.5rem;
+			}
+		}
+	}
+
+	&.correct-only {
+		.popover-body {
+			.card {
+				--bs-card-spacer-x: 0.25rem;
+				--bs-card-spacer-y: 0.25rem;
+			}
+		}
+	}
+
 	.popover-body {
 		.card {
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-			--bs-card-spacer-y: 0.5rem;
 			--bs-card-cap-bg: #ddd;
 
 			.card-header {

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -487,7 +487,8 @@ the value of this option.
 
 =item showAttemptAnswers (boolean, default: 1)
 
-Determines if the student's evaluated (i.e. "Entered") answers will be shown in feedback.
+Determines if the student's evaluated (i.e. "Entered") answers will be shown in
+feedback.
 
 =item showAttemptPreviews (boolean, default: 1)
 
@@ -519,6 +520,13 @@ Determines if correct answers will be shown. If 0, then correct answers are not
 shown. If set to 1, then correct answers are shown but hidden, and a "Reveal"
 button is shown at first. If that button is clicked, then the answer is shown.
 If set to 2, then correct answers are shown immediately.
+
+There is one special case that needs extra explanation.  If this is true
+(greater than zero), C<forceShowAttemptResults> is true, C<forceScaffoldsOpen>
+is true, and C<showAttemptAnswers>, C<showAttemptPreviews>, and C<showMessages>
+are all false, then correct answers will be shown with no other content in the
+feedback popover except a close button, and the popover will open automatically
+on page load.
 
 =item answerPrefix (string, default: '')
 

--- a/macros/core/PGessaymacros.pl
+++ b/macros/core/PGessaymacros.pl
@@ -61,6 +61,7 @@ sub essay_cmp {
 			$options->{manuallyGraded} = 1;
 
 			if ($envir{needs_grading}
+				|| !defined $ansHash->{ans_label}
 				|| !defined $inputs_ref->{"previous_$ansHash->{ans_label}"}
 				|| $inputs_ref->{ $ansHash->{ans_label} } ne $inputs_ref->{"previous_$ansHash->{ans_label}"})
 			{


### PR DESCRIPTION
If the translation options `showCorrectAnswers`,
`forceShowAttemptResults`, and `forceScaffoldsOpen` are all true, and the options `showAttemptAnswers`, `showAttemptPreviews`, and `showMessages` are all false, then correct answers will be shown with no other content in the feedback popover except a close button. Furthermore the popover will open automatically on page load. Obviously scaffold will all be open (since the `forceScaffoldsOpen` option is true).  Otherwise there would be a problem with popovers opening immediately from inside a closed scaffold.

A corresponding pull request to webwork2 will utilize this.

This is a potential approach to resolve #1047.