### PR TITLE
move the essay help text to a general helpLink

### DIFF
--- a/htdocs/helpFiles/Entering-Essays.html
+++ b/htdocs/helpFiles/Entering-Essays.html
@@ -1,0 +1,12 @@
+<h2 style="text-align: center">Entering Essays</h2>
+
+<p>
+	In an essay answer text box, you can type a long answer. After after you hit submit, it will be saved so that your
+	instructor can read it and assign a score at a later time.
+</p>
+<p>If your instructor makes any comments on your answer, those comments will appear on the exercise page.</p>
+<p>
+	You can use the MathQuill equation editor to make your math content look pretty. Once you have constructed a math
+	expression, click the Insert button. In the answer text box, your math content will look like code, but the Preview
+	button will show you what your isntructor will see.
+</p>

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2280,13 +2280,15 @@ sub PTX_cleanup {
                     # form(from the webpage) inside another (the defining form for the problem
 A wide variety of google widgets, youtube videos, and other online resources can be imbedded using this macro. In HTML mode it creates an iframe, in TeX mode it prints the url.
 
-    helpLink($type)     allows site specific help. specified in global.conf or course.conf
+    helpLink($type)
+                   Allows site specific help.
                    The parameter localHelpURL  must be defined in the environment
-                   and is set by default to webwork2/htdocs/helpFiles
+                   and is set by default to pg/htdocs/helpFiles
                    Standard helpFile types
                         'angle'
                         'decimal'
                         'equation'
+                        'essay'
                         'exponent'
                         'formula'
                         'fraction'
@@ -2549,6 +2551,7 @@ sub helpLink {
 		'angle'     => [ 'Entering-Angles.html',       'help (angles)' ],
 		'decimal'   => [ 'Entering-Decimals.html',     'help (decimals)' ],
 		'equation'  => [ 'Entering-Equations.html',    'help (equations)' ],
+		'essay'     => [ 'Entering-Essays.html',       'help (essays)' ],
 		'exponent'  => [ 'Entering-Exponents.html',    'help (exponents)' ],
 		'formula'   => [ 'Entering-Formulas.html',     'help (formulas)' ],
 		'fraction'  => [ 'Entering-Fractions.html',    'help (fractions)' ],

--- a/macros/core/PGessaymacros.pl
+++ b/macros/core/PGessaymacros.pl
@@ -150,23 +150,6 @@ sub NAMED_ESSAY_BOX {
 	);
 }
 
-sub essay_help {
-	return MODES(
-		TeX  => '',
-		HTML => tag(
-			'p',
-			maketext(
-				'This is an essay answer text box. You can type your answer in here and, after you hit submit, '
-					. 'it will be saved so that your instructor can grade it at a later date. If your instructor '
-					. 'makes any comments on your answer those comments will appear on this page after the question '
-					. 'has been graded. You can use LaTeX to make your math equations look pretty. '
-					. 'LaTeX expressions should be enclosed using the parenthesis notation and not dollar signs.'
-			)
-		),
-		PTX => '',
-	);
-}
-
 sub essay_box {
 	my ($row, $col) = @_;
 	$row ||= 8;
@@ -195,7 +178,7 @@ sub explanation_box {
 			($options{message} // 'Explain.')
 			. $PAR
 			. essay_box($options{row} // $options{height} // 8, $options{col} // $options{width} // 75)
-			. (($options{help} // 1) ? essay_help() : '');
+			. (($options{help} // 1) ? $BR . helpLink('essay') : '');
 	}
 }
 


### PR DESCRIPTION
I'd like to request a hotfix variant for #1123. Making this move will simplify the PTX cleanup from Tacoma work that I am trying to finish. If this is part of 2.19, I can eliminate part of the setup that is done for a PTX host course.