### PR TITLE
Fix a warning in the `TriangleGraphTool.pg` sample problem.

### DIFF
--- a/tutorial/sample-problems/Geometry/TriangleGraphTool.pg
+++ b/tutorial/sample-problems/Geometry/TriangleGraphTool.pg
@@ -51,8 +51,7 @@ END_PGML
 BEGIN_PGML_SOLUTION
 The correct answer is
 
-[!A graph of the triangle with vertices ([$x1], [$y1]), ([$x2],[$y2]) and
-([$x3],[$y3])!]{$gt}
+[!A graph of the triangle with vertices ([$x1], [$y1]), ([$x2],[$y2]) and ([$x3],[$y3])!]{$gt}
 END_PGML_SOLUTION
 
 ENDDOCUMENT();


### PR DESCRIPTION
The image alt tag inserted via the PGML image syntax cannot wrap multiple lines.  So that will need to be all on one line.  This is a limitation of the PGML image syntax that we should eliminate.  Image alt text can be lengthy (and still not long enough to neccessitate the new long description), so it would be nice if multiple lines were allowed.