### PR TITLE
On Ubuntu 24.04 the direct GD::gdGiantFont usage causes errors.

### DIFF
--- a/macros/graph/PGstatisticsGraphMacros.pl
+++ b/macros/graph/PGstatisticsGraphMacros.pl
@@ -224,8 +224,7 @@ sub add_boxplot {
 
 	# No go through and add the labels.
 	while ($currentPlot > 0) {
-		my $label = new Label($xmin, $currentPlot - 0.5, $currentPlot, 'black', 'left');
-		$label->font(GD::gdGiantFont);
+		my $label = new Label($xmin, $currentPlot - 0.5, $currentPlot, 'black', 'left', 'giant');
 		$graphRef->lb($label);
 		$currentPlot--;
 	}
@@ -331,8 +330,7 @@ sub add_histogram {
 	# Go through and add the labels on the left part of the graph
 	# No go through and add the labels.
 	while ($currentPlot > 0) {
-		my $label = new Label($xmin, $currentPlot - 0.5, $currentPlot, 'black', 'left');
-		$label->font(GD::gdGiantFont);
+		my $label = new Label($xmin, $currentPlot - 0.5, $currentPlot, 'black', 'left', 'giant');
 		$graphRef->lb($label);
 		$currentPlot--;
 	}


### PR DESCRIPTION
This causes errors when running the unit tests. Eventually, we will switch the unit test workflow to Ubuntu 24.04, and then this will be a problem.  Since the `Label` package provides a way to set this font, this is the way it should be done anyway.