### PR TITLE
Finalize MathQuill for the 2.20 release.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
             "name": "pg.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@openwebwork/mathquill": "^0.11.0-beta.5",
+                "@openwebwork/mathquill": "^0.11.0",
                 "jsxgraph": "^1.10.1",
                 "jszip": "^3.10.1",
                 "jszip-utils": "^0.1.0",
@@ -85,9 +85,9 @@
             }
         },
         "node_modules/@openwebwork/mathquill": {
-            "version": "0.11.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.5.tgz",
-            "integrity": "sha512-vjEQ1Go/UGwfjKSN2Xb9vQucO+LdbrVuL8fUVAfVGcAEIRPGtCvnt3FP612iHgSCdNZkCS/9hkJijfH2YBqBVA==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0.tgz",
+            "integrity": "sha512-w5AlhsnreqCFYePP2V8Ve/hxA8KZvYmyHD5uehCD07PDp/HiL3DSo4mtAyLV7pWTXUoPVLFdnZK/WmrSYs+UdQ==",
             "license": "MPL-2.0"
         },
         "node_modules/@trysound/sax": {
@@ -1749,9 +1749,9 @@
             }
         },
         "@openwebwork/mathquill": {
-            "version": "0.11.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0-beta.5.tgz",
-            "integrity": "sha512-vjEQ1Go/UGwfjKSN2Xb9vQucO+LdbrVuL8fUVAfVGcAEIRPGtCvnt3FP612iHgSCdNZkCS/9hkJijfH2YBqBVA=="
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0.tgz",
+            "integrity": "sha512-w5AlhsnreqCFYePP2V8Ve/hxA8KZvYmyHD5uehCD07PDp/HiL3DSo4mtAyLV7pWTXUoPVLFdnZK/WmrSYs+UdQ=="
         },
         "@trysound/sax": {
             "version": "0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
 	},
 	"dependencies": {
-		"@openwebwork/mathquill": "^0.11.0-beta.5",
+		"@openwebwork/mathquill": "^0.11.0",
 		"jsxgraph": "^1.10.1",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",


### PR DESCRIPTION
A non beta version has now been published from
https://github.com/openwebwork/mathquill/pull/38.

So make that the version for the 2.20 release.  That is version 0.11.0. If there are any other changes to MathQuill the version can still be bumped if needed, but I doubt that there will be at this point.