### PR TITLE
Fix comparison of a fraction to infinity.

### DIFF
--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -1022,7 +1022,7 @@ sub compare {
 		return $l <=> $r;
 	}
 	if ($other->classMatch("Infinity")) {
-		return $other->{isNegative} ? 1 : -1;
+		return ($flag ? -1 : 1) * ($other->{isNegative} ? 1 : -1);
 	}
 	$self->Error("You can't compare %s to %s", $self->showClass, $other->showClass);
 }


### PR DESCRIPTION
If an infinity is the left operand and a `Fraction` the right operand of an inequality operator, then the operator is returning the wrong thing. This is caused by the change in #1208 failing to account for the op order flag when a fraction is compared to an infinity.

For example if `$a = Compute('5 / 3')` (in the `Fraction` context), `$posInf = Compute('-inf')`, and `$negInf = Compute('inf')`, then

`$posInf < $a` is true,
`$posInf > $a` is false,
`$negInf < $a` is false, and
`$negInf > $a` is true.

All of which are exactly the opposite of the correct result.

However,

`$a < $posInf` is true,
`$a > $posInf` is false,
`$a < $negInf` is false, and
`$a > $negInf` is true

as is expected.

The problem is that since the op order flag is not accounted for, the first four comparisons are really returning the result of the latter four comparisons.

With this pull request all of the above comparisons are correct.

Here is a MWE in problem form:

```perl
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'contextFraction.pl');

Context('Fraction');

$a      = Compute('5 / 3');
$posInf = Compute('inf');
$negInf = Compute('-inf');

BEGIN_PGML
[`[$a] > [$negInf]`]: [$a > $negInf ? 'true' : 'false']

[`[$a] > [$posInf]`]: [$a > $posInf ? 'true' : 'false']

[`[$a] < [$negInf]`]: [$a < $negInf ? 'true' : 'false']

[`[$a] < [$posInf]`]: [$a < $posInf ? 'true' : 'false']

[`[$negInf] > [$a]`]: [$negInf > $a ? 'true' : 'false']

[`[$posInf] > [$a]`]: [$posInf > $a ? 'true' : 'false']

[`[$negInf] < [$a]`]: [$negInf < $a ? 'true' : 'false']

[`[$posInf] < [$a]`]: [$posInf < $a ? 'true' : 'false']
END_PGML

ENDDOCUMENT();
```