### PR TITLE
answerHints - Fix for the first issue reported in #1170

### DIFF
--- a/macros/answers/answerHints.pl
+++ b/macros/answers/answerHints.pl
@@ -170,7 +170,8 @@ sub AnswerHints {
 							$wrong = main::Formula($wrong);
 							$wrong = $wrong->{tree}->Compute if $wrong->{tree}{canCompute};
 						}
-						if (($ans->{ans_message} eq "" || $options{replaceMessage})
+						if (($ans->{score} < 1 || $options{checkCorrect})
+							&& ($ans->{ans_message} eq "" || $options{replaceMessage})
 							&& AnswerHints::Compare($wrong, $student, $ans, @{ $options{cmp_options} }))
 						{
 							$ans->{ans_message} = $ans->{error_message} = $message;


### PR DESCRIPTION
This is meant to fix the first issue reported in https://github.com/openwebwork/pg/issues/1170

I put back the test that either the score is less than 1 or that `checkCorrect` was set before triggering a hint when "wrong" is not a subroutine.

The intention is to fix the backwards compatibility for existing content. The "price" is that any very new problems which did not set `checkCorrect` and expect the answerHint code to process an non-code option will need to add it in explictly.

Note: The older version of this test had a third "option" (another '||'). Based on the discussion in https://github.com/openwebwork/pg/issues/964#issuecomment-1816793269  the `|| AnswerHints::Compare($correct, $wrong, $ans)` portion of the old test was removed. @dpvc noted there that it was missing a negation, but felt it could be removed anyway. He removed even more - but the removal of the entire conditional about score < 1 is what is causing my problem.

