### PR TITLE
Fix issue with variable TeX output with var = value inequality.

### DIFF
--- a/macros/contexts/contextInequalities.pl
+++ b/macros/contexts/contextInequalities.pl
@@ -890,7 +890,8 @@ sub type {"Set"}
 sub string {
 	my $self     = shift;
 	my $equation = shift;
-	my $x        = $self->{varName} || ($self->context->variables->names)[0];
+	my $context  = $self->context;
+	my $x        = $self->{varName} || ($context->variables->names)[0];
 	$x = $context->{variables}{$x}{string} if defined $context->{variables}{$x}{string};
 	my @coords = ();
 	foreach my $a (@{ $self->data }) {
@@ -908,7 +909,8 @@ sub string {
 sub TeX {
 	my $self     = shift;
 	my $equation = shift;
-	my $x        = $self->{varName} || ($self->context->variables->names)[0];
+	my $context  = $self->context;
+	my $x        = $self->{varName} || ($context->variables->names)[0];
 	$x = $context->{variables}{$x}{TeX} if defined $context->{variables}{$x}{TeX};
 	$x =~ s/^([^_]+)_?(\d+)$/$1_{$2}/;
 	my @coords = ();


### PR DESCRIPTION
In contextInequalities, the $context variable could be undefined, making it so the TeX formatting of a variable in inequalities of the form Inequality("var = value") was not used. This defines the variable $context = $self->context in the string and TeX methods of Inequalities::Set to ensure any variable definitions are used in the string and TeX output.

Here is a test problem to use, without this the variable's TeX definition is not used.

```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl contextInequalities.pl));
Context('Inequalities')->variables->are(gamma => [ 'Real', TeX => '\gamma ' ]);
$test = Inequality("gamma = 5");

BEGIN_PGML
[`[$test]`]
END_PGML
ENDDOCUMENT();
```