### PR TITLE
Set default options to prevent partial credit or length hints for assignments

### DIFF
--- a/macros/parsers/parserAssignment.pl
+++ b/macros/parsers/parserAssignment.pl
@@ -325,7 +325,7 @@ sub TeX {
 #
 sub cmp_defaults {
 	my $self = shift;
-	{$self->SUPER::cmp_defaults(@_), showLengthHints => 0, partialCredit => 0};
+	{ $self->SUPER::cmp_defaults(@_), showLengthHints => 0, partialCredit => 0 };
 }
 
 #

--- a/macros/parsers/parserAssignment.pl
+++ b/macros/parsers/parserAssignment.pl
@@ -325,7 +325,7 @@ sub TeX {
 #
 sub cmp_defaults {
 	my $self = shift;
-	$self->SUPER::cmp_defaults(@_);
+	{$self->SUPER::cmp_defaults(@_), showLengthHints => 0, partialCredit => 0};
 }
 
 #


### PR DESCRIPTION
This PR sets the defaults for `partialCredit` and `showLenghtHints` for assignments so that unwanted messags and credit aren't given.

This resolves issue #1207.