### PR TITLE
Add MultiAnswer convenience methods (default checker and passing cmp options).

### DIFF
--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -103,6 +103,7 @@ sub cmp {
 	}
 
 	unless (ref($self->{checker}) eq 'CODE') {
+		die "Your checker must be a subroutine." if defined($self->{checker});
 		$self->{checker} = sub {
 			my ($correct, $student, $self, $ans) = @_;
 			my @scores;

--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -62,6 +62,7 @@ sub new {
 		part                => 0,
 		singleResult        => 0,
 		namedRules          => 0,
+		cmpOpts             => undef,
 		checkTypes          => 1,
 		allowBlankAnswers   => 0,
 		tex_separator       => $separator . '\,',
@@ -89,8 +90,10 @@ sub setCmpFlags {
 #  the individual answer checkers.
 #
 sub cmp {
-	my $self    = shift;
-	my %options = @_;
+	my ($self, %options) = @_;
+
+	%options = (%options, %{ $self->{cmpOpts} }) if ref($self->{cmpOpts}) eq 'HASH';
+
 	foreach my $id ('checker', 'separator') {
 		if (defined($options{$id})) {
 			$self->{$id} = $options{$id};
@@ -500,6 +503,12 @@ or one for each answer rule (C<< singleResult => 0 >>). Default: 0.
 Indicates whether to use named rules or default rule names. Use named rules (C<< namedRules => 1 >>)
 if you need to intersperse other rules with the ones for the C<MultiAnswer>. In this case, you must
 use C<NAMED_ANS> instead of C<ANS>. Default: 0.
+
+=head2 cmpOpts
+
+This is a hash of options that will be passed to the cmp method. For example,
+C<< cmpOpts => { weight => 0.5 } >>. This option is provided to make it more convenient to pass
+options to cmp when utilizing PGML. Default: undef (no options are sent).
 
 =head2 checkTypes
 


### PR DESCRIPTION
This adds two conveniences to `parserMultiAnswer.pl`.

* A `cmpOpts` option (taken from `parserRadioMultiAnswer.pl`) to pass a hash of options to all cmp methods.
* A default checker that is used if no checker is defined. This checker just checks which answer parts are equal, and can either return an array of 0s and 1s for each answer part, or a single score of 0 or 1, depending on if the new option `partialCredit` is set or not. `partialCredit` defaults to the value of `$showPartialCorrectAnswers`.
