### PR TITLE
Fix some issues with sample problem documentation generation. (hotfix of #1312)

### DIFF
--- a/tutorial/sample-problems/Geometry/LineSegmentGraphTool.pg
+++ b/tutorial/sample-problems/Geometry/LineSegmentGraphTool.pg
@@ -15,7 +15,7 @@
 #:% type = Sample
 #:% subject = [geometry]
 #:% categories = [graph, graphtool]
-#:% see_also = [VectorGraphTool.pg, TriangleGraphTool.pg, QuadrilateralGraphTool.pg]
+#:% see_also = [GraphToolVectors.pg, TriangleGraphTool.pg, QuadrilateralGraphTool.pg]
 
 #:% section = preamble
 #: Load the PODLINK('parserGraphTool.pl') macro to be able to use the GraphTool.

--- a/tutorial/sample-problems/Parametric/Spacecurve.pg
+++ b/tutorial/sample-problems/Parametric/Spacecurve.pg
@@ -23,8 +23,8 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserMultiAnswer.pl', 'PGcourse.pl');
 $showPartialCorrectAnswers = 0;
 
 #:% section = setup
-#: The PODLINK('MultiAnswer') is used to check the answers together since they
-#: are interdependent.
+#: The PODLINK('parserMultiAnswer.pl') is used to check the answers together
+#: since they are interdependent.
 #:
 #: The option `singleResult => 1` is used since it doesn't make sense to say
 #: that `x(t)` is correct but `z(t)` is incorrect since they depend on one

--- a/tutorial/sample-problems/ProblemTechniques/FormattingDecimals.pg
+++ b/tutorial/sample-problems/ProblemTechniques/FormattingDecimals.pg
@@ -49,7 +49,7 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'PGcourse.pl');
 #: `useBaseTenLog` flag is 0, and the `log` function is the natural logarithm.
 #:
 #: If a function for log base 2 (or another base) is needed see
-#: PROBLINK('AddingFunctions.pg') for how to define and add a new function
+#: PROBLINK('DefiningFunctions.pg') for how to define and add a new function
 #: to the context so that students can enter it in their answers.
 Context()->variables->set(x => { limits => [ 0.1, 4 ] });
 

--- a/tutorial/sample-problems/ProblemTechniques/Multianswer.pg
+++ b/tutorial/sample-problems/ProblemTechniques/Multianswer.pg
@@ -17,7 +17,7 @@
 #:% categories = [multianswer]
 
 #:% section = preamble
-#: Load the PODLINK('parserMultianswer.pl') which provides the `MultiAnswer`
+#: Load the PODLINK('parserMultiAnswer.pl') which provides the `MultiAnswer`
 #: method.
 DOCUMENT();
 loadMacros('PGstandard.pl', 'PGML.pl', 'parserMultiAnswer.pl', 'PGcourse.pl');

--- a/tutorial/sample-problems/VectorCalc/VectorLineSegment1.pg
+++ b/tutorial/sample-problems/VectorCalc/VectorLineSegment1.pg
@@ -20,7 +20,7 @@
 #:% see_also = [VectorParametricLine.pg, VectorLineSegment2.pg]
 
 #:% section = preamble
-#: The PODLINK('parseParametricLine.pl') macro provides the `ParametricLine`
+#: The PODLINK('parserParametricLine.pl') macro provides the `ParametricLine`
 #: function which us used to check the answer.  The
 #: PODLINK('parserMultiAnswer.pl') macro is needed since the answers are
 #: interdependent.

--- a/tutorial/sample-problems/VectorCalc/VectorLineSegment2.pg
+++ b/tutorial/sample-problems/VectorCalc/VectorLineSegment2.pg
@@ -20,7 +20,7 @@
 #:% see_also = [VectorParametricLine.pg, VectorLineSegment1.pg]
 
 #:% section = preamble
-#:  The PODLINK('parseVectorUtils.pl') macro is loaded for the
+#:  The PODLINK('parserVectorUtils.pl') macro is loaded for the
 #: `non_zero_point3D` and `non_zero_vector3D` methods.
 DOCUMENT();
 loadMacros('PGstandard.pl', 'PGML.pl', 'parserVectorUtils.pl', 'PGcourse.pl');

--- a/tutorial/sample-problems/VectorCalc/VectorParametricLine.pg
+++ b/tutorial/sample-problems/VectorCalc/VectorParametricLine.pg
@@ -20,8 +20,8 @@
 #:% see_also = [VectorLineSegment1.pg, VectorLineSegment2.pg]
 
 #:% section = preamble
-#: The PODLINK('parseVectorUtils.pl') macro provides the `non_zero_point3D` and
-#: `non_zero_vector3D` methods. The macro PODLINK('parseParametricLine.pl')
+#: The PODLINK('parserVectorUtils.pl') macro provides the `non_zero_point3D` and
+#: `non_zero_vector3D` methods. The macro PODLINK('parserParametricLine.pl')
 #: provides the `ParametricLine` function used for the answer.
 DOCUMENT();
 loadMacros(

--- a/tutorial/templates/general-layout.mt
+++ b/tutorial/templates/general-layout.mt
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>PG Sample Problems</title>
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 	<style>
 		.navbar {
 			height: 70px;
@@ -26,7 +26,7 @@
 			}
 		}
 	</style>
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
 </head>
 
 <body>

