### PR TITLE
Fix filling of concave quadrilaterals.

### DIFF
--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -354,7 +354,7 @@
 				pairedPointDrag(gt, e, point) {
 					gt.adjustDragPositionRestricted(e, point, point.paired_point);
 					if (point.Y() !== 0) point.setPosition(JXG.COORDS_BY_USER, [point.X(), 0]);
-					gt.setTextCoords(this.X(), 0);
+					gt.setTextCoords(point.X(), 0);
 					gt.updateObjects();
 					gt.updateText();
 				},

--- a/htdocs/js/GraphTool/quadrilateral.js
+++ b/htdocs/js/GraphTool/quadrilateral.js
@@ -88,6 +88,8 @@
 				const scrCoords = new JXG.Coords(JXG.COORDS_BY_USER, [point[1], point[2]], gt.board).scrCoords;
 				const isIn = JXG.Math.Geometry.pnpoly(scrCoords[1], scrCoords[2], this.baseObj.vertices);
 				if (isIn) {
+					if (!this.isCrossed()) return 1;
+
 					let result = 1;
 					for (const [i, border] of this.baseObj.borders.entries()) {
 						if (gt.sign(JXG.Math.innerProduct(point, border.stdform)) > 0) result |= 1 << (i + 1);
@@ -129,6 +131,23 @@
 					[point1, point2, point3]
 				);
 				return new gt.graphObjectTypes.quadrilateral(point1, point2, point3, point4, /solid/.test(string));
+			},
+
+			classMethods: {
+				isCrossed() {
+					const points = this.baseObj.vertices;
+					const borders = this.baseObj.borders;
+					return (
+						(JXG.Math.innerProduct(points[0].coords.usrCoords, borders[2].stdform) > 0 !=
+							JXG.Math.innerProduct(points[1].coords.usrCoords, borders[2].stdform) > 0 &&
+							JXG.Math.innerProduct(points[2].coords.usrCoords, borders[0].stdform) > 0 !=
+								JXG.Math.innerProduct(points[3].coords.usrCoords, borders[0].stdform) > 0) ||
+						(JXG.Math.innerProduct(points[0].coords.usrCoords, borders[1].stdform) > 0 !=
+							JXG.Math.innerProduct(points[3].coords.usrCoords, borders[1].stdform) > 0 &&
+							JXG.Math.innerProduct(points[1].coords.usrCoords, borders[3].stdform) > 0 !=
+								JXG.Math.innerProduct(points[2].coords.usrCoords, borders[3].stdform) > 0)
+					);
+				}
 			},
 
 			helperMethods: {


### PR DESCRIPTION
Currently only the portion of a concave quadrilateral that the fill point is in is filled, and not the entire interior because the current check separates portions that satisfy different inequalities with respect to the borders.  So this makes it so the interior parts are only distinquished for crossed quadrilaterals.

Here is a screen shot demonstrating the issue:
![bad-fill](https://github.com/user-attachments/assets/1f113335-aef5-473c-b68d-06fecd7fa827)

Also fix the documentation about how to use the `%graphToolObjectCmps` hash entry for vectors.  The GraphTool object must be passed so that it can get the `vectorsArePositional` option. This is only for those using this for a custom checker (if anyone does).

This was included in #1206.  However, I am (at least temporarily) changing that pull request to a draft until (and if) some issues are resolved.  These things are unrelated to that pull request really.