### PR TITLE
consistent PTX multiple choice structure

### DIFF
--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -591,11 +591,11 @@ sub CHECKS {
 			my $originalLabels = $self->{originalLabels};
 			if ($originalLabels =~ m/^(123|abc|roman)$/i) {
 				my $marker = '';
-				$marker = "1" if $originalLabels eq '123';
-				$marker = "a" if $originalLabels eq 'abc';
-				$marker = "A" if uc($originalLabels) eq 'ABC' && $originalLabels ne 'abc';
-				$marker = "i" if $originalLabels eq 'roman';
-				$marker = "I" if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
+				$marker = '1' if $originalLabels eq '123';
+				$marker = 'a' if $originalLabels eq 'abc';
+				$marker = 'A' if uc($originalLabels) eq 'ABC' && $originalLabels ne 'abc';
+				$marker = 'i' if $originalLabels eq 'roman';
+				$marker = 'I' if uc($originalLabels) eq 'ROMAN' && $originalLabels ne 'roman';
 
 				$list_type = 'ol';
 				$subtype   = qq( marker="$marker");
@@ -603,9 +603,9 @@ sub CHECKS {
 				$list_type = 'dl';
 				$subtype   = ' width = "narrow"';
 				my %checks_to_labels = map { $checks[$_] => $self->{labels}[$_] } (0 .. $#{ $self->{orderedChoices} });
-				map { $_ =~ s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/gr } @checks;
+				@checks = map { $_ =~ s/^(<li.*?>)/$1<title>$checks_to_labels{$_}<\/title>/gr } @checks;
 			}
-			$checks[0] = qq{<$list_type$subtype name="$name">\n$checks[0]};
+			$checks[0] = qq{<$list_type$subtype name="$name" form="checkboxes">\n$checks[0]};
 			$checks[-1] .= "</$list_type>";
 
 			# Change math delimiters

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -428,9 +428,10 @@ sub MENU {
 	} elsif ($main::displayMode eq 'PTX') {
 		if ($self->{showInStatic}) {
 			$menu = main::tag(
-				'fillin',
+				'ul',
 				name => $name,
-				join('', map { main::tag('choice', $self->quoteXML($_)) } (@list))
+				form => 'popup',
+				join('', map { main::tag('li', $self->quoteXML($_)) } (@list))
 			);
 		} else {
 			$menu = qq(<fillin name="$name"/>);


### PR DESCRIPTION
Once 2.19 is released, I need to make sure that PTX itself is set up to handle what WW 2.19 sends it. With multiple choice questions (radio buttons, popup, checkboxes) there's been a history of inconsistency, and I think I can finally eliminate that in a way that PTX's BDFL can accept, here in this PR that only affects PTX output.

With this change, every multiple choice flavor produces a PTX list (`ul`,  `ol`, or `dl`).

* A popup/dropdown answer always produces a `ul`
* Radio buttons and checkbox lists might produce a `ul`. But if the labels are explicitly declared to be among the supported options `123`, `abc`, `ABC`, `roman`, or `Roman` (latter two only for checkbox lists) then they produce an `ol` with the appropriate marker. And if the labels are set individually for the items, then this produces a `dl` where the `title` for each item is the label.

So far, it's all PTX schema-compliant. (Note that prior to this PR, popup answers are not producing schema-compliant PTX.)

Then there is one last thing. This adds a `form` attribute to the `ul`,  `ol`, or `dl` that indicates if it came from a popup/dropdown list, radio buttons list, or checkbox list. This is not a schema-compliant attribute and it will just be ignored by PTX. But over the coming year, perhaps I can do things with PTX that react to this attribute, ultimately styling the output differently depending on the value of `form`. Perhaps by way of PTX's assembly phase.