### PR TITLE
Update the PG docker build to use Ubuntu 24.04.

### DIFF
--- a/docker/pg.Dockerfile
+++ b/docker/pg.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true


### PR DESCRIPTION
The unit tests use this image.  It should also use the version of Ubuntu that everything else is using now.

Edit: Actually, I forgot the unit test workflow does not use this image anymore.  The workflow directly installs what is needed in an Ubuntu 24.04 image.  So this is just for consistency for anyone that might use this docker image for local testing.