### PR TITLE
Update the Rserve interface.

### DIFF
--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -139,6 +139,12 @@ specialPGEnvironmentVars:
   # Size in pixels of dynamically-generated images, i.e. graphs.
   onTheFlyImageSize: 400
 
+  # To enable Rserve (the R statistical server), uncomment the following two
+  # lines. The R server needs to be installed and running in order for this to
+  # work. See http://webwork.maa.org/wiki/R_in_WeBWorK for more info.
+  #Rserve:
+  #  host: localhost
+
   # Locations of CAPA resources. (Only necessary if you need to use converted CAPA problems.)
   CAPA_Tools: $Contrib_dir/CAPA/macros/CAPA_Tools/
   CAPA_MCTools: $Contrib_dir/Contrib/CAPA/macros/CAPA_MCTools/

--- a/lib/Rserve.pm
+++ b/lib/Rserve.pm
@@ -11,53 +11,34 @@ my $rserve_loaded = eval {
 sub access {
 	die 'Statistics::R::IO::Rserve could not be loaded. Have you installed the module?'
 		unless $rserve_loaded;
-
-	Statistics::R::IO::Rserve->new(@_);
+	return Statistics::R::IO::Rserve->new(@_);
 }
 
-## Evaluates an R expression guarding it inside an R `try` function
-##
-## Returns the result as a REXP if no exceptions were raised, or
-## `die`s with the text of the exception message.
+# Evaluates an R expression guarding it inside an R `try` function
+#
+# Returns the result as a REXP if no exceptions were raised, or
+# `die`s with the text of the exception message.
 sub try_eval {
 	my ($rserve, $query) = @_;
 
-	my $result = $rserve->eval("try({ $query }, silent=TRUE)");
-	die $result->to_pl->[0] if _inherits($result, 'try-error');
-	# die $result->to_pl->[0] if $result->inherits('try-error');
+	my $result = $rserve->eval("try({ $query }, silent = TRUE)");
+	die $result->to_pl->[0] if $result->inherits('try-error');
 
-	$result;
+	return $result;
 }
 
-## Returns a REXP's Perl representation, dereferencing it if it's an
-## array reference
-##
-## `REXP::to_pl` returns a string scalar for Symbol, undef for Null,
-## and an array reference to contents for all vector types. This
-## function is a utility wrapper to make it easy to assign a Vector's
-## representation to an array variable, while still working sensibly
-## for non-arrays.
+# Returns a REXP's Perl representation, dereferencing it if it's an
+# array reference
+#
+# `REXP::to_pl` returns a string scalar for Symbol, undef for Null,
+# and an array reference to contents for all vector types. This
+# function is a utility wrapper to make it easy to assign a Vector's
+# representation to an array variable, while still working sensibly
+# for non-arrays.
 sub unref_rexp {
-	my $rexp = shift;
-
+	my $rexp  = shift;
 	my $value = $rexp->to_pl;
-	if (ref($value) eq ref([])) {
-		@{$value};
-	} else {
-		$value;
-	}
-}
-
-## Reimplements method C<inherits> of class L<Statistics::R::REXP>
-## until I figure out why calling it directly doesn't work in the safe
-## compartment
-sub _inherits {
-	my ($rexp, $class) = @_;
-
-	my $attributes = $rexp->attributes;
-	return unless $attributes && $attributes->{'class'};
-
-	grep {/^$class$/} @{ $attributes->{'class'}->to_pl };
+	return ref($value) eq 'ARRAY' ? @$value : $value;
 }
 
 1;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2231,11 +2231,6 @@ sub PTX_cleanup {
                     # The function should be called either with value specified (immediate reference) or
                     # with url specified in which case the revealed text is taken from the URL $url.
                     # The $display_text is always visible and is clicked to see the contents of the knowl.
-    htmlLink($url, $text)
-                    # Places a reference to the URL with the specified text in the problem.
-                    # A common usage is \{ htmlLink(alias('prob1_help.html') \}, 'for help')
-                    # where alias finds the full address of the prob1_help.html file in the same directory
-                    # as the problem file
     iframe($url, height=>'', width=>'', id=>'', name=>'' )
                     # insert the web page referenced by $url in a space defined by height and width
                     # if the webpage contains a form then this must be inserted between
@@ -2362,18 +2357,31 @@ sub OL {
 	);
 }
 
+=head2 htmlLink
+
+Usage: C<htmlLink($url, $text, @attributes)>
+
+Places an HTML link to C<$url> with the specified C<$text> in the problem. The
+C<@attributes> are optional.  They should be provided as attribute/value pairs,
+but a single text string argument can be given (although calling C<htmlLink> in
+that way is deprecated and should not be done in new problems).  For example,
+
+    BEGIN_PGML
+    Download the [@ htmlLink($url, 'dataset', download => 'dataset.csv') @]*
+    for this problem.
+
+=cut
+
 sub htmlLink {
-	my $url           = shift;
-	my $text          = shift;
-	my $options       = shift;
-	my $sanitized_url = $url;
-	$sanitized_url =~ s/&/&amp;/g;
-	$options = ""                                             unless defined($options);
-	return "$BBOLD [ the link to '$text'  is broken ] $EBOLD" unless defined($url) and $url;
+	my ($url, $text, @options) = @_;
+	return "$BBOLD [ the link to '$text'  is broken ] $EBOLD" unless $url;
+	my $attributes = @options == 1 ? $options[0] : {@options};
 	MODES(
 		TeX  => "{\\bf \\underline{$text}}",
-		HTML => "<A HREF=\"$url\" $options>$text</A>",
-		PTX  => "<url href=\"$sanitized_url\">$text</url>",
+		HTML => ref($attributes) eq 'HASH'
+		? tag('a', href => $url, %$attributes, $text)
+		: qq{<a href="$url" $attributes>$text</a>},
+		PTX => '<url href="' . ($url =~ s/&/&amp;/g) . qq{">$text</url>},
 	);
 }
 

--- a/macros/core/RserveClient.pl
+++ b/macros/core/RserveClient.pl
@@ -1,196 +1,303 @@
 
 =head1 NAME
 
-RserveClient.pl - Macros for evaluating R code on an Rserve server
+RserveClient.pl - Methods for evaluating R code on an Rserve server
 
 =head1 SYNOPSIS
 
-Here's a basic way to call the R server:
+The basic way to call the R server is as follows:
 
     loadMacros('RserveClient.pl');
 
-    rserve_start();
-    my @rnorm = rserve_eval("rnorm(15, mean=$m, sd=$sd)");
+    my @rnorm = rserve_eval("rnorm(15, mean = $m, sd = $sd)");
     rserve_eval(data(stackloss));
     my @coeff = rserve_eval('lm(stack.loss ~ stack.x, stackloss)$coeff');
-    rserve_finish();
-
 
 =head1 DESCRIPTION
 
-The macros in this file provide access to facilities of L<R
-statistical computing environment|http://www.r-project.org>,
+The methods in this macro provide access to facilities of the
+L<R statistical computing environment|http://www.r-project.org>,
 optionally located on another server, by using the
 L<Rserve|http://www.rforge.net/Rserve/> protocol.
 
-B<IMPORTANT:> Before you can use these macros, you will need to
-configure the location of your Rserve host by adding it to
-C<$pg{specialPGEnvironmentVars}{Rserve}{host}>, for instance by
-appending the following line to F<webwork2/conf/localOverrides.conf>:
+B<IMPORTANT:> Before this macro can be used, the server administrator will need
+to configure the location of the Rserve host by setting
+C<< $pg_envir->{specialPGEnvironmentVars}{Rserve}{host} >>. For webwork2 this is
+accomplished by adding the following line to F<webwork2/conf/localOverrides.conf>:
 
-    $pg{specialPGEnvironmentVars}{Rserve} = {host => "localhost"};
+    $pg{specialPGEnvironmentVars}{Rserve} = { host => "localhost" };
 
-Without this configuration in place, Rserve macros will only print out
-a warning about missing configuration and return C<undef>.
+If using PG directly, then uncomment the C<Rserve:> and following C<host:> lines
+in F<pg/conf/pg_config.yml>.
 
-=head1 MACROS
+Without this configuration, the methods in this macro will display a warning
+about the missing configuration and return.
 
-The macros in this file set up a connection to the R server and
-pass a string parameter to R for evaluation.  The resulting
-vector is returned as a perl array object.
+=head1 METHODS
 
-=over 4
+The methods in this file set up a connection to the R server and pass a string
+parameter to R for evaluation.  The result is returned as a Perl object.
 
-=item rserve_eval REXPR
+=head2 rserve_start
 
-Evaluates an R expression, given as text string in REXPR, on the
-L<Rserve|http://www.rforge.net/Rserve/> server and returns its result
-as a Perl representation of the L<Statistics::R::REXP> object.
-Multiple calls within the same problem share the R session and the
-object workspace.
+=head2 rserve_finish
 
-=item rserve_query
+Start up and close the current connection to the Rserve server. In normal use,
+these functions are not needed because a call to any of the other methods will
+handle starting the session if one is not already open, and the session will be
+closed when processing of the current problem is complete.
 
-Evaluates an R expression, given as text string in REXPR, in a
-single-use session on the L<Rserve|http://www.rforge.net/Rserve/>
-server and returns its result as a Perl representation of the
-L<Statistics::R::REXP> object.
+Other than for backward compatibility, the only reason for using these functions
+is to start a new clean session within a single problem. This shouldn't be a
+common occurrence.
 
-This function is different from C<rserve_eval> in that each call is
-completely self-enclosed and its R session is discarded after it
-returns.
+=head2 rserve_eval
 
-=item rserve_start, rserve_finish
+    $result = rserve_eval($rexpr);
 
-Start up and close the current connection to the Rserve server. In
-normal use, these functions are completely optional because the first
-call to C<rserve_eval> will call start the session if one is not
-already open. Similarly, the current session will be closed in its
-destructor when the current question goes out of scope.
+Evaluates an R expression, given as text string in C<$rexpr>, on the
+L<Rserve|http://www.rforge.net/Rserve/> server and returns its result as a Perl
+representation of the L<Statistics::R::REXP> object.  Multiple calls within the
+same problem share the R session and the object workspace.
 
-Other than backward compatibility, the only reason for using these
-functions is to start a new clean session within a single problem,
-which shouldn't be a common occurrence.
+=head2 rserve_query
 
-=item rserve_start_plot [IMG_TYPE, [WIDTH, HEIGHT]]
+    $result = rserve_query($rexpr);
 
-Opens a new R graphics device to capture subsequent graphics output in
-a temporary file on the R server. IMG_TYPE can be 'png', 'jpg', or
-'pdf', with 'png' as the default. If left unspecified, WIDTH and
-HEIGHT, will use the R graphics device's default size. Returns the
-name of the remote file.
+Evaluates an R expression, given as text string in C<$rexpr>, in a single-use
+session on the L<Rserve|http://www.rforge.net/Rserve/> server and returns its
+result as a Perl representation of the L<Statistics::R::REXP> object.
 
+This function is different from C<rserve_eval> in that each call is completely
+self-enclosed and its R session is discarded after it returns.
 
-=item rserve_finish_plot REMOTE_NAME
+=head2 rserve_start_plot
 
-Closes the R graphics capture to file REMOTE_NAME, transfers the file
-to WebWork's temporary file area, and returns the name of the local
-file that can then be used by the image macro.
+    $remoteFile = rserve_start_plot($imgType, $width, $height);
 
-=item rserve_get_file REMOTE_NAME, [LOCAL_NAME]
+Opens a new R graphics device to capture subsequent graphics output in a
+temporary file on the R server. The C<$imgType>, C<$width>, and C<$height>
+arguments are optional. The argument C<$imgType> can be one of 'png', 'jpg', or
+'pdf', and is set to 'png' if this argument is omitted. If C<$width> and
+C<$height> are unspecified, then the R graphics device's default size will be
+used. The name of the remote file is returned.
 
-Transfer the file REMOTE_NAME from the R server to WebWork's temporary
-file area, and returns the name of the local file that can then be
-used by the C<htmlLink> macro. If LOCAL_NAME is not specified, the
-filename portion of the REMOTE_NAME is used.
+=head2 rserve_finish_plot
 
-=back
+    $localFile = rserve_finish_plot($remoteName);
 
+Closes the R graphics capture to file C<$remoteName>, transfers the file to the
+directory specified by C<tempDirectory> in the PG environment, and returns the
+name of the local file that can then be used by the C<image> method.
 
-=head1 DEPENDENCIES
+=head2 rserve_get_file
 
-Requires perl 5.010 or newer and CPAN module Statistics::R::IO, which
-has to be loaded in WebWork's Safe compartment by adding it to
-${pg}{modules}.
+    $localFile = rserve_get_file($remoteName);
 
+Transfer the file C<$remoteName> from the R server to the directory specified by
+C<tempDirectory> in the PG environment, and returns the name of the local file
+that can then be used by the C<htmlLink> method.
+
+This method used to take an optional second argument that specified the local
+file name to save to.  That parameter is deprecated, and is ignored if given.
+
+An example of using this method follows.  It is recommended that the
+C<rserve_data_url> method be used instead of using this method since it takes
+care of the gory details needed to use this method as seen in the example below.
+
+    ($intercept, $slope) = rserve_eval('coef(lm(log(dist) ~ log(speed), data = cars))');
+
+    ($remoteFile) =
+        rserve_eval('filename <- tempfile(fileext = ".csv"); '
+            . 'write.csv(cars, filename); '
+            . 'filename');
+    $url = alias(rserve_get_file($remoteFile));
+
+    BEGIN_PGML
+    What is the slope of the linear regression of log-transformed stopping
+    distance vs. car speed in the dataset linked below: [_]{$slope}{5}
+
+    Download the [@ htmlLink($url, 'dataset', download => 'dataset.csv') @]*
+    file.
+    END_PGML
+
+=head2 rserve_plot
+
+    $image = rserve_plot($rCode, $width, $height, $imgType);
+
+This method essentially combines C<rserve_start_plot>, C<rserve_eval>, and
+C<rserve_finish_plot> into a single method.  For example, calling
+
+    $image = rserve_plot("curve(dnorm(x, mean = $mean), xlim = c(-4, 4)); 0");
+
+is equivalent to calling
+
+    $remoteImage = rserve_start_plot('png');
+    rserve_eval("curve(dnorm(x, mean = $mean), xlim = c(-4, 4)); 0");
+    $image = rserve_finish_plot($remoteImage);
+
+The arguments C<$width>, C<$height>, and C<$imgType> are optional. If C<$width>
+and C<$height> are unspecified, then the R graphics device's default size will
+be used. The argument C<$imgType> can be one of 'png', 'jpg', or 'pdf', and is
+set to 'png' if this argument is omitted or is not one of the allowed values.
+
+As with C<rserve_finish_plot>, the file path that is returned that can be used
+via the C<[!alt text!]{$image}> PGML construct or by the C<image> method.  For
+example,
+
+    BEGIN_PGML
+    What is the mean of the normal distribution shown in the figure below: [_]{$mean}{5}
+
+    [!normal distribution!]{$image}{300}
+    END_PGML
+
+=head2 rserve_data_url
+
+    $url = rserve_data_url($rDataName);
+
+Creates a temporary CSV file on the R server with the data named by
+C<$rDataName>, transfers it to the directory specified by C<tempDirectory> in
+the PG environment, and returns a URL that can by used with the C<htmlLink>
+method. For example,
+
+    ($intercept, $slope) = rserve_eval('coef(lm(log(dist) ~ log(speed), data = cars))');
+    $local_url = rserve_data_url('cars');
+
+    BEGIN_PGML
+    What is the slope of the linear regression of log-transformed stopping
+    distance vs. car speed in the dataset linked below: [_]{$slope}{5}
+
+    Download the [@ htmlLink($url, 'dataset', download => 'dataset.csv') @]*
+    file.
+    END_PGML
+
+Note that it is recommended that the C<download> attribute be added so that the
+download file name will be the value of that attribute rather than the lengthy
+alias name in the C<$url>.
 
 =cut
+
+BEGIN { strict->import; }
 
 my $rserve;    # Statistics::R::IO::Rserve instance
 
 sub _rserve_warn_no_config {
-	my @trace = split /\n/, Value::traceback();
-	my ($function, $line, $file) = $trace[0] =~ /^\s*in ([^ ]+) at line (\d+) of (.*)/;
-
-	$PG->warning_message('Calling '
-			. $function
-			. ' is disabled unless Rserve host is configured in $pg{specialPGEnvironmentVars}{Rserve}{host}');
+	my @trace      = split /\n/, Value::traceback();
+	my ($function) = $trace[0] =~ /^\s*in ([^ ]+) at line \d+ of .*/;
+	$main::PG->warning_message("Calling $function is disabled unless Rserve host is configured in the PG environment.");
+	return;
 }
 
 sub rserve_start {
-	_rserve_warn_no_config && return unless $Rserve->{host};
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
 
-	$rserve = Rserve::access(server => $Rserve->{host}, _usesocket => 1);
+	$rserve = Rserve::access(server => $main::Rserve->{host}, _usesocket => 1);
 
 	# Keep R's RNG reproducible for this problem
-	$rserve->eval("set.seed($problemSeed)");
+	$rserve->eval("set.seed($main::problemSeed)");
+
+	return;
 }
 
 sub rserve_finish {
 	$rserve->close() if $rserve;
 	undef $rserve;
+	return;
 }
 
 sub rserve_eval {
-	_rserve_warn_no_config && return unless $Rserve->{host};
-
 	my $query = shift;
+
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
 
 	rserve_start unless $rserve;
 
 	my $result = Rserve::try_eval($rserve, $query);
-	Rserve::unref_rexp($result);
+	return Rserve::unref_rexp($result);
 }
 
 sub rserve_query {
-	_rserve_warn_no_config && return unless $Rserve->{host};
-
 	my $query = shift;
-	$query = "set.seed($problemSeed)\n" . $query;
-	my $rserve_client = Rserve::access(server => $Rserve->{host}, _usesocket => 1);
+
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
+
+	$query = "set.seed($main::problemSeed)\n" . $query;
+	my $rserve_client = Rserve::access(server => $main::Rserve->{host}, _usesocket => 1);
 	my $result        = Rserve::try_eval($rserve_client, $query);
 	$rserve_client->close;
-	Rserve::unref_rexp($result);
+	return Rserve::unref_rexp($result);
 }
 
 sub rserve_start_plot {
-	_rserve_warn_no_config && return unless $Rserve->{host};
+	my $imgType = shift // 'png';
+	my $width   = shift // '';
+	my $height  = shift // '';
 
-	my $device = shift // 'png';
-	my $width  = shift // '';
-	my $height = shift // '';
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
 
-	die "Unsupported image type $device" unless $device =~ /^(png|pdf|jpg)$/;
-	my $remote_image = (rserve_eval("tempfile(fileext='.$device')"))[0];
+	die "Unsupported image type $imgType" unless $imgType =~ /^(png|pdf|jpg)$/;
+	my ($remote_image) = rserve_eval("tempfile(fileext = '.$imgType')");
 
-	$device =~ s/jpg/jpeg/;
+	rserve_eval(($imgType =~ s/jpg/jpeg/r) . "('$remote_image', width = $width, height = $height)");
 
-	rserve_eval("$device('$remote_image', width = ${width}, height = ${height})");
-
-	$remote_image;
+	return $remote_image;
 }
 
 sub rserve_finish_plot {
-	_rserve_warn_no_config && return unless $Rserve->{host};
+	my $remote_image = shift or die 'Missing remote image name';
 
-	my $remote_image = shift or die "Missing remote image name";
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
 
-	rserve_eval("dev.off()");
+	rserve_eval('dev.off()');
 
-	rserve_get_file($remote_image);
+	return rserve_get_file($remote_image);
 }
 
+# This used to take a second $local parameter that specified the name of the file that would be saved in the temp
+# directory. That parameter is deprecated and is ignored if given. The problem author should have never been given that
+# choice. Furthermore, if the $local parameter was not specified the remote file name was used which changes every time
+# the problem is rendered.  That is a problem because it results in a different file being saved into the temporary
+# directory every time the problem is rendered.  Instead a unique filename is used that is created via PGresource and
+# PGalias (and so is dependent on the problem seed, psvn, problem UUID, etc.).
 sub rserve_get_file {
-	_rserve_warn_no_config && return unless $Rserve->{host};
+	my $remote = shift or die 'Missing remote file name';
 
-	my $remote = shift or die "Missing remote file name";
-	my $local  = shift // $PG->fileFromPath($remote);
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
 
-	$local = $PG->surePathToTmpFile($local);
+	my $ext      = $remote =~ /\.([^.]*)$/ ? $1 : 'png';
+	my $filePath = $main::PG->surePathToTmpFile(
+		($ext =~ /^(png|jpg|pdf)$/ ? 'images/' : 'data/') . $main::PG->getUniqueName($ext) . ".$ext");
 
-	$rserve->get_file($remote, $local);
+	$rserve->get_file($remote, $filePath);
 
-	$local;
+	return $filePath;
+}
+
+sub rserve_plot {
+	my ($rCode, $width, $height, $imgType) = @_;
+
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
+
+	$width  //= '';
+	$height //= '';
+	$imgType = 'png' unless $imgType && $imgType =~ /^(png|pdf|jpg)$/;
+
+	my ($remote_image) = rserve_eval("tempfile(fileext = '.$imgType')");
+	rserve_eval(($imgType =~ s/jpg/jpeg/r) . "('$remote_image', width = $width, height = $height)");
+	rserve_eval($rCode);
+	rserve_eval('dev.off()');
+
+	return rserve_get_file($remote_image);
+}
+
+sub rserve_data_url {
+	my $rDataName = shift;
+
+	unless ($main::Rserve->{host}) { _rserve_warn_no_config; return; }
+
+	my ($remote_file) =
+		rserve_eval(qq{filename <- tempfile(fileext = ".csv"); write.csv($rDataName, filename); filename});
+	return main::alias(rserve_get_file($remote_file));
 }
 
 1;


### PR DESCRIPTION
The primary change in this pull request is how the `rserve_get_file` method in the `RserveClient.pl` macro works.  Previously it accepted a second optional local filename parameter.  That parameter is no longer honored.  If it is given it is ignored.  I don't think that there are any problems in the OPL or Contrib that pass that argument, but even if they do it will still work.  The filename just won't be the chosen one. The filename should not be a problem author choice.  Furthermore, previously the method fell back to using the Rserve remote filename. That is also no longer used.  Instead, the `getUniqueName` method is used that creates a filename that is dependent on the problem seed, psvn, problem UUID, etc. That means that the filename will not change each time that the problem is loaded. Unfortunately, the file is still downloaded every time the problem is loaded and overwrites the existing file (with the same contents), and that can't really be fixed without a major revision of the Rserve setup.

Note that all changes in this pull request are backwards compatible, and all existing problems will continue to function correctly. However, the courses html temporary directory will no longer be filled with files that are only used once before another copy of the file is created by another name the next time the problem is rendered (due to a preview, answer submission, etc.).

In addition there are two new methods added that are more convenient than the previous methods for generating R images or csv files. Those are the `rserve_data_url` and `rserve_plot` methods.  These handle the details of creating these things in a much nicer way.  See the added POD and examples in the POD for the usage and comparison to the old approaches.

The macro code and POD are also rather heavily clean up.  The `Rserve.pm` module is also cleaned up. The `_inherits` method is removed from the `Rserve.pm` module, because contrary to the comments the `inherits` method of the `$rserve` object does work in the safe compartment, and so the `_inherits` method is not needed.

There is one other related change. The `htmlLink` method now has a new calling convention for adding additional attributes to the generated `a` tag. Previously these were added by passing a single string argument. For example, `htmlLink($url, 'dataset', 'download="dataset.csv"')`.  That will still work, but passing the attributes in that way should be considered deprecated.  Instead the attributes should be passed as additional attribute/value pairs after the url and link text. For example, `htmlLink($url, 'dataset', download => 'dataset.csv')`.  Of course, this is useful for Rserve csv files to specify the filename that will be offered when the user clicks to download a csv file.  Particularly since the default will now be something like `ed721060-00b2-37fb-87c4-e3eb36c7ced2___5643740d-c34f-37c8-afc5-c2369fec26e1.csv`. Previously it would have been something like `file1231asdfasdf.csv`. The new alias is worse, but that wasn't good either.