### PR TITLE
make specialAngle return 0 when it would otherwise return 0pi

### DIFF
--- a/macros/math/specialTrigValues.pl
+++ b/macros/math/specialTrigValues.pl
@@ -17,7 +17,8 @@ Imaginary parts separately.
 
 C<specialAngle(x)> returns a MathObject Formula in Numeric context of the form
 "a pi/c" that is the closest possible to x, where a is an integer, and c is from
-a specified set of positive integers. By default, c comes from [1,2,3,4,6].
+a specified set of positive integers. By default, c comes from [1,2,3,4,6]. If
+a equals 0, then this returns Formula('0').
 
 =head2 Options
 
@@ -106,7 +107,7 @@ sub specialAngle {
 	} else {
 		$a = $closest->[0];
 	}
-	my $return = Formula("$a pi $divc");
+	my $return = ($a ne '0') ? Formula("$a pi $divc") : Formula('0');
 	Context($mycontext);
 	return $return;
 }


### PR DESCRIPTION
Prior to this commit, `specialAngle` can return `Formula("0pi")` and that is not simplified automatically. This makes it return `Formula("0")` instead.