### PR TITLE
Switch the default svg method to dvisvgm.

### DIFF
--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -110,7 +110,7 @@ specialPGEnvironmentVars:
 
   # Binary that the PGtikz.pl and PGlateximage.pl macros will use to create svg images.
   # This should be either 'pdf2svg' or 'dvisvgm'.
-  latexImageSVGMethod: pdf2svg
+  latexImageSVGMethod: dvisvgm
 
   # When ImageMagick is used for image conversions, this sets the default options.
   # See https://imagemagick.org/script/convert.php for a full list of options.

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -41,7 +41,7 @@ sub new {
 		texPackages    => [],
 		addToPreamble  => '',
 		ext            => 'svg',
-		svgMethod      => 'pdf2svg',
+		svgMethod      => 'dvisvgm',
 		convertOptions => { input => {}, output => {} },
 		imageName      => ''
 	};


### PR DESCRIPTION
This corresponds to the similar change in webwork2.  Note that this is not used by webwork2 though.