### PR TITLE
more POD cleanup for Value/Matrices.pm

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -6,146 +6,182 @@
 
 =head1 Value::Matrix class
 
+This is the Math Object code for a Matrix.
 
-References:
+=head2 References:
 
-MathObject Matrix methods: L<http://webwork.maa.org/wiki/Matrix_(MathObject_Class)>
-MathObject Contexts: L<http://webwork.maa.org/wiki/Common_Contexts>
-CPAN RealMatrix docs: L<http://search.cpan.org/~leto/Math-MatrixReal-2.09/lib/Math/MatrixReal.pm>
+=over
 
-Allowing Matrices in Fractions:
-L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2978>
+=item L<MathObject Matrix methods|http://webwork.maa.org/wiki/Matrix_(MathObject_Class)>
 
-     Context()->parens->set("[" => {formMatrix => 1});
+=item L<MathObject Contexts|http://webwork.maa.org/wiki/Common_Contexts>
 
-Files interacting with Matrices:
+=item L<CPAN RealMatrix docs|http://search.cpan.org/~leto/Math-MatrixReal-2.09/lib/Math/MatrixReal.pm>
 
-L<MatrixReal1>
+=back
 
-L<MatrixReduce.pl>
+=head2 Matrix-Related libraries and macros:
 
-L<Matrix>
+=over
 
-L<MatrixCheckers.pl> -- checking whether vectors form a basis
+=item L<MatrixReal1>
 
-L<MatrixReduce.pl>  -- tools for  row reduction via elementary matrices
+=item L<MatrixReduce.pl>
 
-L<MatrixUnits.pl>   -- Generates unimodular matrices with real entries
+=item L<Matrix>
 
-L<PGmatrixmacros.pl>
+=item L<MatrixCheckers.pl> -- checking whether vectors form a basis
 
-L<PGmorematrixmacros.pl>
+=item L<MatrixReduce.pl>  -- tools for  row reduction via elementary matrices
 
-L<PGnumericalmacros.pl>
+=item L<MatrixUnits.pl>   -- Generates unimodular matrices with real entries
 
-L<tableau.pl>
+=item L<PGmatrixmacros.pl>
 
-quickMatrixEntry.pl
+=item L<PGmorematrixmacros.pl>
 
-L<LinearProgramming.pl>
+=item L<PGnumericalmacros.pl>
 
-Contexts
+=item L<tableau.pl>
 
-	Matrix -- allows students to enter [[3,4],[3,6]]
-	       -- formMatrix =>1 also allows this?
-	Complex-Matrix -- allows complex entries
+=item L<quickMatrixEntry.pl>
 
-Creation methods
+=item L<LinearProgramming.pl>
 
-	$M1 = Matrix(1, 2, 3);    # 1D tensor (row vector)
-	$M1 = Matrix([1, 2, 3]);
+=back
 
-	$M2 = Matrix([1, 2], [3, 4]);    # 2D tensor (matrix)
-	$M2 = Matrix([[1, 2], [3, 4]]);
+=head2 Contexts
 
