### PR TITLE
Update permissions.

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -191,7 +191,7 @@ sub draw {
 		if (open(my $fh, ">", "$working_dir/image-dvisvgm.tex")) {
 			my @header = $self->header;
 			splice @header, 1, 0, "\\def\\pgfsysdriver{pgfsys-dvisvgm.def}\n";
-			chmod(0777, "$working_dir/image-dvisvgm.tex");
+			chmod(oct(664), "$working_dir/image-dvisvgm.tex");
 			print $fh @header;
 			print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
 			print $fh $self->footer;
@@ -200,7 +200,7 @@ sub draw {
 				. WeBWorK::PG::IO::externalCommand('latex')
 				. " --interaction=nonstopmode image-dvisvgm.tex > latex.stdout 2> /dev/null";
 			move("$working_dir/image-dvisvgm.dvi", "$working_dir/image.dvi");
-			chmod(0777, "$working_dir/image.dvi");
+			chmod(oct(664), "$working_dir/image.dvi");
 		} else {
 			warn "Can't open $working_dir/image-dvisvgm.tex for writing.";
 			return '';
@@ -208,7 +208,7 @@ sub draw {
 	}
 	if ($ext ne 'svg' || ($ext eq 'svg' && $svgMethod ne 'dvisvgm')) {
 		if (open(my $fh, ">", "$working_dir/image.tex")) {
-			chmod(0777, "$working_dir/image.tex");
+			chmod(oct(664), "$working_dir/image.tex");
 			print $fh $self->header;
 			print $fh $self->tex =~ s/\\\\/\\/gr . "\n";
 			print $fh $self->footer;
@@ -216,7 +216,7 @@ sub draw {
 			system "cd $working_dir && "
 				. WeBWorK::PG::IO::externalCommand('latex2pdf')
 				. " --interaction=nonstopmode image.tex > latex.stdout 2> /dev/null";
-			chmod(0777, "$working_dir/image.pdf");
+			chmod(oct(664), "$working_dir/image.pdf");
 		} else {
 			warn "Can't open $working_dir/image.tex for writing.";
 			return '';

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -590,7 +590,7 @@ sub insertGraph {
 		my $graphData = $graph->draw;
 		if ($graphData) {
 			if (open(my $fh, '>', $filePath)) {
-				chmod(0777, $filePath);
+				chmod(oct(664), $filePath);
 				print $fh $graphData;
 				close($fh) or warn "Can't close $filePath";
 			} else {


### PR DESCRIPTION
Change the permissions from `0777` to `0664` (or really `oct(664)` as perlcritic recommends) for the `LaTeXImage.pm` and `PGcore.pm` modules.

There is no reason for these files to be executable and writable by all.