### PR TITLE
Prevent the `click` event on a solution or hint accordion button instead of the details.

### DIFF
--- a/htdocs/js/Problem/details-accordion.js
+++ b/htdocs/js/Problem/details-accordion.js
@@ -6,9 +6,11 @@
 		if (!collapseEl || !button || !details) return;
 
 		const collapse = new bootstrap.Collapse(collapseEl, { toggle: false });
-		button.addEventListener('click', () => collapse.toggle());
+		button.addEventListener('click', (e) => {
+			collapse.toggle();
+			e.preventDefault();
+		});
 
-		details.addEventListener('click', (e) => e.preventDefault());
 		collapseEl.addEventListener('show.bs.collapse', () => {
 			details.open = true;
 			button.classList.remove('collapsed');


### PR DESCRIPTION
<s>Only prevent the default click behavior when the user clicks on the summary or something within the summar. Allow the click event default to occur otherwise.</s>

Instead add `e.preventDefault()` to the `summary.accordion-button` `click` event listener instead of preventing all clicks on the `details` tag.

This fixes issue #1178.

This could be made into a hotfix if desired.