### PR TITLE
Fix the values option of parserPopUp.pl.

### DIFF
--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -269,7 +269,7 @@ sub addLabelsValues {
 	my $self    = shift;
 	my $choices = $self->{orderedChoices};
 	my $labels  = [];
-	my $values  = $self->{values};
+	my $values  = [];
 	my $n       = $self->{n};
 
 	foreach my $i (0 .. $n - 1) {
@@ -278,7 +278,7 @@ sub addLabelsValues {
 			$values->[$i] = $choices->[$i]{ $labels->[$i] };
 		} else {
 			$labels->[$i] = $choices->[$i];
-			$values->[$i] = $choices->[$i] unless (defined($values->[$i]) && $values->[$i] ne '');
+			$values->[$i] = $self->{values}[ $self->{order}[$i] ] // $choices->[$i];
 		}
 
 	}

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -389,10 +389,10 @@ sub MENU {
 
 	if ($main::displayMode =~ m/^HTML/) {
 		$menu = main::tag(
-			'span',
-			class                       => 'text-nowrap',
-			data_feedback_insert_elt    => $name,
-			data_feedback_insert_method => 'append_content',
+			'div',
+			class                        => 'd-inline text-nowrap',
+			data_feedback_insert_element => $name,
+			data_feedback_insert_method  => 'append_content',
 			main::tag(
 				'select',
 				class      => 'pg-select',

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -302,7 +302,7 @@ sub getCorrectChoice {
 	my @choices = @{ $self->{orderedChoices} };
 	foreach my $i (0 .. $#choices) {
 		if ($label eq $self->{labels}[$i]) {
-			$self->{data} = [ $self->{labels}[$i] ];
+			$self->{data} = [ $self->{values}[$i] ];
 			return;
 		}
 	}


### PR DESCRIPTION
The current code sets the correct choice to be the label, and it should be the value.  As such if the values are specified, none of the answers are accepted as correct because the correct label is not equal to the correct value.

Here is a minimal test case:

```perl
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl parserPopUp.pl PGcourse.pl));

$popup = DropDown([ 'first', 'second', 'third' ], 1, values => [ 'a', 'b', 'c' ]);

BEGIN_PGML
Select "second": [_]{$popup}
END_PGML

ENDDOCUMENT();
```

On the develop branch (or main) no answers will be accepted with this problem.  With this pull request the second answer will be accepted as correct.  If you delete the `values` option from the `DropDown` call, then the second answer will be accepted as correct with the develop branch (and main), and with this pull request.