### PR TITLE
Ignore the "separator" for parserCheckboxList.pl and parserRadioButtons.pl in TeX display mode.

### DIFF
--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -614,7 +614,10 @@ sub CHECKS {
 		$checks[-1] .= "</div>";
 	}
 
-	return wantarray ? @checks : join($main::displayMode eq 'PTX' ? '' : $self->{separator}, @checks);
+	return
+		wantarray
+		? @checks
+		: join($main::displayMode eq 'PTX' || $main::displayMode eq 'TeX' ? '' : $self->{separator}, @checks);
 }
 
 sub protect {

--- a/macros/parsers/parserRadioButtons.pl
+++ b/macros/parsers/parserRadioButtons.pl
@@ -699,7 +699,9 @@ sub BUTTONS {
 			. qq{data-feedback-btn-add-class="ms-3">$radio[0]};
 		$radio[-1] .= "</div>";
 	}
-	(wantarray) ? @radio : join(($main::displayMode eq 'PTX') ? '' : $self->{separator}, @radio);
+	wantarray
+		? @radio
+		: join($main::displayMode eq 'PTX' || $main::displayMode eq 'TeX' ? '' : $self->{separator}, @radio);
 }
 
 sub protect {


### PR DESCRIPTION
The default "separator" is a $BR which is defined to be `\\leavemode\\\\\\relax` if the display mode is TeX.  This doesn't work if the CheckboxList or RadioButtons happen to be in a table. Furthermore, the separator doesn't make sense in TeX display mode in any case.  So this makes it so that the separator is just not used in the TeX display mode.

This is to address issue #1300.