### PR TITLE
Prevent the `click` event on a solution or hint accordion button instead of the details. (#1179 hotfix)

### DIFF
--- a/htdocs/js/Problem/details-accordion.js
+++ b/htdocs/js/Problem/details-accordion.js
@@ -6,9 +6,11 @@
 		if (!collapseEl || !button || !details) return;
 
 		const collapse = new bootstrap.Collapse(collapseEl, { toggle: false });
-		button.addEventListener('click', () => collapse.toggle());
+		button.addEventListener('click', (e) => {
+			collapse.toggle();
+			e.preventDefault();
+		});
 
-		details.addEventListener('click', (e) => e.preventDefault());
 		collapseEl.addEventListener('show.bs.collapse', () => {
 			details.open = true;
 			button.classList.remove('collapsed');


### PR DESCRIPTION
Add `e.preventDefault()` to the `summary.accordion-button` `click` event listener instead of preventing all clicks on the `details` tag.

This fixes issue #1178.