### PR TITLE
Fix bracket ends for graphtool intervals with the `useBracketEnds` setting.

### DIFF
--- a/htdocs/js/GraphTool/intervaltools.js
+++ b/htdocs/js/GraphTool/intervaltools.js
@@ -371,9 +371,12 @@
 					if (!gt.isStatic) {
 						point.on('down', () => gt.graphObjectTypes.interval.pointDown(point));
 						point.on('up', () => gt.graphObjectTypes.interval.pointUp(point));
-						if (typeof paired_point !== 'undefined') {
-							point.paired_point = paired_point;
-							paired_point.paired_point = point;
+					}
+
+					if (typeof paired_point !== 'undefined') {
+						point.paired_point = paired_point;
+						paired_point.paired_point = point;
+						if (!gt.isStatic) {
 							paired_point.on('drag', (e) =>
 								gt.graphObjectTypes.interval.pairedPointDrag(e, paired_point)
 							);


### PR DESCRIPTION
In #1157 I made it so that the `up`, `down`, and `drag` handlers for the defining points of graph objects are not added to static graph objects.  However, in doing so for intervals I also made it so that the paired point association is not made.  For most graph objects those associations are only needed when the handlers are added since they are used to prevent points from being moved in such a way to prevent degeneracy for the object.  But for intervals that association is also used to determine which direction the brackets or parentheses should face when the `useBracketEnds` option is used.  As such, now correct answer graphs always show those facing to the right even if they are on the right end.