--- a/tutorial/templates/problem-template.mt
+++ b/tutorial/templates/problem-template.mt
@@ -1,116 +1,111 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title><%= $filename %></title>
 
-		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet" />
-		<script
-			src="https://cdn.jsdelivr.net/npm/@openwebwork/pg-codemirror-editor@0.0.1-beta.28/dist/pg-codemirror-editor.js"
-			defer
-		></script>
-		<link rel="stylesheet" href="<%= $pg_doc_home %>/sample-problem.css" />
-	</head>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= $filename %></title>
 
-	% # Default explanations % my $default = { % preamble => 'These standard macros need to be loaded.', % setup =>
-	'This perl code sets up the problem.', % statement => 'This is the problem statement in PGML.', % answer => 'This is
-	used for answer checking.', % solution => 'A solution should be provided here.' % };
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+	<script
+		src="https://cdn.jsdelivr.net/npm/@openwebwork/pg-codemirror-editor@0.0.5/dist/pg-codemirror-editor.js"
+		defer></script>
+	<link rel="stylesheet" href="<%= $pg_doc_home %>/sample-problem.css">
+</head>
 
-	<body>
-		<div class="container-fluid p-3">
-			<div class="row">
-				<div class="col">
-					<h1><%= $name %></h1>
-					<p><%= $description %></p>
-				</div>
-				<div class="col text-end">
-					<a href="<%= $pg_doc_home =%>/../">Return to the PG docs home</a>
-				</div>
+% # Default explanations
+% my $default = {
+	% preamble  => 'These standard macros need to be loaded.',
+	% setup     => 'This perl code sets up the problem.',
+	% statement => 'This is the problem statement in PGML.',
+	% answer    => 'This is used for answer checking.',
+	% solution  => 'A solution should be provided here.'
+% };
+
+<body>
+	<div class="container-fluid p-3">
+		<div class="row">
+			<div class="col">
+				<h1><%= $name %></h1>
+				<p><%= $description %></p>
 			</div>
