### PR TITLE
Move feedback button for one by one matrix out of matrix.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -496,7 +496,7 @@ sub ans_matrix {
 		close         => $close,
 		sep           => $sep,
 		top_labels    => $toplabels,
-		ans_last_name => ANS_NAME($ename, $rows - 1, $cols - 1)
+		ans_last_name => $rows == 1 && $cols == 1 ? $name : ANS_NAME($ename, $rows - 1, $cols - 1)
 	);
 }
 


### PR DESCRIPTION
A one by one matrix does not have a last answer rule with the MaTrIx prefix or the row and column indices for a suffix.  In this case, the last answer name is of course also the first answer name.  As such the data attribute added was not naming the correct answer rule.

This fixes issue #1129.