### PR TITLE
Switch to using the latest Perl::Tidy (version 20240903) alternate approach.

### DIFF
--- a/.github/workflows/check-formats.yml
+++ b/.github/workflows/check-formats.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy@20220613
+        run: cpanm -n Perl::Tidy@20240903
       - name: Run perltidy
         shell: bash
         run: |

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -21,3 +21,4 @@
 -wn      # Weld nested containers
 -xci     # Extended continuation indentation
 -vxl='q' # No vertical alignment of qw quotes
+-nvsn    # No vertical alignment of signed numbers

--- a/bin/perltidy-pg.rc
+++ b/bin/perltidy-pg.rc
@@ -19,4 +19,3 @@
 -nlop    # No logical padding (this causes mixed tabs and spaces)
 -wn      # Weld nested containers
 -xci     # Extended continuation indentation
--vxl='q' # No vertical alignment of qw quotes

--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -62,9 +62,8 @@ use Mojo::File qw(curfile);
 
 my $pg_root = curfile->dirname->dirname;
 
-die "Version 20220613 or newer of perltidy is required for this script.\n"
-	. "The installed version is $Perl::Tidy::VERSION.\n"
-	unless $Perl::Tidy::VERSION >= 20220613;
+die "Version 20240903 of perltidy is required for this script.\nThe installed version is $Perl::Tidy::VERSION.\n"
+	unless $Perl::Tidy::VERSION == 20240903;
 die "The .perltidyrc file in the pg root directory is not readable.\n"
 	unless -r "$pg_root/.perltidyrc";
 

--- a/lib/Hermite.pm
+++ b/lib/Hermite.pm
@@ -233,7 +233,7 @@ sub internal_critical_points {
 }
 
 sub internal_inflection_points {
-	my ($x0, $l, $lp,, $x1, $r, $rp, $rh_roots, $rf_function) = @_;
+	my ($x0, $l, $lp, $x1, $r, $rp, $rh_roots, $rf_function) = @_;
 	#data for one segment of the hermite spline
 
 	# coefficients for the approximating polynomial

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1156,7 +1156,7 @@ sub ANS_MATRIX {
 	$def   = $self->context->lists->get('Matrix');
 	$open  = $self->{open}  || $def->{open};
 	$close = $self->{close} || $def->{close};
-	return $self->ans_matrix($extend, $name, $self->length, 1, $size, $open, $close, '',, '', %options)
+	return $self->ans_matrix($extend, $name, $self->length, 1, $size, $open, $close, '', '', %options)
 		if ($self->{ColumnVector});
 	$def   = $self->context->lists->get('Vector');
 	$open  = $self->{open}  || $def->{open};

--- a/macros/math/LinearProgramming.pl
+++ b/macros/math/LinearProgramming.pl
@@ -156,7 +156,7 @@ sub lp_pivot_element {
 			} else {    # Test to see if this is an improvement
 				if ($fracmode
 					? ($m[$prow][$ncols]->scalar()) / ($m[$prow][$pcol]->scalar()) >
-					($m[$j][$ncols]->scalar() / $m[$j][$pcol]->scalar())
+						($m[$j][$ncols]->scalar() / $m[$j][$pcol]->scalar())
 					: ($m[$prow][$ncols] / $m[$prow][$pcol] > $m[$j][$ncols] / $m[$j][$pcol]))
 				{
 					$prow = $j;

--- a/macros/math/PGnauStats.pl
+++ b/macros/math/PGnauStats.pl
@@ -452,7 +452,7 @@ sub SpecialData {
 sub PercentStemAndLeaf {
 	my (@dat) = @_;
 
-	my ($i, $j, $s1, $s2, $all, $low, $max, $num, $row, $cols, $high, @list, $sort, $var1, $var2,, $tex_table,
+	my ($i, $j, $s1, $s2, $all, $low, $max, $num, $row, $cols, $high, @list, $sort, $var1, $var2, $tex_table,
 		$html_table);
 
 	while (isstring($dat[0]) == 1) {

--- a/macros/math/customizeLaTeX.pl
+++ b/macros/math/customizeLaTeX.pl
@@ -36,7 +36,7 @@ sub implies {
 sub vectorstyle {
 	my $v = shift;
 	return "\\vec{$v}"
-		#return "$v";
+	#return "$v";
 }
 
 sub polynomials_of_degree_up_to_degree_over_ring_in_variable {
@@ -121,10 +121,10 @@ sub quaternions {
 
 	return "Q_8"
 
-		# Alternatives
+	# Alternatives
 
-		# return "H_8"
-		# return "Q"
+	# return "H_8"
+	# return "Q"
 }
 
 1;

--- a/macros/math/draggableSubsets.pl
+++ b/macros/math/draggableSubsets.pl
@@ -359,8 +359,7 @@ sub cmp_preprocess {
 		$ans->{preview_latex_string} = join(
 			',',
 			map {
-				"\\{\\text{"
-					. join(',', map { $self->{shuffledSet}[$_] } grep { $_ >= 0 } @{ $_->{data} }) . "}\\}"
+				"\\{\\text{" . join(',', map { $self->{shuffledSet}[$_] } grep { $_ >= 0 } @{ $_->{data} }) . "}\\}"
 			} @{ $ans->{student_value}{data} }
 		);
 	}


### PR DESCRIPTION
A new `--valign-signed-numbers` option has been added in the version of Perl::Tidy and is the default.  That option has been disabled to reduce the number of code changes.
    
All of the other changes to the code made by the updated version are definite improvements.
    
Note that the `bin/dev_scripts/run-perltidy.pl` script now insists on this specific version of perltidy instead of this version or newer.  This is because every time a new version of perltidy comes out, it changes things.  So developers really need to be using the same version or it will not be consistent with the github workflow result.

Finally, the `-vxl='q'` option to disable alignment of qw quotes has been removed from the `bin/perltidy-pg.rc` file.  The upside of this is that those using the `WeBWorK::PG::Tidy` module (either via the `bin/perldity-pg.pl` script or via webwork2) can use any version of Perl::Tidy, even those from before the 20220613 version.

The first commit makes the changes for the switch to the new version, and the second commit is merely the result of running `perltidy` with the new version and rules.