### PR TITLE
Add previous answers to MathQuill inputs on the next tick.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -533,7 +533,7 @@
 			answerQuill.mathField.latex(answerQuill.latexInput.value);
 			answerQuill.mathField.moveToLeftEnd();
 			answerQuill.mathField.blur();
-		}, 0);
+		}, 100);
 	};
 
 	// Set up MathQuill inputs that are already in the page.

--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -529,9 +529,11 @@
 		};
 		answerQuill.addEventListener('keydown', answerQuill.keydownHandler);
 
-		answerQuill.mathField.latex(answerQuill.latexInput.value);
-		answerQuill.mathField.moveToLeftEnd();
-		answerQuill.mathField.blur();
+		setTimeout(() => {
+			answerQuill.mathField.latex(answerQuill.latexInput.value);
+			answerQuill.mathField.moveToLeftEnd();
+			answerQuill.mathField.blur();
+		}, 0);
 	};
 
 	// Set up MathQuill inputs that are already in the page.


### PR DESCRIPTION
This fixes https://github.com/openwebwork/mathquill/issues/30. Although, I am not sure what is going on here.    For some reason delaying filling in previous answers until the "next tick" (a timeout with 0 delay) fixes the problem.  Probably the MathQuill math field is not fully initialized until after the mqeditor setup method completes.

I am unable to reproduce the issue using the development build of MathQuill directly via `npm run serve`.