### PR TITLE
prevent extra p surrounding multiple choice ul in PTX

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2193,7 +2193,10 @@ sub PTX_cleanup {
 	if ($displayMode eq 'PTX') {
 		#encase entire string in <p>
 		#except not for certain "sub" structures that are also passed through EV3
-		$string = "<p>" . $string . "</p>" unless (($string =~ /^<fillin[^>]*\/>$/) or ($string =~ /^<var.*<\/var>$/s));
+		$string = "<p>" . $string . "</p>"
+			unless (($string =~ /^<fillin[^>]*\/>$/)
+				|| ($string =~ /^<var.*<\/var>$/s)
+				|| ($string =~ /^<ul[^>]*form=[^>]*>/s));
 
 		#inside a li, the only permissible children are title, p, image, video, and tabular
 		#insert opening and closing p, to be removed later if they enclose a title, image, video or tabular


### PR DESCRIPTION
This should have been included in #1090.

Without getting into the weeds too much, consider something like:
```
$rational = DropDown(["is","is not",], 1);

BEGIN_PGML
The number [`\sqrt{2}`] [_]{$rational}{5} rational.
```

Without this commit, the PTX output is like:
```
<p>The number <m>\sqrt{2}</m> <p><ul form="popup" ...> ...
```
Note the `p` within a `p`.

With this commit, the PTX output is:
```
<p>The number <m>\sqrt{2}</m> <ul form="popup" ...> ...
```
