### PR TITLE
PTX: when removing unwanted p in a cell, consider that the cell may h…

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2240,7 +2240,7 @@ sub PTX_cleanup {
 		do {
 			$previous = $string;
 			$string =~
-				s/(?s)(<tabular[^>]*>(?:\s|<col (?:(?!width=").)*?>)((?!<\/tabular>).)*?<cell>((?!<\/tabular>).)*?)<p>(((?!<\/tabular>).)*?)<\/p>(((?!<\/tabular>).)*?<\/tabular>)/$1$4$6/g;
+				s/(?s)(<tabular[^>]*>(?:\s|<col (?:(?!width=").)*?>)((?!<\/tabular>).)*?<cell[^>]*>((?!<\/tabular>).)*?)<p>(((?!<\/tabular>).)*?)<\/p>(((?!<\/tabular>).)*?<\/tabular>)/$1$4$6/g;
 		} until ($previous eq $string);
 
 	}


### PR DESCRIPTION
…ave attributes

The regex in this line is pretty dense. What this block tries to do is described in the comment above this line. This regex does not literally do that, but it is close. To really do what the comment describes would require a lot of work.

In the meantime, there was a small flaw with the regex that this fixes. There is a place in the regex looking for a `cell` tag, and the assumption was it would be like `<cell>`. But it might be like `<cell bottom="minor">` or something like that with attributes. The change makes it matches those situations too.