### PR TITLE
Protect \columnbreak in DragNDrop TeX output.

### DIFF
--- a/lib/DragNDrop.pm
+++ b/lib/DragNDrop.pm
@@ -187,8 +187,11 @@ sub TeX {
 		}
 		$out .= "}";
 
-		if ($i % 2 == 0) { $out .= "\\columnbreak\n\n" if $i != $#{ $self->{defaultBuckets} } }
-		else             { $out .= "\\ifdefined\\nocolumns\\end{multicols}\\else\\fi\n\\end{minipage}\n" }
+		if ($i % 2 == 0) {
+			$out .= "\\ifdefined\\nocolumns\\columnbreak\\else\\fi\n\n" if $i != $#{ $self->{defaultBuckets} };
+		} else {
+			$out .= "\\ifdefined\\nocolumns\\end{multicols}\\else\\fi\n\\end{minipage}\n";
+		}
 		$out .= "\\vspace{0.75\\baselineskip}\n";
 	}
 	$out .= "\n\\hrule\n\\vspace{0.25\\baselineskip}\n";


### PR DESCRIPTION
The TeX output in DragNDrop puts the multicols environment behind an `\ifdefined` conditional, but the `\columnbreak` line is always included, causing the hardcopy build to fail when the multicols environment is not used. This puts the same conditional on the `\columnbreak` line so it is only included if the multicols environment is actually being used.

The following problem's hardcopy won't correctly build from the problem editor with the empty theme without this change. The error in the hardcopy.log is "! Package multicol Error: \columnbreak outside multicols."

```
DOCUMENT();
loadMacros(qw{PGstandard.pl PGML.pl draggableProof.pl});
$Proof = DraggableProof([ 'A', 'B', 'C', 'D' ], [ 'E', 'F', 'G' ]);
BEGIN_PGML
[_]{$Proof}
END_PGML
ENDDOCUMENT();
```