### PR TITLE
Implement makeZero() for matrices (and other types).

### DIFF
--- a/lib/Parser/BOP/multiply.pm
+++ b/lib/Parser/BOP/multiply.pm
@@ -61,7 +61,7 @@ sub _reduce {
 	my $reduce = $self->{equation}{context}{reduction};
 	return $self->{rop}                                   if $self->{lop}{isOne}  && $reduce->{'1*x'};
 	return $self->{lop}                                   if $self->{rop}{isOne}  && $reduce->{'x*1'};
-	return $self->makeZero($self->{rop}, $self->{lop})    if $self->{lop}{isZero} && $reduce->{'0*x'};
+	return $self->makeZero($self->{lop}, $self->{rop})    if $self->{lop}{isZero} && $reduce->{'0*x'};
 	return $self->makeZero($self->{lop}, $self->{rop})    if $self->{rop}{isZero} && $reduce->{'x*0'};
 	return $self->makeNeg($self->{lop}{op}, $self->{rop}) if $self->{lop}->isNeg  && $reduce->{'(-x)*y'};
 	return $self->makeNeg($self->{lop}, $self->{rop}{op}) if $self->{rop}->isNeg  && $reduce->{'x*(-y)'};


### PR DESCRIPTION
A new approach in the makeZero method of Parser::BOP to turn each operand into an object of the correct type with nothing but zeros as entries, and then returns a product of the results. If it doesn't know how to make an all-zero version, it leaves it as multiplication by zero.

This is used in the reduction rules `0*x` and `x*0` to return a zero object of the product. Then differentiation of variables uses this process to take derivatives of variables treated as constants to allow taking derivatives of variables that represent Points, Vectors, and Matrices. Error messages are added if attempting to take a derivative of variables that are not numbers.

This also corrects an issue to allow taking the derivative of a formula with a single variable without explicitly stating the variable via `$MO->D`. Fixes #1239.

Attached is a problem I used to test various cases.

[makeZero-tests.pg.txt](https://github.com/user-attachments/files/20541789/makeZero-tests.pg.txt)
