### PR TITLE
adjust by larger amount in 'digits' comparisons

### DIFF
--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -147,22 +147,23 @@ sub compare {
 			my $digits      = (1 > int($tolerance) ? 1 : int($tolerance + 0.5)) - 1;
 			my $extraDigits = int($self->getFlag('tolExtraDigits'));
 			my $tdigits     = (0 < $extraDigits ? $extraDigits + $digits : $digits);
-			my $exp         = substr(sprintf("%E", $b), -3) - 15;    # Adjust $a by an amount in the round-off error
-			$a += ($a <=> 0) * "1E$exp";                             #   range so that it rounds better in sprintf
-			$b += ($b <=> 0) * "1E$exp";                             # Same for $b
-			my $bd = sprintf("%.${tdigits}E", $b);                   # Round $b to the number of tdigits
-			$bd =~ s/^.*\.(.*?)0*E.*$/$1/;                           # Get the decimal part without trailing zeros
-			my $bn = CORE::length($bd);                              # Number of those decimal digits
-			$bn = $digits if ($bn < $digits);                        #  (with a minimum of $digits);
-			my $aE = sprintf("%.${bn}E", $a);                        # Round $a to $bn digits
-			my $bE = sprintf("%.${bn}E", $b);                        # Round $b to $bn digits
-			return 0 if $aE eq $bE;                                  # Return equal if they are
+			# Adjust $a by an amount in the round-off error range so that it rounds better in sprintf
+			my $exp = substr(sprintf("%E", $b), -3) + substr(sprintf("%E", $zeroLevel), -3);
+			$a += ($a <=> 0) * "1E$exp";
+			$b += ($b <=> 0) * "1E$exp";              # Same for $b
+			my $bd = sprintf("%.${tdigits}E", $b);    # Round $b to the number of tdigits
+			$bd =~ s/^.*\.(.*?)0*E.*$/$1/;            # Get the decimal part without trailing zeros
+			my $bn = CORE::length($bd);               # Number of those decimal digits
+			$bn = $digits if ($bn < $digits);         #  (with a minimum of $digits);
+			my $aE = sprintf("%.${bn}E", $a);         # Round $a to $bn digits
+			my $bE = sprintf("%.${bn}E", $b);         # Round $b to $bn digits
+			return 0 if $aE eq $bE;                   # Return equal if they are
 
-			if ($self->getFlag('tolTruncation')) {                   # If truncation is allowed
-				$aE = sprintf("%.15E", $a);                          #   Get $a to full resolution
+			if ($self->getFlag('tolTruncation')) {    # If truncation is allowed
+				$aE = sprintf("%.15E", $a);           #   Get $a to full resolution
 				$aE =~ s/\.(\d{$bn}).*E/.$1E/;
-				$aE =~ s/\.E/E/;                                     #   Truncate it to the required number of digits
-				return 0 if $aE eq $bE;                              #   Return equal if they are
+				$aE =~ s/\.E/E/;                      #   Truncate it to the required number of digits
+				return 0 if $aE eq $bE;               #   Return equal if they are
 			}    #
 			return $a <=> $b;    # Otherwise compare numbers as perl reals
 		}


### PR DESCRIPTION
In `develop` (or `2.18`) try the following:

```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl));

Context("Numeric")->flags->set(tolType => 'digits');
$a = Real("500*(1+13/100)^2");

BEGIN_PGML
[`[$a]={}`] [_]{$a}
END_PGML

ENDDOCUMENT();
```

It will show you `638.45`, but will not accept `638.45` as correct.

The actual value of `$a` is a bit smaller due to machine rounding error. I believe what is happening is that `13/100` introduces rounding error. If that were all, then I think there would not be a problem. The code in `lib/Value/Real.pm` starting at line 150 gets around small rounding errors. But I believe that the squaring in this expression compounds the error enough so that those lines of code are no longer enough.

This change ties the approach to machine rounding issues to the value of the `zeroLevel` flag. With the default for that, this changes the `15` to `14`, making a larger bump at the new lines 152/153.

@dpvc, if you have time to think about this, does this seem like an OK solution?

Another approach I was thinking about was that for `digits`, that instead of comparing using a MathObject's value, use its string. Apply the same basic logic, but use whatever the context wants the string to look like as the basis for comparison. Then at least in the situation like this example, you would not have PG telling you the answer is `638.45`, but refusing to accept `638.45` as correct.