### PR TITLE
Fix an issue with the graphtool default number line interval checker.

### DIFF
--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -440,9 +440,12 @@ sub new {
 	my ($self, @options) = @_;
 	my $class   = ref($self) || $self;
 	my $context = Parser::Context->getCopy('Point');
-	$context->parens->set('{' => { close => '}', type => 'List', formList => 1, formMatrix => 0, removable => 0 });
+	$context->parens->set(
+		'{' => { close => '}', type => 'List', formList => 1, formMatrix => 0, removable => 0 },
+		'[' => { type  => 'Interval' }
+	);
 	$context->lists->set(
-		'GraphTool' => {
+		GraphTool => {
 			class       => 'Parser::List::List',
 			open        => '',
 			close       => '',


### PR DESCRIPTION
The checker for intervals compares the interval graphed by the student to the correct interval as MathObjects.  However, the context of the graphtool is a modified `Point` context.  This generally is fine.  A half open or half closed interval or an unbounded interval is still an interval and the comparison works.  However, a bounded open interval or a bounded closed interval both end up being points. As a result if the correct answer is a bounded open interval and the student graphs an interval with the same endpoints, but closed, the current checker counts that as correct.

To fix this, this sets the '[' paren to always be an interval the same as in the `Interval` context.  The graphtool answers given by javascript will never need that to be anything else, so this works.

A minimal working example that demonstrates the issue is the following problem:

```perl
DOCUMENT();
loadMacros(qw{PGstandard.pl PGML.pl parserGraphTool.pl});

$graph = GraphTool("{interval, (1, 5)}")->with(
    availableTools => [ 'IntervalTool', 'IncludeExcludePointTool' ],
    numberLine     => 1
);

BEGIN_PGML
Graph the interval [`(1, 5)`].

[_]{$graph}
END_PGML

ENDDOCUMENT();
```

For the develop or main branch if you graph the closed interval from 1 to 5, it is counted correct. Of course, with this pull request it is incorrect.

Note that for all branches and this pull request the open interval from 1 to 5 is counted correct.  Of course a half open (or half closed) interval from 1 to 5 and all other incorrect answers are counted incorrect.

You can also experiment with other correct answers, and they all should work with this pull request.