### PR TITLE
Add an option to show the "universal set" in `draggableSubsets.pl` problems.

### DIFF
--- a/htdocs/js/DragNDrop/dragndrop.js
+++ b/htdocs/js/DragNDrop/dragndrop.js
@@ -123,6 +123,7 @@
 
 			if (bucketPool.showUniversalSet) {
 				if (bucketData.isUniversalSet) {
+					options.sort = false;
 					options.group.pull = 'clone';
 					options.group.put = false;
 				} else {

--- a/htdocs/js/DragNDrop/dragndrop.js
+++ b/htdocs/js/DragNDrop/dragndrop.js
@@ -9,6 +9,7 @@
 			this.answerName = el.dataset.answerName ?? '';
 			this.buckets = [];
 			this.removeButtonText = el.dataset.removeButtonText ?? 'Remove';
+			this.allowReusingItems = el.dataset.allowReusingItems;
 
 			this.answerInput = el.parentElement.querySelector(`input[name="${this.answerName}"]`);
 			if (!this.answerInput) {
@@ -97,12 +98,39 @@
 			if (window.MathJax) {
 				MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise([this.el]));
 			}
+			this.allowReusingItems = this.bucketPool.allowReusingItems;
 
-			this.sortable = Sortable.create(this.ddList, {
-				group: bucketPool.answerName,
-				animation: 150,
-				onEnd: () => this.bucketPool.updateAnswerInput()
-			});
+			if (this.allowReusingItems) {
+				if (id === 0) {
+					this.sortable = Sortable.create(this.ddList, {
+						animation: 150,
+						sort: false,
+						onEnd: () => this.bucketPool.updateAnswerInput(),
+						group: {
+							name: bucketPool.answerName,
+							pull: 'clone',
+							put: false
+						}
+					});
+				} else {
+					this.sortable = Sortable.create(this.ddList, {
+						animation: 150,
+						onEnd: () => this.bucketPool.updateAnswerInput(),
+						removeOnSpill: true,
+						group: {
+							name: bucketPool.answerName,
+							put: (to, _from, dragEl) =>
+								!Array.from(to.el.children).some((child) => child.dataset.id === dragEl.dataset.id)
+						}
+					});
+				}
+			} else {
+				this.sortable = Sortable.create(this.ddList, {
+					group: bucketPool.answerName,
+					animation: 150,
+					onEnd: () => this.bucketPool.updateAnswerInput()
+				});
+			}
 		}
 
 		htmlBucket(label, removable, indices = []) {

--- a/lib/DragNDrop.pm
+++ b/lib/DragNDrop.pm
@@ -138,6 +138,7 @@ sub new {
 		addButtonText     => 'Add Bucket',
 		removeButtonText  => 'Remove',
 		multicolsWidth    => '300pt',
+		allowReusingItems => 0,
 		%options,
 		},
 		ref($self) || $self;
@@ -147,6 +148,7 @@ sub HTML {
 	my $self = shift;
 
 	my $out = qq{<div class="dd-bucket-pool" data-answer-name="$self->{answerName}"};
+	$out .= " data-allow-reusing-items = 1" if $self->{allowReusingItems};
 	$out .= ' data-item-list="' . PGcore::encode_pg_and_html(encode_json($self->{itemList})) . '"';
 	$out .= ' data-default-state="' . PGcore::encode_pg_and_html(encode_json($self->{defaultBuckets})) . '"';
 	$out .= qq{ data-remove-button-text="$self->{removeButtonText}"};

--- a/lib/DragNDrop.pm
+++ b/lib/DragNDrop.pm
@@ -88,6 +88,16 @@ This sets the size for which the TeX output for hardcopy uses two columns or not
 If the current C<\linewidth> is greater than or equal to this size then two columns
 will be used, otherwise only single column is used.
 
+=item showUniversalSet (Default: C<0>)
+
+If 1 then the set of all elements passed in the C<$itemList> will be shown
+in a separate bucket.  Elements can be dragged from this set and into other
+buckets, but not into it.
+
+=item universalSetLabel (Default: C<< 'Universal Set' >>)
+
+Label shown for the universal set bucket if C<showUniversalSet> is 1.
+
 =back
 
 =head2 METHODS
@@ -138,7 +148,8 @@ sub new {
 		addButtonText     => 'Add Bucket',
 		removeButtonText  => 'Remove',
 		multicolsWidth    => '300pt',
-		allowReusingItems => 0,
+		showUniversalSet  => 0,
+		universalSetLabel => 'Universal Set',
 		%options,
 		},
 		ref($self) || $self;
@@ -148,11 +159,12 @@ sub HTML {
 	my $self = shift;
 
 	my $out = qq{<div class="dd-bucket-pool" data-answer-name="$self->{answerName}"};
-	$out .= " data-allow-reusing-items = 1" if $self->{allowReusingItems};
 	$out .= ' data-item-list="' . PGcore::encode_pg_and_html(encode_json($self->{itemList})) . '"';
 	$out .= ' data-default-state="' . PGcore::encode_pg_and_html(encode_json($self->{defaultBuckets})) . '"';
 	$out .= qq{ data-remove-button-text="$self->{removeButtonText}"};
 	$out .= qq{ data-label-format="$self->{bucketLabelFormat}"} if $self->{bucketLabelFormat};
+	$out .= " data-show-universal-set"                          if $self->{showUniversalSet};
+	$out .= qq{ data-universal-set-label="$self->{universalSetLabel}"};
 	$out .= '>';
 
 	$out .= '<div class="dd-buttons"';
@@ -168,7 +180,19 @@ sub HTML {
 sub TeX {
 	my $self = shift;
 
-	my $out =
+	my $out = '';
+
+	if ($self->{showUniversalSet}) {
+		$out .= "\n\\hrule\n\\vspace{0.5\\baselineskip}\n";
+		$out .= "\\parbox{0.9\\linewidth}{\n";
+		$out .= "$self->{universalSetLabel}\n";
+		$out .= "\\begin{itemize}\n";
+		$out .= "\\item $_\n" for (@{ $self->{itemList} });
+		$out .= "\\end{itemize}\n";
+		$out .= "}\n";
+	}
+
+	$out .=
 		"\n\\hrule\n\\vspace{0.5\\baselineskip}\n\\newif\\ifdndcolumns\n"
 		. "\\ifdim\\linewidth<$self->{multicolsWidth}\\relax\\dndcolumnsfalse\\else\\dndcolumnstrue\\fi\n";
 

--- a/lib/DragNDrop.pm
+++ b/lib/DragNDrop.pm
@@ -164,7 +164,7 @@ sub HTML {
 	$out .= qq{ data-remove-button-text="$self->{removeButtonText}"};
 	$out .= qq{ data-label-format="$self->{bucketLabelFormat}"} if $self->{bucketLabelFormat};
 	$out .= " data-show-universal-set"                          if $self->{showUniversalSet};
-	$out .= qq{ data-universal-set-label="$self->{universalSetLabel}"};
+	$out .= ' data-universal-set-label="' . PGcore::encode_pg_and_html($self->{universalSetLabel}) . '"';
 	$out .= '>';
 
 	$out .= '<div class="dd-buttons"';

--- a/macros/math/draggableSubsets.pl
+++ b/macros/math/draggableSubsets.pl
@@ -227,7 +227,7 @@ sub new {
 		AddButtonText     => 'Add Bucket',
 		RemoveButtonText  => 'Remove',
 		ShowUniversalSet  => 0,
-		UniversalSetLabel => '',
+		UniversalSetLabel => 'Universal Set',
 		%options
 		},
 		ref($invocant) || $invocant;

--- a/macros/math/draggableSubsets.pl
+++ b/macros/math/draggableSubsets.pl
@@ -69,11 +69,12 @@ Available Options:
     DefaultSubsets    => <array reference>
     OrderedSubsets    => 0 or 1
     AllowNewBuckets   => 0 or 1
-    AllowReusingItems => 0 or 1
     BucketLabelFormat => <string>
     ResetButtonText   => <string>
     AddButtonText     => <string>
     RemoveButtonText  => <string>
+    ShowUniversalSet  => 0 or 1
+    UniversalSetLabel => <string>
 
 Their usage is demonstrated in the example below.
 
@@ -135,12 +136,6 @@ Their usage is demonstrated in the example below.
         # The default value if not given is 1.
         AllowNewBuckets => 1,
 
-        # 0 is the conventional approach, by which the repository bucket is 
-        # depleted if an item an item is dragged from that bucket. 
-        # 1 means that items are replenished in the repository bucket once 
-        # dragged. The default value if not given is 0.
-        AllowReusingItems => 0,
-
         # If this option is defined then labels for buckets for which a specific
         # label is not provided will be created by replacing %s with the bucket
         # number to this prefix.  These labels will also be used for buckets
@@ -162,6 +157,16 @@ Their usage is demonstrated in the example below.
         # This is the text label for the remove button that is added to any
         # removable buckets.  The default value if not given is "Remove".
         RemoveButtonText => 'Delete'
+
+        # If this is true then a separate bucket containing the full set passed
+        # as the first argument above (the universal set) will be shown, and the
+        # elements of the set can be distributed to the other subsets (or
+        # buckets) that are shown.  The default value if not given is 0.
+        ShowUniversalSet => 1,
+
+        # Label for the bucket representing the universal set.
+        #  The default value if not given is "Universal Set".
+        UniversalSetLabel => 'Universal Set',
 
         # These are options that will be passed to the $draggable->cmp method.
         cmpOptions => { checker => sub { ... } }
@@ -221,14 +226,43 @@ sub new {
 		ResetButtonText   => 'Reset',
 		AddButtonText     => 'Add Bucket',
 		RemoveButtonText  => 'Remove',
-		AllowReusingItems => 0,
+		ShowUniversalSet  => 0,
+		UniversalSetLabel => '',
 		%options
 		},
 		ref($invocant) || $invocant;
 
-	#If AllowReusingItem is set, bucket 0 should contain the full set of elements for grading
-	my $maxindex = scalar @{ $base->{set} } - 1;    #Number of elements -1
-	if ($base->{AllowReusingItems}) { $subsets->[0] = [ 0 .. $maxindex ]; }
+	Value::Error('Answer subsets must be an array reference.') unless ref($subsets) eq 'ARRAY';
+
+	my %seenIndices;
+	for my $subset (@$subsets) {
+		Value::Error('Each answer subset must be a reference to an array of indices.')
+			unless ref($subset) eq 'ARRAY';
+		for (@$subset) {
+			Value::Error('An index in an answer subset is out of range.') unless $_ < @$set;
+			Value::Error('An index is repeated in multiple answer subsets. '
+					. 'This can only be the case if ShowUniversalSet is 1.')
+				if !$base->{ShowUniversalSet} && $seenIndices{$_};
+			$seenIndices{$_} = 1;
+		}
+	}
+
+	Value::Error('Default subsets must be an array reference.')
+		unless ref($base->{DefaultSubsets}) eq 'ARRAY';
+
+	%seenIndices = ();
+	for my $subset (@{ $base->{DefaultSubsets} }) {
+		Value::Error('Each default subset must be a hash reference.') unless ref($subset) eq 'HASH';
+		Value::Error('Each default subset must have "indices" which must be a reference to an array of indices.')
+			unless ref($subset->{indices}) eq 'ARRAY';
+		for (@{ $subset->{indices} }) {
+			Value::Error('An index in a default subset is out of range.') unless $_ < @$set;
+			Value::Error('An index is repeated in multiple default subsets.'
+					. 'This can only be the case if ShowUniversalSet is 1.')
+				if !$base->{ShowUniversalSet} && $seenIndices{$_};
+			$seenIndices{$_} = 1;
+		}
+	}
 
 	$base->{order} = do {
 		my @indices = 0 .. $#{ $base->{set} };
@@ -243,7 +277,6 @@ sub new {
 		'(' => { close => ')', type => 'List', formList => 1, formMatrix => 0, removable => 0 },
 		'{' => { close => '}', type => 'Set',  formList => 0, formMatrix => 0, removable => 0, emptyOK => 1 }
 	);
-
 	$context->lists->set(
 		'DraggableSubsets' => {
 			class       => 'Parser::List::List',
@@ -304,7 +337,8 @@ sub ans_rule {
 		resetButtonText   => $self->{ResetButtonText},
 		addButtonText     => $self->{AddButtonText},
 		removeButtonText  => $self->{RemoveButtonText},
-		allowReusingItems => $self->{AllowReusingItems},
+		showUniversalSet  => $self->{ShowUniversalSet},
+		universalSetLabel => $self->{UniversalSetLabel},
 	);
 
 	my $ans_rule = main::NAMED_HIDDEN_ANS_RULE($self->ANS_NAME);
@@ -333,18 +367,7 @@ sub cmp_defaults {
 
 sub cmp {
 	my ($self, %options) = @_;
-	my $nbuc = scalar @{ $self->{set} };    #number of buckets
-	if ($self->{AllowReusingItems}) {
-		$tmp = $self->SUPER::cmp(%{ $self->{cmpOptions} }, %options)->withPostFilter(sub {
-			$ansHash          = shift;
-			$ncor             = $ansHash->{score} * $nbuc;    #number of buckets correct
-			$ansHash->{score} = ($ncor - 1) / ($nbuc - 1);
-			return $ansHash;
-		});
-		return $tmp;
-	} else {
-		return $self->SUPER::cmp(%{ $self->{cmpOptions} }, %options);
-	}
+	return $self->SUPER::cmp(%{ $self->{cmpOptions} }, %options);
 }
 
 sub TeX {


### PR DESCRIPTION
This extends @sfiedle1's work in #1258, and implements the structural rework that I suggested in the conversation for that pull request (albeit slightly modified).

There are two new options for the `draggableSubsets.pl` macro.  They are `ShowUniversalSet` and `UniversalSetLabel`.

If `ShowUniversalSet` is 1, then the set of all elements that are passed as the first argument for the `DraggableSubsets` method will be shown as a separate drag and drop bucket.  This bucket is always above the other usual drag and drop buckets (both in HTML and TeX).  The elements of the universal set can be dragged multiple times to the other buckets.  Really this is a copy of the element, so all elements always remain in the universal set.

The `UniversalSetLabel` option is a string that will be shown as the label of the universal set bucket.

Note that this approach doesn't require any special handling for grading the answer regardless of if `$showPartialCorrectAnswers` is true or not, because the universal set bucket is not part of the answer in any case.  It is not listed in any of the answer previews, and is not part of the grading in any way. It is purely a source of elements.

I also added some validation of the answers and default subsets that are passed to the DraggableSubsets method.  Previously invalid inputs would have caused rather unexpected things.  Now they will be errors (specifically `Value::Error`s).

In my original comment to #1258 I suggested a `ShowUniversalSet` option and a related `AllowReusableElements` option.  The latter option was dropped because I realized it doesn't really make sense in the context of a universal set. I initially implemented it, but basically it made the "universal set" bucket really just a regular bucket just like all of the others, and it really wasn't a "universal set" anymore since it didn't always have all elements. I thought of a way that it could make sense in which it always has all elements, but only one copy was allowed to be dragged to the other buckets.  So only one duplicate, no reuse after that.  That would take some effort to implement (mostly in the javascript code), but could be done. I don't know that this would really be that useful though, so I didn't implement it for now.

A MWE for testing this is as follows:

```perl
DOCUMENT();

loadMacros(qw{PGstandard.pl PGML.pl draggableSubsets.pl PGcourse.pl});

$draggable = DraggableSubsets(
    [ 'orange', 'blue', 'apple' ],
    [ [ 0, 1 ], [ 0, 2 ] ],
    DefaultSubsets => [
        { label => 'Color', indices => [] },
        { label => 'Fruit', indices => [] },
    ],
    ShowUniversalSet  => 1,
    UniversalSetLabel =>
        'Classify each item below as a color, fruit, or both.',
    AllowNewBuckets => 0
);

BEGIN_PGML
[_]{$draggable}
END_PGML

ENDDOCUMENT();
```

To test this you should also test modifications of the above problem with other options.  For example, change to `AllowNewBuckets => 1`, and test addition and removal of buckets particularly removal after elements have been added to the bucket.  Add indices to the `DefaultSubsets` so elements are initially shown in those and behavior when elements are dragged in an out.