### PR TITLE
macros to show a text file and a problem file alongside its code

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3220,6 +3220,24 @@ sub tag {
 	return "<$tag" . ($attributes_str ? " $attributes_str" : '') . '>' . ($SELF_CLOSING{$tag} ? '' : "$content</$tag>");
 }
 
+# Show text and problem code
+# argument should be a path to a text file, relative to templates folder
+sub text_file {
+	TEXT(
+		MODES(HTML => '<pre>', TeX => '\begin{verbatim}', PTX => '<pre>'),
+		${ read_whole_problem_file($envir{templateDirectory} . shift) },
+		MODES(HTML => '</pre>', TeX => '\end{verbatim}', PTX => '</pre>')
+	);
+}
+
+# argument should be a path to a pg file, relative to templates folder
+sub problem_with_code {
+	my $filepath = shift;
+	text_file($filepath);
+	TEXT($HR);
+	includePGproblem($filepath);
+}
+
 ###########
 # Auxiliary macros
 


### PR DESCRIPTION
With this, have a problem file like

```
DOCUMENT();
loadMacros("PGbasicmacros.pl");
problem_with_code('newProblem.pg');
ENDDOCUMENT();
```

That is, assuming `newProblem.pg` is a problem file in your templates folder. You will see the problem file's text, then a horizontal rule, then the problem rendered.

I'm unsure if this would be useful, but perhaps in some place where we'd want to show the sample problem code alongside rendered output.