### PR TITLE
Give explicit multiplication the special mq_precedence as well.

### DIFF
--- a/lib/Parser/Context.pm
+++ b/lib/Parser/Context.pm
@@ -216,7 +216,7 @@ sub usePrecedence {
 		/^Standard/i and do {
 			$self->operators->set(
 				' *' => { precedence => 3, mq_precedence => 2.9 },
-				'* ' => { precedence => 3 },
+				'* ' => { precedence => 3, mq_precedence => 2.9 },
 				' /' => { precedence => 3 },
 				'/ ' => { precedence => 3 },
 				fn   => { precedence => 7.5 },


### PR DESCRIPTION
Implied multiplication ` *` currently has the precedence of 2.9 when MathQuill is used.  This means that `(x-3)/4 (x+8)/7` is interpreted as `\frac{(x-3)}{4} * \frac{(x+8)}{7}`.

However, `(x-3)/4 * (x+8)/7` is interpreted as
`\frac{\frac{(x-3)/4 * (x+8)}{7}`.  That should also be interpreted as `\frac{(x-3)}{4} * \frac{(x+8)}{7}` and is with the mq_precendence for `* ` also set to 2.9.

Note that @dpvc mentioned considering changing this precedence in general and dropping the special `mq_precedence`.  Should this be considered?  See https://github.com/openwebwork/pg/pull/1107#issuecomment-2514811933 and the discussion after it.  Although, does that still apply with the `* ` operator?