### PR TITLE
Remove a local link in the `package-lock.json` file.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -26,43 +26,6 @@
                 "yargs": "^17.7.2"
             }
         },
-        "../../../../home/rice/Projects/Webwork/MathQuill/mathquill": {
-            "name": "@openwebwork/mathquill",
-            "version": "0.11.0-beta.1",
-            "extraneous": true,
-            "license": "MPL-2.0",
-            "devDependencies": {
-                "@awmottaz/prettier-plugin-void-html": "^1.6.1",
-                "@stylistic/eslint-plugin": "^2.7.2",
-                "copy-webpack-plugin": "^12.0.2",
-                "css-loader": "^7.1.2",
-                "css-minimizer-webpack-plugin": "^7.0.0",
-                "eslint": "^9.9.1",
-                "eslint-config-prettier": "^9.1.0",
-                "eslint-webpack-plugin": "^4.2.0",
-                "globals": "^15.9.0",
-                "less": "^4.2.0",
-                "less-loader": "^12.2.0",
-                "mini-css-extract-plugin": "^2.9.1",
-                "mocha": "^10.7.3",
-                "postcss-less": "^6.0.0",
-                "prettier": "^3.3.3",
-                "rollup": "^4.21.2",
-                "rollup-plugin-dts": "^6.1.1",
-                "rollup-plugin-ts": "^3.4.5",
-                "stylelint": "^16.9.0",
-                "stylelint-config-html": "^1.1.0",
-                "stylelint-config-standard": "^36.0.1",
-                "stylelint-webpack-plugin": "^5.0.1",
-                "ts-loader": "^9.5.1",
-                "tsconfig-replace-paths": "^0.0.14",
-                "typescript": "^5.5.4",
-                "typescript-eslint": "^8.4.0",
-                "webpack": "^5.94.0",
-                "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^5.1.0"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",


### PR DESCRIPTION
This is a remnant from testing the recent MathQuill changes locally, that seems to have stayed there even after uninstalling the local link. This was never supposed to have been committed.