### PR TITLE
Update the package-lock.json to point to the latest MathQuill commit.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -804,8 +804,7 @@
 		},
 		"node_modules/mathquill": {
 			"version": "0.10.1",
-			"resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
-			"license": "MPL-2.0"
+			"resolved": "git+ssh://git@github.com/openwebwork/mathquill.git#1e8607024f4d817263f58974eba566d5a93f01e4"
 		},
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
@@ -2238,7 +2237,7 @@
 			"dev": true
 		},
 		"mathquill": {
-			"version": "git+ssh://git@github.com/openwebwork/mathquill.git#ebd17ed4b3de1ec79a3dd866cb9b2691d19e1dbc",
+			"version": "git+ssh://git@github.com/openwebwork/mathquill.git#1e8607024f4d817263f58974eba566d5a93f01e4",
 			"from": "mathquill@github:openwebwork/mathquill#WeBWorK-2.19"
 		},
 		"mdn-data": {


### PR DESCRIPTION
Pull request https://github.com/openwebwork/mathquill/pull/28 was merged into MathQuill.  That commit is now tagged for WeBWorK-2.19.  So if you run `npm install` it will install that commit.  However, if you run `npm ci` it will get the commit before it because that is what is in the package-lock.json file.