### PR TITLE
Mark units that are aliases, and use alias string for uString comparisons so sameUnits will allow plurals, etc. (#1193)

### DIFF
--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -786,11 +786,19 @@ our %known_units = (
 	},
 );
 
+# A map from unit name to its aliases
+our %unit_aliases;
+
+# A map from units name to what it is an alias for
+our %unit_aliased_to;
+
 # Process aliases.
 for my $unit (keys %known_units) {
 	if (ref $known_units{$unit}{aliases} eq 'ARRAY') {
 		my $aliases = delete $known_units{$unit}{aliases};
-		$known_units{$_} = $known_units{$unit} for @$aliases;
+		$known_units{$_}     = $known_units{$unit} for @$aliases;
+		$unit_aliased_to{$_} = $unit               for @$aliases;
+		$unit_aliases{$unit} = $aliases;
 	}
 }
 


### PR DESCRIPTION
This PR addresses the issue raised in #1193, where aliases for units are not accepted when `sameUnits => 1` is specified.

Because the `lib/Units.pm` file removes the `aliases` array from the `%Units::known_units` hash, we can't currently determine what is an alias and what isn't, so this PR adds new hashes to `Units.pm` that the units context can use to identify aliases.  One maps the original to the array of aliases for it, and one maps from aliases to the original that they are aliases for.  The former isn't used in the units context, so can be removed if you want.

The changes to the units context itself are to include a new `ustring` property for units that are aliases of another unit, and changes to the `uString()` method to cause it to use the `ustring` value, if present when constructing the unit string.  This is only used internally to compare the units for a correct and student answer, so this doesn't affect the string or TeX value that is produced, but does normalize the unit names for aliases so that any alias will match.