### PR TITLE
Fix coordinate hints in the GraphTool for restricted sine wave points.

### DIFF
--- a/htdocs/js/GraphTool/cubictool.js
+++ b/htdocs/js/GraphTool/cubictool.js
@@ -8,8 +8,16 @@
 			preInit(gt, point1, point2, point3, point4, solid) {
 				[point1, point2, point3, point4].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
-					point.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-					point.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+					if (!gt.isStatic) {
+						point.on('down', () => {
+							point.dragging = true;
+							gt.board.containerObj.style.cursor = 'none';
+						});
+						point.on('up', () => {
+							delete point.dragging;
+							gt.board.containerObj.style.cursor = 'auto';
+						});
+					}
 				});
 				return gt.graphObjectTypes.cubic.createCubic(point1, point2, point3, point4, solid, gt.color.curve);
 			},
@@ -163,6 +171,7 @@
 
 				groupedPointDrag(gt, e) {
 					gt.graphObjectTypes.cubic.adjustDragPosition(e, this, this.grouped_points);
+					gt.setTextCoords(this.X(), this.Y());
 					gt.updateObjects();
 					gt.updateText();
 				},
@@ -439,6 +448,7 @@
 
 				gt.setTextCoords(this.hlObjs.hl_point.X(), this.hlObjs.hl_point.Y());
 				gt.board.update();
+				return true;
 			},
 
 			deactivate(gt) {

--- a/htdocs/js/GraphTool/cubictool.js
+++ b/htdocs/js/GraphTool/cubictool.js
@@ -9,14 +9,8 @@
 				[point1, point2, point3, point4].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
 					if (!gt.isStatic) {
-						point.on('down', () => {
-							point.dragging = true;
-							gt.board.containerObj.style.cursor = 'none';
-						});
-						point.on('up', () => {
-							delete point.dragging;
-							gt.board.containerObj.style.cursor = 'auto';
-						});
+						point.on('down', () => gt.onPointDown(point));
+						point.on('up', () => gt.onPointUp(point));
 					}
 				});
 				return gt.graphObjectTypes.cubic.createCubic(point1, point2, point3, point4, solid, gt.color.curve);

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -790,6 +790,16 @@ window.graphTool = (containerId, options) => {
 		gt.updateText();
 	};
 
