### PR TITLE
If `$showPartialCorrectAnswers = 0` and all answers are correct, then show all correct.

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1174,9 +1174,12 @@ sub post_process_content {
 		$self->{safe}->share_from('main', [qw(%Mojo::Base:: %Mojo::Collection:: %Mojo::DOM::)]);
 		our $problemDOM =
 			Mojo::DOM->new->xml($self->{rh_pgcore}{displayMode} eq 'PTX')->parse(${ $self->{PG_PROBLEM_TEXT_REF} });
-		our $pageHeader = Mojo::DOM->new(${ $self->{PG_HEADER_TEXT_REF} });
-		$self->{safe}->share('$problemDOM', '$pageHeader');
-		$self->{safe}->reval('for (@{ $main::PG->{content_post_processors} }) { $_->($problemDOM, $pageHeader); }', 1);
+		our $pageHeader    = Mojo::DOM->new(${ $self->{PG_HEADER_TEXT_REF} });
+		our $problemResult = $self->rh_problem_result;
+		$self->{safe}->share('$problemDOM', '$pageHeader', '$problemResult');
+		$self->{safe}->reval(
+			'for (@{ $main::PG->{content_post_processors} }) { $_->($problemDOM, $pageHeader, $problemResult); }',
+			1);
 		warn "ERRORS from post processing PG text:\n$@\n" if $@;
 
 		$self->{PG_PROBLEM_TEXT_REF} = \($problemDOM->to_string);

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1020,7 +1020,7 @@ sub ENDDOCUMENT {
 
 	if ($main::displayMode =~ /HTML/i && ($rh_envir->{showFeedback} || $rh_envir->{forceShowAttemptResults})) {
 		add_content_post_processor(sub {
-			my $problemContents = shift;
+			my ($problemContents, $pageHeader, $problemResult) = @_;
 
 			my $numCorrect        = 0;
 			my $numBlank          = 0;
@@ -1082,8 +1082,13 @@ sub ENDDOCUMENT {
 					push(@{ $options{feedbackElements} }, @$elements);
 				}
 
-				if (($rh_envir->{showAttemptResults} && $PG->{flags}{showPartialCorrectAnswers})
-					|| $rh_envir->{forceShowAttemptResults})
+				if (
+					(
+						$rh_envir->{showAttemptResults} && ($PG->{flags}{showPartialCorrectAnswers}
+							|| (defined $problemResult->{score} && $problemResult->{score} >= 1))
+					)
+					|| $rh_envir->{forceShowAttemptResults}
+					)
 				{
 					if ($showCorrectOnly) {
 						$options{resultClass} = 'correct-only';
@@ -1322,9 +1327,6 @@ sub ENDDOCUMENT {
 			}
 
 			# Generate the result summary if results are being shown.
-			# FIXME: This is set up to occur when it did previously.  That is it ignores the value of
-			# $PG->{flags}{showPartialCorrectAnswers}. It seems that is incorrect, as it makes that setting rather
-			# pointless.  The summary still reveals if the answer is correct or not.
 			if ($rh_envir->{showAttemptResults} || $rh_envir->{forceShowAttemptResults}) {
 				my @summary;
 


### PR DESCRIPTION
This makes it so that if `$showPartialCorrectAnswers = 0` and all answers are correct, then the feedback buttons are all green revealing that all answers are correct.

This works by passing the problem state found when evaluating answers into the post content processor methods (it is a new third parameter passed to the callback). The ENDDOCUMENT post processor then uses this to quickly determine that the score for the problem is 1 (or more), and in that case shows the usual feedback showing that all answers are correct.

This avoids looping multiple times to determine correctness of the problem.

This is as discussed in https://github.com/openwebwork/pg/issues/1096.  This is a change in behavior, so may need further discussion and a consensus.