### PR TITLE
Rewrite the PG uniq function to return the array in a consistent order

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2634,13 +2634,9 @@ Usage:
 
 #  uniq gives unique elements of a list:
 sub uniq {
-	my @in   = @_;
-	my %temp = ();
-	while (@in) {
-		$temp{ shift(@in) }++;
-	}
-	my @out = keys %temp;    # sort is causing trouble with Safe.??
-	@out;
+	my @in = @_;
+	my %seen;
+	return grep { !$seen{$_}++ } @in;
 }
 
 sub lex_sort {


### PR DESCRIPTION
This is to address #1275.  Find a MWE to test there.

With this update (supplied by @drgrice1 ) `uniq` now always returns the array in the same order.