### PR TITLE
Fix problem with implied multiplication in fraction context, and some typos. (#1166)

### DIFF
--- a/lib/Parser/Function.pm
+++ b/lib/Parser/Function.pm
@@ -214,7 +214,7 @@ sub checkComplexOrMatrix {
 	my $self = shift;
 	my $op   = $self->{params}[0];
 	return if ($self->checkArgCount(1));
-	$self->Error("Function '%s' requires a Complex or Matrixinput", $self->{name})
+	$self->Error("Function '%s' requires a Complex or Matrix input", $self->{name})
 		unless $op->isNumber || $op->type eq "Matrix" || $self->context->flag("allowBadFunctionInputs");
 	$self->{type} = $op->typeRef;
 }

--- a/macros/contexts/contextExtensions.pl
+++ b/macros/contexts/contextExtensions.pl
@@ -104,8 +104,8 @@ sub create {
 #
 #      would attach the class context::Quaternions::BOP::add to the
 #      plus sign in our Quaternion setting.  If the space operator (' ')
-#      in your list, and if the original context has it point to an
-#      operator that is NOT in your list, then that references operator
+#      is in your list, and if the original context has it point to an
+#      operator that is NOT in your list, then that referenced operator
 #      is redirected automatically to 'BOP::Space' in your base context
 #      package.  In our case, we would want to include a definition for
 #      context::Quaternions::BOP::Space in order to cover that possibility.

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -585,7 +585,8 @@ sub _check {
 	#  This is not a mixed number, so convert to original class and do
 	#  its _check
 	#
-	unless ($allowMixedNumbers
+	unless ($self->{bop} eq 'mixedNum'
+		&& $allowMixedNumbers
 		&& $self->extensionClassMatch($self->{lop}, 'INTEGER', 'MINUS')
 		&& !$self->{lop}{hadParens}
 		&& $self->extensionClassMatch($self->{rop}, 'FRACTION')
@@ -594,7 +595,13 @@ sub _check {
 	{
 		$self->{bop} = $self->{def}{string};
 		$self->{def} = $context->{operators}{ $self->{bop} };
-		return $self->mutate->_check;
+		my $class = $self->{def}{class};
+		if ($class eq ref($self) || $class =~ m/^context::Fraction::BOP::[Ss]pace$/) {
+			$self->mutate;
+		} else {
+			bless $self, $class;
+		}
+		return $self->_check;
 	}
 	$self->{type} = $context::Fraction::MIXED;
 	$self->Error("Mixed numbers are not allowed; you must use a pure fraction")
@@ -611,7 +618,7 @@ sub _check {
 }
 
 #
-#  For when the space operator's space property sends to an
+#  For when the space operator's string property sends to an
 #  operator we didn't otherwise subclass.
 #
 package context::Fraction::BOP::Space;


### PR DESCRIPTION
This PR fixes the problem raised in #1166.  This was due to mishandling of the "space" operator used for implied multiplication.  The issue resulted from setting the cached operator definition to the `string` operator, but mutating the operator to the wrong class in some instances (it should be to the class for the new operator, not the original space operator's class).

This PR checks whether to mutate to the original space class or to bless the operator to the `string` operator's class.

It also fixes a couple of typos (one in an unrelated file -- hope that is OK).

Resolves issue #1166.