### PR TITLE
Add the `a` trig functions to the mqeditor autoCommands.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -47,7 +47,9 @@
 			sumStartsWithNEquals: true,
 			supSubsRequireOperand: true,
 			autoCommands: ['pi', 'sqrt', 'root', 'vert', 'inf', 'union', 'abs', 'deg', 'AA', 'angstrom', 'ln', 'log']
-				.concat(['sin', 'cos', 'tan', 'sec', 'csc', 'cot'].reduce((a, t) => a.concat([t, `arc${t}`]), []))
+				.concat(
+					['sin', 'cos', 'tan', 'sec', 'csc', 'cot'].reduce((a, t) => a.concat([t, `arc${t}`, `a${t}`]), [])
+				)
 				.join(' '),
 			rootsAreExponents: true,
 			logsChangeBase: true,

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -804,8 +804,7 @@
 		},
 		"node_modules/mathquill": {
 			"version": "0.10.1",
-			"resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
-			"license": "MPL-2.0"
+			"resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#6ef3e23833194c47d7a521c39b44d1f02327d50f"
 		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
@@ -2238,7 +2237,7 @@
 			"dev": true
 		},
 		"mathquill": {
-			"version": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
+			"version": "git+ssh://git@github.com/openwebwork/mathquill.git#6ef3e23833194c47d7a521c39b44d1f02327d50f",
 			"from": "mathquill@github:openwebwork/mathquill#WeBWorK-2.19"
 		},
 		"mdn-data": {


### PR DESCRIPTION
This depends on https://github.com/openwebwork/mathquill/pull/29.  This temporarily has switched the version of MathQuill in the package.json file to the branch for that pull request.  That is why this is being created as a draft pull request and should not be merged until that is removed.  This is for ease of testing.  When you run `npm ci` it will install the MathQuill from that branch.