### PR TITLE
Fraction eval method should return Real MathObject not perl real

### DIFF
--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -45,7 +45,7 @@ sub new {
 	# caller to pass in a problemUUID that will provide the required uniqueness.  That could include a course name, a
 	# student login name, etc.
 	$self->{unique_id_stub} = create_uuid_as_string(UUID_V3, UUID_NS_URL,
-		join('-', $envir->{psvn} // (), $envir->{problemSeed}, $envir->{problemUUID} // ()));
+		join('-', $envir->{psvn} // (), $envir->{problemSeed} // (), $envir->{problemUUID} // ()));
 
 	# Check the parameters.
 	$self->warning_message('The displayMode is not defined')    unless $self->{displayMode};

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -47,7 +47,7 @@ must enter a whole number or a fraction in this context.  It is also
 permissible to enter a whole number WITH a fraction, as in C<2 1/2> for
 "two and one half", or C<5/2>.
 
-The fourth is the same as LimiteFraction, but students must enter proper
+The fourth is the same as LimitedFraction, but students must enter proper
 fractions, and results are shown as proper fractions.
 
 It is also possible to add fractions to an existing context using

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -210,7 +210,7 @@ C<requirePureFractions> and C<requireProperFractions> to 1.
 Thie determines the tolerance to use when comparing a fraction to a
 real number.  The fraction will be converted to a real, and then this
 is used as the tolerance in a relative-tolerance comparison of the two
-reals.  The default is 10E-10, meaning the decimal must match to
+reals.  The default is 1E-10, meaning the decimal must match to
 roughly 10 digits.
 
 =item S<C<< contFracMaxDen >>>

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -909,7 +909,7 @@ sub isOne  { (shift)->eval == 1 }
 sub eval {
 	my $self = shift;
 	my ($a, $b) = $self->value;
-	return $a / $b;
+	return $self->Package('Real')->new($self->context, $a / $b);
 }
 
 #


### PR DESCRIPTION
This PR corrects an error where the `eval()` method of a Fraction MathObject would return a perl real rather than a MathObject Real.  That lead to comparisons that didn't use the fuzzy tolerances, which in turn lead to values that differ by small round-off errors being considered not equal when they should be equal.  E.g., Fraction(-25,3) not equaling (8/3)*(-2)-3.

This also changes the `compare()` method to use a better comparison for fractions, and a more precise tolerance value for comparing a fraction and a real, given by the new `fractionTolerance` flag.  Comparisons between a fraction and anything other than a fraction, real, or infinity will produce error messages.

This resolves issue #1204 without making it too easy to use a decimal value to match a fraction.

