### PR TITLE
allow characters for lte and gte in a few contexts

### DIFF
--- a/macros/contexts/contextInequalities.pl
+++ b/macros/contexts/contextInequalities.pl
@@ -148,6 +148,7 @@ sub Init {
 			TeX           => '\le ',
 			class         => 'Inequalities::BOP::inequality',
 			eval          => 'evalLessThanOrEqualTo',
+			alternatives  => ["\x{2264}"],
 			combine       => 1
 		},
 		'=<' => {
@@ -170,6 +171,7 @@ sub Init {
 			TeX           => '\ge ',
 			class         => 'Inequalities::BOP::inequality',
 			eval          => 'evalGreaterThanOrEqualTo',
+			alternatives  => ["\x{2265}"],
 			combine       => 1
 		},
 		'=>' => {
@@ -200,7 +202,8 @@ sub Init {
 			string        => ' != ',
 			TeX           => '\ne ',
 			class         => 'Inequalities::BOP::inequality',
-			eval          => 'evalNotEqualTo'
+			eval          => 'evalNotEqualTo',
+			alternatives  => ["\x{2260}"]
 		},
 
 		'and' => {

--- a/macros/parsers/parserLinearInequality.pl
+++ b/macros/parsers/parserLinearInequality.pl
@@ -104,6 +104,7 @@ sub Init {
 			string        => ' <= ',
 			TeX           => '\le ',
 			kind          => "le",
+			alternatives  => ["\x{2264}"],
 			class         => 'LinearInequality::inequality',
 			formulaClass  => "LinearInequality"
 		},
@@ -126,6 +127,7 @@ sub Init {
 			TeX           => '\ge ',
 			kind          => 'ge',
 			reverse       => 'le',
+			alternatives  => ["\x{2265}"],
 			class         => 'LinearInequality::inequality',
 			formulaClass  => "LinearInequality"
 		},


### PR DESCRIPTION
This is so a student can directly enter ≤ and ≥ in contexts where `<=` and `>=` are valid operators.

It affects a bit more than just the two files here, because at least one context (Inequality-SetBuilder) is built on top of `contextInequalities.pl`. 