### PR TITLE
Prevent scaffolds from revealing correct answers when feedback is not permitted (really) - hotfix

### DIFF
--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -593,9 +593,8 @@ sub add_container {
 					'div',
 					class => 'accordion-header'
 						. (
-							$iscorrect && ($main::envir{showFeedback} || $main::envir{forceShowAttemptResults})
-							? ' iscorrect'
-							: ' iswrong'
+							$iscorrect && (($main::envir{showFeedback} && $main::envir{showAttemptResults})
+								|| $main::envir{forceShowAttemptResults}) ? ' iscorrect' : ' iswrong'
 						)
 						. ($canopen ? ' canopen' : ' cannotopen'),
 					id => "$label-header",


### PR DESCRIPTION
In #986 I believed that this was set.  But either something has changed since then, or I didn't have it right at that point.

In that pull request I claimed that when an answer preview occurs, scaffolds will open but not receive the green color if all answers within are correct.  In particular, if a preview occurs it should not reveal that answers are correct.  Unfortunately, it still is.

This fixes that by only giving the correct colors when attempt results are allowed.