### PR TITLE
preserve the order that is used for items in NAMED_POP_UP_LIST

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -751,7 +751,8 @@ sub checkbox {
 sub NAMED_POP_UP_LIST {
 	my ($name, @list) = @_;
 
-	my %options = ref($list[0]) eq 'ARRAY' ? (map { $_ => $_ } @{ $list[0] }) : @list;
+	my %options      = ref($list[0]) eq 'ARRAY' ? (map { $_ => $_ } @{ $list[0] }) : @list;
+	my @ordered_keys = ref($list[0]) eq 'ARRAY' ? @{ $list[0] } : @list[ grep { !($_ % 2) } 0 .. $#list ];
 
 	my $moodle_prefix = $envir{use_opaque_prefix} ? '%%IDPREFIX%%' : '';
 
@@ -775,7 +776,7 @@ sub NAMED_POP_UP_LIST {
 				join(
 					'',
 					map { tag('option', value => $_, $_ eq $answer_value ? (selected => undef) : (), $options{$_}) }
-						keys %options
+						@ordered_keys
 				)
 			)
 		);


### PR DESCRIPTION
This is about the forum issue that was revealed at:
https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8535

I think that once upon a time, perl did not randomize the order of a hash, and this macro presented the items in a dropdown list in the order the author gave them. But when perl moved to randomize hash order, then this macro started presenting options in random order on every page load. So the change here captures the original order of the hash keys and uses that.

I have not surveyed how `NAMED_POP_UP_LIST` is used, and whether the random ordering might be a good thing for some uses. Although, that seems unlikely.

I have also not surveyed surrounding macros to see if other things would benefit from a similar change.