### PR TITLE
Remove obsolete display modes.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -640,7 +640,6 @@ sub format_delimiter {
 		if $tth || $displayMode eq 'HTML_tth' || $displayMode !~ m/^HTML_/;
 	my $rule = '\vrule width 0pt height ' . $rows . 'em depth 0pt';
 	$rule  = '\Rule{0pt}{' . (1.2 * $rows) . 'em}{0pt}' if $displayMode eq 'HTML_MathJax';
-	$rule  = '\rule 0pt ' . (1.2 * $rows) . 'em 0pt'    if $displayMode eq 'HTML_jsMath';
 	$delim = '\\' . $delim                              if $delim eq '{' || $delim eq '}';
 	return '\(\left' . $delim . $rule . '\right.\)';
 }

--- a/macros/core/PGanswermacros.pl
+++ b/macros/core/PGanswermacros.pl
@@ -1225,7 +1225,6 @@ C<check_syntax( $rh_ans, %options)>
 
 returns an answer hash.
 
-latex2html preview code are installed in the answer hash.
 The input has been transformed, changing 7pi to 7*pi  or 7x to 7*x.
 Syntax error messages may be generated and stored in student_ans
 Additional syntax error messages are stored in {ans_message} and duplicated in {error_message}

--- a/macros/core/PGanswermacros.pl
+++ b/macros/core/PGanswermacros.pl
@@ -584,14 +584,6 @@ sub function_from_string2 {
 
 	    	if ( defined($PG_eval_errors) and $PG_eval_errors =~ /\S/ ) {
 	    	    $PGanswerMessage	= clean_up_error_msg($PG_eval_errors);
-# This message seemed too verbose, but it does give extra information, we'll see if it is needed.
-#                    "<br> There was an error in evaluating your function <br>
-# 					! . $originalEqn . q! <br>
-# 					at ( " . join(', ', @VARS) . " ) <br>
-# 					 $PG_eval_errors
-# 					";   # this message appears in the answer section which is not process by Latex2HTML so it must
-# 					     # be in HTML.  That is why $BR is NOT used.
-
 			}
 			(wantarray) ? ($out, $PGanswerMessage): $out;   # PGanswerMessage may be undefined.
 	    };

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1130,7 +1130,6 @@ a hard copy output.
               HTML       => "output this in HTML mode",
               HTML_tth   => "output this in HTML_tth mode",
               HTML_dpng  => "output this in HTML_dpng mode",
-              Latex2HTML => "output this in Latex2HTML mode",
              )
 
     M3      (tex_version, latex2html_version, html_version) #obsolete
@@ -1139,25 +1138,17 @@ a hard copy output.
 
 sub M3 {
 	my ($tex, $l2h, $html) = @_;
-	MODES(TeX => $tex, Latex2HTML => $l2h, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
+	MODES(TeX => $tex, HTML => $html, HTML_tth => $html, HTML_dpng => $html);
 }
 
 # MODES() is now table driven
 our %DISPLAY_MODE_FAILOVER = (
-	TeX              => [],
-	HTML             => [],
-	PTX              => ["HTML"],
-	HTML_tth         => [ "HTML", ],
-	HTML_dpng        => [ "HTML_tth",  "HTML", ],
-	HTML_jsMath      => [ "HTML_dpng", "HTML_tth", "HTML", ],
-	HTML_MathJax     => [ "HTML_dpng", "HTML_tth", "HTML", ],
-	HTML_asciimath   => [ "HTML_dpng", "HTML_tth", "HTML", ],
-	HTML_LaTeXMathML => [ "HTML_dpng", "HTML_tth", "HTML", ],
-	# legacy modes -- these are not supported, but some problems might try to
-	# set the display mode to one of these values manually and some macros may
-	# provide rendered versions for these modes but not the one we want.
-	Latex2HTML => [ "TeX", "HTML", ],
-	HTML_img   => [ "HTML_dpng", "HTML_tth", "HTML", ],
+	TeX          => [],
+	HTML         => [],
+	PTX          => ["HTML"],
+	HTML_tth     => ["HTML"],
+	HTML_dpng    => [ "HTML_tth",  "HTML" ],
+	HTML_MathJax => [ "HTML_dpng", "HTML_tth", "HTML" ]
 );
 
 # This replaces M3.  You can add new modes at will to this one.
@@ -1246,63 +1237,60 @@ sub ALPHABET {
 
 ###############################################################
 # Some constants which are different in tex and in HTML
-# The order of arguments is TeX, Latex2HTML, HTML
+# The order of arguments is TeX, HTML
 # Adopted Davide Cervone's improvements to PAR, LTS, GTS, LTE, GTE, LBRACE, RBRACE, LB, RB. 7-14-03 AKP
 sub PAR {
 	MODES(
-		TeX        => '\\vskip\\baselineskip ',
-		Latex2HTML => '\\begin{rawhtml}<P>\\end{rawhtml}',
-		HTML       => '<div style="margin-top:1em"></div>',
-		PTX        => "\n\n"
+		TeX  => '\\vskip\\baselineskip ',
+		HTML => '<div style="margin-top:1em"></div>',
+		PTX  => "\n\n"
 	);
 }
-#sub BR { MODES( TeX => '\\par\\noindent ', Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}', HTML => '<BR>'); };
+#sub BR { MODES( TeX => '\\par\\noindent ', HTML => '<BR>'); };
 # Alternate definition of BR which is slightly more flexible and gives more white space in printed output
 # which looks better but kills more trees.
 sub BR {
 	MODES(
-		TeX        => '\\leavevmode\\\\\\relax ',
-		Latex2HTML => '\\begin{rawhtml}<BR>\\end{rawhtml}',
-		HTML       => '<BR>',
-		PTX        => "\n\n"
+		TeX  => '\\leavevmode\\\\\\relax ',
+		HTML => '<BR>',
+		PTX  => "\n\n"
 	);
 }
 
 sub BRBR {
 	MODES(
-		TeX        => '\\leavevmode\\\\\\relax \\leavevmode\\\\\\relax ',
-		Latex2HTML => '\\begin{rawhtml}<BR><BR>\\end{rawhtml}',
-		HTML       => '<P>',
-		PTX        => "\n"
+		TeX  => '\\leavevmode\\\\\\relax \\leavevmode\\\\\\relax ',
+		HTML => '<P>',
+		PTX  => "\n"
 	);
 }
-sub LQ { MODES(TeX => "\\lq\\lq{}", Latex2HTML => '"', HTML    => '&quot;', PTX => '<lq/>'); }
-sub RQ { MODES(TeX => "\\rq\\rq{}", Latex2HTML => '"', HTML    => '&quot;', PTX => '<rq/>'); }
-sub BM { MODES(TeX => '\\(', Latex2HTML => '\\(', HTML_MathJax => '\\(', HTML => '', PTX => '<m>'); }; # begin math mode
-sub EM { MODES(TeX => '\\)', Latex2HTML => '\\)', HTML_MathJax => '\\)', HTML => '', PTX => '</m>'); };  # end math mode
+sub LQ { MODES(TeX => "\\lq\\lq{}", HTML         => '&quot;', PTX  => '<lq/>'); }
+sub RQ { MODES(TeX => "\\rq\\rq{}", HTML         => '&quot;', PTX  => '<rq/>'); }
+sub BM { MODES(TeX => '\\(',        HTML_MathJax => '\\(',    HTML => '', PTX => '<m>'); };     # begin math mode
+sub EM { MODES(TeX => '\\)',        HTML_MathJax => '\\)',    HTML => '', PTX => '</m>'); };    # end math mode
 
 sub BDM {
-	MODES(TeX => '\\[', Latex2HTML => '\\[', HTML_MathJax => '\\[', HTML => '<P ALIGN=CENTER>', PTX => '<me>');
-};    #begin displayMath mode
+	MODES(TeX => '\\[', HTML_MathJax => '\\[', HTML => '<P ALIGN=CENTER>', PTX => '<me>');
+};                                                                                              #begin displayMath mode
 
 sub EDM {
-	MODES(TeX => '\\]', Latex2HTML => '\\]', HTML_MathJax => '\\]', HTML => '</P>', PTX => '</me>');
-};    #end displayMath mode
+	MODES(TeX => '\\]', HTML_MathJax => '\\]', HTML => '</P>', PTX => '</me>');
+};                                                                                              #end displayMath mode
 
 sub LTS {
-	MODES(TeX => '<', Latex2HTML => '\\lt ', HTML => '&lt;', HTML_tth => '<', PTX => '\lt');
+	MODES(TeX => '<', HTML => '&lt;', HTML_tth => '<', PTX => '\lt');
 };    #only for use in math mode
 
 sub GTS {
-	MODES(TeX => '>', Latex2HTML => '\\gt ', HTML => '&gt;', HTML_tth => '>', PTX => '\gt');
+	MODES(TeX => '>', HTML => '&gt;', HTML_tth => '>', PTX => '\gt');
 };    #only for use in math mode
 
 sub LTE {
-	MODES(TeX => '\\le ', Latex2HTML => '\\le ', HTML => '<U>&lt;</U>', HTML_tth => '\\le ', PTX => '\leq');
+	MODES(TeX => '\\le ', HTML => '<U>&lt;</U>', HTML_tth => '\\le ', PTX => '\leq');
 };    #only for use in math mode
 
 sub GTE {
-	MODES(TeX => '\\ge ', Latex2HTML => '\\ge ', HTML => '<U>&gt;</U>', HTML_tth => '\\ge ', PTX => '\geq');
+	MODES(TeX => '\\ge ', HTML => '<U>&gt;</U>', HTML_tth => '\\ge ', PTX => '\geq');
 };    #only for use in math mode
 
 sub BEGIN_ONE_COLUMN {    # deprecated
@@ -1328,80 +1316,77 @@ sub HINT_HEADING {
 		PTX  => ''
 	);
 }
