### PR TITLE
Remove unload event listener from JavaScript.

### DIFF
--- a/htdocs/js/DragNDrop/dragndrop.js
+++ b/htdocs/js/DragNDrop/dragndrop.js
@@ -182,7 +182,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/DropDown/dropdown.js
+++ b/htdocs/js/DropDown/dropdown.js
@@ -57,7 +57,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/Essay/essay.js
+++ b/htdocs/js/Essay/essay.js
@@ -76,6 +76,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -91,7 +91,4 @@
 		});
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/ImageView/imageview.js
+++ b/htdocs/js/ImageView/imageview.js
@@ -330,7 +330,4 @@
 		});
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -599,7 +599,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -431,7 +431,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/QuickMatrixEntry/quickmatrixentry.js
+++ b/htdocs/js/QuickMatrixEntry/quickmatrixentry.js
@@ -128,5 +128,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/RadioButtons/RadioButtons.js
+++ b/htdocs/js/RadioButtons/RadioButtons.js
@@ -47,7 +47,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.js
+++ b/htdocs/js/RadioMultiAnswer/RadioMultiAnswer.js
@@ -153,7 +153,4 @@
 		}
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();

--- a/htdocs/js/Scaffold/scaffold.js
+++ b/htdocs/js/Scaffold/scaffold.js
@@ -34,7 +34,4 @@
 		});
 	});
 	observer.observe(document.body, { childList: true, subtree: true });
-
-	// Stop the mutation observer when the window is closed.
-	window.addEventListener('unload', () => observer.disconnect());
 })();


### PR DESCRIPTION
The 'unload' event listener is deprecated, in addition since all javascript is stopped when the window unloads, it is unnecessary to also disconnect the mutation observer when the window unloads. This removes all the unload event listeners.