### PR TITLE
Improve the accuracy of the degree unit.

### DIFF
--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -92,7 +92,7 @@ our %known_units = (
 
 	# ANGLES: fundamental unit rad (radian)
 	deg => {    # degree
-		factor  => 0.0174532925,
+		factor  => $PI / 180,
 		rad     => 1,
 		aliases => [ "\x{00B0}", 'degree', 'degrees' ]
 	},


### PR DESCRIPTION
Currently the factor of a the base radian unit is hard coded with accuracy to 9 signigicant digits. This changes to computing the factor from the variable `$PI` defined in `Units.pm` to be `4 atan2(1, 1)` which gives as good of accuracy as can be obtained (seems to be 15 significant digits of accuracy).

I have seen propogation of rounding error occur too frequently with the current estimate. That of course can still happen, but this makes it better at least.