### PR TITLE
update several matrix methods to apply to degree n matrices

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -307,7 +307,7 @@ returns C<(2,2,2)>
 
 #
 #  Recursively get the dimensions of the matrix.
-#  Returns (d_1,d_2,...,d_n) for an degree n Matrix.
+#  Returns (d_1,d_2,...,d_n) for a degree n Matrix.
 #
 sub dimensions {
 	my $self = shift;
@@ -359,8 +359,8 @@ Usage:
 sub isSquare {
 	my $self = shift;
 	my @d    = $self->dimensions;
-	if (scalar(@d) == 1) { return $d[0] == 1 }
-	return ($d[-1] == $d[-2]);
+	return $d[0] == 1 if scalar(@d) == 1;
+	return $d[-1] == $d[-2];
 }
 
 =head3 C<isRow>
@@ -798,7 +798,7 @@ sub transpose {
 
 =head3 C<I>
 
-Get a identity Matrix of the requested size
+Get an identity Matrix of the requested size
 
     Value::Matrix->I(n)
 
@@ -1209,7 +1209,7 @@ sub det {
 sub inverse {
 	my $self = shift;
 	my @d    = $self->dimensions;
-	my @M    = ();
+	my @M;
 	for my $i (0 .. $d[0] - 1) {
 		if (scalar(@d) == 2) {
 			$self->wwMatrixLR;

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -83,8 +83,9 @@ Examples:
 
 =head3 Conversion
 
-    $matrix->value produces an array of numbers (for a degree 1 Matrix) or array refs representing the rows.
-    These are perl numbers and array refs, not MathObjects.
+    $matrix->value produces an array of references to nested arrays, except at
+    the deepest level, where there will be the more basic MathObjects that make
+    up the Matrix (e.g. Real, Complex, Fraction, a mix of these, etc)
 
     $M1->value is (1, 2, 3)
     $M2->value is ([1, 2], [3, 4])

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -418,9 +418,7 @@ sub isOne {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isOne) {
-				return 0;
-			}
+			return 0 unless $row->isOne;
 		}
 	}
 	return 1;
@@ -470,9 +468,7 @@ sub isUpperTriangular {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isUpperTriangular) {
-				return 0;
-			}
+			return 0 unless $row->isUpperTriangular;
 		}
 	}
 	return 1;
@@ -499,9 +495,7 @@ sub isLowerTriangular {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isLowerTriangular) {
-				return 0;
-			}
+			return 0 unless $row->isLowerTriangular;
 		}
 	}
 	return 1;
@@ -537,9 +531,7 @@ sub isSymmetric {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isSymmetric) {
-				return 0;
-			}
+			return 0 unless $row->isSymmetric;
 		}
 	}
 	return 1;
@@ -588,15 +580,13 @@ sub isREF {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isREF) {
-				return 0;
-			}
+			return 0 unless $row->isREF;
 		}
 	}
 	return 1;
 }
 
-=head3 C<isREF>
+=head3 C<isRREF>
 
 Check if a Matrix is in reduced row echelon form (for degree > 2, applies to frontal slice matrices)
 
@@ -631,9 +621,7 @@ sub isRREF {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			if (!$row->isRREF) {
-				return 0;
-			}
+			return 0 unless $row->isREF;
 		}
 	}
 	return 1;

--- a/t/math_objects/matrix.t
+++ b/t/math_objects/matrix.t
@@ -105,15 +105,82 @@ subtest 'Use isSquare, isOne, and isRow methods' => sub {
 };
 
 subtest 'Use tests for triangular matrices' => sub {
-	my $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 0, 6, 7, 8 ], [ 0, 0,  11, 12 ], [ 0,  0,  0,  16 ] ]);
+	my $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 0, 6, 7, 8 ], [ 0, 0, 11, 12 ], [ 0, 0, 0, 16 ] ]);
 	my $A2 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [ 13, 14, 15, 16 ] ]);
