### PR TITLE
replace scaffold yellow with lightblue

### DIFF
--- a/htdocs/js/Scaffold/scaffold.scss
+++ b/htdocs/js/Scaffold/scaffold.scss
@@ -22,7 +22,7 @@
 		}
 
 		&.canopen > button.accordion-button {
-			background: yellow;
+			background: lightblue;
 		}
 
 		&.iscorrect > button.accordion-button {
@@ -45,7 +45,7 @@
 	}
 
 	.accordion-header.canopen button.accordion-button:focus {
-		box-shadow: inset 0 0 3px 2px #aa0;
+		box-shadow: inset 0 0 3px 2px #00c;
 	}
 
 	& > div.accordion-collapse {


### PR DESCRIPTION
This replaces the yellow background in scaffold problem headers with lightblue. This is the color that is used on a section's header/button when you are able to open/close that section and do not yet have that section correctly answered. Note that gray is used when you do not yet have access to a section, and lightgreen is used when you have answered that section correctly.

To me the yellow is just too...yellow.

This looks fine (to me) in all four themes, but perhaps the yellow theme needs special attention. Although, to me the current scaffold yellow is so bright that even in the yellow theme, I don't think it looks good.

If people like this and we're still doing non-critical hotfixes, I can open another PR. I'm assuming that this is noncritical and we have to stop somewhere.