+	gt.onPointDown = (point) => {
+		point.dragging = true;
+		gt.board.containerObj.style.cursor = 'none';
+	};
+
+	gt.onPointUp = (point) => {
+		delete point.dragging;
+		gt.board.containerObj.style.cursor = 'auto';
+	};
+
 	gt.createPoint = (x, y, paired_point, restrict) => {
 		const point = gt.board.create('point', [gt.snapRound(x, gt.snapSizeX), gt.snapRound(y, gt.snapSizeY)], {
 			snapSizeX: gt.snapSizeX,
@@ -798,14 +808,8 @@ window.graphTool = (containerId, options) => {
 		});
 		point.setAttribute({ snapToGrid: true });
 		if (!gt.isStatic) {
-			point.on('down', () => {
-				point.dragging = true;
-				gt.board.containerObj.style.cursor = 'none';
-			});
-			point.on('up', () => {
-				delete point.dragging;
-				gt.board.containerObj.style.cursor = 'auto';
-			});
+			point.on('down', () => gt.onPointDown(point));
+			point.on('up', () => gt.onPointUp(point));
 			if (typeof paired_point !== 'undefined') {
 				point.paired_point = paired_point;
 				paired_point.paired_point = point;
@@ -1775,15 +1779,17 @@ window.graphTool = (containerId, options) => {
 
 			gt.board.off('up');
 
-			this.point1.setAttribute(gt.definingPointAttributes);
-			this.point1.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-			this.point1.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+			const point1 = this.point1;
+			delete this.point1;
 
-			const point2 = gt.createPoint(coords[1], coords[2], this.point1);
-			gt.selectedObj = new gt.graphObjectTypes.line(this.point1, point2, gt.drawSolid);
+			point1.setAttribute(gt.definingPointAttributes);
+			point1.on('down', () => gt.onPointDown(point1));
+			point1.on('up', () => gt.onPointUp(point1));
+
+			const point2 = gt.createPoint(coords[1], coords[2], point1);
+			gt.selectedObj = new gt.graphObjectTypes.line(point1, point2, gt.drawSolid);
 			gt.selectedObj.focusPoint = point2;
 			gt.graphedObjs.push(gt.selectedObj);
-			delete this.point1;
 
 			this.finish();
 		}
@@ -1921,15 +1927,17 @@ window.graphTool = (containerId, options) => {
 
 			gt.board.off('up');
 
-			this.center.setAttribute(gt.definingPointAttributes);
-			this.center.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-			this.center.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+			const center = this.center;
+			delete this.center;
 
-			const point = gt.createPoint(coords[1], coords[2], this.center);
-			gt.selectedObj = new gt.graphObjectTypes.circle(this.center, point, gt.drawSolid);
+			center.setAttribute(gt.definingPointAttributes);
+			center.on('down', () => gt.onPointDown(center));
+			center.on('up', () => gt.onPointUp(center));
+
+			const point = gt.createPoint(coords[1], coords[2], center);
+			gt.selectedObj = new gt.graphObjectTypes.circle(center, point, gt.drawSolid);
 			gt.selectedObj.focusPoint = point;
 			gt.graphedObjs.push(gt.selectedObj);
-			delete this.center;
 
 			this.finish();
 		}
@@ -2081,15 +2089,17 @@ window.graphTool = (containerId, options) => {
 
 			gt.board.off('up');
 
-			this.vertex.setAttribute(gt.definingPointAttributes);
-			this.vertex.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-			this.vertex.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+			const vertex = this.vertex;
+			delete this.vertex;
 
-			const point = gt.createPoint(coords[1], coords[2], this.vertex, true);
-			gt.selectedObj = new gt.graphObjectTypes.parabola(this.vertex, point, this.vertical, gt.drawSolid);
+			vertex.setAttribute(gt.definingPointAttributes);
+			vertex.on('down', () => gt.onPointDown(vertex));
+			vertex.on('up', () => gt.onPointUp(vertex));
+
+			const point = gt.createPoint(coords[1], coords[2], vertex, true);
+			gt.selectedObj = new gt.graphObjectTypes.parabola(vertex, point, this.vertical, gt.drawSolid);
 			gt.selectedObj.focusPoint = point;
 			gt.graphedObjs.push(gt.selectedObj);
-			delete this.vertex;
 
 			this.finish();
 		}

--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -369,14 +369,8 @@
 					point.setAttribute({ snapToGrid: true });
 
 					if (!gt.isStatic) {
-						point.on('down', () => {
-							point.dragging = true;
-							gt.graphObjectTypes.interval.pointDown(point);
-						});
-						point.on('up', () => {
-							delete point.dragging;
-							gt.graphObjectTypes.interval.pointUp(point);
-						});
+						point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
+						point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
 						if (typeof paired_point !== 'undefined') {
 							point.paired_point = paired_point;
 							paired_point.paired_point = point;
@@ -424,6 +418,7 @@
 
 				pointDown(gt, point) {
 					if (gt.activeTool !== gt.selectTool) return;
+					point.dragging = true;
 
 					const thisObj = gt.graphedObjs.filter(
 						(obj) => obj.definingPts.filter((pt) => pt === point).length
@@ -443,7 +438,8 @@
 					gt.board.containerObj.style.cursor = 'none';
 				},
 
-				pointUp(gt) {
+				pointUp(gt, point) {
+					delete point.dragging;
 					gt.board.containerObj.style.cursor = 'auto';
 				},
 

--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -354,6 +354,7 @@
 				pairedPointDrag(gt, e, point) {
 					gt.adjustDragPositionRestricted(e, point, point.paired_point);
 					if (point.Y() !== 0) point.setPosition(JXG.COORDS_BY_USER, [point.X(), 0]);
+					gt.setTextCoords(this.X(), 0);
 					gt.updateObjects();
 					gt.updateText();
 				},
@@ -368,8 +369,14 @@
 					point.setAttribute({ snapToGrid: true });
 
 					if (!gt.isStatic) {
-						point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
-						point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
+						point.on('down', () => {
+							point.dragging = true;
+							gt.graphObjectTypes.interval.pointDown(point);
+						});
+						point.on('up', () => {
+							delete point.dragging;
+							gt.graphObjectTypes.interval.pointUp(point);
+						});
 						if (typeof paired_point !== 'undefined') {
 							point.paired_point = paired_point;
 							paired_point.paired_point = point;

--- a/htdocs/js/GraphTool/pointtool.js
+++ b/htdocs/js/GraphTool/pointtool.js
@@ -28,8 +28,14 @@
 				this.focusPoint = this.baseObj;
 
 				if (!gt.isStatic) {
-					this.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-					this.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+					this.on('down', () => {
+						this.baseObj.dragging = true;
+						gt.board.containerObj.style.cursor = 'none';
+					});
+					this.on('up', () => {
+						delete this.baseObj.dragging;
+						gt.board.containerObj.style.cursor = 'auto';
+					});
 					this.on('drag', (e) => {
 						gt.adjustDragPosition(e, this.baseObj);
 						gt.updateText();

--- a/htdocs/js/GraphTool/pointtool.js
+++ b/htdocs/js/GraphTool/pointtool.js
@@ -28,14 +28,8 @@
 				this.focusPoint = this.baseObj;
 
 				if (!gt.isStatic) {
-					this.on('down', () => {
-						this.baseObj.dragging = true;
-						gt.board.containerObj.style.cursor = 'none';
-					});
-					this.on('up', () => {
-						delete this.baseObj.dragging;
-						gt.board.containerObj.style.cursor = 'auto';
-					});
+					this.on('down', () => gt.onPointDown(this.baseObj));
+					this.on('up', () => gt.onPointUp(this.baseObj));
 					this.on('drag', (e) => {
 						gt.adjustDragPosition(e, this.baseObj);
 						gt.updateText();

--- a/htdocs/js/GraphTool/quadratictool.js
+++ b/htdocs/js/GraphTool/quadratictool.js
@@ -8,8 +8,16 @@
 			preInit(gt, point1, point2, point3, solid) {
 				[point1, point2, point3].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
-					point.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-					point.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+					if (!gt.isStatic) {
+						point.on('down', () => {
+							point.dragging = true;
+							gt.board.containerObj.style.cursor = 'none';
+						});
+						point.on('up', () => {
+							delete point.dragging;
+							gt.board.containerObj.style.cursor = 'auto';
+						});
+					}
 				});
 				return gt.graphObjectTypes.quadratic.createQuadratic(point1, point2, point3, solid, gt.color.curve);
 			},
@@ -123,6 +131,7 @@
 
 				groupedPointDrag(gt, e) {
 					gt.graphObjectTypes.quadratic.adjustDragPosition(e, this, this.grouped_points);
+					gt.setTextCoords(this.X(), this.Y());
 					gt.updateObjects();
 					gt.updateText();
 				},

--- a/htdocs/js/GraphTool/quadratictool.js
+++ b/htdocs/js/GraphTool/quadratictool.js
@@ -9,14 +9,8 @@
 				[point1, point2, point3].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
 					if (!gt.isStatic) {
-						point.on('down', () => {
-							point.dragging = true;
-							gt.board.containerObj.style.cursor = 'none';
-						});
-						point.on('up', () => {
-							delete point.dragging;
-							gt.board.containerObj.style.cursor = 'auto';
-						});
+						point.on('down', () => gt.onPointDown(point));
+						point.on('up', () => gt.onPointUp(point));
 					}
 				});
 				return gt.graphObjectTypes.quadratic.createQuadratic(point1, point2, point3, solid, gt.color.curve);

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -25,6 +25,17 @@
 				this.focusPoint = shiftPoint;
 			},
 
+			updateTextCoords(gt, coords) {
+				for (const point of this.definingPts) {
+					if (point.dragged || point.hasPoint(coords.scrCoords[1], coords.scrCoords[2])) {
+						delete point.dragged;
+						gt.setTextCoords(point.X(), point.Y());
+						return true;
+					}
+				}
+				return false;
+			},
+
 			stringify(gt) {
 				return [
 					this.baseObj.getAttribute('dash') == 0 ? 'solid' : 'dashed',
@@ -182,6 +193,8 @@
 						]);
 
 					if (shiftPoint) periodPoint?.setPosition(JXG.COORDS_BY_USER, [periodPoint.X(), shiftPoint.Y()]);
+
+					if (e.type === 'pointermove') this.dragged = true;
 
 					gt.updateObjects();
 					gt.updateText();

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -8,8 +8,16 @@
 			preInit(gt, shiftPoint, periodPoint, amplitudePoint, solid) {
 				[shiftPoint, periodPoint, amplitudePoint].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
-					point.on('down', () => (gt.board.containerObj.style.cursor = 'none'));
-					point.on('up', () => (gt.board.containerObj.style.cursor = 'auto'));
+					if (!gt.isStatic) {
+						point.on('down', () => {
+							point.dragging = true;
+							gt.board.containerObj.style.cursor = 'none';
+						});
+						point.on('up', () => {
+							delete point.dragging;
+							gt.board.containerObj.style.cursor = 'auto';
+						});
+					}
 				});
 				return gt.graphObjectTypes.sineWave.createSineWave(
 					shiftPoint,
@@ -23,17 +31,6 @@
 			postInit(_gt, shiftPoint, periodPoint, amplitudePoint) {
 				this.definingPts.push(shiftPoint, periodPoint, amplitudePoint);
 				this.focusPoint = shiftPoint;
-			},
-
-			updateTextCoords(gt, coords) {
-				for (const point of this.definingPts) {
-					if (point.dragged || point.hasPoint(coords.scrCoords[1], coords.scrCoords[2])) {
-						delete point.dragged;
-						gt.setTextCoords(point.X(), point.Y());
-						return true;
-					}
-				}
-				return false;
 			},
 
 			stringify(gt) {
@@ -194,8 +191,7 @@
 
 					if (shiftPoint) periodPoint?.setPosition(JXG.COORDS_BY_USER, [periodPoint.X(), shiftPoint.Y()]);
 
-					if (e.type === 'pointermove') this.dragged = true;
-
+					gt.setTextCoords(this.X(), this.Y());
 					gt.updateObjects();
 					gt.updateText();
 				},

--- a/htdocs/js/GraphTool/sinewavetool.js
+++ b/htdocs/js/GraphTool/sinewavetool.js
@@ -9,14 +9,8 @@
 				[shiftPoint, periodPoint, amplitudePoint].forEach((point) => {
 					point.setAttribute(gt.definingPointAttributes);
 					if (!gt.isStatic) {
-						point.on('down', () => {
-							point.dragging = true;
-							gt.board.containerObj.style.cursor = 'none';
-						});
-						point.on('up', () => {
-							delete point.dragging;
-							gt.board.containerObj.style.cursor = 'auto';
-						});
+						point.on('down', () => gt.onPointDown(point));
+						point.on('up', () => gt.onPointUp(point));
 					}
 				});
 				return gt.graphObjectTypes.sineWave.createSineWave(


### PR DESCRIPTION
After construction of a sine wave is completed, if the point that determines amplitude is selected and moved with the mouse, then the x-coordinate of the point can't change.  However, the x-coordinate of the coordinate hints in the lower right corner of the board does change if the mouse is moved to the left and right while dragging that point, and should not be.

The same thing happens with the point that determines period on relative to the vertical axis.  The y-coordinate of that point can't change, but the y-coordinate of the coordinate hints do change if the mouse is moved up or down.

This pull request fixes the issue by overriding the default graph object `updateTextCoords` method for the sine wave graph object.  A flag set on the point when it is dragged, and the `updateTextCoords` override checks for the flag and sets the coordinate hints with the coordinates of the point instead of using the mouse cursor coordinates which might be incorrect.

This is similar to the issue that @Alex-Jordan noticed in #1157, although that was during the construction phase of the sine wave.

To test you can use the attached problem:  [GraphSineWavePi.pg.txt](https://github.com/user-attachments/files/18582191/GraphSineWavePi.pg.txt)

In that problem, graph a sine wave by plotting all three points.  Then click on either the amplitude or period point (the second or third point graphed during the construction phase), and try to drag the point in the direction it can't move.  With the develop branch you will see the coordinate change in the direction the point can't go.  With this pull request that coordinate stays fixed.