-sub US { MODES(TeX => '\\_', Latex2HTML => '\\_', HTML => '_', PTX => '_'); };    # underscore, e.g. file${US}name
+sub US { MODES(TeX => '\\_', HTML => '_', PTX => '_'); };    # underscore, e.g. file${US}name
 
+# force a space in latex, doesn't force extra space in html
 sub SPACE {
-	MODES(TeX => '\\ ', Latex2HTML => '\\ ', HTML => '&nbsp;', PTX => ' ');
-};    # force a space in latex, doesn't force extra space in html
-sub NBSP    { MODES(TeX => '~',            Latex2HTML => '~',            HTML => '&nbsp;',    PTX => '<nbsp/>'); }
-sub NDASH   { MODES(TeX => '--',           Latex2HTML => '--',           HTML => '&ndash;',   PTX => '<ndash/>'); }
-sub MDASH   { MODES(TeX => '---',          Latex2HTML => '---',          HTML => '&mdash;',   PTX => '<mdash/>'); }
-sub BBOLD   { MODES(TeX => '{\\bf ',       Latex2HTML => '{\\bf ',       HTML => '<STRONG>',  PTX => '<alert>'); }
-sub EBOLD   { MODES(TeX => '}',            Latex2HTML => '}',            HTML => '</STRONG>', PTX => '</alert>'); }
-sub BLABEL  { MODES(TeX => '',             Latex2HTML => '',             HTML => '<LABEL>',   PTX => ''); }
-sub ELABEL  { MODES(TeX => '',             Latex2HTML => '',             HTML => '</LABEL>',  PTX => ''); }
-sub BITALIC { MODES(TeX => '{\\it ',       Latex2HTML => '{\\it ',       HTML => '<I>',       PTX => '<em>'); }
-sub EITALIC { MODES(TeX => '} ',           Latex2HTML => '} ',           HTML => '</I>',      PTX => '</em>'); }
-sub BUL     { MODES(TeX => '\\underline{', Latex2HTML => '\\underline{', HTML => '<U>',       PTX => '<em>'); }
-sub EUL     { MODES(TeX => '}',            Latex2HTML => '}',            HTML => '</U>',      PTX => '</em>'); }
+	MODES(TeX => '\\ ', HTML => '&nbsp;', PTX => ' ');
+}
+sub NBSP    { MODES(TeX => '~',            HTML => '&nbsp;',    PTX => '<nbsp/>'); }
+sub NDASH   { MODES(TeX => '--',           HTML => '&ndash;',   PTX => '<ndash/>'); }
+sub MDASH   { MODES(TeX => '---',          HTML => '&mdash;',   PTX => '<mdash/>'); }
+sub BBOLD   { MODES(TeX => '{\\bf ',       HTML => '<STRONG>',  PTX => '<alert>'); }
+sub EBOLD   { MODES(TeX => '}',            HTML => '</STRONG>', PTX => '</alert>'); }
+sub BLABEL  { MODES(TeX => '',             HTML => '<LABEL>',   PTX => ''); }
+sub ELABEL  { MODES(TeX => '',             HTML => '</LABEL>',  PTX => ''); }
+sub BITALIC { MODES(TeX => '{\\it ',       HTML => '<I>',       PTX => '<em>'); }
+sub EITALIC { MODES(TeX => '} ',           HTML => '</I>',      PTX => '</em>'); }
+sub BUL     { MODES(TeX => '\\underline{', HTML => '<U>',       PTX => '<em>'); }
+sub EUL     { MODES(TeX => '}',            HTML => '</U>',      PTX => '</em>'); }
 
 sub BCENTER {
 	MODES(
-		TeX        => '\\begin{center} ',
-		Latex2HTML => ' \\begin{rawhtml} <div align="center"> \\end{rawhtml} ',
-		HTML       => '<div align="center">',
-		PTX        => ''
+		TeX  => '\\begin{center} ',
+		HTML => '<div align="center">',
+		PTX  => ''
 	);
 }
 
 sub ECENTER {
 	MODES(
-		TeX        => '\\end{center} ',
-		Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ',
-		HTML       => '</div>',
-		PTX        => ''
+		TeX  => '\\end{center} ',
+		HTML => '</div>',
+		PTX  => ''
 	);
 }
 
 sub BLTR {
 	MODES(
-		TeX        => ' ',
-		Latex2HTML => ' \\begin{rawhtml} <div dir="ltr"> \\end{rawhtml} ',
-		HTML       => '<span dir="ltr">',
-		PTX        => ''
+		TeX  => ' ',
+		HTML => '<span dir="ltr">',
+		PTX  => ''
 	);
 }
-sub ELTR { MODES(TeX => ' ', Latex2HTML => ' \\begin{rawhtml} </div> \\end{rawhtml} ', HTML => '</span>', PTX => ''); }
-sub BKBD { MODES(TeX => '\\texttt{', Latex2HTML => '',                                 HTML => '<KBD>',   PTX => ''); }
-sub EKBD { MODES(TeX => '}',         Latex2HTML => '',                                 HTML => '</KBD>',  PTX => ''); }
+sub ELTR { MODES(TeX => ' ',         HTML => '</span>', PTX => ''); }
+sub BKBD { MODES(TeX => '\\texttt{', HTML => '<KBD>',   PTX => ''); }
+sub EKBD { MODES(TeX => '}',         HTML => '</KBD>',  PTX => ''); }
 
 sub HR {
 	MODES(
-		TeX        => '\\par\\hrulefill\\par ',
-		Latex2HTML => '\\begin{rawhtml} <HR> \\end{rawhtml}',
-		HTML       => '<HR>',
-		PTX        => ''
+		TeX  => '\\par\\hrulefill\\par ',
+		HTML => '<HR>',
+		PTX  => ''
 	);
 }
 
 sub LBRACE {
-	MODES(TeX => '\{', Latex2HTML => '\\lbrace', HTML => '{', HTML_tth => '\\lbrace', PTX => '{');
+	MODES(TeX => '\{', HTML => '{', HTML_tth => '\\lbrace', PTX => '{');
 };    #not for use in math mode
 
 sub RBRACE {
-	MODES(TeX => '\}', Latex2HTML => '\\rbrace', HTML => '}', HTML_tth => '\\rbrace', PTX => '}');
+	MODES(TeX => '\}', HTML => '}', HTML_tth => '\\rbrace', PTX => '}');
 };    #not for use in math mode
 
 sub LB {
-	MODES(TeX => '\{', Latex2HTML => '\\lbrace', HTML => '{', HTML_tth => '\\lbrace', PTX => '{');
+	MODES(TeX => '\{', HTML => '{', HTML_tth => '\\lbrace', PTX => '{');
 };    #not for use in math mode
 
 sub RB {
-	MODES(TeX => '\}', Latex2HTML => '\\rbrace', HTML => '}', HTML_tth => '\\rbrace', PTX => '}');
+	MODES(TeX => '\}', HTML => '}', HTML_tth => '\\rbrace', PTX => '}');
 };    #not for use in math mode
