### PR TITLE
Set max width for radio buttons and checkbox containing divs.

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -180,6 +180,11 @@
 	}
 
 	.radio-buttons-container,
+	.checkboxes-container {
+		max-width: calc(100% - 1rem - 25px);
+	}
+
+	.radio-buttons-container,
 	.checkboxes-container,
 	.applet-container,
 	.graphtool-outer-container,


### PR DESCRIPTION
The feedback button for parserRadioButtons and parserCheckboxList can be pushed outside the problem's div if the choices are too long. This sets a max width for the containing div to ensure the feedback is no longer pushed outside the problem's div boundaries.