### PR TITLE
only use parentheses (not brackets) for Formula strings

### DIFF
--- a/lib/Parser/Context/Default.pm
+++ b/lib/Parser/Context/Default.pm
@@ -434,6 +434,7 @@ $flags = {
 	reduceConstants            => 1,              # 1 = automatically combine constants
 	reduceConstantFunctions    => 1,              # 1 = compute function values of constants
 	showExtraParens            => 1,              # 1 = add useful parens, 2 = make things painfully unambiguous
+	stringifyNoBrackets        => 0,              # 1 = only use parentheses not brackets when stringifying
 	formatStudentAnswer        => 'evaluated',    # or 'parsed' or 'reduced'
 	allowMissingOperands       => 0,              # 1 is used by Typeset context
 	allowMissingFunctionInputs => 0,              # 1 is used by Typeset context

--- a/lib/Parser/Item.pm
+++ b/lib/Parser/Item.pm
@@ -113,12 +113,12 @@ sub canBeInUnion {0}
 sub isSetOfReals { (shift)->type =~ m/^(Interval|Union|Set)$/ }
 
 #
-#  Add parens to an expression (alternating the type of paren)
+#  Add parens to an expression (alternating the type of paren unless stringifyNoBrackets is set)
 #
 sub addParens {
 	my $self   = shift;
 	my $string = shift;
-	if ($string =~ m/^[^\[]*\(/) { return '[' . $string . ']' }
+	return '[' . $string . ']' if $string =~ m/^[^\[]*\(/ && !$self->context->flag('stringifyNoBrackets');
 	return '(' . $string . ')';
 }
 

--- a/lib/Plots/Data.pm
+++ b/lib/Plots/Data.pm
@@ -260,7 +260,8 @@ sub function_string {
 	my $format      = $formula->context->{format}{number};
 	$formula->context->flags->set(showExtraParens => 2);
 	$formula->context->{format}{number} = "%f#";
-	my $func = $formula->string;
+	# Get no bracket string for $formula
+	my $func = $formula . "";
 	$func =~ s/\s//g;
 	$formula->context->flags->set(showExtraParens => $extraParens);
 	$formula->context->{format}{number} = $format;
@@ -368,8 +369,6 @@ sub function_string {
 		}
 	}
 
-	$out =~ s/\[/(/g;
-	$out =~ s/\]/)/g;
 	return $out;
 }
 

--- a/lib/Value/Formula.pm
+++ b/lib/Value/Formula.pm
@@ -112,7 +112,14 @@ sub _dot {
 	$l->SUPER::_dot($r, $flag);
 }
 
-sub pdot { '(' . (shift->stringify) . ')' }
+sub pdot {
+	my $self       = shift;
+	my $nobrackets = $self->context->flag('stringifyNoBrackets');
+	$self->context->flags->set(stringifyNoBrackets => 1);
+	my $string = '(' . ($self->stringify) . ')';
+	$self->context->flags->set(stringifyNoBrackets => $nobrackets);
+	return $string;
+}
 
 #
 #  Call the Parser::Function call function


### PR DESCRIPTION
The string method of a MathObject Formula alternates nested parens between parentheses and brackets. The presence of any brackets means the formula string cannot be used as the function for a pgfplots graph to plot. (See [an old forum post](https://forums.openwebwork.org/mod/forum/discuss.php?d=8084).)

I can't think of a need for the brackets. Only a problem author will have reason to directly see the string method of a Formula, and while the brackets would help them more clearly see groupings, they can probably deal with just having all parentheses.

So this PR changes it so that it's all parentheses, no brackets. I considered making a context flag for this but at the moment I don't see the point. This may be controversial, and I am hoping @dpvc can weigh in.