-			<div class="row">
-				<div class="col">
-					<h2>Complete Code</h2>
-					<p>Download file: <a href="<%= $filename =%>"><%= $filename =%></a></p>
-				</div>
-				% if (scalar(@{$metadata->{$filename}{macros}}) > 0 ) {
+			<div class="col text-end">
+				<a href="<%= $pg_doc_home =%>/../">Return to the PG docs home</a>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col">
+				<h2>Complete Code</h2>
+				<p>Download file: <a href="<%= $filename =%>"><%= $filename =%></a></p>
+			</div>
+			% if (scalar(@{$metadata->{$filename}{macros}}) > 0 ) {
 				<div class="col">
 					<h2>POD for Macro Files</h2>
 					<ul>
-						% for my $macro (@{$metadata->{$filename}{macros}}) { % if ($macro_locations->{$macro}) {
-						<li><a href="<%= $pod_root %>/<%= $macro_locations->{$macro} %>"><%= $macro =%></a></li>
-						% } else {
-						<li class="text-danger"><%= $macro %></li>
-						% } % }
-					</ul>
-				</div>
-				%} % if ($metadata->{$filename}{related} && scalar(@{$metadata->{$filename}{related}}) > 0) {
-				<div class="col">
-					<h2>See Also</h2>
-					<ul>
-						% for (@{$metadata->{$filename}{related}}) {
-						<li>
-							<a href="<%= $pg_doc_home =%>/<%= $metadata->{$_}{dir} =%>/<%= $_ =~ s/.pg$//r =%>.html">
-								<%= $metadata->{$_}{name} =%></a
-							>
-						</li>
+						% for my $macro (@{$metadata->{$filename}{macros}}) {
+							% if ($macro_locations->{$macro}) {
+								<li><a href="<%= $pod_root %>/<%= $macro_locations->{$macro} %>"><%= $macro =%></a></li>
+							% } else {
+								<li class="text-danger"><%= $macro %></li>
+							% }
 						% }
 					</ul>
 				</div>
 				% }
-			</div>
-			<div class="row">
-				<div class="col text-center"><h2 class="fw-bold fs-3">PG problem file</h2></div>
-				<div class="col text-center"><h2 class="fw-bold fs-3">Explanation</h2></div>
-			</div>
-			% for (@$blocks) {
-			<div class="row">
-				<div class="col-sm-12 col-md-6 order-md-first order-last p-0 position-relative overflow-x-hidden">
-					<button
-						class="clipboard-btn btn btn-sm btn-secondary position-absolute top-0 end-0 me-1 mt-1 z-1"
-						type="button"
-						data-code="<%== $_->{code} %>"
-						aria-label="copy to clipboard"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							fill="currentColor"
-							class="bi bi-clipboard-fill"
-							viewBox="0 0 16 16"
-						>
-							<path
-								fill-rule="evenodd"
-								d="M10 1.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-1Zm-5 0A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5v1A1.5 1.5 0 0 1 9.5 4h-3A1.5 1.5 0 0 1 5 2.5v-1Zm-2 0h1v1A2.5 2.5 0 0 0 6.5 5h3A2.5 2.5 0 0 0 12 2.5v-1h1a2 2 0 0 1 2 2V14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3.5a2 2 0 0 1 2-2Z"
-							/>
-						</svg>
-					</button>
-					<pre class="PGCodeMirror m-0 h-100 p-3 border border-secondary overflow-x-scroll">
-<%== $_->{code} %>
-					</pre
-					>
-				</div>
-				<div
-					class="explanation <%= $_->{section} %> col-sm-12 col-md-6 order-md-last order-first p-3 border border-dark"
-				>
-					<p><b><%= ucfirst($_->{section}) %></b></p>
-					% if ($_->{doc}) { <%= $_->{doc} %> %} else { <%= $default->{$_->{section}} %> %}
-				</div>
+			% if ($metadata->{$filename}{related} && scalar(@{$metadata->{$filename}{related}}) > 0) {
+			<div class="col">
+				<h2>See Also</h2>
+				<ul>
+					% for (@{$metadata->{$filename}{related}}) {
+					<li>
+						<a href="<%= $pg_doc_home =%>/<%= $metadata->{$_}{dir} =%>/<%= $_ =~ s/.pg$//r =%>.html">
+							<%= $metadata->{$_}{name} =%>
+						</a>
+					</li>
+					% }
+				</ul>
 			</div>
 			% }
 		</div>
+		<div class="row">
+			<div class="col text-center"><h2 class="fw-bold fs-3">PG problem file</h2></div>
+			<div class="col text-center"><h2 class="fw-bold fs-3">Explanation</h2></div>
+		</div>
+		% for (@$blocks) {
+			<div class="row">
+				<div class="col-sm-12 col-md-6 order-md-first order-last p-0 position-relative overflow-x-hidden">
+					<button class="clipboard-btn btn btn-sm btn-secondary position-absolute top-0 end-0 me-1 mt-1 z-1"
+						type="button" data-code="<%== $_->{code} %>" aria-label="copy to clipboard">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+							class="bi bi-clipboard-fill" viewBox="0 0 16 16">
+							<path fill-rule="evenodd" d="M10 1.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-1Zm-5 0A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5v1A1.5 1.5 0 0 1 9.5 4h-3A1.5 1.5 0 0 1 5 2.5v-1Zm-2 0h1v1A2.5 2.5 0 0 0 6.5 5h3A2.5 2.5 0 0 0 12 2.5v-1h1a2 2 0 0 1 2 2V14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3.5a2 2 0 0 1 2-2Z"/>
+						</svg>
+					</button>
+					<pre class="PGCodeMirror m-0 h-100 p-3 border border-secondary overflow-x-scroll"><%== $_->{code} %></pre>
+				</div>
+				<div class="explanation <%= $_->{section} %> col-sm-12 col-md-6 order-md-last order-first p-3 border border-dark">
+					<p><b><%= ucfirst($_->{section}) %></b></p>
+					% if ($_->{doc}) {
+						<%= $_->{doc} %>
+					% } else {
+						<%= $default->{$_->{section}} %>
+					% }
+				</div>
+			</div>
+		% }
+	</div>
 
-		<script type="module">
-			for (const pre of document.body.querySelectorAll('pre.PGCodeMirror')) {
-				PGCodeMirrorEditor.runMode(pre.textContent, pre);
-			}
+	<script type="module">
+		for (const pre of document.body.querySelectorAll('pre.PGCodeMirror')) {
+			PGCodeMirrorEditor.runMode(pre.textContent, pre);
+		}
 
-			for (const btn of document.querySelectorAll('.clipboard-btn')) {
-				if (navigator.clipboard)
-					btn.addEventListener('click', () => navigator.clipboard.writeText(btn.dataset.code));
-				else btn?.remove();
-			}
-		</script>
-	</body>
+		for (const btn of document.querySelectorAll('.clipboard-btn')) {
+			if (navigator.clipboard)
+				btn.addEventListener('click', () => navigator.clipboard.writeText(btn.dataset.code));
+			else btn?.remove();
+		}
+	</script>
+</body>
+
 </html>


### PR DESCRIPTION
When I updated the sample problem documentation to use CodeMirror 6, apparently prettier accidentally ran on the `problem-template.mt` file (due to the format on save feature in my editor).  Since that is a Mojolicious template file, prettier does not do the right thing, and messed that file up pretty well.  So this fixes the resulting issues.

Also, fix several typos in the sample problems that have a PODLINK or PROBLINK that have incorrect macro or sample problem file names.  These cause "use of unitialized value" warnings when the `parse-problem-doc.pl` script is executed. These warnings also occur when loading these sample problems via webwork2.

Finally, switch the sample problem templates to using the same version of Bootstrap that webwork2 uses.

This hotfix is needed so that we can update the sample problems and macros for PG 2.20 at https://openwebwork.github.io/pg-docs.