### PR TITLE
Fix repositioniong of the feedback popover when typing in MathQuill inputs.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -37,7 +37,9 @@
 		if (input.classList.contains('partially-correct')) answerQuill.classList.add('partially-correct');
 
 		// Find the feedback button for this input if there is one on the page.
-		const feedbackBtn = document.querySelector(`button[data-answer-label="${answerLabel}"`);
+		const feedbackBtn = Array.from(document.querySelectorAll(`button[data-answer-labels]`)).find((btn) =>
+			JSON.parse(btn.dataset.answerLabels).includes(answerLabel)
+		);
 
 		// Default options.
 		const cfgOptions = {

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1222,7 +1222,7 @@ sub ENDDOCUMENT {
 								}
 							)->to_string
 						),
-						answer_label           => $answerLabel,
+						answer_labels          => JSON->new->encode($response_obj->{response_order}),
 						bs_toggle              => 'popover',
 						bs_trigger             => 'click',
 						bs_placement           => $showCorrectOnly ? 'right' : 'bottom',


### PR DESCRIPTION
When an answer has multiple responses and a MathQuill input for a response that is not the first one is typed in with a feedback popover open, the feedback popover does not correctly resposition. This is because currently only the first answer label is saved in the data attribute.  So when the mqeditor sets up the later responses which have different answer labels, it doesn't see the feedback button.  So now all answer labels for the response group are saved as a JSON encoded array. The mqeditor then searches the feedback buttons on the page to find the one with the correct answer label.

Here is a MWE for testing this:
```perl
DOCUMENT();
loadMacros('PGstandard.pl', 'PGML.pl');
Context('Matrix');
$A = Matrix([ [ 0, -1 ], [ 1, 0 ] ]);
BEGIN_PGML
Enter [`[$A]`]: [_]*{$A}{10}
END_PGML
ENDDOCUMENT();
```

If you type in a matrix entry other than the first column of the first row when a feedback popover is open, then the popover position is not updated with the develop branch, but is with this pull request.

Note that this also occurs with `MultiAnswer` objects with `singleResult => 1` set.

Now, I was actually trying to fix @somiaj's comment in https://github.com/openwebwork/webwork2/issues/2524#issuecomment-2323460189. I believe that this might also fix that issue.  I can't test that because I can't reproduce this issue (my computer is to fast?). However, I have good reason to believe that this will fix it.