### PR TITLE
Update WeBWorK::PG::Tidy to handle content after ENDDOCUMENT.

### DIFF
--- a/lib/WeBWorK/PG/Tidy.pm
+++ b/lib/WeBWorK/PG/Tidy.pm
@@ -95,8 +95,8 @@ my $postfilter = sub {
 	$evalString =~ s/(.*)->tex\(<<END_LATEX_IMAGE\);/$1->BEGIN_LATEX_IMAGE/g;
 
 	# Care is needed to reverse the preprocessing here.
-	# First in all occurences of an odd number of backslashes the first backslash is replaced with two tildes.
-	$evalString =~ s/(?<!\\) \\ ((?:\\{2})*) (?!\\)/~~$1/gx;
+	# First in all occurences of an odd number of backslashes the last backslash is replaced with two tildes.
+	$evalString =~ s/(?<!\\) \\ ((?:\\{2})*) (?!\\)/$1~~/gx;
 	# Then all pairs of backslashes are replaced with a single backslash.
 	$evalString =~ s/\\\\/\\/g;
 


### PR DESCRIPTION
The content is removed but saved before perltidy is called.  Then put back after perltidy is done.  So its contents will not change.  That is with the exception of possibly adding `();` if that is not there.  Note that if you have something like `ENDDOCUMENT('invalid arg');` the `'invalid arg'` will be removed.