### PR TITLE
When typing in a MathQuill input, update positions of all feedback popovers.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -36,11 +36,6 @@
 		if (input.classList.contains('incorrect')) answerQuill.classList.add('incorrect');
 		if (input.classList.contains('partially-correct')) answerQuill.classList.add('partially-correct');
 
-		// Find the feedback button for this input if there is one on the page.
-		const feedbackBtn = Array.from(document.querySelectorAll(`button[data-answer-labels]`)).find((btn) =>
-			JSON.parse(btn.dataset.answerLabels).includes(answerLabel)
-		);
-
 		// Default options.
 		const cfgOptions = {
 			spaceBehavesLikeTab: true,
@@ -269,8 +264,10 @@
 					answerQuill.latexInput.value = '';
 				}
 
-				// If the feedback popover is open, then update its position.
-				if (feedbackBtn) bootstrap.Popover.getInstance(feedbackBtn)?.update();
+				// If any feedback popovers are open, then update their positions.
+				for (const popover of document.querySelectorAll('.ww-feedback-btn')) {
+					bootstrap.Popover.getInstance(popover)?.update();
+				}
 			};
 
 			input.after(answerQuill);


### PR DESCRIPTION
This fixes the issue reported by @somiaj in
https://github.com/openwebwork/pg/pull/1110#issuecomment-2380357222.