### PR TITLE
Mathquill accessibility improvements

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@openwebwork/mathquill": "^0.11.0-beta.1",
+                "@openwebwork/mathquill": "^0.11.0-beta.2",
                 "jsxgraph": "^1.9.2",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@openwebwork/mathquill": {
-            "version": "0.11.0-beta.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.1.tgz",
-            "integrity": "sha512-DNUwP0tNhBva/QYA5bThpM+YZpbJJ2o6uYRQ1Q1QSClGJxN/fGVxHXgv0ZRYmhybtgV94thjttGVCdxRcVn/Wg==",
+            "version": "0.11.0-beta.2",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.2.tgz",
+            "integrity": "sha512-cSUpkAesOPxXfQ/fWJSkmsauhvOMnUqlpib3BQu0QpgOQuYBMIrvpnKf+DsMf7FOEXix+BYlrpcE3sVoPuihhg==",
             "license": "MPL-2.0"
         },
         "node_modules/@trysound/sax": {
@@ -1746,9 +1746,9 @@
             }
         },
         "@openwebwork/mathquill": {
-            "version": "0.11.0-beta.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.1.tgz",
-            "integrity": "sha512-DNUwP0tNhBva/QYA5bThpM+YZpbJJ2o6uYRQ1Q1QSClGJxN/fGVxHXgv0ZRYmhybtgV94thjttGVCdxRcVn/Wg=="
+            "version": "0.11.0-beta.2",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.2.tgz",
+            "integrity": "sha512-cSUpkAesOPxXfQ/fWJSkmsauhvOMnUqlpib3BQu0QpgOQuYBMIrvpnKf+DsMf7FOEXix+BYlrpcE3sVoPuihhg=="
         },
         "@trysound/sax": {
             "version": "0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
         "prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
     },
     "dependencies": {
-        "@openwebwork/mathquill": "^0.11.0-beta.1",
+        "@openwebwork/mathquill": "^0.11.0-beta.2",
         "jsxgraph": "^1.9.2",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",


### PR DESCRIPTION
This makes changes to the `mqeditor.js` code to use the changes in https://github.com/openwebwork/mathquill/pull/33.

There are no actual changes needed to use the "mathspeak" addition for screen reader usage.  However, there are changes needed for the focus/blur behavior change.

Also, this takes advantage of the fixed "enter" handler.

Note that since the npm package was not published (and shouldn't be until after the MathQuill pull request is merged), it takes a bit of effort to test this.  The commands to do this on an Ubuntu system are below.  Those commands should generally work on any system though.

First check out this pull request.

Next, it is recommended that you set npm to install global packages in your user's home directory.  You can do this by running `npm config set prefix="~/.local"`.  This is not required, but if you don't then global packages (and links used here) will be installed to the global location (`/usr/lib/node_modules` on Ubuntu).  Note that if you don't do this then you will need to use `sudo` to install a global package or link.

For the rest run the following commands (you may need or want to adapt locations in some cases):
```bash
cd
git clone -b mathspeak --single-branch https://github.com/drgrice1/mathquill
cd mathquill
npm ci
npm run build
npm link # (add sudo here if you didn't set the prefix above)
cd /opt/webwork/pg/htdocs
npm uninstall @openwebwork/mathquill # get the npm package out of the way
npm link @openwebwork/mathquill
./generate-assets.js
```

Clean up afterward.   From the /opt/webwork/pg/htdocs directory run:
```bash
npm unlink @openwebwork/mathquill
npm unlink @openwebwork/mathquill -q # (add sudo here again if you didn't set the prefix)
rm -r ~/mathquill
git checkout package.json package-lock.json
npm ci
```

Once the MathQuill pull request is merged, I will publish the npm package and update the package.json file in this pull request.  So this should not be merged until after that is done.

