### PR TITLE
Fix points at infinity for intervals.

### DIFF
--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -640,9 +640,10 @@ window.graphTool = (containerId, options) => {
 		return x > 0 ? 1 : -1;
 	};
 
-	// These return true if the given x coordinate is off the board or within epsilon of the edge of the board.
-	gt.isPosInfX = (x) => x >= gt.board.getBoundingBox()[2] - JXG.Math.eps;
-	gt.isNegInfX = (x) => x <= gt.board.getBoundingBox()[0] + JXG.Math.eps;
+	// These return true if the given x coordinate is off the board or within twice epsilon of the edge of the board.
+	// Note that twice epsilon is used since the board is extended by epsilon in each direction.
+	gt.isPosInfX = (x) => x >= gt.board.getBoundingBox()[2] - 2 * JXG.Math.eps;
+	gt.isNegInfX = (x) => x <= gt.board.getBoundingBox()[0] + 2 * JXG.Math.eps;
 
 	// Use this instead of gt.board.hasPoint.  That method uses strict inequality.
 	// Using inequality with equality allows points on the edge of the board.


### PR DESCRIPTION
Since the board is now extended by epsilon in each direction, the tests for a point at infinity need to check that a point is within twice epsilon of the board edge.

There is a delicate balance with things because of snap rounding, and extending the board non-incrementally relative to the snap round increment causes this issue.  That may need to be rethought.  For now this seems to resolve the issue.

An example problem for which this is an issue follows:

```perl
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');

$x = random(-5,     -1);
$y = random($x + 1,  5);

$gt = GraphTool("{interval,(-inf,$x]},{interval,($y,inf)}")->with(
    numberLine     => 1,
    bBox           => [ -7, 7 ],
    ticksDistanceX => 1,
);

BEGIN_PGML
Graph the solution set for the compound linear inequality
[`x \leq [$x]`] and [`x > [$y]`].

[_]{$gt}
END_PGML

BEGIN_PGML_SOLUTION
The correct answer is

[! the correct answer !]{$gt}{300}
END_PGML_SOLUTION

ENDDOCUMENT();
```

In the solution the arrows at infinity are open dots instead without this pull request.