-sub DOLLAR  { MODES(TeX => '\\$',       Latex2HTML => '&#36;',     HTML => '&#36;', PTX => '$'); }
-sub PERCENT { MODES(TeX => '\\%',       Latex2HTML => '\\%',       HTML => '%',     PTX => '%'); }
-sub CARET   { MODES(TeX => '\\verb+^+', Latex2HTML => '\\verb+^+', HTML => '^',     PTX => '^'); }
+sub DOLLAR  { MODES(TeX => '\\$',       HTML => '&#36;', PTX => '$'); }
+sub PERCENT { MODES(TeX => '\\%',       HTML => '%',     PTX => '%'); }
+sub CARET   { MODES(TeX => '\\verb+^+', HTML => '^',     PTX => '^'); }
 sub PI      { 4 * atan2(1, 1); }
 sub E       { exp(1); }
 sub LATEX   { MODES(TeX => '\\LaTeX', HTML => '\\(\\mathrm\\LaTeX\\)', PTX => '<latex/>'); }
@@ -1599,10 +1584,9 @@ sub openDivSpan {
 	# internalBalancingIncrement("open${type}");
 
 	MODES(
-		TeX        => "$tex_code",
-		Latex2HTML => qq!\\begin{rawhtml}<$type $html_attribs>\\end{rawhtml}!,
-		HTML       => qq!<$type $html_attribs>\n!,
-		PTX        => "$ptx_code",
+		TeX  => "$tex_code",
+		HTML => qq!<$type $html_attribs>\n!,
+		PTX  => "$ptx_code",
 	);
 }
 
@@ -1627,10 +1611,9 @@ sub closeDivSpan {
 	# internalBalancingDecrement("open${type}");
 
 	MODES(
-		TeX        => "$tex_code",
-		Latex2HTML => qq!\\begin{rawhtml}</$type>\\end{rawhtml}!,
-		HTML       => qq!</$type>\n!,
-		PTX        => "$ptx_code",
+		TeX  => "$tex_code",
+		HTML => qq!</$type>\n!,
+		PTX  => "$ptx_code",
 	);
 }
 
@@ -1730,7 +1713,7 @@ In .pg files use single backslashes. This is in accordance with the usual rules 
 in PG.
 
 For the moment this change only works in image mode.  It does not work in
-jsMath or MathJax mode.  Stay tuned.
+MathJax mode.  Stay tuned.
 
 Adding this command
 
