### PR TITLE
Better method for updating the feedback popover position.

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -14,7 +14,9 @@
 		// Render MathJax previews.
 		if (window.MathJax) {
 			feedbackBtn.addEventListener('show.bs.popover', () => {
-				MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise(['.popover-body']));
+				MathJax.startup.promise = MathJax.startup.promise.then(() =>
+					MathJax.typesetPromise(['.popover-body']).then(() => feedbackPopover.update())
+				);
 			});
 		}
 
@@ -70,7 +72,6 @@
 		if (feedbackBtn.dataset.showCorrectOnly) {
 			setTimeout(() => {
 				feedbackBtn.click();
-				setTimeout(() => feedbackPopover.update(), 100);
 			}, 0);
 		}
 	};


### PR DESCRIPTION
This is an alternate and better approach to repositioning the feedback popover after the "Show Correct Answers" button is used.

This is to address issue https://github.com/openwebwork/webwork2/issues/2524.