### PR TITLE
also close image description details if you touch outside of the details

### DIFF
--- a/htdocs/js/Problem/generic.js
+++ b/htdocs/js/Problem/generic.js
@@ -60,9 +60,11 @@
 			if (imageDescription.open) {
 				document.addEventListener('keydown', escapeCloseDetails);
 				document.addEventListener('pointerdown', clickCloseDetails);
+				document.addEventListener('touch', clickCloseDetails);
 			} else {
 				document.removeEventListener('keydown', escapeCloseDetails);
 				document.removeEventListener('pointerdown', clickCloseDetails);
+				document.removeEventListener('touch', clickCloseDetails);
 			}
 		});
 	}


### PR DESCRIPTION
This makes it so if you are using a touchscreen device you can close the image long description by touching outside of the details, just extending what @drgrice1 already did for clicking outside of the details.