### PR TITLE
Add a sine wave tool to the graphtool.

### DIFF
--- a/htdocs/js/GraphTool/cubictool.js
+++ b/htdocs/js/GraphTool/cubictool.js
@@ -240,13 +240,12 @@
 				};
 
 				this.phase2 = (coords) => {
-					// Don't allow the second point to be created on the same
-					// vertical line as the first point or off the board.
-					if (
-						this.point1.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
-					)
-						return;
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point,
+					// then use the highlight point coordinates instead.
+					if (Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps)
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 
@@ -272,14 +271,15 @@
 				};
 
 				this.phase3 = (coords) => {
-					// Don't allow the third point to be created on the same vertical line as the
-					// first point, on the same vertical line as the second point, or off the board.
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point, or on the same
+					// vertical line as the second point, then use the highlight point coordinates instead.
 					if (
-						this.point1.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						this.point2.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
+						Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
+						Math.abs(this.point2.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps
 					)
-						return;
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 					this.point3 = gt.graphObjectTypes.cubic.createPoint(coords[1], coords[2], [
@@ -311,16 +311,17 @@
 				};
 
 				this.phase4 = (coords) => {
-					// Don't allow the fourth point to be created on the same vertical line as the first
-					// point, on the same vertical line as the second point, on the same vertical line as
-					// the third point, or off the board.
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point, on the same vertical
+					// line as the second point, or on the same vertical line as the third point, then use the highlight
+					// point coordinates instead.
 					if (
-						this.point1.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						this.point2.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						this.point3.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
+						Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
+						Math.abs(this.point2.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
+						Math.abs(this.point3.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps
 					)
-						return;
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 

--- a/htdocs/js/GraphTool/cubictool.js
+++ b/htdocs/js/GraphTool/cubictool.js
@@ -179,25 +179,30 @@
 						}
 					);
 					point.setAttribute({ snapToGrid: true });
-					if (typeof grouped_points !== 'undefined' && grouped_points.length) {
-						point.grouped_points = [];
-						grouped_points.forEach((paired_point) => {
-							point.grouped_points.push(paired_point);
-							if (!paired_point.grouped_points) {
-								paired_point.grouped_points = [];
-								paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
-							}
-							paired_point.grouped_points.push(point);
-							if (
-								!paired_point.eventHandlers.drag ||
-								paired_point.eventHandlers.drag.every(
-									(dragHandler) => dragHandler.handler !== gt.graphObjectTypes.cubic.groupedPointDrag
+
+					if (!gt.isStatic) {
+						if (typeof grouped_points !== 'undefined' && grouped_points.length) {
+							point.grouped_points = [];
+							grouped_points.forEach((paired_point) => {
+								point.grouped_points.push(paired_point);
+								if (!paired_point.grouped_points) {
+									paired_point.grouped_points = [];
+									paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
+								}
+								paired_point.grouped_points.push(point);
+								if (
+									!paired_point.eventHandlers.drag ||
+									paired_point.eventHandlers.drag.every(
+										(dragHandler) =>
+											dragHandler.handler !== gt.graphObjectTypes.cubic.groupedPointDrag
+									)
 								)
-							)
-								paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
-						});
-						point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag, point);
+									paired_point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag);
+							});
+							point.on('drag', gt.graphObjectTypes.cubic.groupedPointDrag, point);
+						}
 					}
+
 					return point;
 				}
 			}

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -629,6 +629,7 @@ window.graphTool = (containerId, options) => {
 		gt.setMessageText(
 			gt.tools
 				.map((tool) => (typeof tool.helpText === 'function' ? tool.helpText() : tool.helpText || ''))
+				.concat([gt.selectedObj?.helpText()])
 				.filter((helpText) => !!helpText)
 		);
 	};
@@ -845,6 +846,8 @@ window.graphTool = (containerId, options) => {
 			if (this.baseObj.rendNode === e.target) return true;
 			return this.definingPts.some((point) => point.rendNode === e.target);
 		}
+
+		helpText() {}
 
 		update() {}
 
@@ -1305,6 +1308,11 @@ window.graphTool = (containerId, options) => {
 					return false;
 				}
 
+				helpText() {
+					if ('helpText' in graphObject) return graphObject.helpText.call(this, gt);
+					else if (parentObject) return super.helpText();
+				}
+
 				update() {
 					if ('update' in graphObject) graphObject.update.call(this, gt);
 					else if (parentObject) super.update();
@@ -1519,6 +1527,7 @@ window.graphTool = (containerId, options) => {
 							lastSelected = gt.selectedObj;
 						} else {
 							focusPoint?.rendNode.focus();
+							gt.updateHelp();
 							return;
 						}
 					}
@@ -1566,7 +1575,10 @@ window.graphTool = (containerId, options) => {
 					}
 
 					// Attach a focusin handler to all points to update the coordinates display.
-					point.focusInHandler = () => gt.setTextCoords(point.X(), point.Y());
+					point.focusInHandler = () => {
+						gt.setTextCoords(point.X(), point.Y());
+						setTimeout(() => gt.updateHelp());
+					};
 					point.rendNode.addEventListener('focusin', point.focusInHandler);
 				});
 			}

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -482,7 +482,7 @@ window.graphTool = (containerId, options) => {
 			});
 		}
 
