### PR TITLE
let width specifications in niceTables be numbers from (0,1]

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1586,6 +1586,7 @@ sub getPTXthickness {
 
 sub getWidthPercent {
 	my $width = shift;
+	return $width             if (substr($width, -1) eq '%');
 	return $width * 100 . '%' if ($width =~ /^0*(0(\.\d*)?|1(\.0*)?)$/);
 	my $x    = 0;
 	my $unit = 'cm';


### PR DESCRIPTION
niceTables allows width specification for columns or cells using the LaTeX column type `p{width}`. With this PR, `width` can now be a decimal from 0 (exclusive) to 1 (inclusive). This is understood to be a portion of the available width.
* In HTML, something like `40%` should appear in CSS.
* In TeX, something like `0.4\linewidth` should appear in appropriate places.
* In PTX, something like `40%` should appear in either
    * a `col`'s `width` attribute (for a DataTable)
    * or an `sbsgroup`'s `widths` attribute (for a LayoutTable).

Note that PTX has no way to specify a width for an individual cell.

You can try with this test file:


```
DOCUMENT();

loadMacros(qw(PGstandard.pl PGML.pl PGcourse.pl));

BEGIN_PGML

[#
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. .]
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. .]
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. .]
#]{padding => [0,1], align => 'p{0.4}lp{1in}'}

----

[#
	[. This table should have a 40% width cell, an unspecified cell, and a 1-inch column. .]{halign => 'p{0.4}'}
	[. This table should have a 40% width cell, an unspecified cell, and a 1-inch column. .]
	[. This table should have a 40% width cell, an unspecified cell, and a 1-inch column. .]{halign => 'p{1in}'}
#]{padding => [0,1]}

----

[#
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. And then overrided by a 50% cell, a 1in cell, and a 20% cell .]{halign => 'p{0.5}'}
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. And then overrided by a 50% cell, a 1in cell, and a 20% cell .]{halign => 'p{1in}'}
	[. This table should have a 40% width column, an unspecified column, and a 1-inch column. And then overrided by a 50% cell, a 1in cell, and a 20% cell .]{halign => 'p{0.2}'}
#]{padding => [0,1], align => 'p{0.4}lp{1in}', center => 0}

----
# Layout Table

[#
	[. This table should have a 40% width column, an unspecified column, and a 30% column. .]
	[. This table should have a 40% width column, an unspecified column, and a 30% column. .]
	[. This table should have a 40% width column, an unspecified column, and a 30% column. .]
#]*{padding => [0,1], align => 'p{0.4}lp{0.3}', center => 0}

END_PGML

ENDDOCUMENT();
```

