### PR TITLE
Remove the localization `tense` method.

### DIFF
--- a/lib/WeBWorK/PG/Localize.pm
+++ b/lib/WeBWorK/PG/Localize.pm
@@ -13,7 +13,6 @@ Locale::Maketext::Lexicon->import({
 	_decode     => 1,
 	_encoding   => undef,
 });
-*tense = sub { \$_[1] . ((\$_[2] eq 'present') ? 'ing' : 'ed') };
 
 # This subroutine is used to pass a language handle into the safe
 # compartment so that maketext can be used in problems and macros.


### PR DESCRIPTION
This method is not used, and definitely never should be.  The method was intended to be used in a maketext call with `[tense,_1,present]` or `[tense,_1]`.  If `present` is given then 'ing' is appended to the given interpolated value, otherwise 'ed' is appended.  However, there is no possible way that will be valid for most languages other than English, and hence this was entirely invalid to use and should not exist. This method is a carry over from the original code here which was copied from the `Locale::Maketext::Simple` package.