### PR TITLE
Add usesAllOf method to Value::Formula.

### DIFF
--- a/lib/Value/Formula.pm
+++ b/lib/Value/Formula.pm
@@ -599,9 +599,18 @@ sub isConstant {
 #  Check if the Formula includes one of the named variables
 #
 sub usesOneOf {
-	my $self = shift;
-	foreach my $x (@_) { return 1 if $self->{variables}{$x} }
+	my ($self, @vars) = @_;
+	for my $x (@vars) { return 1 if $self->{variables}{$x} }
 	return 0;
+}
+
+#
+#  Check if the Formula includes all of the named variables
+#
+sub usesAllOf {
+	my ($self, @vars) = @_;
+	for my $x (@vars) { return 0 unless $self->{variables}{$x} }
+	return 1;
 }
 
 ###########################################################################


### PR DESCRIPTION
This method is similar to usesOneOf, but only returns true if all of the variables in the list are used. This is a convenience method to not have to call usesOneOf multiple times to check if multiple variables are being used.