### PR TITLE
don't let a negative score be reported

### DIFF
--- a/macros/contexts/contextFiniteSolutionSets.pl
+++ b/macros/contexts/contextFiniteSolutionSets.pl
@@ -283,6 +283,7 @@ sub _contextFiniteSolutionSets_init {
 					. join(',', map { $_->TeX } (@correctanswers))
 					. "\\right\\}\\)");
 		}
+		$score = 0 if $score < 0;
 		return ($score, @errors);
 	};
 }


### PR DESCRIPTION
Answers for this context are finite sets, like {1,2,3}. The scoring that happens in for answers attempts to give partial credit for answers like {1}, {1,2}, {1,2,4}, {1,2,3,4} etc. The idea is to use 3 as the denominator (in this case where the correct answer has three numbers) and then for the numerator:

- +1 for each correct number
- -1 for each incorrect number or repeat of a correct number

But that can lead to a negative total. It doesn't get recorded int he database as a negative score (I think) but it does lead to students seeing things like "-100% correct" in the feedback.

So the change here ensures that if a negative total has been reached, that will be replaced with 0.