### PR TITLE
Fix a typo that causes reductions of constants to persist where they shouldn't.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -170,7 +170,7 @@ sub cmp_parse {
 			/reduced/i   and do {
 				my $oldFlags = contextSet($context, reduceConstants => 1, reduceConstantFunctions => 0);
 				$ans->{student_ans} = preformat($ans->{student_formula}->substitute()->string);
-				contextSet($context, %{$oldFags});
+				contextSet($context, %{$oldFlags});
 				last;
 			};
 			warn "Unknown student answer format |$ans->{formatStudentAnswer}|";


### PR DESCRIPTION
This typo dates back to 2005, but is an obvious typo.