### PR TITLE
Switch the default latex variant to xelatex.

### DIFF
--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -86,7 +86,7 @@ externalPrograms:
   curl: /usr/bin/curl
   tar: /bin/tar
   latex: /usr/bin/latex --no-shell-escape
-  pdflatex: /usr/bin/pdflatex --no-shell-escape
+  latex2pdf: /usr/bin/xelatex --no-shell-escape
   dvisvgm: /usr/bin/dvisvgm
   pdf2svg: /usr/bin/pdf2svg
   convert: /usr/bin/convert

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -214,8 +214,8 @@ sub draw {
 			print $fh $self->footer;
 			close $fh;
 			system "cd $working_dir && "
-				. WeBWorK::PG::IO::externalCommand('pdflatex')
-				. " --interaction=nonstopmode image.tex > pdflatex.stdout 2> /dev/null";
+				. WeBWorK::PG::IO::externalCommand('latex2pdf')
+				. " --interaction=nonstopmode image.tex > latex.stdout 2> /dev/null";
 			chmod(0777, "$working_dir/image.pdf");
 		} else {
 			warn "Can't open $working_dir/image.tex for writing.";
@@ -251,7 +251,7 @@ sub draw {
 			}
 		} else {
 			warn "The pdf file was not created.";
-			if (open(my $err_fh, "<", "$working_dir/pdflatex.stdout")) {
+			if (open(my $err_fh, "<", "$working_dir/latex.stdout")) {
 				while (my $error = <$err_fh>) {
 					warn $error;
 				}

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2896,7 +2896,7 @@ sub image {
 		if ($displayMode eq 'TeX') {
 			my $imagePath = $imageURL;    # in TeX mode, alias gives us a path, not a URL
 
-			# We're going to create PDF files with our TeX (using pdflatex), so
+			# We're going to create PDF files with our TeX (using LaTeX), so
 			# alias should have given us the path to a PNG image.
 			if ($imagePath) {
 				if ($valign eq 'top') {


### PR DESCRIPTION
The pg environment variable is now `$externalPrograms{latex2pdf}`. This was changed as discussed in the development meeting today because it is odd for it to be named pdflatex if we are not using pdflatex, and to match the corresponding webwork2 change.  See https://github.com/openwebwork/webwork2/pull/2462.