### PR TITLE
Fix an uninitialized value in the openDivSpan method of PGbasicmacros.pl

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1580,8 +1580,8 @@ sub openDivSpan {
 		WARN_MESSAGE("openDivSpan called with an invalid first argument. The entire call was discarded.");
 		return ();
 	}
-	my $option_ref = {};
-	my $html_attribs;
+	my $option_ref   = {};
+	my $html_attribs = '';
 	if (ref($_[0]) eq 'HASH') {
 		$option_ref   = shift;
 		$html_attribs = processDivSpanOptions($option_ref);


### PR DESCRIPTION
This was reported in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=4767#p21510. See some of the problems posed in that thread for testing.