### PR TITLE
Fix parameter check in BeginList function

### DIFF
--- a/macros/ui/unionLists.pl
+++ b/macros/ui/unionLists.pl
@@ -54,7 +54,7 @@ Example:
 
 sub BeginList {
 	my $LIST = 'OL';
-	$LIST = shift if (uc($_[0]) eq "OL" or uc($_[0]) eq "UL");
+	$LIST = uc(shift) if (defined($_[0]) && (uc($_[0]) eq "OL" or uc($_[0]) eq "UL"));
 	my $enum    = ($LIST eq 'OL' ? "enumerate" : "itemize");
 	my %options = @_;
 	$LIST .= ' TYPE="' . $options{type} . '"'   if defined($options{type});


### PR DESCRIPTION
This fixes two issues with a check in BeginList; first, it accessed a parameter without checking it if existed first, resulting in undefined value warnings; and second it tested the validity of the uppercase version of the parameter but then used the literal parameter in the assignment.