-		const resize = () => {
+		const resize = (gt.resize = () => {
 			// If the container does not have width or height (for example if the graph is inside a closed scaffold when
 			// the window is resized), then delay resizing the graph until the container does have width and height.
 			if (!gt.board.containerObj.offsetWidth || !gt.board.containerObj.offsetHeight) {
@@ -501,7 +501,7 @@ window.graphTool = (containerId, options) => {
 				gt.graphedObjs.forEach((object) => object.onResize());
 				gt.staticObjs.forEach((object) => object.onResize());
 			}
-		};
+		});
 
 		window.addEventListener('resize', resize);
 
@@ -2696,4 +2696,8 @@ window.graphTool = (containerId, options) => {
 		gt.updateText();
 		gt.updateUI();
 	}
+
+	// When MathJax accessibility is enabled the tick label positions are off.
+	// Updating the board after the labels are typeset fixes this.
+	if (window.MathJax) MathJax.startup.promise = MathJax.startup.promise.then(() => gt.board.update());
 };

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -128,6 +128,11 @@ window.graphTool = (containerId, options) => {
 	// Merge options that are set by the problem.
 	if (typeof options.JSXGraphOptions === 'object') JXG.merge(cfgOptions, options.JSXGraphOptions);
 
+	cfgOptions.boundingBox[0] = cfgOptions.boundingBox[0] - JXG.Math.eps;
+	cfgOptions.boundingBox[1] = cfgOptions.boundingBox[1] + JXG.Math.eps;
+	cfgOptions.boundingBox[2] = cfgOptions.boundingBox[2] + JXG.Math.eps;
+	cfgOptions.boundingBox[3] = cfgOptions.boundingBox[3] - JXG.Math.eps;
+
 	const setupBoard = () => {
 		gt.board = JXG.JSXGraph.initBoard(`${containerId}_graph`, cfgOptions);
 		gt.board.suspendUpdate();

--- a/htdocs/js/GraphTool/graphtool.scss
+++ b/htdocs/js/GraphTool/graphtool.scss
@@ -231,6 +231,10 @@
 			&.gt-interval-bracket-tool {
 				background-image: url('images/IntervalBracketTool.svg');
 			}
+
+			&.gt-sine-wave-tool {
+				background-image: url('images/SineWaveTool.svg');
+			}
 		}
 	}
 

--- a/htdocs/js/GraphTool/images/SineWaveTool.svg
+++ b/htdocs/js/GraphTool/images/SineWaveTool.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" id="SVGRoot" version="1.1" viewBox="0 0 32 32" height="32px" width="32px">
+    <g id="layer1">
+        <path style="opacity:1;fill:none;stroke:#000000;stroke-width:1.51728106;stroke-dasharray:none" d="M 3.7745 16.1808 C 4.9579 12.4657 6.1413 8.7892 7.3247 6.4729 C 8.508 4.1565 9.6914 3.2485 10.8748 4.0752 c 1.1834 0.8267 2.3668 3.3709 3.5502 6.7181 c 1.1834 3.3473 2.3668 7.4279 3.5501 10.7751 c 1.1834 3.3472 2.3668 5.8914 3.5502 6.7181 c 1.1834 0.8267 2.3668 -0.0813 3.5502 -2.3977 c 1.1834 -2.3163 2.3668 -5.9928 3.5501 -9.708" id="sine-wave" />
+        <circle id="point1" cx="3.5" cy="16" style="display:inline;fill:blue;stroke-width:0.79351956" r="2.5" />
+		<circle id="point2" cx="28.5" cy="16" style="display:inline;fill:blue;stroke-width:0.79351956" r="2.5" />
+        <circle id="point3" cx="10.2" cy="3.5" style="display:inline;fill:blue;stroke-width:0.79351956" r="2.5" />
+    </g>
+</svg>

--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -559,12 +559,12 @@
 				};
 
 				this.phase2 = (coords) => {
-					// Don't allow the second point to be created on the first point or off the board.
-					if (
-						this.point1.X() === gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
-					)
-						return;
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are the same as those of the first point,
+					// then use the highlight point coordinates instead.
+					if (Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps)
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 

--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -366,14 +366,20 @@
 						...gt.graphObjectTypes.interval.maybeBracketAttributes()
 					});
 					point.setAttribute({ snapToGrid: true });
-					point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
-					point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
-					if (typeof paired_point !== 'undefined') {
-						point.paired_point = paired_point;
-						paired_point.paired_point = point;
-						paired_point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(e, paired_point));
-						point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(e, point));
+
+					if (!gt.isStatic) {
+						point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
+						point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
+						if (typeof paired_point !== 'undefined') {
+							point.paired_point = paired_point;
+							paired_point.paired_point = point;
+							paired_point.on('drag', (e) =>
+								gt.graphObjectTypes.interval.pairedPointDrag(e, paired_point)
+							);
+							point.on('drag', (e) => gt.graphObjectTypes.interval.pairedPointDrag(e, point));
+						}
 					}
+
 					if (!gt.options.useBracketEnds) return point;
 
 					point.rendNode.classList.add('hidden-end-point');

