### PR TITLE
Remove the `max-width` on radio or checkbox sub part answers of a `RadioMultiAnswer`.

### DIFF
--- a/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.scss
+++ b/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.scss
@@ -28,6 +28,11 @@
 			display: inline-block;
 			margin-left: 5px;
 			line-height: 26px;
+
+			.radio-buttons-container,
+			.checkboxes-container {
+				max-width: 100%;
+			}
 		}
 
 		input[type='radio'] {


### PR DESCRIPTION
The `.radio-content` div of a `RadioMultiAnsswer` already constrains the width.  The constraint on width for a `.radio-buttons-container` or `.checkboxes-container` added to `problem.scss` in #1128 then doubles with that to make things look rather bad.

Here is a MWE for checkboxes. Compare this problem on develop with this pull request.

```
DOCUMENT();

loadMacros(
    'PGstandard.pl',             'PGML.pl',
    'parserRadioMultiAnswer.pl', 'parserCheckboxList.pl',
);

$checkList = CheckboxList(
    [ [ 'Part 1', 'Part 2', 'Part 3' ] ], [ 0, 1 ],
    labels        => 'ABC',
    displayLabels => 1
);

$rma = RadioMultiAnswer(
    [ [ "The solutions are: %s", $checkList ], ['This makes no sense.'] ],
    0);

BEGIN_PGML
Give the answer.  (Hint: The solutions are Part 1 and Part2.)

[_]{$rma}
END_PGML

ENDDOCUMENT();
```