-	$M3 = Matrix([[1, 2], [3, 4]], [[5, 6], [7, 8]]);    # 3D tensor
-	$M3 = Matrix([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
+=over
 
-	$M4 = ...
+=item C<Matrix>
 
-Commands added in Value::matrix
+Allows students to enter C<[[3,4],[3,6]]>
 
-	Conversion
-		$matrix->value produces an array of numbers (for a 1D tensor) or array refs representing the rows.
-		These are perl numbers and array refs, not MathObjects.
-		$M1->value is (1, 2, 3)
-		$M2->value is ([1, 2], [3, 4])
-		$M3->value is ([[1, 2], [3, 4]], [[5, 6], [7, 8]])
-		$matrix->wwMatrix produces CPAN MatrixReal1 matrix, used for computation subroutines and can only
-		be used on 1D tensors (row vector) or 2D tensors (matrix).
+=item C<Complex-Matrix>
 
-	Information
-		$matrix->dimensions produces an array. For an n-dimensional tensor, the array has n entries for
-		the n dimensions.
+Allows complex entries
 
-	Access values
+=back
 
-		row(i) : MathObjectMatrix
-			For a 1D tensor, produces a 1D tensor
-			For nD tensor with n > 1, produces a (n-1)D tensor
-		column(j) : MathObjectMatrix or Real or Complex
-			For a 1D tensor, produces a Real or Complex
-			For nD tensor with n > 1, produces an nD tensor where 2nd dimension is 1
-		element : Real or Complex value when passed the same number of arguments as the dimension of the tensor.
-			If passed more than n arguments, null. If the dimension of the tensor is n and element is passed
-			k arguments with k < n, then this produces the corresponding (n-k)-dimensional tensor.
+=head2 Creation of Matrices
 
-	Assign values
+Examples:
 
-		these need to be added:
+    $M1 = Matrix(1, 2, 3);    # 1D (row vector)
+    $M1 = Matrix([1, 2, 3]);
 
-see C<change_matrix_entry()> in MatrixReduce and L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2970>
+    $M2 = Matrix([1, 2], [3, 4]);    # 2D (matrix)
+    $M2 = Matrix([[1, 2], [3, 4]]);
 
-	Advanced
-		$matrix->data:  ARRAY reference (internal data) of MathObjects (Real,Complex, Fractions)
-		                stored at each location.
+    $M3 = Matrix([[1, 2], [3, 4]], [[5, 6], [7, 8]]);    # 3D (tensor)
+    $M3 = Matrix([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
 
+    $M4 = ...
 
-Passthrough methods covering subroutines in Matrix.pm which overrides or
-augment CPAN's MatrixReal1.pm.  Matrix is a specialized subclass of MatrixReal1.pm
+=head2 Commands added in Value::matrix
 
+=head3 Conversion
+
+    $matrix->value produces an array of numbers (for a 1D tensor) or array refs representing the rows.
+    These are perl numbers and array refs, not MathObjects.
+
+    $M1->value is (1, 2, 3)
+    $M2->value is ([1, 2], [3, 4])
+    $M3->value is ([[1, 2], [3, 4]], [[5, 6], [7, 8]])
+
+    $matrix->wwMatrix produces CPAN MatrixReal1 matrix, used for computation subroutines and can only
+    be used on 1D tensors (row vector) or 2D tensors (matrix).
+
+=head3 Information
+
+    $matrix->dimensions produces an array. For an n-dimensional tensor, the array has n entries for
+    the n dimensions.
+
+=head3 Access values
+
+    row(i) : MathObjectMatrix
+        For a 1D tensor, produces a 1D tensor
+        For nD tensor with n > 1, produces a (n-1)D tensor
+
+    column(j) : MathObjectMatrix or Real or Complex
+        For a 1D tensor, produces a Real or Complex
+        For nD tensor with n > 1, produces an nD tensor where 2nd dimension is 1
+
+    element : Real or Complex value when passed the same number of arguments as the dimension of the tensor.
+        If passed more than n arguments, null. If the dimension of the tensor is n and element is passed
+	k arguments with k < n, then this produces the corresponding (n-k)-dimensional tensor.
+
+=head3 Update values (these need to be added)
+
+    see C<change_matrix_entry()> in MatrixReduce and L<http://webwork.maa.org/moodle/mod/forum/discuss.php?d=2970>
+
+=head3 Advanced
+
+    $matrix->data: ARRAY reference (internal data) of MathObjects (Real, Complex, Fractions)
+        stored at each location.
+
+=head2 Passthrough methods
+
+These cover subroutines in C<Matrix.pm> (which overrides or augment CPAN's C<MatrixReal1.pm>).
+C<Matrix> is a specialized subclass of C<MatrixReal1.pm>.
 The actual calculations for these methods are done in C<pg/lib/Matrix.pm>
 
-	trace
-	proj
-	proj_coeff
-	L
-	R
-	PL
-	PR
+    trace
+    proj
+    proj_coeff
+    L
+    R
+    PL
+    PR
 
-Passthrough methods covering subroutines in C<pg/lib/MatrixReal1.pm>
-(this has been modified to handle complex numbers)
-The actual calculations are done in C<MatrixReal1.pm> subroutines
-The commands below are Value::Matrix B<methods> unless otherwise noted.
+These cover subroutines in C<pg/lib/MatrixReal1.pm> (this has been modified to handle complex numbers)
+The actual calculations are done in C<MatrixReal1.pm> subroutines.
+The commands below are C<Value::Matrix> methods unless otherwise noted.
 
+    condition
+    det
+    inverse
+    is_symmetric
+    decompose_LR
+    dim
+    norm_one
+    norm_max
+    kleene
+    normalize
+    solve_LR($v)    - LR decomposition
+    solve($M,$v)    - function version of solve_LR
+    order_LR        - order of LR decomposition matrix (number of non-zero equations)(also order() )
+    order($M)       - function version of order_LR
+    solve_GSM
+    solve_SSM
+    solve_RM
 
+=head2 Fractions in Matrices
 
-	condition
-	det
-	inverse
-	is_symmetric
-	decompose_LR
-	dim
-	norm_one
-	norm_max
-	kleene
-	normalize
-	solve_LR($v)    - LR decomposition
-	solve($M,$v)    - function version of solve_LR
-	order_LR        - order of LR decomposition matrix (number of non-zero equations)(also order() )
-	order($M)       - function version of order_LR
-	solve_GSM
-	solve_SSM
-	solve_RM
+One can use fractions in Matrices by including C<Context("Fraction")>.  For example
+
+    Context("Fraction");
+
+    $A = Matrix([
+      [Fraction(1,1), Fraction(1,2), Fraction(1,3)],
+      [Fraction(1,2), Fraction(1,3), Fraction(1,4)],
+      [Fraction(1,3), Fraction(1,4), Fraction(1,5)]
+    ]);
+
+and operations will be done using rational arithmetic. Also helpful is the method
+C<apply_fraction_to_matrix_entries> in the L<MatrixReduce.pl> macro. Some additional information can be
+found at L<https://webwork.maa.org/moodle/mod/forum/discuss.php?d=2978>.
+
+=head2 methods
 
 =cut
 
-#
 package Value::Matrix;
 my $pkg = 'Value::Matrix';
 
 use strict;
+use warnings;
 no strict "refs";
 use Matrix;
 use Complex1;
@@ -189,7 +225,7 @@ sub matrixMatrix {    #internal
 	my ($x, $m);
 	my @M         = ();
 	my $isFormula = 0;
-	foreach $x (@_) {
+	for $x (@_) {
 		if (Value::isFormula($x)) { push(@M, $x); $isFormula = 1 }
 		else {
 			$m = $self->new($context, $x);
@@ -198,7 +234,7 @@ sub matrixMatrix {    #internal
 		}
 	}
 	my ($type, $len) = ($M[0]->entryType->{name}, $M[0]->length);
-	foreach $x (@M) {
+	for $x (@M) {
 		Value::Error("Matrix rows must all be the same type")
 			unless (defined($x->entryType) && $type eq $x->entryType->{name});
 		Value::Error("Matrix rows must all be the same length") unless ($len eq $x->length);
@@ -217,7 +253,7 @@ sub numberMatrix {    #internal
 	my $context   = shift;
 	my @M         = ();
 	my $isFormula = 0;
-	foreach my $x (@_) {
+	for my $x (@_) {
 		$x = Value::makeValue($x, context => $context);
 		Value::Error("Matrix row entries must be numbers: $x ") unless _isNumber($x);
 		push(@M, $x);
@@ -227,10 +263,19 @@ sub numberMatrix {    #internal
 	bless { data => [@M], context => $context }, $class;
 }
 
-#
-#  Recursively get the entries in the matrix and return
-#  an array of (references to arrays of ... ) numbers
-#
+=head3 C<value>
+
+Returns the array of arrayrefs of the matrix.
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A->value;
+
+    # returns ([1,2,3,4],[5,6,7,8],[9,10,11,12])
+
+=cut
+
 sub value {
 	my $self = shift;
 	my $M    = $self->data;
@@ -240,9 +285,27 @@ sub value {
 	return @M;
 }
 
+=head3 C<dimensions>
+
+Returns the dimensions of the matrix as an array
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A->dimensions;
+
+returns the array C<(3,4)>
+
+    $B = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
+    $B->dimensions;
+
+returns C<(2,2,2)>
+
+=cut
+
 #
 #  Recursively get the dimensions of the matrix.
-#  Returns (n) for a 1 x n, or (n,m) for an n x m, etc.
+#  Returns (d_1,d_2,...,d_n) for an nD matrix.
 #
 sub dimensions {
 	my $self = shift;
@@ -262,36 +325,69 @@ sub typeRef {
 	return Value::Type($self->class, $self->length, $self->data->[0]->typeRef);
 }
 
-#
-#  True if the matrix is a square matrix
-#
+=head3 C<isSquare>
+
+Return true is the matrix is 1D of length 1 or 2D and square, false otherwise
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $B = Matrix([ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ]);
+
+    $A->isSquare; # is '' (false)
+    $B->isSquare; # is 1 (true);
+
+=cut
+
 sub isSquare {
 	my $self = shift;
 	my @d    = $self->dimensions;
-	return 0 if scalar(@d) > 2;
 	return 1 if scalar(@d) == 1 && $d[0] == 1;
+	return 0 if scalar(@d) != 2;
 	return $d[0] == $d[1];
 }
 
-#
-#  True if the matrix is 1-dimensional (i.e., is a matrix row)
-#
+=head3 C<isRow>
+
+Return true if the matix is 1-dimensional (i.e., is a matrix row)
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $row_vect = Matrix([ 1, 2, 3, 4 ]);
+
+    $A->isRow;         # is '' (false)
+    $row_vect->isRow;  # is 1 (true)
+
+=cut
+
 sub isRow {
 	my $self = shift;
 	my @d    = $self->dimensions;
 	return scalar(@d) == 1;
 }
 
-#
-#  See if the matrix is an Identity matrix
-#
+=head3 C<isOne>
+
+Check for identity matrix.
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [13, 14, 15, 16] ]);
+    $A->isOne;  # is false
+
+    $B = Matrix([ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ]);
+    $B->isOne; # is true;
+
+=cut
+
 sub isOne {
 	my $self = shift;
 	return 0 unless $self->isSquare;
 	my $i = 0;
-	foreach my $row (@{ $self->{data} }) {
+	for my $row (@{ $self->{data} }) {
 		my $j = 0;
-		foreach my $k (@{ $row->{data} }) {
+		for my $k (@{ $row->{data} }) {
 			return 0 unless $k eq (($i == $j) ? "1" : "0");
 			$j++;
 		}
@@ -300,12 +396,23 @@ sub isOne {
 	return 1;
 }
 
-#
-#  See if the matrix is all zeros
-#
+=head3 C<isZero>
+
+Check for zero matrix.
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [13, 14, 15, 16] ]);
+    $A->isZero;  # is false
+
+    $B = Matrix([ [ 0, 0, 0 ], [ 0, 0, 0 ], [ 0, 0, 0 ] ]);
+    $B->isZero; # is true;
+
+=cut
+
 sub isZero {
 	my $self = shift;
-	foreach my $x (@{ $self->{data} }) { return 0 unless $x->isZero }
+	for my $x (@{ $self->{data} }) { return 0 unless $x->isZero }
 	return 1;
 }
 
@@ -462,7 +569,7 @@ sub add {
 	Value::Error("Can't add Matrices with different dimensions")
 		unless scalar(@l) == scalar(@r);
 	my @s = ();
-	foreach my $i (0 .. scalar(@l) - 1) { push(@s, $l[$i] + $r[$i]) }
+	for my $i (0 .. scalar(@l) - 1) { push(@s, $l[$i] + $r[$i]) }
 	return $self->inherit($other)->make(@s);
 }
 
@@ -473,7 +580,7 @@ sub sub {
 	Value::Error("Can't subtract Matrices with different dimensions")
 		unless scalar(@l) == scalar(@r);
 	my @s = ();
-	foreach my $i (0 .. scalar(@l) - 1) { push(@s, $l[$i] - $r[$i]) }
+	for my $i (0 .. scalar(@l) - 1) { push(@s, $l[$i] - $r[$i]) }
 	return $self->inherit($other)->make(@s);
 }
 
@@ -481,17 +588,18 @@ sub mult {
 	my ($l, $r, $flag) = @_;
 	my $self  = $l;
 	my $other = $r;
-	#
-	#  Constant multiplication
+
+	#  Perform constant multiplication.
 	#
 	if (_isNumber($r)) {
 		my @coords = ();
-		foreach my $x (@{ $l->data }) { push(@coords, $x * $r) }
+		for my $x (@{ $l->data }) { push(@coords, $x * $r) }
 		return $self->make(@coords);
 	}
-	#
-	#  Make points and vectors into columns if they are on the right
-	#
+
+	#  Make points and vectors into columns if they are on the right.
+	$r = !$flag && Value::classMatch($r, 'Point', 'Vector') ? ($self->promote($r))->transpose : $self->promote($r);
+
 	if   (!$flag && Value::classMatch($r, 'Point', 'Vector')) { $r = ($self->promote($r))->transpose }
 	else                                                      { $r = $self->promote($r) }
 	#
@@ -501,19 +609,18 @@ sub mult {
 	if (scalar(@dl) == 1) { @dl = (1, @dl); $l = $self->make($l) }
 	if (scalar(@dr) == 1) { @dr = (@dr, 1); $r = $self->make($r)->transpose }
 	Value::Error("Can only multiply 2-dimensional matrices") if scalar(@dl) > 2 || scalar(@dr) > 2;
-	Value::Error("Matrices of dimensions %dx%d and %dx%d can't be multiplied", @dl, @dr)
-		unless ($dl[1] == $dr[0]);
-	#
-	#  Do matrix multiplication
-	#
+	Value::Error("Matrices of dimensions %dx%d and %dx%d can't be multiplied", @dl, @dr) unless ($dl[1] == $dr[0]);
+
+	#  Perform matrix multiplication.
+
 	my @l = $l->value;
 	my @r = $r->value;
 	my @M = ();
-	foreach my $i (0 .. $dl[0] - 1) {
+	for my $i (0 .. $dl[0] - 1) {
 		my @row = ();
-		foreach my $j (0 .. $dr[1] - 1) {
+		for my $j (0 .. $dr[1] - 1) {
 			my $s = 0;
-			foreach my $k (0 .. $dl[1] - 1) { $s += $l[$i]->[$k] * $r[$k]->[$j] }
+			for my $k (0 .. $dl[1] - 1) { $s += $l[$i]->[$k] * $r[$k]->[$j] }
 			push(@row, $s);
 		}
 		push(@M, $self->make(@row));
@@ -529,7 +636,7 @@ sub div {
 	Value::Error("Matrices can only be divided by Numbers") unless _isNumber($r);
 	Value::Error("Division by zero") if $r == 0;
 	my @coords = ();
-	foreach my $x (@{ $l->data }) { push(@coords, $x / $r) }
+	for my $x (@{ $l->data }) { push(@coords, $x / $r) }
 	return $self->make(@coords);
 }
 
@@ -548,20 +655,18 @@ sub power {
 	Value::Error("Matrix powers must be non-negative integers") unless _isNumber($r) && $r =~ m/^\d+$/;
 	return $context->Package("Matrix")->I($l->length, $context) if $r == 0;
 	my $M = $l;
-	foreach my $i (2 .. $r) { $M = $M * $l }
+	for my $i (2 .. $r) { $M = $M * $l }
 	return $M;
 }
 
-#
 #  Do lexicographic comparison (row by row)
-#
 sub compare {
 	my ($self, $l, $r) = Value::checkOpOrderWithPromote(@_);
 	Value::Error("Can't compare Matrices with different dimensions")
 		unless join(',', $l->dimensions) eq join(',', $r->dimensions);
 	my @l = @{ $l->data };
 	my @r = @{ $r->data };
-	foreach my $i (0 .. scalar(@l) - 1) {
+	for my $i (0 .. scalar(@l) - 1) {
 		my $cmp = $l[$i] <=> $r[$i];
 		return $cmp if $cmp;
 	}
@@ -571,7 +676,7 @@ sub compare {
 sub neg {
 	my $self   = promote(@_);
 	my @coords = ();
-	foreach my $x (@{ $self->data }) { push(@coords, -$x) }
+	for my $x (@{ $self->data }) { push(@coords, -$x) }
 	return $self->make(@coords);
 }
 
@@ -580,40 +685,59 @@ sub conj { shift->twiddle(@_) }
 sub twiddle {
 	my $self   = promote(@_);
 	my @coords = ();
-	foreach my $x (@{ $self->data }) { push(@coords, ($x->can("conj") ? $x->conj : $x)) }
+	for my $x (@{ $self->data }) { push(@coords, ($x->can("conj") ? $x->conj : $x)) }
 	return $self->make(@coords);
 }
 
-#
-#  Transpose an  n x m  matrix
-#
+=head3 C<transpose>
+
+Take the transpose of a matrix.
+
+Usage:
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A->transpose;
+
+=cut
+
 sub transpose {
 	my $self = promote(@_);
 	my @d    = $self->dimensions;
 	if (scalar(@d) == 1) { @d = (1, @d); $self = $self->make($self) }
 	Value::Error("Can't transpose %d-dimensional matrices", scalar(@d)) unless scalar(@d) == 2;
+
 	my @M = ();
 	my $M = $self->data;
-	foreach my $j (0 .. $d[1] - 1) {
+	for my $j (0 .. $d[1] - 1) {
 		my @row = ();
-		foreach my $i (0 .. $d[0] - 1) { push(@row, $M->[$i]->data->[$j]) }
+		for my $i (0 .. $d[0] - 1) { push(@row, $M->[$i]->data->[$j]) }
 		push(@M, $self->make(@row));
 	}
 	return $self->make(@M);
 }
 
-#
-#  Get an identity matrix of the requested size
-#  Value::Matrix->I(n)
-#  $A->I    # n is the number of rows of $A
-#
+=head3 C<I>
+
+Get an identity matrix of the requested size
+
+    Value::Matrix->I(n)
+
+Usage:
+
+    Value::Matrix->I(3); # returns a 3 by 3 identity matrix.
+    $A->I; # return an n by n identity matrix, where n is the number of rows of A
+
+=cut
+
 sub I {
 	my $self    = shift;
 	my $d       = shift;
 	my $context = shift || $self->context;
 	$d = ($self->dimensions)[0] if !defined $d && ref($self);
+
 	Value::Error("You must provide a dimension for the Identity matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                 unless $d =~ m/^[1-9]\d*$/;
+
 	my @M    = ();
 	my $REAL = $context->Package('Real');
 
@@ -623,29 +747,95 @@ sub I {
 	return $self->make($context, @M);
 }
 
-#
-#  Get an elementary matrix of the requested size and type
-#  Value::Matrix->E(n,[i,j])   nxn, swap rows i and j
-#  Value::Matrix->E(n,[i,j],k) nxn, replace row i with row i added to k times row j
-#  Value::Matrix->E(n,[i],k)   nxn, scale row i by k
-#  $A->E([i,j])      # n is the number of rows of $A
-#  $A->E([i,j],k)    # n is the number of rows of $A
-#  $A->E([i],k)      # n is the number of rows of $A
-#
+=head3 C<E>
+
+Get an elementary matrix of the requested size and type. These include matrix that upon left multiply will
+perform row operations.
+
+=over
+
+=item * Row Swap
+
+To perform a row swap between rows C<i> and C<j>, then C<E(n,[i, j])>.
+
+Usage:
+
+    Value::Matrix->E(3, [ 1, 3 ]);
+
+returns the matrix
+
+    [[0, 0, 1],
+    [0, 1, 0],
+    [1, 0, 0]]
+
+or if the matrix C<$A> exists then
+
+    $A->E([1, 3]);
+
+where the size of the resulting matrix is the number of rows of C<$A>.
+
+=item * Multiply a row by a constant
+
+To create the matrix that will multiply a row C<i>, by constant C<k>, then C<E(n,[i],k)>
+
+Usage:
+
+    Value::Matrix->E(4, [2], 3);
+
+generates the matrix
+
+    [ [ 1, 0, 0, 0 ],
+      [ 0, 4, 0, 0 ],
+      [ 0, 0, 1, 0 ],
+      [ 0, 0, 0, 1 ] ]
+
+or if the matrix C<$A> exists then
+
+    $A->E([4], 3);
+
+will generate the elementary matrix of size number of rows of C<$A>, which multiplies row 4 by 3.
+
+=item * Multiply a row by a constant and add to another row.
+
+To create the matrix that will multiply a row C<i>, by constant C<k> and add to row C<j> then C<E(n,[i, j],k)>
+
+Usage:
+
+    Value::Matrix->E(4, [ 3, 2 ], -3);
+
+generates the matrix:
+
+    [ [ 1, 0, 0, 0 ],
+      [ 0, 1, 0, 0 ],
+      [ 0, -3, 1, 0 ],
+      [ 0, 0, 0, 1 ] ]
+
+or if the matrix C<$A> exists then
+
+    $A->E([3, 4], -5);
+
+will generate the elementary matrix of size number of rows of C<$A>, which multiplies row 3 by -5 and adds to row 4.
+
+=back
+
+=cut
+
 sub E {
 	my ($self, $d, $rows, $k, $context) = @_;
 	if (ref $d eq 'ARRAY') {
 		($rows, $k, $context) = ($d, $rows, $k);
 		$d = ($self->dimensions)[0] if ref($self);
 	}
-	$context = $self->context                                             unless $context;
-	Value::Error("You must provide a dimension for an Elementary matrix") unless defined $d;
-	Value::Error("Dimension must be a positive integer")                  unless $d =~ m/^[1-9]\d*$/;
+	$context = $self->context unless $context;
 	my @ij = @{$rows};
+
+	Value::Error("You must provide a dimension for an Elementary matrix")             unless defined $d;
+	Value::Error("Dimension must be a positive integer")                              unless $d =~ m/^[1-9]\d*$/;
 	Value::Error("Either one or two rows must be specified for an Elementary matrix") unless (@ij == 1 || @ij == 2);
 	Value::Error(
 		"If only one row is specified for an Elementary matrix, then a number to scale by must also be specified")
 		if (@ij == 1 && !defined $k);
+
 	for (@ij) {
 		Value::Error("Row indices must be integers between 1 and $d")
 			unless ($_ =~ m/^[1-9]\d*$/ && $_ >= 1 && $_ <= $d);
@@ -670,13 +860,40 @@ sub E {
 	return $self->make($context, @M);
 }
 
-#
-#  Get a permutation matrix of the requested size
-#  E.g. P(3,[1,2,3])  corresponds to cycle (123) applied to rows of I_3i,
-#  and  P(6,[1,4],[2,4,6]) corresponds to cycle product (14)(246) applied to rows of I_6
-#  Value::Matrix->P(n,(cycles))
-#  $A->P((cycles))     # n is the number of rows of $A
-#
+=head3 C<P>
+
+Creates a permutation matrix of the requested size.
+
+C<< Value::Matrix->P(n,(cycles)) >> in general where C<cycles> is a sequence of array references
+of the cycles.
+
+If one has an existing matrix C<$A>, then C<< $A->P(cycles) >> generals a permutation matrix of the
+same size as C<$A>.
+
+Usage:
+
+    Value::Matrix->P(3,[1, 2, 3]);  # corresponds to cycle (123) applied to rows of I_3.
+
+returns the matrix [[0,1,0],[0,0,1],[1,0,0]]
+
+    Value::Matrix->P(6,[1,3],[2,4,6]);  # permutation matrix on cycle product (13)(246)
+
+returns the matrix
+
+    [[0,0,1,0,0,0],
+    [0,0,0,0,0,1],
+    [1,0,0,0,0,0],
+    [0,1,0,0,0,0],
+    [0,0,0,0,1,0],
+    [0,0,0,1,0,0]]
+
+    $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [13, 14, 15, 16] ]);
+    $P3 = $A->P([1,4]);
+
+returns the matrix [[0,0,0,1],[0,1,0,0],[0,0,1,0],[1,0,0,0]]
+
+=cut
+
 sub P {
 	my ($self, $d, @cycles) = @_;
 	if (ref $d eq 'ARRAY') {
@@ -685,6 +902,7 @@ sub P {
 	}
 	my $context = $self->context;
 	$d = ($self->dimensions)[0] if !defined $d && ref($self) && $self->isSquare;
+
 	Value::Error("You must provide a dimension for a Permutation matrix") unless defined $d;
 	Value::Error("Dimension must be a positive integer")                  unless $d =~ m/^[1-9]\d*$/;
 	for my $c (@cycles) {
@@ -715,18 +933,28 @@ sub P {
 	return $self->make($context, @M);
 }
 
-#
-#  Get an all zero matrix of the requested size
-#  Value::Matrix->Zero(m,n)
-#  Value::Matrix->Zero(n)
-#  $A->Zero    # n is the number of rows of $A
-#
+=head3 C<Zero>
+
+Create a zero matrix of requested size.  If called on existing matrix, creates a matrix as
+the same size as given matrix.
+
+Usage:
+
+    Value::Matrix->Zero(m,n);  # creates a m by n zero matrix.
+    Value::Matrix->Zero(n);    # creates an n ny n zero matrix.
+
+    $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A1->Zero;    # generates a zero matrix as same size as $A1.
+
+=cut
+
 sub Zero {
 	my ($self, $m, $n, $context) = @_;
 	$context = $self->context unless $context;
 	$n       = $m                     if !defined $n && defined $m;
 	$m       = ($self->dimensions)[0] if !defined $m && ref($self);
 	$n       = ($self->dimensions)[1] if !defined $n && ref($self);
+
 	Value::Error("You must provide dimensions for the Zero matrix") unless defined $m          && defined $n;
 	Value::Error("Dimension must be a positive integer")            unless $m =~ m/^[1-9]\d*$/ && $n =~ m/^[1-9]\d*$/;
 	my @M    = ();
@@ -738,26 +966,43 @@ sub Zero {
 	return $self->make($context, @M);
 }
 
-#
-#  Extract a given row from the matrix
-#
+=head3 C<row>
+
+Extract a given row from the matrix.
+
+Usage:
+
+    $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A1->row(2);  # returns the row Matrix [5,6,7,8]
+
+=cut
+
 sub row {
 	my $self = (ref($_[0]) ? $_[0] : shift);
 	my $M    = $self->promote(shift);
 	my $i    = shift;
-	return if $i == 0;
-	$i--   if $i > 0;
+	Value::Error("Row must be a positive integer") unless $i =~ m/^[1-9]\d*$/;
+	$i-- if $i > 0;
 	if ($M->isRow) { return if $i != 0 && $i != -1; return $M }
 	return $M->data->[$i];
 }
 
-#
-#  Extract a given column from the matrix
-#
+=head3 C<column>
+
+Extract a given column from the matrix.
+
+Usage:
+
+    $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A1->column(2);  # returns the column Matrix [[2],[6],[10]]
+
+=cut
+
 sub column {
 	my $self = (ref($_[0]) ? $_[0] : shift);
 	my $M    = $self->promote(shift);
 	my $j    = shift;
+	Value::Error("Column must be a positive integer") unless $j =~ m/^[1-9]\d*$/;
 	return if $j == 0;
 	$j--   if $j > 0;
 	my @d = $M->dimensions;
@@ -767,13 +1012,27 @@ sub column {
 	}
 	return if $j + 1 > $d[1] || $j < -$d[1];
 	my @col = ();
-	foreach my $row (@{ $M->data }) { push(@col, $self->make($row->data->[$j])) }
+	for my $row (@{ $M->data }) { push(@col, $self->make($row->data->[$j])) }
 	return $self->make(@col);
 }
 
-#
-#  Extract a given element from the matrix
-#
+=head3 C<element>
+
+Extract an element from the given row/col.
+
+Usage:
+
+    $A    = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+    $A->element(2,3); # returns 7
+
+    $B = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
+    $B->element(1,2,1); # returns 3;
+
+    $row = Matrix([4,3,2,1]);
+    $row->element(2); # returns 3;
+
+=cut
+
 sub element {
 	my $self = (ref($_[0]) ? $_[0] : shift);
 	my $M    = $self->promote(shift);
@@ -784,10 +1043,7 @@ sub element {
 # @@@ removeRow, removeColumn @@@
 # @@@ Minor @@@
 
-##################################################
-#
 #  Convert MathObject Matrix to old-style Matrix
-#
 sub wwMatrix {
 	my $self = (ref($_[0]) ? $_[0] : shift);
 	my $M    = $self->promote(shift);
@@ -798,14 +1054,14 @@ sub wwMatrix {
 	Value->Error("Matrix must be two-dimensional to convert to MatrixReal1") if scalar(@d) > 2;
 	if (scalar(@d) == 1) {
 		$wwM = new Matrix(1, $d[0]);
-		foreach my $j (0 .. $d[0] - 1) {
+		for my $j (0 .. $d[0] - 1) {
 			$wwM->[0][0][$j] = $self->wwMatrixEntry($M->data->[$j]);
 		}
 	} else {
 		$wwM = new Matrix(@d);
-		foreach my $i (0 .. $d[0] - 1) {
+		for my $i (0 .. $d[0] - 1) {
 			my $row = $M->data->[$i];
-			foreach my $j (0 .. $d[1] - 1) {
+			for my $j (0 .. $d[1] - 1) {
 				$wwM->[0][$i][$j] = $self->wwMatrixEntry($row->data->[$j]);
 			}
 		}
@@ -1014,7 +1270,7 @@ sub TeX {
 	my $d;
 
 	if ($self->isRow) {
-		foreach my $x (@{ $self->data }) {
+		for my $x (@{ $self->data }) {
 			if (Value::isValue($x)) {
 				$x->{format} = $self->{format} if defined $self->{format};
 				push(@entries, $x->TeX($equation));
@@ -1025,8 +1281,8 @@ sub TeX {
 		$TeX .= join(' &', @entries) . "\n";
 		$d = scalar(@entries);
 	} else {
-		foreach my $row (@{ $self->data }) {
-			foreach my $x (@{ $row->data }) {
+		for my $row (@{ $self->data }) {
+			for my $x (@{ $row->data }) {
 				if (Value::isValue($x)) {
 					$x->{format} = $self->{format} if defined $self->{format};
 					push(@entries, $x->TeX($equation));
@@ -1043,7 +1299,4 @@ sub TeX {
 	return '\left' . $open . '\begin{array}{' . ('c' x $d) . '}' . "\n" . $TeX . '\end{array}\right' . $close;
 }
 
-###########################################################################
-
 1;
-


### PR DESCRIPTION
This continues #1188, with POD changes (and minor code changes like `foreach` to `for`) that are largely the same as in #1076. For that reason I credited the commit to @pstaabp (hope that's OK). The diff between this branch and the #1076 branch should be a bit smaller than between #1076 and develop, only showing the new additions in #1076 plus some consequences of small things cleaned up here or in #1188.

To review this, you should just confirm that it is moving or lightly editing POD. And that any code changes are trivial/minor.

The next phase for this would be enhancing or changing existing methods, if we want to do any of that. For example enhancements like letting the `row` method take multiple arguments. And changes like treating 1D Matrix objects as column vectors instead of row vectors (regarding their presentation and interactions with 2D Matrix objects).