--- a/htdocs/js/GraphTool/quadratictool.js
+++ b/htdocs/js/GraphTool/quadratictool.js
@@ -199,13 +199,12 @@
 				};
 
 				this.phase2 = (coords) => {
-					// Don't allow the second point to be created on the same
-					// vertical line as the first point or off the board.
-					if (
-						this.point1.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
-					)
-						return;
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point,
+					// then use the highlight point coordinates instead.
+					if (Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps)
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 
@@ -231,14 +230,15 @@
 				};
 
 				this.phase3 = (coords) => {
-					// Don't allow the third point to be created on the same vertical line as the
-					// first point, on the same vertical line as the second point, or off the board.
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point, or on the same
+					// vertical line as the second point, then use the highlight point coordinates instead.
 					if (
-						this.point1.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						this.point2.X() == gt.snapRound(coords[1], gt.snapSizeX) ||
-						!gt.boardHasPoint(coords[1], coords[2])
+						Math.abs(this.point1.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
+						Math.abs(this.point2.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps
 					)
-						return;
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 

--- a/htdocs/js/GraphTool/quadratictool.js
+++ b/htdocs/js/GraphTool/quadratictool.js
@@ -139,25 +139,28 @@
 						}
 					);
 					point.setAttribute({ snapToGrid: true });
-					if (typeof grouped_points !== 'undefined' && grouped_points.length) {
-						point.grouped_points = [];
-						grouped_points.forEach((paired_point) => {
-							point.grouped_points.push(paired_point);
-							if (!paired_point.grouped_points) {
-								paired_point.grouped_points = [];
-								paired_point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag);
-							}
-							paired_point.grouped_points.push(point);
-							if (
-								!paired_point.eventHandlers.drag ||
-								paired_point.eventHandlers.drag.every(
-									(dragHandler) =>
-										dragHandler.handler !== gt.graphObjectTypes.quadratic.groupedPointDrag
+
+					if (!gt.isStatic) {
+						if (typeof grouped_points !== 'undefined' && grouped_points.length) {
+							point.grouped_points = [];
+							grouped_points.forEach((paired_point) => {
+								point.grouped_points.push(paired_point);
+								if (!paired_point.grouped_points) {
+									paired_point.grouped_points = [];
+									paired_point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag);
+								}
+								paired_point.grouped_points.push(point);
+								if (
+									!paired_point.eventHandlers.drag ||
+									paired_point.eventHandlers.drag.every(
+										(dragHandler) =>
+											dragHandler.handler !== gt.graphObjectTypes.quadratic.groupedPointDrag
+									)
 								)
-							)
-								paired_point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag);
-						});
-						point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag, point);
+									paired_point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag);
+							});
+							point.on('drag', gt.graphObjectTypes.quadratic.groupedPointDrag, point);
+						}
 					}
 					return point;
 				}

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -1,0 +1,441 @@
+/* global graphTool, JXG */
+
+(() => {
+	if (graphTool && graphTool.sineWaveTool) return;
+
+	graphTool.sineWaveTool = {
+		SineWave: {
+			preInit(gt, shiftPoint, periodPoint, amplitudePoint, solid) {
+				[shiftPoint, periodPoint, amplitudePoint].forEach((point) => {
+					point.setAttribute(gt.definingPointAttributes);
+					point.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
+					point.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+				});
+				return gt.graphObjectTypes.sineWave.createSineWave(
+					shiftPoint,
+					() => (2 * Math.PI) / (periodPoint.X() - shiftPoint.X()),
+					() => amplitudePoint.Y() - shiftPoint.Y(),
+					solid,
+					gt.color.curve
+				);
+			},
+
+			postInit(_gt, shiftPoint, periodPoint, amplitudePoint) {
+				this.definingPts.push(shiftPoint, periodPoint, amplitudePoint);
+				this.focusPoint = shiftPoint;
+			},
+
+			stringify(gt) {
+				return [
+					this.baseObj.getAttribute('dash') == 0 ? 'solid' : 'dashed',
+					`(${gt.snapRound(this.definingPts[0].X(), gt.snapSizeX)},${gt.snapRound(
+						this.definingPts[0].Y(),
+						gt.snapSizeY
+					)})`,
+					gt.snapRound(this.definingPts[1].X() - this.definingPts[0].X(), gt.snapSizeX),
+					gt.snapRound(this.definingPts[2].Y() - this.definingPts[0].Y(), gt.snapSizeY)
+				].join(',');
+			},
+
+			fillCmp(gt, point) {
+				return gt.sign(point[2] - this.baseObj.Y(point[1]));
+			},
+
+			restore(gt, string) {
+				const data = string.match(
+					new RegExp(
+						[
+							gt.pointRegexp, // phase shift and y translation point
+							/\s*,\s*/, // comma
+							/(-?[0-9]*(?:\.[0-9]*)?)/, // period
+							/\s*,\s*/, // comma
+							/(-?[0-9]*(?:\.[0-9]*)?)/ // amplitude
+						]
+							.map((r) => r.source)
+							.join('')
+					)
+				);
+				if (!data || data.length !== 5) return false;
+
+				const shiftPoint = gt.graphObjectTypes.sineWave.createPoint(
+					gt.snapRound(parseFloat(data[1]), gt.snapSizeX),
+					gt.snapRound(parseFloat(data[2]), gt.snapSizeY)
+				);
+				const periodPoint = gt.graphObjectTypes.sineWave.createPoint(
+					gt.snapRound(shiftPoint.X() + parseFloat(data[3]), gt.snapSizeX),
+					shiftPoint.Y(),
+					shiftPoint
+				);
+				const amplitudePoint = gt.graphObjectTypes.sineWave.createPoint(
+					(3 * shiftPoint.X()) / 4 + periodPoint.X() / 4,
+					gt.snapRound(shiftPoint.Y() + parseFloat(data[4]), gt.snapSizeY),
+					shiftPoint,
+					periodPoint
+				);
+				return new gt.graphObjectTypes.sineWave(shiftPoint, periodPoint, amplitudePoint, /solid/.test(string));
+			},
+
+			helperMethods: {
+				createSineWave(gt, point, period, amplitude, solid, color) {
+					return gt.board.create(
+						'curve',
+						[
+							// x and y coordinate of point on curve
+							(x) => x,
+							(x) => amplitude() * Math.sin(period() * (x - point.X())) + point.Y(),
+							// domain minimum and maximum
+							() => gt.board.getBoundingBox()[0],
+							() => gt.board.getBoundingBox()[2]
+						],
+						{
+							strokeWidth: 2,
+							highlight: false,
+							strokeColor: color ? color : gt.color.underConstruction,
+							dash: solid ? 0 : 2
+						}
+					);
+				},
+
+				// Prevent a point from being moved off the board by a drag. If xRestrict is provided, then also prevent
+				// the point from being moved into the same vertical line as that point.  If yRestrict is provided, then
+				// also prevent the point from being moved into the same horizontal line as that point.  Note that when
+				// this method is called, the point has already been moved by JSXGraph.  Note that this ensures that the
+				// sine wave does not degenerate into a line or even worse a point.
+				adjustDragPosition(gt, e, point, xRestrict = undefined, yRestrict = undefined) {
+					const bbox = gt.board.getBoundingBox();
+
+					// Clamp the coordinates to the board.
+					let x = point.X() < bbox[0] ? bbox[0] : point.X() > bbox[2] ? bbox[2] : point.X();
+					let y = point.Y() < bbox[3] ? bbox[3] : point.Y() > bbox[1] ? bbox[1] : point.Y();
+
+					if (xRestrict) {
+						// Adjust the position of the point if it is on the same
+						// vertical line as its xRestrict point.
+						let xDir;
+
+						if (e.type === 'pointermove') {
+							const coords = gt.getMouseCoords(e);
+							xDir = coords.usrCoords[1] > xRestrict.X() ? 1 : -1;
+						} else if (e.type === 'keydown') {
+							xDir = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+						}
+
+						if (Math.abs(x - xRestrict.X()) < JXG.Math.eps) x += xDir * gt.snapSizeX;
+
+						// If the computed new coordinate is off the board,
+						// then move the coordinate the other direction instead.
+						if (x < bbox[0]) x = bbox[0] + gt.snapSizeX;
+						else if (x > bbox[2]) x = bbox[2] - gt.snapSizeX;
+					}
+
+					if (yRestrict) {
+						// Adjust the position of the point if it is on the same
+						// horizontal line as its yRestrict point.
+						let yDir;
+
+						if (e.type === 'pointermove') {
+							const coords = gt.getMouseCoords(e);
+							yDir = coords.usrCoords[2] > yRestrict.Y() ? 1 : -1;
+						} else if (e.type === 'keydown') {
+							yDir = e.key === 'ArrowUp' ? 1 : e.key === 'ArrowDown' ? -1 : 0;
+						}
+
+						if (Math.abs(y - yRestrict.Y()) < JXG.Math.eps) y += yDir * gt.snapSizeY;
+
+						// If the computed new coordinate is off the board,
+						// then move the coordinate the other direction instead.
+						if (y < bbox[3]) y = bbox[3] + gt.snapSizeY;
+						else if (y > bbox[1]) y = bbox[1] - gt.snapSizeY;
+					}
+
+					if (
+						!gt.boardHasPoint(point.X(), point.Y()) ||
+						Math.abs(point.X() - x) >= JXG.Math.eps ||
+						Math.abs(point.Y() - y) >= JXG.Math.eps
+					)
+						point.setPosition(JXG.COORDS_BY_USER, [x, y]);
+				},
+
+				pointDrag(gt, e) {
+					gt.graphObjectTypes.sineWave.adjustDragPosition(
+						e,
+						this,
+						!this.shiftPoint ? this.periodPoint : !this.periodPoint ? this.shiftPoint : undefined,
+						!this.shiftPoint ? this.amplitudePoint : !this.amplitudePoint ? this.shiftPoint : undefined
+					);
+
+					const shiftPoint = this.shiftPoint ?? this;
+					const periodPoint = this.periodPoint ?? this;
+					const amplitudePoint = this.amplitudePoint ?? this;
+
+					if (shiftPoint && periodPoint)
+						amplitudePoint?.setPosition(JXG.COORDS_BY_USER, [
+							(3 * shiftPoint.X()) / 4 + periodPoint.X() / 4,
+							amplitudePoint.Y()
+						]);
+
+					if (shiftPoint) periodPoint?.setPosition(JXG.COORDS_BY_USER, [periodPoint.X(), shiftPoint.Y()]);
+
+					gt.updateObjects();
+					gt.updateText();
+				},
+
+				createPoint(gt, x, y, shiftPoint = undefined, periodPoint = undefined) {
+					const point = gt.board.create('point', [x, y], {
+						size: 2,
+						snapSizeX: periodPoint ? 1e-10 : gt.snapSizeX,
+						snapSizeY: shiftPoint && !periodPoint ? 1e-10 : gt.snapSizeY,
+						withLabel: false
+					});
+					point.setAttribute({ snapToGrid: true });
+
+					if (!gt.isStatic) {
+						if (shiftPoint) {
+							point.shiftPoint = shiftPoint;
+							if (!shiftPoint.periodPoint) shiftPoint.periodPoint = point;
+							else if (!shiftPoint.amplitudePoint) shiftPoint.amplitudePoint = point;
+							if (!shiftPoint.eventHandlers.drag)
+								shiftPoint.on('drag', gt.graphObjectTypes.sineWave.pointDrag);
+							point.on('drag', gt.graphObjectTypes.sineWave.pointDrag);
+						}
+
+						if (periodPoint) {
+							point.periodPoint = periodPoint;
+							if (!periodPoint.amplitudePoint) periodPoint.amplitudePoint = point;
+						}
+					}
+
+					return point;
+				}
+			}
+		},
+
+		SineWaveTool: {
+			iconName: 'sine-wave',
+			tooltip: 'Sine Wave Tool: Graph a sine wave.',
+
+			initialize(gt) {
+				this.supportsSolidDash = true;
+
+				this.phase1 = (coords) => {
+					// Don't allow the point to be created off the board.
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					gt.board.off('up');
+
+					this.shiftPoint = gt.graphObjectTypes.sineWave.createPoint(
+						gt.snapRound(coords[1], gt.snapSizeX),
+						gt.snapRound(coords[2], gt.snapSizeY)
+					);
+					this.shiftPoint.setAttribute({ fixed: true, highlight: false });
+
+					// Get a new x coordinate that is to the right, unless that is off the board.
+					// In that case go left instead.
+					let newX = this.shiftPoint.X() + gt.snapSizeX;
+					if (newX > gt.board.getBoundingBox()[2]) newX = this.shiftPoint.X() - gt.snapSizeX;
+
+					this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [newX, this.shiftPoint.Y()], gt.board));
+
+					this.helpText = 'Move the highlighted point left or right to adjust the period.';
+					gt.updateHelp();
+
+					gt.board.on('up', (e) => this.phase2(gt.getMouseCoords(e).usrCoords));
+
+					gt.board.update();
+				};
+
+				this.phase2 = (coords) => {
+					// Don't allow the second point to be created on the same
+					// vertical line as the first point or off the board.
+					if (
+						Math.abs(this.shiftPoint.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
+						!gt.boardHasPoint(coords[1], coords[2])
+					)
+						return;
+
+					gt.board.off('up');
+
+					this.periodPoint = gt.graphObjectTypes.sineWave.createPoint(
+						gt.snapRound(coords[1], gt.snapSizeX),
+						this.shiftPoint.Y(),
+						this.shiftPoint
+					);
+					this.periodPoint.setAttribute({ fixed: true, highlight: false });
+
+					// Get a new y coordinate that is above, unless that is off the board.
+					// In that case go down instead.
+					let newY = this.shiftPoint.Y() + gt.snapSizeY;
+					if (newY > gt.board.getBoundingBox()[1]) newY = this.shiftPoint.Y() - gt.snapSizeY;
+
+					this.updateHighlights(
+						new JXG.Coords(
+							JXG.COORDS_BY_USER,
+							[(3 * this.shiftPoint.X()) / 4 + this.periodPoint.X() / 4, newY],
+							gt.board
+						)
+					);
+
+					this.helpText = 'Move the highlighted point up or down to adjust the amplitude.';
+					gt.updateHelp();
+
+					gt.board.on('up', (e) => this.phase3(gt.getMouseCoords(e).usrCoords));
+
+					gt.board.update();
+				};
+
+				this.phase3 = (coords) => {
+					// Don't allow the third point to be created on the same
+					// horizontal line as the first point, or off the board.
+					if (
+						Math.abs(this.shiftPoint.Y() - gt.snapRound(coords[2], gt.snapSizeY)) < JXG.Math.eps ||
+						!gt.boardHasPoint(coords[1], coords[2])
+					)
+						return;
+
+					gt.board.off('up');
+
+					const amplitudePoint = gt.graphObjectTypes.sineWave.createPoint(
+						(3 * this.shiftPoint.X()) / 4 + this.periodPoint.X() / 4,
+						gt.snapRound(coords[2], gt.snapSizeY),
+						this.shiftPoint,
+						this.periodPoint
+					);
+					gt.selectedObj = new gt.graphObjectTypes.sineWave(
+						this.shiftPoint,
+						this.periodPoint,
+						amplitudePoint,
+						gt.drawSolid
+					);
+					gt.selectedObj.focusPoint = amplitudePoint;
+					gt.graphedObjs.push(gt.selectedObj);
+					delete this.shiftPoint;
+					delete this.periodPoint;
+
+					this.finish();
+				};
+			},
+
+			handleKeyEvent(gt, e) {
+				if (!this.hlObjs.hl_point || !gt.board.containerObj.contains(document.activeElement)) return;
+
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					e.stopPropagation();
+
+					if (this.periodPoint) this.phase3(this.hlObjs.hl_point.coords.usrCoords);
+					else if (this.shiftPoint) this.phase2(this.hlObjs.hl_point.coords.usrCoords);
+					else this.phase1(this.hlObjs.hl_point.coords.usrCoords);
+				}
+			},
+
+			updateHighlights(gt, e) {
+				this.hlObjs.hl_period_sine_wave?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+				this.hlObjs.hl_sine_wave?.setAttribute({ dash: gt.drawSolid ? 0 : 2 });
+				this.hlObjs.hl_point?.rendNode.focus();
+
+				let coords;
+				if (e instanceof MouseEvent && e.type === 'pointermove') {
+					coords = gt.getMouseCoords(e);
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [
+						this.shiftPoint && this.periodPoint
+							? (3 * this.shiftPoint.X()) / 4 + this.periodPoint.X() / 4
+							: coords.usrCoords[1],
+						this.shiftPoint && !this.periodPoint ? this.shiftPoint.Y() : coords.usrCoords[2]
+					]);
+				} else if (e instanceof KeyboardEvent && e.type === 'keydown') {
+					coords = this.hlObjs.hl_point.coords;
+				} else if (e instanceof JXG.Coords) {
+					coords = e;
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [coords.usrCoords[1], coords.usrCoords[2]]);
+				} else return false;
+
+				if (!this.hlObjs.hl_point) {
+					this.hlObjs.hl_point = gt.board.create('point', [coords.usrCoords[1], coords.usrCoords[2]], {
+						size: 2,
+						color: gt.color.underConstruction,
+						snapToGrid: true,
+						snapSizeX: gt.snapSizeX,
+						snapSizeY: gt.snapSizeY,
+						highlight: false,
+						withLabel: false
+					});
+					this.hlObjs.hl_point.rendNode.focus();
+				}
+
+				// Make sure the highlight point is not moved off the board, that the sine wave is not degenerate.
+				if (e instanceof Event) {
+					gt.graphObjectTypes.sineWave.adjustDragPosition(
+						e,
+						this.hlObjs.hl_point,
+						this.shiftPoint,
+						this.periodPoint
+					);
+				}
+
+				if (this.periodPoint && !this.hlObjs.hl_sine_wave) {
+					// Remove the temporary highlight sine wave from the period phase if it exists.
+					if (this.hlObjs.hl_period_sine_wave) {
+						gt.board.removeObject(this.hlObjs.hl_period_sine_wave);
+						delete this.hlObjs.hl_period_sine_wave;
+					}
+
+					this.hlObjs.hl_point.setAttribute({ snapSizeX: 1e-10, snapSizeY: gt.snapSizeY });
+					this.hlObjs.hl_point?.setPosition(JXG.COORDS_BY_USER, [
+						(3 * this.shiftPoint.X()) / 4 + this.periodPoint.X() / 4,
+						this.hlObjs.hl_point.Y()
+					]);
+
+					// Local references are needed because the coordinate methods can
+					// be called after this.shiftPoint and this.periodPoint are deleted.
+					const shiftPoint = this.shiftPoint;
+					const periodPoint = this.periodPoint;
+
+					this.hlObjs.hl_sine_wave = gt.graphObjectTypes.sineWave.createSineWave(
+						this.shiftPoint,
+						() => (2 * Math.PI) / (periodPoint.X() - shiftPoint.X()),
+						() => this.hlObjs.hl_point.Y() - shiftPoint.Y(),
+						gt.drawSolid
+					);
+				} else if (this.shiftPoint && !this.periodPoint && !this.hlObjs.hl_period_sine_wave) {
+					this.hlObjs.hl_point.setAttribute({ snapSizeY: 1e-10 });
+
+					// A local reference is needed because the coordinate methods
+					// can be called after this.shiftPoint is deleted.
+					const shiftPoint = this.shiftPoint;
+
+					this.hlObjs.hl_period_sine_wave = gt.graphObjectTypes.sineWave.createSineWave(
+						this.shiftPoint,
+						() => (2 * Math.PI) / (this.hlObjs.hl_point.X() - shiftPoint.X()),
+						() => gt.snapSizeY,
+						gt.drawSolid
+					);
+				}
+
+				gt.setTextCoords(this.hlObjs.hl_point.X(), this.hlObjs.hl_point.Y());
+				gt.board.update();
+			},
+
+			deactivate(gt) {
+				delete this.helpText;
+				gt.board.off('up');
+				['shiftPoint', 'periodPoint', 'amplitudePoint'].forEach(function (point) {
+					if (this[point]) gt.board.removeObject(this[point]);
+					delete this[point];
+				}, this);
+				gt.board.containerObj.style.cursor = 'auto';
+			},
+
+			activate(gt) {
+				gt.board.containerObj.style.cursor = 'none';
+
+				// Draw a highlight point on the board.
+				this.updateHighlights(new JXG.Coords(JXG.COORDS_BY_USER, [0, 0], gt.board));
+
+				this.helpText = 'Move the highlighted point to set the phase shift and vertical translation.';
+				gt.updateHelp();
+
+				gt.board.on('up', (e) => this.phase1(gt.getMouseCoords(e).usrCoords));
+			}
+		}
+	};
+})();

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -225,8 +225,8 @@
 				this.supportsSolidDash = true;
 
 				this.phase1 = (coords) => {
-					// Don't allow the point to be created off the board.
-					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+					// If the current coordinates are off the board, then use the highlight point coordinates instead.
+					if (!gt.boardHasPoint(coords[1], coords[2])) coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 
@@ -252,13 +252,13 @@
 				};
 
 				this.phase2 = (coords) => {
-					// Don't allow the second point to be created on the same
-					// vertical line as the first point or off the board.
+					// If the current coordinates are on the same vertical line as the first point or off the board,
+					// then use the coordinates of the highlight point instead.
 					if (
-						Math.abs(this.shiftPoint.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps ||
-						!gt.boardHasPoint(coords[1], coords[2])
+						!gt.boardHasPoint(coords[1], coords[2]) ||
+						Math.abs(this.shiftPoint.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps
 					)
-						return;
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 
@@ -291,13 +291,13 @@
 				};
 
 				this.phase3 = (coords) => {
-					// Don't allow the third point to be created on the same
-					// horizontal line as the first point, or off the board.
+					// If the current coordinates are on the same horizontal line as the first point or off the board,
+					// then use the highlight point coordinates instead.
 					if (
 						Math.abs(this.shiftPoint.Y() - gt.snapRound(coords[2], gt.snapSizeY)) < JXG.Math.eps ||
 						!gt.boardHasPoint(coords[1], coords[2])
 					)
-						return;
+						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
 
@@ -369,7 +369,7 @@
 					this.hlObjs.hl_point.rendNode.focus();
 				}
 
-				// Make sure the highlight point is not moved off the board, that the sine wave is not degenerate.
+				// Make sure the highlight point is not moved off the board, and that the sine wave is not degenerate.
 				if (e instanceof Event) {
 					gt.graphObjectTypes.sineWave.adjustDragPosition(
 						e,
@@ -420,6 +420,7 @@
 
 				gt.setTextCoords(this.hlObjs.hl_point.X(), this.hlObjs.hl_point.Y());
 				gt.board.update();
+				return true;
 			},
 
 			deactivate(gt) {

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -75,6 +75,13 @@
 				return new gt.graphObjectTypes.sineWave(shiftPoint, periodPoint, amplitudePoint, /solid/.test(string));
 			},
 
+			helpText(_gt) {
+				if (this.focusPoint == this.definingPts[1])
+					return 'Note that the selected point can only be moved left and right.';
+				else if (this.focusPoint == this.definingPts[2])
+					return 'Note that the selected point can only be moved up and down.';
+			},
+
 			helperMethods: {
 				createSineWave(gt, point, period, amplitude, solid, color) {
 					return gt.board.create(

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -225,8 +225,8 @@
 				this.supportsSolidDash = true;
 
 				this.phase1 = (coords) => {
-					// If the current coordinates are off the board, then use the highlight point coordinates instead.
-					if (!gt.boardHasPoint(coords[1], coords[2])) coords = this.hlObjs.hl_point.coords.usrCoords;
+					// Don't allow the point to be created off the board
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
 
 					gt.board.off('up');
 
@@ -252,12 +252,11 @@
 				};
 
 				this.phase2 = (coords) => {
-					// If the current coordinates are on the same vertical line as the first point or off the board,
-					// then use the coordinates of the highlight point instead.
-					if (
-						!gt.boardHasPoint(coords[1], coords[2]) ||
-						Math.abs(this.shiftPoint.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps
-					)
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same vertical line as the first point,
+					// then use the highlight point coordinates instead.
+					if (Math.abs(this.shiftPoint.X() - gt.snapRound(coords[1], gt.snapSizeX)) < JXG.Math.eps)
 						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');
@@ -291,12 +290,11 @@
 				};
 
 				this.phase3 = (coords) => {
-					// If the current coordinates are on the same horizontal line as the first point or off the board,
+					if (!gt.boardHasPoint(coords[1], coords[2])) return;
+
+					// If the current coordinates are on the same horizontal line as the first point,
 					// then use the highlight point coordinates instead.
-					if (
-						Math.abs(this.shiftPoint.Y() - gt.snapRound(coords[2], gt.snapSizeY)) < JXG.Math.eps ||
-						!gt.boardHasPoint(coords[1], coords[2])
-					)
+					if (Math.abs(this.shiftPoint.Y() - gt.snapRound(coords[2], gt.snapSizeY)) < JXG.Math.eps)
 						coords = this.hlObjs.hl_point.coords.usrCoords;
 
 					gt.board.off('up');

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
             "license": "GPL-2.0+",
             "dependencies": {
                 "@openwebwork/mathquill": "^0.11.0-beta.3",
-                "jsxgraph": "^1.9.2",
+                "jsxgraph": "^1.10.1",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
                 "plotly.js-dist-min": "^2.32.0",
@@ -754,9 +754,10 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "node_modules/jsxgraph": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.9.2.tgz",
-            "integrity": "sha512-vaZe7PRY6lCtLHzDQJUEZj7qJhi58aXMvZN8eP2U2955y1y13myphDaQjsHuNuj2mdlANohtFzz/bdoifebV+g==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.10.1.tgz",
+            "integrity": "sha512-N7WQmjeiiGKiJPr4iGUHgf8uRazOo9qaGLjX/tLWvrup67FUVD4eEctSLO1HuNcOSthwl16aTc692TKf/vZxNw==",
+            "license": "(MIT OR LGPL-3.0-or-later)",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -2199,9 +2200,9 @@
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "jsxgraph": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.9.2.tgz",
-            "integrity": "sha512-vaZe7PRY6lCtLHzDQJUEZj7qJhi58aXMvZN8eP2U2955y1y13myphDaQjsHuNuj2mdlANohtFzz/bdoifebV+g=="
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.10.1.tgz",
+            "integrity": "sha512-N7WQmjeiiGKiJPr4iGUHgf8uRazOo9qaGLjX/tLWvrup67FUVD4eEctSLO1HuNcOSthwl16aTc692TKf/vZxNw=="
         },
         "jszip": {
             "version": "3.10.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@openwebwork/mathquill": "^0.11.0-beta.3",
-        "jsxgraph": "^1.9.2",
+        "jsxgraph": "^1.10.1",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",
         "plotly.js-dist-min": "^2.32.0",

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -220,8 +220,7 @@ be shown as multiples of this symbol.
 
 This can be used in combination with the C<scaleX> option to show tick labels at multiples of
 pi, for instance. This can be accomplished using the settings C<< scaleX => pi->value >> and
-C<< scaleSymbolX => "~~x{03C0}" >>. Note that value of C<scaleSymbolX> shown is the unicode pi
-symbol, and that C<~~> is the PG escape character (normally a backslash in Perl).
+C<< scaleSymbolX => '\pi' >>.
 
 =item xAxisLabel, yAxisLabel (Default: C<< xAxisLabel => 'x', yAxisLabel => 'y' >>)
 
@@ -267,28 +266,30 @@ for the 1 dimensional mode when numberLine is 1.
 
 =item coordinateHintsType (Default: C<< coordinateHintsType => 'decimal' >>)
 
-This changes the way coordinate hints are shown.  By default the coordinates are displayed as
-decimal numbers accurate to five decimal places.  If this is set to 'fraction', then those
-decimals will be converted and displayed as fractions.  If this is set to 'mixed', then those
-decimals will be converted and displayed as mixed numbers.  For example, if the snapSizeX is set
-to 1/3, then what would be displayed as 4.66667 with the default 'decimal' setting, would be
-instead be displayed as 14/3 with the 'fraction' setting, and '4 2/3' with the 'mixed' setting.
-Note that these fractions are typeset by MathJax.
+This changes the way coordinate hints and axes tick labels are shown.  By default these are
+displayed as decimal numbers accurate to five decimal places.  If this is set to 'fraction',
+then those decimals will be converted and displayed as fractions.  If this is set to 'mixed',
+then those decimals will be converted and displayed as mixed numbers.  For example, if the
+snapSizeX is set to 1/3, then what would be displayed as 4.66667 with the default 'decimal'
+setting, would be instead be displayed as 14/3 with the 'fraction' setting, and '4 2/3' with the
+'mixed' setting.  Note that these fractions are typeset by MathJax.
 
-Make sure that the snap size is given with decent accuracy.  For example, if the snap size to
-0.33333, then instead of 1/3 being displayed, 33333/1000000 will be displayed.  It is
+Make sure that the snap size is given with decent accuracy.  For example, if the snap size is
+set to 0.33333, then instead of 1/3 being displayed, 33333/1000000 will be displayed.  It is
 recommended to actually give an actual fraction for the snap size (like 1/3), and let perl and
 javascript compute that to get the best result.
 
 =item coordinateHintsTypeX (Default: C<< coordinateHintsTypeX => undef >>)
 
-This does the same as the coordinateHintsType option, but only for the x-coordinate.
-If this is undefined then the coordinateHintsType option is used for the x-coordinate.
+This does the same as the coordinateHintsType option, but only for the x-coordinate and x-axis
+tick labels.  If this is undefined then the coordinateHintsType option is used for the
+x-coordinate and x-axis tick labels.
 
 =item coordinateHintsTypeY (Default: C<< coordinateHintsTypeY => undef >>)
 
-This does the same as the coordinateHintsType option, but only for the y-coordinate.
-If this is undefined then the coordinateHintsType option is used for the y-coordinate.
+This does the same as the coordinateHintsType option, but only for the y-coordinate and y-axis
+tick labels.  If this is undefined then the coordinateHintsType option is used for the
+y-coordinate and y-axis tick labels.
 
 =item availableTools (Default: C<< availableTools => [ "LineTool", "CircleTool",
     "VerticalParabolaTool", "HorizontalParabolaTool", "FillTool", "SolidDashTool" ] >>)


### PR DESCRIPTION
The tool can be added by setting `availableTools => [ 'SineWaveTool' ]` in the `->with` call when creating a `GraphTool` object. Of course other tools can be added in the list as well.  The tool works by plotting three points.  The first point determines the phase shift (or x translation) and y translation.  The second point determines the amplitude.  Note that point can only be moved horizontally, and is forced to always stay on the same horizontal line as the first point.  The third point determines the amplitude. That point can only be moved vertically, and is forced to stay at the peak of the first crest of the sine wave.  So if `(x1, y1)` is the first point, `x2` the x-coordinate of the second point, and `y3` the y-coordinate of the third point, then the function is `f(x) = y3 * sin(2 * pi / x2 * (x - x1)) + y1`.

An example problem is attached: [GraphSineWavePi.pg.txt](https://github.com/user-attachments/files/18044341/GraphSineWavePi.pg.txt)
    
There are several new GraphTool options added to make it so that the axis labels can be multiples of `pi`.  They are `scaleX`, `scaleY`, `scaleSymbolX`, and `scaleSymbolY`.  The "scale" options are the scale of the ticks on the x and y axes. That is the distance between two successive ticks on the axis (including both major and minor ticks).  The "scaleSymbol" options are the scale symbols for the ticks on the x and y axes. The labels on the axis will be shown as multiples of this symbol.
    
These options can be used in combination to show tick labels at multiples of pi by using the settings `scaleX => pi->value` and `scaleSymbolX => '\pi'`.
    
The coordinate hints in the lower right corner have also been updated to use these options if set.
    
Also make the axis tick labels be shown according to the `coordinateHintsType` settings.  This reworks the coordinate hints code considerably.  The JSXGraph `formatLabelText` method of the default axes ticks is overriden so that tick labels can be formatted according to our `coordinateHintsType` settings.  Note that there is a JSXGraph tick label `toFraction` option that is similar and is used in the default `formatLabelText` method, but it always uses mixed numbers. Furthermore, the `scaleSymbol` is included in what is typeset by MathJax (the default method does not do this).  This looks better and also means that instead of needing to use the unicode symbol for pi, the LaTeX `\pi` command can be used instead. Note that MathJax actually supports the unicode symbol and typesets it the same as `\pi`.  So if the `coordinateHintsType` setting is 'mixed' then both the coordinate hints shown in the lower right corner of the graph (or upper left for number lines) and the labels on the axes will be shown as mixed numbers, and if the setting is 'fraction' then both will be displayed as improper fractions, and with the default 'decimal' setting both will be decimals.  Note that the `useMathJax: true` and `display: 'html'` settings are now set for the axes tick labels so that fractions are displayed typeset by MathJax.  Note that this is stated for the `coordinateHintsType` setting, but really applies to the `coordinateHintsTypeX` and `coordinateHintsTypeY` settings as well for per coordinate and axis behavior.
    
Now the `coordinateHintsType` settings are perhaps not appropriately named since they apply to more than just the coordinate hints, and also apply to axis labels. But I don't feel like adding another setting for this and consistency between the hint coordinates and axis labels is better.
    
The JSXGraph `generateLabelText` method of the axes ticks is also overridden so that zero is also typeset using MathJax.  The default JSXGraph method never does this even if the other labels are typeset using MathJax and gives an inconsistent appearance in that case.

Add a way for a graph object to add to the help.  A graph object can only add to the help when it is selected.  The help is also updated when focus moves within the object to different defining points.  So the graph object can give a different message depending on which point is focused.  The sine wave tool uses this to let the user know restrictions on how the focused point can move.

There is a general and minor change to some other graph objects.  The "down", "up", and "drag" handlers are no longer attached to static graph object points. For most objects this doesn't matter because the points are hidden. So the points can't be clicked on or dragged in any case.  However, for the "fill" graph object the paint bucket icon is still visible for static fill objects, and then clicking on the icon you see the mouse cursor disappear.  The icon still can't be dragged because it is fixed, but the cursor disappearing sort of indicates that the icon has been grabbed for a drag which is somewhat counter intuitive when you can't actually do so. These handlers aren't needed for static objects in any case.

Note that JSXGraph is updated to the latest version.