@@ -1765,7 +1748,7 @@ sub addToTeXPreamble {
 		# when printing hardcopy.  --it's weird and there must be a better way.
 		TEXT("\\ifdefined\\nocolumns\\else \\end{multicols} \\fi\n",
 			$str, "\n", "\\ifdefined\\nocolumns\\else \\begin{multicols}{2}\\columnwidth=\\linewidth \\fi\n");
-	} else {    # for jsMath and MathJax mode
+	} else {    # for MathJax mode
 		my $mathstr = "\\(" . $str . "\\)";    #add math mode.
 		$mathstr =~ s/\\/\\\\/g;               # protect math modes ($str has a true TeX command,
 											   # with single backslashes.  The backslashes have not
@@ -1781,10 +1764,7 @@ sub addToTeXPreamble {
 The mathematical formulas are run through the macro C<FEQ> (Format EQuations) which performs
 several substitutions (see below).
 In C<HTML_tth> mode the resulting code is processed by tth to obtain an HTML version
-of the formula. (In the future processing by WebEQ may be added here as another option.)
-The Latex2HTML mode does nothing
-at this stage; it creates the entire problem before running it through
-TeX and creating the GIF images of the equations.
+of the formula.
 
 The resulting string is output (and usually fed into TEXT to be printed in the problem).
 
@@ -1956,18 +1936,6 @@ sub general_math_ev3 {
 		## remove leading and trailing spaces as per Davide Cervone.
 		$out =~ s/^\s+//;
 		$out =~ s/\s+$//;
-	} elsif ($displayMode eq "HTML_img") {
-		$out = math2img($in, $mode);
-	} elsif ($displayMode eq "HTML_jsMath") {
-		$in =~ s/&/&amp;/g;
-		$in =~ s/</&lt;/g;
-		$in =~ s/>/&gt;/g;
-		$out = '<SPAN CLASS="math">' . $in . '</SPAN>' if $mode eq "inline";
-		$out = '<DIV CLASS="math">' . $in . '</DIV>'   if $mode eq "display";
-	} elsif ($displayMode eq "HTML_asciimath") {
-		$in  = HTML::Entities::encode_entities($in);
-		$out = "`$in`"                                   if $mode eq "inline";
-		$out = '<DIV ALIGN="CENTER">`' . $in . '`</DIV>' if $mode eq "display";
 	} elsif ($displayMode eq "PTX") {
 		# protect XML control characters
 		$in =~ s/\&(?!([\w#]+;))/\\amp /g;
@@ -1989,12 +1957,6 @@ sub general_math_ev3 {
 		} elsif ($mode eq 'display') {
 			$out = "<me>$in</me>";
 		}
-	} elsif ($displayMode eq "HTML_LaTeXMathML") {
-		$in = HTML::Entities::encode_entities($in);
-		$in = '{' . $in . '}';
-		$in =~ s/\{\s*(\\(display|text|script|scriptscript)style)/$1\{/g;
-		$out = '$$' . $in . '$$'                                          if $mode eq "inline";
-		$out = '<DIV ALIGN="CENTER">$$\displaystyle{' . $in . '}$$</DIV>' if $mode eq "display";
 	} elsif ($displayMode eq "HTML") {
 		$in_delim = HTML::Entities::encode_entities($in_delim);
 		$out      = "<span class='tex2jax_ignore'>$in_delim</span>";
@@ -2377,28 +2339,25 @@ sub OL {
 	my @alpha = ('A' .. 'Z', 'AA' .. 'ZZ');
 	my $letter;
 	my $out = MODES(
-		TeX        => "\\begin{enumerate}\n",
-		Latex2HTML => " \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
-		HTML       => "<BLOCKQUOTE>\n",
-		PTX        => '<ol label="A.">' . "\n",
+		TeX  => "\\begin{enumerate}\n",
+		HTML => "<BLOCKQUOTE>\n",
+		PTX  => '<ol label="A.">' . "\n",
 	);
 	my $elem;
 	foreach $elem (@array) {
 		$letter = shift @alpha;
 		$out .= MODES(
-			TeX        => "\\item[$ALPHABET[$i].] $elem\n",
-			Latex2HTML => " \\begin{rawhtml} <LI> \\end{rawhtml} $elem  ",
-			HTML       => "<br /> <b>$letter.</b> $elem\n",
-			HTML_dpng  => "<br /> <b>$letter.</b> $elem \n",
-			PTX        => "<li><p>$elem</p></li>\n",
+			TeX       => "\\item[$ALPHABET[$i].] $elem\n",
+			HTML      => "<br /> <b>$letter.</b> $elem\n",
+			HTML_dpng => "<br /> <b>$letter.</b> $elem \n",
+			PTX       => "<li><p>$elem</p></li>\n",
 		);
 		$i++;
 	}
 	$out .= MODES(
-		TeX        => "\\end{enumerate}\n",
-		Latex2HTML => " \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
-		HTML       => "</BLOCKQUOTE>\n",
-		PTX        => '</ol>' . "\n",
+		TeX  => "\\end{enumerate}\n",
+		HTML => "</BLOCKQUOTE>\n",
+		PTX  => '</ol>' . "\n",
 	);
 }
 
@@ -2717,16 +2676,10 @@ sub begintable {
 		$out .= "\n\\par\\smallskip\\begin{center}\\begin{tabular}{" . "|c" x $number . "|} \\hline\n";
 	} elsif ($displayMode eq 'PTX') {
 		$out .= "\n" . '<tabular top="medium" bottom="medium" left="medium" right="medium">' . "\n";
-	} elsif ($displayMode eq 'Latex2HTML') {
-		$out .= "\n\\begin{rawhtml} <TABLE, BORDER=1>\n\\end{rawhtml}";
 	} elsif ($displayMode eq 'HTML_MathJax'
 		|| $displayMode eq 'HTML_dpng'
 		|| $displayMode eq 'HTML'
-		|| $displayMode eq 'HTML_tth'
-		|| $displayMode eq 'HTML_jsMath'
-		|| $displayMode eq 'HTML_asciimath'
-		|| $displayMode eq 'HTML_LaTeXMathML'
-		|| $displayMode eq 'HTML_img')
+		|| $displayMode eq 'HTML_tth')
 	{
 		$out .= '<table class="pg-table">';
 	} else {
@@ -2741,16 +2694,10 @@ sub endtable {
 		$out .= "\n\\end {tabular}\\end{center}\\par\\smallskip\n";
 	} elsif ($displayMode eq 'PTX') {
 		$out .= "\n" . '</tabular>' . "\n";
-	} elsif ($displayMode eq 'Latex2HTML') {
-		$out .= "\n\\begin{rawhtml} </TABLE >\n\\end{rawhtml}";
 	} elsif ($displayMode eq 'HTML_MathJax'
 		|| $displayMode eq 'HTML_dpng'
 		|| $displayMode eq 'HTML'
-		|| $displayMode eq 'HTML_tth'
-		|| $displayMode eq 'HTML_jsMath'
-		|| $displayMode eq 'HTML_asciimath'
-		|| $displayMode eq 'HTML_LaTeXMathML'
-		|| $displayMode eq 'HTML_img')
+		|| $displayMode eq 'HTML_tth')
 	{
 		$out .= '</table>';
 	} else {
@@ -2775,23 +2722,10 @@ sub row {
 			$out .= '<cell>' . shift(@elements) . '</cell>' . "\n";
 		}
 		$out .= '</row>' . "\n";
-	} elsif ($displayMode eq 'Latex2HTML') {
-		$out .= "\n\\begin{rawhtml}\n<TR>\n\\end{rawhtml}\n";
-		while (@elements) {
-			$out .=
-				" \n\\begin{rawhtml}\n<TD> \n\\end{rawhtml}\n"
-				. shift(@elements)
-				. " \n\\begin{rawhtml}\n</TD> \n\\end{rawhtml}\n";
-		}
-		$out .= " \n\\begin{rawhtml}\n</TR> \n\\end{rawhtml}\n";
 	} elsif ($displayMode eq 'HTML_MathJax'
 		|| $displayMode eq 'HTML_dpng'
 		|| $displayMode eq 'HTML'
-		|| $displayMode eq 'HTML_tth'
-		|| $displayMode eq 'HTML_jsMath'
-		|| $displayMode eq 'HTML_asciimath'
-		|| $displayMode eq 'HTML_LaTeXMathML'
-		|| $displayMode eq 'HTML_img')
+		|| $displayMode eq 'HTML_tth')
 	{
 		$out .= "<TR>\n";
 		while (@elements) {
@@ -2933,19 +2867,10 @@ sub image {
 			} else {
 				$out = "";
 			}
-		} elsif ($displayMode eq 'Latex2HTML') {
-			my $wid = ($envir->{onTheFlyImageSize} || 0) + 30;
-			$out =
-				qq!\\begin{rawhtml}\n<A HREF="$imageURL" TARGET="_blank" onclick="window.open(this.href, this.target, 'width=$wid, height=$wid, scrollbars=yes, resizable=on'); return false;"><IMG SRC="$imageURL"$width_attrib$height_attrib></A>\n
-			\\end{rawhtml}\n !
 		} elsif ($displayMode eq 'HTML_MathJax'
 			|| $displayMode eq 'HTML_dpng'
 			|| $displayMode eq 'HTML'
-			|| $displayMode eq 'HTML_tth'
-			|| $displayMode eq 'HTML_jsMath'
-			|| $displayMode eq 'HTML_asciimath'
-			|| $displayMode eq 'HTML_LaTeXMathML'
-			|| $displayMode eq 'HTML_img')
+			|| $displayMode eq 'HTML_tth')
 		{
 			my $altattrib = '';
 			if (defined $alt_list[0]) { $altattrib = 'alt="' . encode_pg_and_html(shift @alt_list) . '"' }
@@ -3047,20 +2972,10 @@ sub video {
 				. maketext("This problem contains a video which must be viewed online.")
 				. "} \\end{center}";
 
-		} elsif ($displayMode eq 'Latex2HTML') {
-			$out = qq!\\begin{rawhtml}<VIDEO WIDTH="$width" HEIGHT="$height" CONTROLS>\n
-			<SOURCE SRC="$videoURL" TYPE="video/$type">\n
-			${htmlmessage}\n
-			</VIDEO>\n
-			\\end{rawhtml}\n !
 		} elsif ($displayMode eq 'HTML_MathJax'
 			|| $displayMode eq 'HTML_dpng'
 			|| $displayMode eq 'HTML'
-			|| $displayMode eq 'HTML_tth'
-			|| $displayMode eq 'HTML_jsMath'
-			|| $displayMode eq 'HTML_asciimath'
-			|| $displayMode eq 'HTML_LaTeXMathML'
-			|| $displayMode eq 'HTML_img')
+			|| $displayMode eq 'HTML_tth')
 		{
 			$out = qq!<VIDEO WIDTH="$width" HEIGHT="$height" CONTROLS>\n
 			<SOURCE SRC="$videoURL" TYPE="video/$type">\n
@@ -3094,11 +3009,6 @@ sub caption {
 	$out = " $out  "  if $displayMode eq 'HTML';
 	$out = " $out  "  if $displayMode eq 'HTML_tth';
 	$out = " $out  "  if $displayMode eq 'HTML_dpng';
-	$out = " $out  "  if $displayMode eq 'HTML_img';
-	$out = " $out  "  if $displayMode eq 'HTML_jsMath';
-	$out = " $out  "  if $displayMode eq 'HTML_asciimath';
-	$out = " $out  "  if $displayMode eq 'HTML_LaTeXMathML';
-	$out = " $out  "  if $displayMode eq 'Latex2HTML';
 	$out;
 }
 
@@ -3139,33 +3049,10 @@ sub imageRow {
 		}
 		chop($out);
 		$out .= "\\\\ \\hline \n\\end {tabular}\\end{center}\\par\\smallskip\n";
-	} elsif ($displayMode eq 'Latex2HTML') {
-
-		$out .= "\n\\begin{rawhtml} <TABLE  BORDER=1><TR>\n\\end{rawhtml}\n";
-		while (@images) {
-			$out .=
-				"\n\\begin{rawhtml} <TD>\n\\end{rawhtml}\n"
-				. &image(shift(@images), %options)
-				. "\n\\begin{rawhtml} </TD>\n\\end{rawhtml}\n";
-		}
-
-		$out .= "\n\\begin{rawhtml}</TR><TR>\\end{rawhtml}\n";
-		while (@captions) {
-			$out .=
-				"\n\\begin{rawhtml} <TH>\n\\end{rawhtml}\n"
-				. &caption(shift(@captions))
-				. "\n\\begin{rawhtml} </TH>\n\\end{rawhtml}\n";
-		}
-
-		$out .= "\n\\begin{rawhtml} </TR> </TABLE >\n\\end{rawhtml}";
 	} elsif ($displayMode eq 'HTML_MathJax'
 		|| $displayMode eq 'HTML_dpng'
 		|| $displayMode eq 'HTML'
-		|| $displayMode eq 'HTML_tth'
-		|| $displayMode eq 'HTML_jsMath'
-		|| $displayMode eq 'HTML_asciimath'
-		|| $displayMode eq 'HTML_LaTeXMathML'
-		|| $displayMode eq 'HTML_img')
+		|| $displayMode eq 'HTML_tth')
 	{
 		$out .= "<P>\n <TABLE BORDER=2 CELLPADDING=3 CELLSPACING=2><TR ALIGN=CENTER VALIGN=MIDDLE>\n";
 		while (@images) {

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1133,6 +1133,7 @@ a hard copy output.
              )
 
     M3      (tex_version, latex2html_version, html_version) #obsolete
+            Note the LaTeX2HTML version remains for backward compatibility.
 
 =cut
 
@@ -2814,7 +2815,7 @@ sub image {
 	$valign = 'top'    if ($out_options{valign} eq 'top');
 	$valign = 'bottom' if ($out_options{valign} eq 'bottom');
 
-	# if width and/or height are explicit, create string for attribute to be used in HTML, LaTeX2HTML
+	# if width and/or height are explicit, create string for attribute to be used in HTML
 	my $width_attrib  = ($width)  ? qq{ width="$width"}   : '';
 	my $height_attrib = ($height) ? qq{ height="$height"} : '';
 

--- a/macros/deprecated/Alfredmacros.pl
+++ b/macros/deprecated/Alfredmacros.pl
@@ -32,9 +32,8 @@ sub doubleclickprevent {
 #math mode. This macro warns the user to use JS math mode if they are not.
 sub jsMathwarn {
 	TEXT(MODES(
-		TeX         => '',
-		HTML_jsMath => '',
-		HTML        => $HR
+		TeX  => '',
+		HTML => $HR
 			. "Warning: to use this problem, you need to"
 			. "select jsMath mode in the Display Options panel at the left"
 			. $HR,
@@ -43,9 +42,8 @@ sub jsMathwarn {
 
 sub jsmathmode {
 	TEXT(MODES(
-		TeX         => '',
-		HTML_jsMath => '',
-		HTML        => $HR
+		TeX  => '',
+		HTML => $HR
 			. "Warning: to use this problem, you need to "
 			. "select jsMath mode in the Display Options panel at the left"
 			. $HR,
@@ -373,4 +371,3 @@ sub tablefrac {
 	}
 	return $upper . $BR . $divisionbar . $BR . $lower;
 }
-

--- a/macros/graph/imageChoice.pl
+++ b/macros/graph/imageChoice.pl
@@ -81,9 +81,8 @@ sub img_print_a {
 		push(
 			@labels,
 			MODES(
-				TeX        => "\\hfil \\textbf{$main::ALPHABET[$i]}",
-				Latex2HTML => $bHTML . "<CENTER><B>$main::ALPHABET[$i]</B></CENTER>" . $eHTML,
-				HTML       => "<CENTER><B>$main::ALPHABET[$i]</B></CENTER>"
+				TeX  => "\\hfil \\textbf{$main::ALPHABET[$i]}",
+				HTML => "<CENTER><B>$main::ALPHABET[$i]</B></CENTER>"
 			)
 		);
 		if ((++$i % $m) == 0) {

--- a/macros/graph/unionImage.pl
+++ b/macros/graph/unionImage.pl
@@ -98,9 +98,8 @@ sub Image {
 	$TeX  = '\includegraphics[width=' . $ratio . '\linewidth]{' . $image . '}';
 	$TeX  = '\centerline{' . $TeX . '}' if $tcenter;
 	MODES(
-		TeX        => $TeX . "\n",
-		Latex2HTML => $bHTML . $HTML . $eHTML,
-		HTML       => $HTML
+		TeX  => $TeX . "\n",
+		HTML => $HTML
 	);
 }
 

--- a/macros/math/PGmatrixmacros.pl
+++ b/macros/math/PGmatrixmacros.pl
@@ -228,16 +228,10 @@ sub dm_begin_matrix {
 			$out .= '\begingroup\setbox3=\hbox{\ensuremath{';
 		}
 		$out .= '\displaystyle\left' . $opts{'left'} . "\\begin{array}{$aligns} \n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		$out .= "\n\\begin{rawhtml} <TABLE  BORDER=0>\n\\end{rawhtml}";
 	} elsif ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		$out .= qq!<TABLE class="matrix" BORDER="0" style="border-collapse: separate; border-spacing:10px 0px;">\n!;
 	} elsif ($main::displayMode eq 'PTX') {
@@ -255,10 +249,6 @@ sub dm_special_tops {
 	my @alignList  = @{ $opts{'alignList'} };
 	my ($j,   $k);
 	my ($brh, $erh) = ("", "");    # Start and end raw html
-	if ($main::displayMode eq 'Latex2HTML') {
-		$brh = "\\begin{rawhtml}";
-		$erh = "\\end{rawhtml}";
-	}
 
 	if ($main::displayMode eq 'TeX' or $opts{'force_tex'}) {
 		for $j (@top_labels) {
@@ -274,11 +264,7 @@ sub dm_special_tops {
 	} elsif ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		$out .= "$brh<tr><td>$erh";    # Skip a column for the left brace
 		for $j (@top_labels) {
@@ -306,19 +292,11 @@ sub dm_mat_left {
 	my $out = '';
 	my $j;
 	my ($brh, $erh) = ("", "");    # Start and end raw html
-	if ($main::displayMode eq 'Latex2HTML') {
-		$brh = "\\begin{rawhtml}";
-		$erh = "\\end{rawhtml}";
-	}
 
 	if ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		$out .= "$brh<tr valign=\"center\"><td nowrap=\"nowrap\" align=\"left\" rowspan=\"$numrows\">$erh";
 		$out .= dm_image_delimeter($numrows, $opts{'left'});
@@ -339,10 +317,6 @@ sub dm_mat_right {
 	my $out     = '';
 	my $j;
 	my ($brh, $erh) = ("", "");    # Start and end raw html
-	if ($main::displayMode eq 'Latex2HTML') {
-		$brh = "\\begin{rawhtml}";
-		$erh = "\\end{rawhtml}";
-	}
 
 	if ($main::displayMode eq 'TeX' or $opts{'force_tex'} or $main::displayMode eq 'PTX') {
 		return "";
@@ -351,11 +325,7 @@ sub dm_mat_right {
 	if ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		$out .= "$brh<td nowrap=\"nowrap\" align=\"right\" rowspan=\"$numrows\">$erh";
 
@@ -380,16 +350,10 @@ sub dm_end_matrix {
 			$out .= '}} \dimen3=\ht3 \advance\dimen3 by 3ex \ht3=\dimen3' . "\n" . '\box3\endgroup';
 		}
 		$out .= $opts{'force_tex'} ? '' : "\\) ";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		$out .= "\n\\begin{rawhtml} </TABLE >\n\\end{rawhtml}";
 	} elsif ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		$out .= "</TABLE>\n";
 	} elsif ($main::displayMode eq 'PTX') {
@@ -478,10 +442,6 @@ sub dm_mat_row {
 	my ($brh, $erh) = ("", "");    # Start and end raw html
 	my $element;
 	my $colcount = 0;
-	if ($main::displayMode eq 'Latex2HTML') {
-		$brh = "\\begin{rawhtml}";
-		$erh = "\\end{rawhtml}";
-	}
 	if ($main::displayMode eq 'TeX' or $opts{'force_tex'}) {
 		while (@elements) {
 			$colcount++;
@@ -508,11 +468,7 @@ sub dm_mat_row {
 	} elsif ($main::displayMode eq 'HTML_MathJax'
 		or $main::displayMode eq 'HTML_dpng'
 		or $main::displayMode eq 'HTML_tth'
-		or $main::displayMode eq 'HTML_jsMath'
-		or $main::displayMode eq 'HTML_asciimath'
-		or $main::displayMode eq 'HTML_LaTeXMathML'
-		or $main::displayMode eq 'HTML'
-		or $main::displayMode eq 'HTML_img')
+		or $main::displayMode eq 'HTML')
 	{
 		if (not $opts{'isfirst'}) { $out .= "$brh\n<TR>\n$erh"; }
 		while (@elements) {
@@ -540,9 +496,6 @@ sub dm_mat_row {
 				$element = shift(@elements);
 				if (ref($element) eq 'Fraction') {
 					$element = $element->print_inline();
-#}elsif( $element =~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/ and $element != sprintf($opts{'num_format'},$element) and $element - sprintf($opts{'num_format'},$element) < $main::functZeroLevelTolDefault){
-#	$element = sprintf($opts{'num_format'},$element);
-#	$element = 0 if abs($element) < $main::functZeroLevelTolDefault;
 				}
 				$out .= "$brh<TD nowrap=\"nowrap\" align=\"$myalign\">$erh";
 				$out .= '<table border="1"><tr><td>'
@@ -636,10 +589,6 @@ sub mbox {
 	my $out = "";
 	my $j;
 	my ($brh, $erh) = ("", "");    # Start and end raw html if needed
-	if ($main::displayMode eq 'Latex2HTML') {
-		$brh = "\\begin{rawhtml}";
-		$erh = "\\end{rawhtml}";
-	}
 	my @hlist = @{$inList};
 	if ($main::displayMode eq 'TeX') {
 		if ($opts{allowbreaks} ne 'no') { $out .= '\mbox{'; }

--- a/macros/misc/unionMacros.pl
+++ b/macros/misc/unionMacros.pl
@@ -11,13 +11,6 @@ sub _unionMacros_init { };    # don't reload this file
 $WW = "WeBWorK";
 
 #
-#  Shorthands for entering and leaving rawhtml mode in
-#  LaTeX2HTML (since they are so commonly used).
-#
-$bHTML = '\begin{rawhtml}';
-$eHTML = '\end{rawhtml}';
-
-#
 #  HTML(htmlcode)
 #  HTML(htmlcode,texcode)
 #
@@ -57,7 +50,7 @@ $BSMALL = HTML('<SMALL>',  '{\small ');
 $ESMALL = HTML('</SMALL>', '}');
 
 #
-#  Remove extra space in bold in latex2html mode
+#  Remove extra space in bold
 #
 $BBOLD = HTML('<B>',  '{\bf ');
 $EBOLD = HTML('</B>', '}');

--- a/macros/misc/unionMacros.pl
+++ b/macros/misc/unionMacros.pl
@@ -21,15 +21,14 @@ $eHTML = '\end{rawhtml}';
 #  HTML(htmlcode)
 #  HTML(htmlcode,texcode)
 #
-#  Insert $html in HTML mode or \begin{rawhtml}$html\end{rawhtml} in
-#  Latex2HTML mode.  In TeX mode, insert nothing for the first form, and
-#  $tex for the second form.
+#  Insert $html in HTML mode.  In TeX mode, insert nothing for the first form,
+#  and $tex for the second form.
 #
 sub HTML {
 	my ($html, $tex) = @_;
 	return ('') unless (defined($html) && $html ne '');
 	$tex = ''   unless (defined($tex));
-	MODES(TeX => $tex, Latex2HTML => $bHTML . $html . $eHTML, HTML => $html);
+	MODES(TeX => $tex, HTML => $html);
 }
 
 #
@@ -105,10 +104,9 @@ $BBR = HTML('<BR>');
 #  Broser-only \displaystyle
 #
 $DISPLAY = MODES(
-	TeX        => '',
-	Latex2HTML => '\displaystyle ',
-	HTML_tth   => '\displaystyle ',
-	HTML       => ''
+	TeX      => '',
+	HTML_tth => '\displaystyle ',
+	HTML     => ''
 );
 
 #
@@ -118,9 +116,8 @@ sub Title {
 	my $title = shift;
 
 	TEXT(MODES(
-		TeX        => "\\par\\begin{centering}{\\bf $title}\\par\\end{centering}\\nobreak\n",
-		Latex2HTML => $bHTML . '<CENTER><H2>' . $title . '</H2></CENTER>' . $eHTML,
-		HTML       => '<CENTER><H2>' . $title . '</H2></CENTER>'
+		TeX  => "\\par\\begin{centering}{\\bf $title}\\par\\end{centering}\\nobreak\n",
+		HTML => '<CENTER><H2>' . $title . '</H2></CENTER>'
 	));
 }
 

--- a/macros/misc/unionUtils.pl
+++ b/macros/misc/unionUtils.pl
@@ -125,11 +125,10 @@ sub DMATH {
 	}
 
 	MODES(
-		TeX        => '\(\displaystyle ' . $math . '\)',
-		Latex2HTML => '\(\displaystyle ' . $math . '\)',
-		HTML       => $math,
-		HTML_tth   => $math,
-		HTML_dpng  => $math,
+		TeX       => '\(\displaystyle ' . $math . '\)',
+		HTML      => $math,
+		HTML_tth  => $math,
+		HTML_dpng => $math,
 	);
 }
 

--- a/macros/parsers/parserUtils.pl
+++ b/macros/parsers/parserUtils.pl
@@ -10,15 +10,14 @@ $eHTML = '\end{rawhtml}';
 #  HTML(htmlcode)
 #  HTML(htmlcode,texcode)
 #
-#  Insert $html in HTML mode or \begin{rawhtml}$html\end{rawhtml} in
-#  Latex2HTML mode.  In TeX mode, insert nothing for the first form, and
-#  $tex for the second form.
+#  Insert $html in HTML mode.  In TeX mode, insert nothing for the first form,
+#  and $tex for the second form.
 #
 sub HTML {
 	my ($html, $tex) = @_;
 	return ('') unless (defined($html) && $html ne '');
 	$tex = ''   unless (defined($tex));
-	MODES(TeX => $tex, Latex2HTML => $bHTML . $html . $eHTML, HTML => $html);
+	MODES(TeX => $tex, HTML => $html);
 }
 
 #
@@ -42,8 +41,8 @@ $EBLOCKQUOTE = HTML('</BLOCKQUOTE>');
 #
 #  Smart-quotes in TeX mode, regular quotes in HTML mode
 #
-$LQ = MODES(TeX => '``', Latex2HTML => '"', HTML => '"');
-$RQ = MODES(TeX => "''", Latex2HTML => '"', HTML => '"');
+$LQ = MODES(TeX => '``', HTML => '"');
+$RQ = MODES(TeX => "''", HTML => '"');
 
 #
 #  make sure all characters are displayed
@@ -59,4 +58,3 @@ sub protectHTML {
 sub _parserUtils_init { }
 
 1;
-

--- a/macros/parsers/parserUtils.pl
+++ b/macros/parsers/parserUtils.pl
@@ -4,9 +4,6 @@
 
 # loadMacros("unionImage.pl", "unionTables.pl",);
 
-$bHTML = '\begin{rawhtml}';
-$eHTML = '\end{rawhtml}';
-
 #  HTML(htmlcode)
 #  HTML(htmlcode,texcode)
 #

--- a/macros/parsers/parserVectorUtils.pl
+++ b/macros/parsers/parserVectorUtils.pl
@@ -67,12 +67,11 @@ sub BoldMath {
 	my $v    = shift;
 	my $HTML = '<B><I>' . $v . '</B></I>';
 	MODES(
-		TeX        => "\\boldsymbol{$v}",    #  doesn't seem to work in TeX mode
-											 #    TeX => "\\mathbf{$v}",      #  gives non-italic bold in TeX mode
-		Latex2HTML => "\\boldsymbol{$v}",
-		HTML       => $HTML,
-		HTML_tth   => '\begin{rawhtml}' . $HTML . '\end{rawhtml}',
-		HTML_dpng  => "\\boldsymbol{$v}",
+		TeX       => "\\boldsymbol{$v}",    #  doesn't seem to work in TeX mode
+											#    TeX => "\\mathbf{$v}",      #  gives non-italic bold in TeX mode
+		HTML      => $HTML,
+		HTML_tth  => '\begin{rawhtml}' . $HTML . '\end{rawhtml}',
+		HTML_dpng => "\\boldsymbol{$v}",
 	);
 }
 

--- a/macros/parsers/parserVectorUtils.pl
+++ b/macros/parsers/parserVectorUtils.pl
@@ -56,10 +56,9 @@ sub Overline {
     BoldMath($vectorName)
 
 This gets a bold letter in TeX as well as HTML modes.
-Although \boldsymbol{} works fine on screen in latex2html mode,
-the PDF file produces non-bold letters.  I haven't been able to
-track this down, so used \mathbf{} in TeX mode, which produces
-roman bold, not math-italic bold.
+Although \boldsymbol{} works fine on screen, the PDF file produces non-bold
+letters.  I haven't been able to track this down, so used \mathbf{} in TeX mode,
+which produces roman bold, not math-italic bold.
 
 =cut
 

--- a/macros/ui/PGchoicemacros.pl
+++ b/macros/ui/PGchoicemacros.pl
@@ -268,22 +268,12 @@ sub std_print_q {
 	my (@questions) = @_;
 	my $length      = $self->{ans_rule_len};
 	my $out         = "";
-	#if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
 	if ($main::displayMode =~ /^HTML/) {
 		my $i = 1;
 		my $quest;
 		$out = "\n<P>\n";
 		foreach $quest (@questions) {
 			$out .= ans_rule($length) . "&nbsp;<B>$i.</B> $quest<BR>";
-			$i++;
-		}
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		$out = "\\par\n";
-		foreach $quest (@questions) {
-			$out .= ans_rule($length)
-				. "\\begin{rawhtml}<B>$i. </B>\\end{rawhtml} $quest\\begin{rawhtml}<BR>\\end{rawhtml}\n";
 			$i++;
 		}
 	} elsif ($main::displayMode eq 'TeX') {
@@ -335,7 +325,6 @@ sub pop_up_list_print_q {
 	my @list        = @{ $self->{ra_pop_up_list} };
 	my $out         = "";
 
-	#if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
 	if ($main::displayMode =~ /^HTML/) {
 		my $i = 1;
 		my $quest;
@@ -344,17 +333,6 @@ sub pop_up_list_print_q {
 			$i++;
 		}
 		$out .= "<br>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		foreach $quest (@questions) {
-			$out .=
-				" \\begin{rawhtml}<p><B>\\end{rawhtml}"
-				. pop_up_list(@list)
-				. " $i. \\begin{rawhtml}</B>\\end{rawhtml}   $quest";
-			$i++;
-		}
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n";
 		my $i = 1;
@@ -401,11 +379,7 @@ sub quest_first_pop_up_list_print_q {
 	if ($main::displayMode eq 'HTML_MathJax'
 		|| $main::displayMode eq 'HTML_dpng'
 		|| $main::displayMode eq 'HTML'
-		|| $main::displayMode eq 'HTML_tth'
-		|| $main::displayMode eq 'HTML_jsMath'
-		|| $main::displayMode eq 'HTML_asciimath'
-		|| $main::displayMode eq 'HTML_LaTeXMathML'
-		|| $main::displayMode eq 'HTML_img')
+		|| $main::displayMode eq 'HTML_tth')
 	{
 		my $i = 1;
 		my $quest;
@@ -414,17 +388,6 @@ sub quest_first_pop_up_list_print_q {
 			$i++;
 		}
 		$out .= "<br>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		foreach $quest (@questions) {
-			$out .=
-				" \\begin{rawhtml}<p><B>\\end{rawhtml}"
-				. pop_up_list(@list)
-				. " $i. \\begin{rawhtml}</B>\\end{rawhtml}   $quest";
-			$i++;
-		}
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n";
 		my $i = 1;
@@ -472,11 +435,7 @@ sub ans_in_middle_pop_up_list_print_q {
 	if ($main::displayMode eq 'HTML_MathJax'
 		|| $main::displayMode eq 'HTML_dpng'
 		|| $main::displayMode eq 'HTML'
-		|| $main::displayMode eq 'HTML_tth'
-		|| $main::displayMode eq 'HTML_jsMath'
-		|| $main::displayMode eq 'HTML_asciimath'
-		|| $main::displayMode eq 'HTML_LaTeXMathML'
-		|| $main::displayMode eq 'HTML_img')
+		|| $main::displayMode eq 'HTML_tth')
 	{
 		my $i = 1;
 		my $quest;
@@ -485,17 +444,6 @@ sub ans_in_middle_pop_up_list_print_q {
 			$i++;
 		}
 		$out .= "";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		foreach $quest (@questions) {
-			$out .=
-				" \\begin{rawhtml}<p><B>\\end{rawhtml}"
-				. pop_up_list(@list)
-				. " $i. \\begin{rawhtml}</B>\\end{rawhtml}   $quest";
-			$i++;
-		}
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n";
 		my $i = 1;
@@ -570,10 +518,7 @@ sub std_print_a {
 	my @alpha   = ('A' .. 'Z', 'AA' .. 'ZZ');
 	my $letter;
 	my $out = &main::MODES(
-		TeX        => "\\begin{enumerate}\n",
-		Latex2HTML => " \\begin{rawhtml} <OL TYPE=\"A\" VALUE=\"1\"> \\end{rawhtml} ",
-		# kludge to fix IE/CSS problem
-		#"<OL COMPACT TYPE=\"A\" START=\"1\">\n"
+		TeX  => "\\begin{enumerate}\n",
 		HTML => "<BLOCKQUOTE>\n",
 		PTX  => '<ol label="A.">' . "\n",
 	);
@@ -581,18 +526,14 @@ sub std_print_a {
 	foreach $elem (@array) {
 		$letter = shift @alpha;
 		$out .= &main::MODES(
-			TeX        => "\\item[$main::ALPHABET[$i].] $elem\n",
-			Latex2HTML => " \\begin{rawhtml} <LI> \\end{rawhtml} $elem  ",
-			#"<LI> $elem</LI>\n"
+			TeX  => "\\item[$main::ALPHABET[$i].] $elem\n",
 			HTML => "<br /> <b>$letter.</b> $elem\n",
 			PTX  => "<li>$elem</li>\n",
 		);
 		$i++;
 	}
 	$out .= &main::MODES(
-		TeX        => "\\end{enumerate}\n",
-		Latex2HTML => " \\begin{rawhtml} </OL>\n \\end{rawhtml} ",
-		#"</OL>\n"
+		TeX  => "\\end{enumerate}\n",
 		HTML => "</BLOCKQUOTE>\n",
 		PTX  => "</ol>",
 	);
@@ -627,7 +568,7 @@ sub radio_print_a {
 	my $out       = "";
 	my $i         = 0;
 	my @in        = ();
-	#if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
+
 	if ($main::displayMode =~ /^HTML/) {
 		foreach my $ans (@answers) {
 			push(@in, ($main::ALPHABET[$i], "<B> $main::ALPHABET[$i]. </B> $ans"));
@@ -636,14 +577,6 @@ sub radio_print_a {
 		my @radio_buttons = ans_radio_buttons(@in);
 		$out = "\n<BR>" . join "\n<BR>", @radio_buttons;
 		$out .= "<BR>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		foreach my $ans (@answers) {
-			push(@in, ($main::ALPHABET[$i], "\\begin{rawhtml}<B> $main::ALPHABET[$i]. </B> \\end{rawhtml} $ans"));
-			$i++;
-		}
-		my @radio_buttons = ans_radio_buttons(@in);
-		$out = "\\begin{rawhtml}<BR>\\end{rawhtml}" . join "\\begin{rawhtml}<BR>\\end{rawhtml}", @radio_buttons;
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		foreach my $ans (@answers) {
 			push(@in, ($main::ALPHABET[$i], "$main::ALPHABET[$i]. $ans"));
@@ -688,7 +621,7 @@ sub checkbox_print_a {
 	my $out       = "";
 	my $i         = 0;
 	my @in        = ();
-	# 	if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
+
 	if ($main::displayMode =~ /^HTML/) {
 		foreach my $ans (@answers) {
 			push(@in, ($main::ALPHABET[$i], "<B> $main::ALPHABET[$i]. </B> $ans"));
@@ -697,14 +630,6 @@ sub checkbox_print_a {
 		my @checkboxes = ans_checkbox(@in);
 		$out = "\n<BR>" . join "\n<BR>", @checkboxes;
 		$out .= "<BR>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		foreach my $ans (@answers) {
-			push(@in, ($main::ALPHABET[$i], "\\begin{rawhtml}<B> $main::ALPHABET[$i]. </B> \\end{rawhtml} $ans"));
-			$i++;
-		}
-		my @checkboxes = ans_checkbox(@in);
-		$out = "\\begin{rawhtml}<BR>\\end{rawhtml}" . join "\\begin{rawhtml}<BR>\\end{rawhtml}", @checkboxes;
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		foreach my $ans (@answers) {
 			push(@in, ($main::ALPHABET[$i], "$main::ALPHABET[$i]. $ans"));
@@ -824,7 +749,7 @@ sub shuffle {
 sub match_questions_list {
 	my (@questions) = @_;
 	my $out = "";
-	#if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
+
 	if ($main::displayMode =~ /^HTML/) {
 		my $i = 1;
 		my $quest;
@@ -833,17 +758,6 @@ sub match_questions_list {
 			$i++;
 		}
 		$out .= "<br>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		foreach $quest (@questions) {
-			$out .=
-				" \\begin{rawhtml}<BR>\\end{rawhtml} "
-				. ans_rule(4)
-				. "\\begin{rawhtml}<B>\\end{rawhtml} $i. \\begin{rawhtml}</B>\\end{rawhtml}   $quest";  #"$i.   $quest";
-			$i++;
-		}
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n";
 		my $i = 1;
@@ -868,7 +782,7 @@ sub match_questions_list {
 sub match_questions_list_varbox {
 	my ($length, @questions) = @_;
 	my $out = "";
-	#if ($main::displayMode eq 'HTML' || $main::displayMode eq 'HTML_tth') {
+
 	if ($main::displayMode =~ /^HTML/) {
 		my $i = 1;
 		my $quest;
@@ -877,17 +791,6 @@ sub match_questions_list_varbox {
 			$i++;
 		}
 		$out .= "<br>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		my $i = 1;
-		my $quest;
-		foreach $quest (@questions) {
-			$out .=
-				" \\begin{rawhtml}<BR>\\end{rawhtml} "
-				. ans_rule($length)
-				. "\\begin{rawhtml}<B>\\end{rawhtml} $i. \\begin{rawhtml}</B>\\end{rawhtml}   $quest";  #"$i.   $quest";
-			$i++;
-		}
-		$out .= " \\begin{rawhtml}<BR>\\end{rawhtml} ";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n";
 		my $i = 1;
@@ -908,4 +811,3 @@ sub match_questions_list_varbox {
 =cut
 
 1;
-

--- a/macros/ui/alignedChoice.pl
+++ b/macros/ui/alignedChoice.pl
@@ -33,19 +33,6 @@ sub aligned_print_q {
 			$out .= "<TR><TD HEIGHT=\"$rsep\"></TD></TR>\n" if ($rsep);
 		}
 		$out .= "</TABLE>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		$out = "\\par\n\\begin{rawhtml}" . "<TABLE BORDER=0 CELLSPACING=$sep CELLPADDING=0>\\end{rawhtml}\n";
-		foreach $quest (@questions) {
-			if (ref($quest) eq 'ARRAY') { ($quest, $rest) = @{$quest} }
-			else                        { $rest = '' }
-			$out .= "\\begin{rawhtml}<TR VALIGN=$valign>";
-			$out .= "<TD VALIGN=MIDDLE><B>" . $i++ . ".</B>&nbsp;</TD>" if ($numbered);
-			$out .= "<TD ALIGN=$align>\\end{rawhtml}$quest\\begin{rawhtml}</TD>";
-			$out .= "<TD>=</TD>" if ($equals);
-			$out .= "<TD>\\end{rawhtml}" . ans_rule($length) . $rest . "\\begin{rawhtml}</TD></TR>\\end{rawhtml}";
-			$out .= "\\begin{rawhtml}<TR><TD HEIGHT=\"$rsep\"></TD></TR>\\end{rawhtml}\n" if ($rsep);
-		}
-		$out .= "\\begin{rawhtml}</TABLE>\n\\end{rawhtml}";
 	} elsif ($main::displayMode eq 'TeX') {
 		my $num = '';
 		$num = 'r' if ($numbered);

--- a/macros/ui/choiceUtils.pl
+++ b/macros/ui/choiceUtils.pl
@@ -30,22 +30,6 @@ sub alt_print_q {
 				. ".</B>&nbsp;</TD><TD>$quest</TD></TR>\n";
 		}
 		$out .= "</TABLE>\n";
-	} elsif ($main::displayMode eq 'Latex2HTML') {
-		$out = "\\par\n\\begin{rawhtml}" . "<TABLE BORDER=0 CELLSPACING=$sep CELLPADDING=0>\\end{rawhtml}\n";
-		foreach $quest (@questions) {
-			$out .=
-				'\begin{rawhtml}<TR VALIGN="'
-				. $valign . '">'
-				. '<TD>\end{rawhtml}'
-				. ans_rule($length)
-				. '\begin{rawhtml}&nbsp;</TD>'
-				. '<TD><B>'
-				. $i++
-				. '.&nbsp;</B></TD><TD>\\end{rawhtml} '
-				. $quest
-				. '\begin{rawhtml}</TD></TR>\\end{rawhtml}' . "\n";
-		}
-		$out .= "\\begin{rawhtml}</TABLE>\n\\end{rawhtml}";
 	} elsif ($main::displayMode eq 'TeX') {
 		$out = "\n\\par\\begin{enumerate}\n\\advance\\leftskip by 2em";
 		foreach $quest (@questions) { $out .= "\\item[" . ans_rule($length) . ' ' . $i++ . ".] $quest\n" }
@@ -64,25 +48,21 @@ sub alt_print_a {
 	my $i       = 0;
 
 	my $out = MODES(
-		TeX        => "\\begin{enumerate}\n",
-		Latex2HTML => qq{\\begin{rawhtml}<TABLE BORDER="0" CELLSPACING="$sep" CELLPADDING=0>\\end{rawhtml}\n},
-		HTML       => qq{<TABLE BORDER="0" CELLSPACING="$sep" CELLPADDING=0>},
+		TeX  => "\\begin{enumerate}\n",
+		HTML => qq{<TABLE BORDER="0" CELLSPACING="$sep" CELLPADDING=0>},
 	);
 	my $elem;
 	foreach $elem (@array) {
 		my $c = $main::ALPHABET[$i];
 		$out .= MODES(
-			TeX        => "\\item[$c.] $elem\n",
-			Latex2HTML => qq{\\begin{rawhtml}<TR VALIGN="$valign"><TD STYLE="height: 1.5em"><B>$c.</B>&nbsp;</TD>}
-				. qq{<TD>\\end{rawhtml}$elem\\begin{rawhtml}</TD></TR>\\end{rawhtml}\n},
+			TeX  => "\\item[$c.] $elem\n",
 			HTML => qq{<TR VALIGN="$valign"><TD STYLE="height: 1.5em"><B>$c.</B>&nbsp;</TD><TD>$elem</TD></TR>\n},
 		);
 		$i++;
 	}
 	$out .= MODES(
-		TeX        => "\\end{enumerate}\n",
-		Latex2HTML => "\\begin{rawhtml}</TABLE>\\end{rawhtml}\n",
-		HTML       => "</TABLE>\n",
+		TeX  => "\\end{enumerate}\n",
+		HTML => "</TABLE>\n",
 	);
 	$out;
 }


### PR DESCRIPTION
The remaining display modes are HTML_MathJax, HTML_dpng, HTML, TeX, PTX, and HTML_tth (see below).  These correspond to MathJax, images, plainText, tex, PTX, and nothing (HTML_tth is only a fallback mode). This mapping is in lib/WeBWorK/PG.pm.

HTML_tth is left for now due to the issue with problems incorrectly using some PGbasicmacros variables outside of math mode as document at https://webwork.maa.org/wiki/Installation_Manual_for_2.19_on_Ubuntu#PGbasicmacros.pl.

I have had this sitting around long enough.  I am putting it in.