### PR TITLE
preserve the order that is used for items in NAMED_POP_UP_LIST (hotfix for #1102)

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -751,7 +751,8 @@ sub checkbox {
 sub NAMED_POP_UP_LIST {
 	my ($name, @list) = @_;
 
-	my %options = ref($list[0]) eq 'ARRAY' ? (map { $_ => $_ } @{ $list[0] }) : @list;
+	my %options      = ref($list[0]) eq 'ARRAY' ? (map { $_ => $_ } @{ $list[0] }) : @list;
+	my @ordered_keys = ref($list[0]) eq 'ARRAY' ? @{ $list[0] } : @list[ grep { !($_ % 2) } 0 .. $#list ];
 
 	my $moodle_prefix = $envir{use_opaque_prefix} ? '%%IDPREFIX%%' : '';
 
@@ -775,7 +776,7 @@ sub NAMED_POP_UP_LIST {
 				join(
 					'',
 					map { tag('option', value => $_, $_ eq $answer_value ? (selected => undef) : (), $options{$_}) }
-						keys %options
+						@ordered_keys
 				)
 			)
 		);


### PR DESCRIPTION
This is a hotfix for #1102. I'm short on time this morning, and I still haven't patrolled neighboring code to see if a similar change from array to hash structure was made that might want a similar update.