### PR TITLE
Fix the text button on the mqeditor toolbutton.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -62,19 +62,11 @@
 		cfgOptions.handlers = {
 			// Disable the toolbar when a text block is entered.
 			textBlockEnter: () => {
-				if (answerQuill.toolbar) {
-					// This is a workaround for a Google Chrome oddity. For some reason, if a button is disabled, then
-					// when it loses focus, the relatedTarget in the focusout event is not set even though the
-					// relatedTarget is not the button at all, but where the focus is going. Firefox and Safari
-					// (apparently) still set the relatedTarget.
-					answerQuill.toolbar.preventRemove = true;
-					answerQuill.toolbar.querySelectorAll('button').forEach((button) => (button.disabled = true));
-				}
+				answerQuill.toolbar?.querySelectorAll('button').forEach((button) => (button.disabled = true));
 			},
 			// Re-enable the toolbar when a text block is exited.
 			textBlockExit: () => {
-				if (answerQuill.toolbar)
-					answerQuill.toolbar.querySelectorAll('button').forEach((button) => (button.disabled = false));
+				answerQuill.toolbar?.querySelectorAll('button').forEach((button) => (button.disabled = false));
 			}
 		};
 
@@ -355,12 +347,9 @@
 						(e.relatedTarget.closest('.quill-toolbar') ||
 							e.relatedTarget.classList.contains('symbol-button') ||
 							e.relatedTarget === answerQuill.textarea)) ||
-					(answerQuill.clearButton && e.relatedTarget === answerQuill.clearButton) ||
-					answerQuill.toolbar?.preventRemove
-				) {
-					if (answerQuill.toolbar) delete answerQuill.toolbar.preventRemove;
+					(answerQuill.clearButton && e.relatedTarget === answerQuill.clearButton)
+				)
 					return;
-				}
 
 				toolbarRemove();
 			});
@@ -400,8 +389,8 @@
 				answerQuill.toolbar.tooltips.push(new bootstrap.Tooltip(button, { placement: 'left' }));
 
 				button.addEventListener('click', () => {
-					answerQuill.mathField.cmd(button.dataset.latex);
 					answerQuill.textarea.focus();
+					answerQuill.mathField.cmd(button.dataset.latex);
 				});
 			}
 
@@ -566,8 +555,6 @@
 		});
 
 		answerQuill.textarea.addEventListener('focusout', (e) => {
-			if (answerQuill.toolbar) delete answerQuill.toolbar.preventRemove;
-
 			if (
 				!document.hasFocus() ||
 				(e.relatedTarget &&

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@openwebwork/mathquill": "^0.11.0-beta.2",
+                "@openwebwork/mathquill": "^0.11.0-beta.3",
                 "jsxgraph": "^1.9.2",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@openwebwork/mathquill": {
-            "version": "0.11.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.2.tgz",
-            "integrity": "sha512-cSUpkAesOPxXfQ/fWJSkmsauhvOMnUqlpib3BQu0QpgOQuYBMIrvpnKf+DsMf7FOEXix+BYlrpcE3sVoPuihhg==",
+            "version": "0.11.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.3.tgz",
+            "integrity": "sha512-ydgzM56NJHZan+LJdnxucxLQTtg7v/JPKHuDzXGtyS3dZnwohLYbeR7+PBXTFacff7EtT2u+eQhg8OooZUOAWA==",
             "license": "MPL-2.0"
         },
         "node_modules/@trysound/sax": {
@@ -1748,9 +1748,9 @@
             }
         },
         "@openwebwork/mathquill": {
-            "version": "0.11.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.2.tgz",
-            "integrity": "sha512-cSUpkAesOPxXfQ/fWJSkmsauhvOMnUqlpib3BQu0QpgOQuYBMIrvpnKf+DsMf7FOEXix+BYlrpcE3sVoPuihhg=="
+            "version": "0.11.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.3.tgz",
+            "integrity": "sha512-ydgzM56NJHZan+LJdnxucxLQTtg7v/JPKHuDzXGtyS3dZnwohLYbeR7+PBXTFacff7EtT2u+eQhg8OooZUOAWA=="
         },
         "@trysound/sax": {
             "version": "0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
         "prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
     },
     "dependencies": {
-        "@openwebwork/mathquill": "^0.11.0-beta.2",
+        "@openwebwork/mathquill": "^0.11.0-beta.3",
         "jsxgraph": "^1.9.2",
         "jszip": "^3.10.1",
         "jszip-utils": "^0.1.0",


### PR DESCRIPTION
<s>When a text block is entered all of the buttons on the toolbar are disabled.  So when a user clicks on the text button, focus moves from the MathQuill input to the text button, and then the text block is created.  At this point the text block is entered and the buttons disabled.  Then focus is sent back to the MathQuill input.  However, for some reasone with the button disabled, Google Chrome decides not to set the relatedTarget to the MathQuill textarea in the focusout event on the toolbar. Then the mqeditor focusout handler doesn't know that focus is going back to the MathQuill textarea and removes the toolbar.  Then things go haywire, and that triggers the removal of the text block that was just created as well. Other browsers (Firefox and apparently Safari) still set the relatedTarget correctly in this case.</s>

<s>This implements a bit of a hack and sets a preventRemove flag on the toolbar when the buttons are disabled, and when the focusout handler occurs it sees the flag and doesn't remove the toolbar.</s>

Edit: This now implements a better and simpler fix.  This simply focuses the MathQuill input before issuing the toolbar button command.  That means that the blur of the button and focus of the input occurs before the text block is started in the input.  As a result the buttons of the toolbar are not disabled until after that all happens, and Google Chrome still sends the relatedTarget.

This fixes issue #1175.

Also remove an erroneous console.log that was left in a previous commit.

I also noticed another bug with text blocks while working on this.  When focus is lost from the MathQuill input entirely and the cursor is inside an empty text block, then the text block is not removed as it should be. Furthermore, if the text block is clicked on after that an exception is thrown.  This ensures the text block is removed in this case so that when focus returns the exception is not thrown. That bug is fixed in https://github.com/openwebwork/mathquill/pull/35, and the dependency updated here.