### PR TITLE
Only show non empty messages in feedback.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1198,9 +1198,9 @@ sub ENDDOCUMENT {
 					'button',
 					type  => 'button',
 					class => "ww-feedback-btn btn btn-sm $options{btnClass} $options{btnAddClass}"
-						. ($rh_envir->{showMessages} && $ansHash->{ans_message} ? ' with-message' : ''),
+						. ($rh_envir->{showMessages} && $ansHash->{ans_message} =~ /\S/ ? ' with-message' : ''),
 					'aria-label' => (
-						$rh_envir->{showMessages} && $ansHash->{ans_message}
+						$rh_envir->{showMessages} && $ansHash->{ans_message} =~ /\S/
 						? maketext('[_1] with message', $options{resultTitle})
 						: $options{resultTitle}
 					),
@@ -1238,7 +1238,7 @@ sub ENDDOCUMENT {
 									class => 'card',
 									sub {
 										(
-											$rh_envir->{showMessages} && $ansHash->{ans_message}
+											$rh_envir->{showMessages} && $ansHash->{ans_message} =~ /\S/
 											? $feedbackLine->(
 												'', $ansHash->{ans_message} =~ s/\n/<br>/gr,
 												'feedback-message'


### PR DESCRIPTION
Some problems prevent messages by overriding the default message with the string consisting of a single space.  See the sample problem `tutorials/sample-problems/Algebra/EquationImplicitFunction.pg` for example.  If those messages are used, then the feedback button shows the dot indicating the presence of a message even if there really isn't a message.  To fix this, the answer messages are only shown if they do not consist entirely of whitespace.

Note that I do not consider this a good practice for problem authors to employ.  Even the previous attempts table in WeBWorK 2.18 or before would have shown the message column in this case even though there are no actual messages.  Furthermore, in most cases there are better ways to prevent these messages from occuring.  In the case of the sample problem mentioned above, I believe that there is something wrong with `paserImplicitEquation.pl` macro's `createPoints` method that causes the message to be displayed for some answers where it should not be, and that is a bug that should be looked into. So I would be completely fine with not accepting this pull request.