### PR TITLE
Bump the version of MathQuill to pull in the removal of default `autoOperatorNames`.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@openwebwork/mathquill": "^0.11.0-beta.3",
+                "@openwebwork/mathquill": "^0.11.0-beta.5",
                 "jsxgraph": "^1.10.1",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@openwebwork/mathquill": {
-            "version": "0.11.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.4.tgz",
-            "integrity": "sha512-UmbiHIYzwkYwzNvvZ/JfRgk/n+FvwEiWIQDM1By2HJmk7Ton40LmsJSDV3Rwb945sRVbVOVtvqPoLTWivds7ww==",
+            "version": "0.11.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.5.tgz",
+            "integrity": "sha512-vjEQ1Go/UGwfjKSN2Xb9vQucO+LdbrVuL8fUVAfVGcAEIRPGtCvnt3FP612iHgSCdNZkCS/9hkJijfH2YBqBVA==",
             "license": "MPL-2.0"
         },
         "node_modules/@trysound/sax": {
@@ -1749,9 +1749,9 @@
             }
         },
         "@openwebwork/mathquill": {
-            "version": "0.11.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.4.tgz",
-            "integrity": "sha512-UmbiHIYzwkYwzNvvZ/JfRgk/n+FvwEiWIQDM1By2HJmk7Ton40LmsJSDV3Rwb945sRVbVOVtvqPoLTWivds7ww=="
+            "version": "0.11.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.5.tgz",
+            "integrity": "sha512-vjEQ1Go/UGwfjKSN2Xb9vQucO+LdbrVuL8fUVAfVGcAEIRPGtCvnt3FP612iHgSCdNZkCS/9hkJijfH2YBqBVA=="
         },
         "@trysound/sax": {
             "version": "0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
 	},
 	"dependencies": {
-		"@openwebwork/mathquill": "^0.11.0-beta.4",
+		"@openwebwork/mathquill": "^0.11.0-beta.5",
 		"jsxgraph": "^1.10.1",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",


### PR DESCRIPTION
See https://github.com/openwebwork/mathquill/pull/37.

All default `autoOperatorNames` are removed to address https://github.com/openwebwork/webwork2/issues/2203 and https://github.com/openwebwork/webwork2/issues/2681.

Any of those operators can be added back if desired, but having them by default continues to cause issues with typing other things.