### PR TITLE
Make crossed quadrilaterals fill only the region containing the fill point.

### DIFF
--- a/htdocs/js/GraphTool/quadrilateral.js
+++ b/htdocs/js/GraphTool/quadrilateral.js
@@ -65,11 +65,9 @@
 				].join(',');
 			},
 
-			// Note that this is an interior fill which is a bit inconsistent with the other fill cmp methods for other
-			// graph objects.  Other grap objects use an inequality fill.
 			fillCmp(gt, point) {
 				// Check to see if the point is on the border.
-				for (i = 0, j = this.definingPts.length - 1; i < this.definingPts.length; j = i++) {
+				for (let i = 0, j = this.definingPts.length - 1; i < this.definingPts.length; j = i++) {
 					if (
 						point[1] <= Math.max(this.definingPts[i].X(), this.definingPts[j].X()) &&
 						point[1] >= Math.min(this.definingPts[i].X(), this.definingPts[j].X()) &&
@@ -89,7 +87,13 @@
 				// Check to see if the point is inside.
 				const scrCoords = new JXG.Coords(JXG.COORDS_BY_USER, [point[1], point[2]], gt.board).scrCoords;
 				const isIn = JXG.Math.Geometry.pnpoly(scrCoords[1], scrCoords[2], this.baseObj.vertices);
-				if (isIn) return 1;
+				if (isIn) {
+					let result = 1;
+					for (const [i, border] of this.baseObj.borders.entries()) {
+						if (gt.sign(JXG.Math.innerProduct(point, border.stdform)) > 0) result |= 1 << (i + 1);
+					}
+					return result;
+				}
 				return -1;
 			},
 
@@ -143,6 +147,8 @@
 						Math.abs(x - groupedPoints[0].X()) < JXG.Math.eps &&
 						Math.abs(y - groupedPoints[0].Y()) < JXG.Math.eps
 					) {
+						let xDir = 0,
+							yDir = 0;
 						// Adjust position of the point if it has the same coordinates as its only grouped point.
 						if (e.type === 'pointermove') {
 							const coords = gt.getMouseCoords(e);

--- a/htdocs/js/GraphTool/triangle.js
+++ b/htdocs/js/GraphTool/triangle.js
@@ -135,6 +135,8 @@
 						Math.abs(x - groupedPoints[0].X()) < JXG.Math.eps &&
 						Math.abs(y - groupedPoints[0].Y()) < JXG.Math.eps
 					) {
+						let xDir = 0,
+							yDir = 0;
 						// Adjust position of the point if it has the same coordinates as its paired point.
 						if (e.type === 'pointermove') {
 							const coords = gt.getMouseCoords(e);


### PR DESCRIPTION
This is to fix a comment I placed in the code about filling quadrilaterals, and the comment made by @Alex-Jordan in https://github.com/openwebwork/pg/pull/1191#issuecomment-2683381959.

The code implemented in #1191 fills the entire interior of a quadrilateral even if it is a crossed quadrilateral (that is a quadrilateral with two edges that intersect). That is inconsistent with all of the other graph tool objects in some sense.  To be more consistent only the region inside the quadrilateral that satisfies the same inequalities relative to the borders should be filled.  So that is what this does.

I also was doing some benchmarking of the TikZ fill code used for generating hardcopy and noticed that some things were rather slow. The slow down it turns out was using MathObject Reals in computations. There is no need for the MathObject structure in those computations, so all of the fill code now uses the perl values instead. It isn't even funny how much faster computations are with pure perl numbers versus MathObject Reals. The difference is rather extreme. Performing something like 10000 basic arithmetic operations with MathObject Reals takes more than five seconds, but with pure perl numbers it takes less than 20 milliseconds.