+	my $A3 = Matrix($A1, $A1);
+	my $A4 = Matrix($A2, $A1);
 	ok $A1->isUpperTriangular,  'test for upper triangular matrix';
 	ok !$A2->isUpperTriangular, 'not an upper triangular matrix';
+	ok $A3->isUpperTriangular,  'test for upper triangular degree 3 matrix';
+	ok !$A4->isUpperTriangular, 'not an upper triangular degree 3 matrix';
 	my $B1 = Matrix([ [ 1, 0, 0, 0 ], [ 5, 6, 0, 0 ], [ 9, 10, 11, 0 ], [ 13, 14, 15, 16 ] ]);
-	ok $B1->isLowerTriangular, 'test for lower triangular matrix';
 	my $B2 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
+	my $B3 = Matrix($B1, $B1);
+	my $B4 = Matrix($B2, $B2);
+	ok $B1->isLowerTriangular,  'test for lower triangular matrix';
 	ok !$B2->isLowerTriangular, 'not a lower triangular matrix.';
+	ok $B3->isLowerTriangular,  'test for lower triangular degree 3 matrix';
+	ok !$B4->isLowerTriangular, 'not a lower triangular degree 3 matrix.';
 
+};
+
+subtest 'Test if a Matrix is symmetric' => sub {
+	my $A = Matrix(5);
+	ok $A->isSymmetric, 'test a degree 1 Matrix of length 1 is symmetric';
+	my $B = Matrix([ 1, 2 ], [ 2, 3 ]);
+	my $C = Matrix([ 1, 2 ], [ 3, 4 ]);
+	ok $B->isSymmetric,  'test a degree 2 symmetric Matrix';
+	ok !$C->isSymmetric, 'test a degree 2 nonsymmetric Matrix';
+	my $D = Matrix($B, $B);
+	my $E = Matrix($B, $C);
+	ok $D->isSymmetric,  'test a degree 3 symmetric Matrix';
+	ok !$E->isSymmetric, 'test a degree 3 nonsymmetric Matrix';
+};
+
+subtest 'Test if a Matrix is orthogonal' => sub {
+	my $A = Matrix(-1);
+	my $B = Matrix( 2);
+	ok $A->isOrthogonal,  'test a degree 1 orthogonal Matrix';
+	ok !$B->isOrthogonal, 'test a degree 1 nonorthogonal Matrix';
+	my $C = Matrix([ 3 / 5, 4 / 5 ], [ -4 / 5, 3 / 5 ]);
+	my $D = Matrix([ 1, 2 ], [ 3, 4 ]);
+	ok $C->isOrthogonal,  'test a degree 2 orthogonal Matrix';
+	ok !$D->isOrthogonal, 'test a degree 2 nonorthogonal Matrix';
+	# uncomment these once transposition is valid for higher degree Matrices
+	#my $E = Matrix($C, [ [ 0, 1 ], [ -1, 0 ] ]);
+	#my $F = Matrix($D, $C);
+	#ok $E->isOrthogonal,  'test a degree 3 orthogonal Matrix';
+	#ok !$F->isOrthogonal, 'test a degree 3 nonorthogonal Matrix';
+};
+
+subtest 'Test if Matrix is in (R)REF' => sub {
+	my $A1 = Matrix(0);
+	my $A2 = Matrix(1);
+	my $A3 = Matrix(2);
+	my $A4 = Matrix(1, 3, 4);
+	my $A5 = Matrix(2, 3, 4);
+	my $A6 = Matrix(0, 3, 4);
+	my $A7 = Matrix(0, 1, 4);
+	ok $A1->isRREF,  "$A1 is in RREF";
+	ok $A2->isRREF,  "$A2 is in RREF";
+	ok !$A3->isRREF, "$A3 is not in RREF";
+	ok $A4->isRREF,  "$A4 is in RREF";
+	ok !$A5->isRREF, "$A5 is not in RREF";
+	ok !$A6->isRREF, "$A6 is not in RREF";
+	ok $A7->isRREF,  "$A7 is in RREF";
+
+	my $B1 = Matrix([ 1, 2, 3 ], [ 0, 4, 5 ]);
+	my $B2 = Matrix([ 1, 2, 3 ], [ 0, 1, 5 ]);
+	my $B3 = Matrix([ 1, 0, 3 ], [ 0, 1, 5 ]);
+	my $B4 = Matrix([ 0, 1, 3 ], [ 2, 1, 5 ]);
+	ok $B1->isREF,   "$B1 is in REF";
+	ok !$B1->isRREF, "$B1 is not in RREF";
+	ok $B2->isREF,   "$B2 is in REF";
+	ok !$B2->isRREF, "$B2 is not in RREF";
+	ok $B3->isREF,   "$B3 is in REF";
+	ok $B3->isRREF,  "$B3 is in RREF";
+	ok !$B4->isREF,  "$B4 is not in REF";
+	ok !$B4->isRREF, "$B4 is not in RREF";
 };
 
 subtest 'Transpose a Matrix' => sub {

--- a/t/math_objects/matrix.t
+++ b/t/math_objects/matrix.t
@@ -15,18 +15,18 @@ loadMacros('MathObjects.pl');
 
 Context('Matrix');
 use Data::Dumper;
-subtest 'Creating degree 1 matrices (row vector)' => sub {
+subtest 'Creating a degree 1 Matrix (row vector)' => sub {
 	ok my $M1 = Matrix(1, 2, 3), 'Create a row vector';
 	is $M1->class, 'Matrix', 'M1 is a Matrix';
 	my $M2 = Compute('[1,2,3]');
 	is $M2->class,     'Matrix',    'Creation using Compute results in a Matrix.';
-	is [ $M1->value ], [ 1, 2, 3 ], 'M1 is the row matrix [1,23]';
-	is [ $M2->value ], [ 1, 2, 3 ], 'M2 is the row matrix [1,23]';
+	is [ $M1->value ], [ 1, 2, 3 ], 'M1 is the row matrix [1,2,3]';
+	is [ $M2->value ], [ 1, 2, 3 ], 'M2 is the row matrix [1,2,3]';
 	is $M1->degree,    1,           'M1 is a degree 1 matrix.';
 	is $M2->degree,    1,           'M2 is a degree 1 matrix.';
 };
 
-subtest 'Creating Matrices' => sub {
+subtest 'Creating a degree 2 Matrix' => sub {
 	my $values = [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ];
 	my $A      = Matrix($values);
 	is $A->class,     'Matrix', 'Input as array ref is a Matrix.';
@@ -39,7 +39,7 @@ subtest 'Creating Matrices' => sub {
 	is $C->degree, 2,        'C is a degree 2 matrix.';
 };
 
-subtest 'Creating Tensors (degree 3)' => sub {
+subtest 'Creating a degree 3 Matrix (tensor)' => sub {
 	my $values = [ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ];
 	ok my $M3 = Matrix([ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ]), 'Creation of a tensor';
 	is $M3->class, 'Matrix', 'Checking the result is a Matrix';
@@ -48,7 +48,7 @@ subtest 'Creating Tensors (degree 3)' => sub {
 	is $M3->degree, 3, 'M3 is a degree 3 matrix.';
 };
 
-subtest 'Matrix Dimensions' => sub {
+subtest 'Get dimensions' => sub {
 	my $A       = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
 	my $B       = Matrix([ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ]);
 	my $C       = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
@@ -63,30 +63,48 @@ subtest 'Matrix Dimensions' => sub {
 	is \@dimsRow, [4],         'The dimensions of a row vector are correct.';
 };
 
-subtest 'isSquare and isOne' => sub {
-	my $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
-	my $B = Matrix([ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ]);
-	ok !$A->isSquare, 'The matrix A is not square.';
-	ok $B->isSquare,  'The matrix B is square.';
+subtest 'Use isSquare, isOne, and isRow methods' => sub {
+	my $A1 = Matrix([ 1, 2, 3, 4 ]);
+	my $B1 = Matrix([1]);
+	my $C1 = Matrix([2]);
+	ok !$A1->isSquare, 'The matrix A1 is not square.';
+	ok $B1->isSquare,  'The matrix B1 is square.';
+	ok $C1->isSquare,  'The matrix C1 is square.';
+	ok !$A1->isOne,    'The matrix A1 is not an identity.';
+	ok $B1->isOne,     'The matrix B1 is an identity.';
+	ok !$C1->isOne,    'The matrix C1 is not an identity.';
+	ok $A1->isRow,     'The matrix A1 is a row.';
+	ok $B1->isRow,     'The matrix B1 is a row.';
+	ok $C1->isRow,     'The matrix C1 is a row.';
 
-	my $row_vect = Matrix([ 1, 2, 3, 4 ]);
-	ok $row_vect->isRow, 'The matrix [[1,2,3,4]] is a row vector.';
-	ok !$A->isRow,       'The matrix A is not a row vector.';
+	my $A2 = Matrix([ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ]);
+	my $B2 = Matrix([ 1, 0 ], [ 0, 1 ]);
+	my $C2 = Matrix([ 2, 0 ], [ 1, 2 ]);
+	ok !$A2->isSquare, 'The matrix A2 is not square.';
+	ok $B2->isSquare,  'The matrix B2 is square.';
+	ok $C2->isSquare,  'The matrix C2 is square.';
+	ok !$A2->isOne,    'The matrix A2 is not an identity.';
+	ok $B2->isOne,     'The matrix B2 is an identity.';
+	ok !$C2->isOne,    'The matrix C2 is not an identity.';
+	ok !$A2->isRow,    'The matrix A2 is not a row.';
+	ok !$B2->isRow,    'The matrix B2 is not a row.';
+	ok !$C2->isRow,    'The matrix C2 is not a row.';
 
-	ok !$A->isOne, 'The matrix A is not an identity matrix.';
-	ok $B->isOne,  'The matrix B is an identity matrix.';
-
-	# tensors (degree 3)
-	my $D = Matrix([ [ [ 1, 0 ], [ 0, 1 ] ], [ [ 1, 0 ], [ 0, 1 ] ] ]);
-	my $E = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ] ]);
-	my $F = Matrix([ [ [ 1, 2 ] ], [ [ 3, 4 ] ] ]);
-	ok $D->isOne,     "The tensor D's last two dimensions is an identity";
-	ok !$E->isOne,    "The tensor E's last two dimensions is not an identity";
-	ok $E->isSquare,  'The tensor E is square.';
-	ok !$F->isSquare, 'The tensor F is not square.';
+	my $A3 = Matrix([ [ 1, 2, 3 ], [ 4, 5, 6 ] ], [ [ 7, 8, 9 ], [ 10, 11, 12 ] ]);
+	my $B3 = Matrix([ [ 1, 0 ], [ 0, 1 ] ], [ [ 1, 0 ], [ 0, 1 ] ]);
+	my $C3 = Matrix([ [ 2, 0 ], [ 0, 1 ] ], [ [ 1, 0 ], [ 0, 1 ] ]);
+	ok !$A3->isSquare, 'The matrix A3 is not square.';
+	ok $B3->isSquare,  'The matrix B3 is square.';
+	ok $C3->isSquare,  'The matrix C3 is square.';
+	ok !$A3->isOne,    'The matrix A3 is not an identity.';
+	ok $B3->isOne,     'The matrix B3 is an identity.';
+	ok !$C3->isOne,    'The matrix C3 is not an identity.';
+	ok !$A3->isRow,    'The matrix A3 is not a row.';
+	ok !$B3->isRow,    'The matrix B3 is not a row.';
+	ok !$C3->isRow,    'The matrix C3 is not a row.';
 };
 
-subtest 'Triangular Matrices' => sub {
+subtest 'Use tests for triangular matrices' => sub {
 	my $A1 = Matrix([ [ 1, 2, 3, 4 ], [ 0, 6, 7, 8 ], [ 0, 0,  11, 12 ], [ 0,  0,  0,  16 ] ]);
 	my $A2 = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ], [ 13, 14, 15, 16 ] ]);
 	ok $A1->isUpperTriangular,  'test for upper triangular matrix';
@@ -98,14 +116,14 @@ subtest 'Triangular Matrices' => sub {
 
 };
 
-subtest 'Transpose' => sub {
+subtest 'Transpose a Matrix' => sub {
 	my $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
 	my $B = Matrix([ [ 1, 5, 9 ], [ 2, 6, 10 ], [ 3, 7, 11 ], [ 4, 8, 12 ] ]);
 	is $A->transpose->TeX, $B->TeX, 'Test the tranpose of a matrix.';
 
 	my $row       = Matrix([ 1, 2, 3, 4 ]);
 	my $row_trans = Matrix([ [1], [2], [3], [4] ]);
-	is $row->transpose->TeX, $row_trans->TeX, 'Transpose of a Matrix with one row.';
+	is $row->transpose->TeX, $row_trans->TeX, 'Transpose of a degree 1 Matrix.';
 
 	my $C = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
 	like dies {
@@ -118,10 +136,10 @@ subtest 'Extract an element' => sub {
 	my $B   = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
 	my $row = Matrix([ 1, 2, 3, 4 ]);
 
-	is $A->element(1, 1),    1,  'extract an element from a 2D matrix.';
-	is $A->element(3, 2),    10, 'extract an element from a 2D matrix.';
-	is $B->element(1, 2, 1), 3,  'extract an element from a 3D matrix.';
-	is $row->element(2),     2,  'extract an element from a row matrix';
+	is $A->element(1, 1),    1,  'extract an element from a degree 2 matrix.';
+	is $A->element(3, 2),    10, 'extract an element from a degree 2 matrix.';
+	is $B->element(1, 2, 1), 3,  'extract an element from a degree 3 matrix.';
+	is $row->element(2),     2,  'extract an element from a degree 1 matrix.';
 };
 
 subtest 'Extract a column' => sub {
@@ -134,7 +152,7 @@ subtest 'Extract a column' => sub {
 	}, qr/Column must be a positive integer/, 'Test that an error is thrown for passing a non-positive integer.';
 };
 
-subtest 'Identity matrix' => sub {
+subtest 'Construct an identity matrix' => sub {
 	my $I = Value::Matrix->I(3);
 	my $B = Matrix([ [ 1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ]);
 	my $A = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ] ]);
@@ -143,7 +161,7 @@ subtest 'Identity matrix' => sub {
 	is $A->I->TeX, $B->TeX, 'Create a 3 x 3 identity matrix by using an existing matrix.';
 };
 
-subtest 'Permutation matrices' => sub {
+subtest 'Construct a permutation matrix' => sub {
 	my $P1 = Value::Matrix->P(3, [ 1, 2, 3 ]);
 	is $P1->TeX, Matrix([ [ 0, 0, 1 ], [ 1, 0, 0 ], [ 0, 1, 0 ] ])->TeX, 'Create permuation matrix on cycle (123)';
 
@@ -165,7 +183,7 @@ subtest 'Permutation matrices' => sub {
 		'Create a permutation matrix based on an existing matrix.';
 };
 
-subtest 'Zero matrix' => sub {
+subtest 'Construct a zero matrix' => sub {
 	my $Z1 = Matrix([ [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]);
 	my $Z2 = Matrix([ [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ], [ 0, 0, 0, 0 ] ]);
 	is Value::Matrix->Zero(3, 4)->TeX, $Z1->TeX, 'Create a 3 by 4 zero matrix.';
@@ -179,7 +197,7 @@ subtest 'Zero matrix' => sub {
 	}, qr/Dimension must be a positive integer/, 'Test that an error is thrown for passing a non-positive integer.';
 };
 
-subtest 'Add Matrices' => sub {
+subtest 'Add matrices' => sub {
 	my $row1 = Matrix(1, 2, 3);
 	my $row2 = Matrix(4, 5, 6);
 	my $sum1 = Matrix(5, 7, 9);
@@ -209,7 +227,7 @@ subtest 'Add Matrices' => sub {
 		'Test that adding tensors of different dimsensions throws an error.';
 };
 
-subtest 'Subtract Matrices' => sub {
+subtest 'Subtract matrices' => sub {
 	my $row1  = Matrix( 1,  2,  3);
 	my $row2  = Matrix( 4,  5,  6);
 	my $diff1 = Matrix(-3, -3, -3);
@@ -239,7 +257,7 @@ subtest 'Subtract Matrices' => sub {
 		'Test that subtracting tensors of different dimsensions throws an error.';
 };
 
-subtest 'Multiply Matrices' => sub {
+subtest 'Multiply matrices' => sub {
 
 	my $A     = Matrix([ [ 1, 2, 3 ],   [ 4, 5, 6 ],     [ 7, 8, 9 ] ]);
 	my $B     = Matrix([ [ 0, 1, 0 ],   [ -1, 2, -3 ],   [ -2, -1, 0 ] ]);
@@ -265,27 +283,9 @@ subtest 'Multiply Matrices' => sub {
 	my $v     = Vector(1,  2,  3);
 	my $prod5 = Vector(14, 32, 50);
 	ok $A*$v == $prod5, 'Multiply a 3 by 3 matrix and a vector of length 3';
-
-	#tensors
-	# my $M1 = Matrix([ [ [ 1, 0 ], [ 0, 1 ] ], [ [ 1, 0 ], [ 0, 1 ] ] ]);
-	# my $M2 = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]);
-	# my $M3 = Matrix([ [ [ 2, 2 ], [ 3, 5 ] ], [ [ 6, 6 ], [ 7, 9 ] ] ]);
-	# ok $M1 + $M2 == $M3, 'Checking the sum of two tensors';
-
-	# my $row3 = Matrix([ 1, 2, 3, 4 ]);
-	# like dies { $row1 + $row3 }, qr/Can't add Matrices with different dimensions/,
-	# 	'Test that adding row matrices of different dimsensions throws an error.';
-
-	# my $C = Matrix([ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ]);
-	# like dies { $A + $C }, qr/Can't add Matrices with different dimensions/,
-	# 	'Test that adding matrices of different dimsensions throws an error.';
-
-	# my $M4 = Matrix([ [ [ 1, 2 ], [ 3, 4 ] ] ]);
-	# like dies { $M3 + $M4 }, qr/Can't add Matrices with different dimensions/,
-	# 	'Test that adding tensors of different dimsensions throws an error.';
 };
 
-subtest 'Elementary Matrices' => sub {
+subtest 'Construct an elementary matrix' => sub {
 	my $E1 = Value::Matrix->E(3, [ 1, 3 ]);
 	is $E1->TeX, Matrix([ [ 0, 0, 1 ], [ 0, 1, 0 ], [ 1, 0, 0 ] ])->TeX, 'Elementary Matrix with a row swap';
 


### PR DESCRIPTION
This builds on #1215. If #1215 is updated following feedback, I will update here too. Once #1215 is merged, this diff should be more manageable.

In addition to changes from #1215, this has:

- some more POD and code comments updated to reflect how methods can be applied to degree n matrices, as well as specify in some places where the method only applies for degree 2 matrices
- make the following methods apply to degree n matrices: `isUpperTriangular`, `isLowerTriangular`, `isDiagonal`, `isSymmetric`, `isOrthogonal`, `isREF`, `isRREF`. For a degree 1 Matrix, it is interpreted as a 1xk degree 2 Matrix. For degree > 2, these features can apply to all of the degree 2 matrices in the frontal slice.