### PR TITLE
Fix a typo in a GraphTool class name.

### DIFF
--- a/htdocs/js/GraphTool/circletool.js
+++ b/htdocs/js/GraphTool/circletool.js
@@ -63,7 +63,7 @@
 		},
 
 		CircleTool(gt) {
-			return class CirlceTool extends gt.GenericTool {
+			return class CircleTool extends gt.GenericTool {
 				object = 'circle';
 				useStandardActivation = true;
 				activationHelpText = 'Plot the center of the circle.';


### PR DESCRIPTION
This works with the typo because the class name isn't actually used directly.  It is an abstract name.  But still is a typo to fix.