### PR TITLE
fix logic for when to check answer hints

### DIFF
--- a/macros/answers/answerHints.pl
+++ b/macros/answers/answerHints.pl
@@ -32,8 +32,10 @@ set options for the message.  These can include:
 
 =item C<S<< checkCorrect => 0 or 1 >>>
 
-1 means check for messages even
-if the answer is correct.
+In the list of incorrect answers to compare the student's answer with, 1 means
+for each CODE reference incorrect answer, check the student's answer against
+that CODE reference incorrect answer for messages even if the student answer is
+correct.
 Default: 0
 
 =item C<S<< replaceMessage => 0 or 1 >>>
@@ -45,9 +47,10 @@ Default: 0
 
 =item C<S<< checkTypes => 0 or 1 >>>
 
-1 means only perform the test
-if the student answer is the
-same type as the correct one.
+In the list of incorrect answers to compare the student's answer with, 1 means
+for each CODE reference incorrect answer, check the student's answer against
+that CODE reference incorrect answer for messages only when the the student
+answer the same type as the correct answer.
 Default: 1
 
 =item C<S<< processPreview => 0 or 1 >>>

--- a/macros/answers/answerHints.pl
+++ b/macros/answers/answerHints.pl
@@ -123,7 +123,6 @@ sub AnswerHints {
 			my $hash    = $context->{answerHash};
 			$context->{answerHash} = $ans;
 			my $processPreview = $correct->getFlag('answerHintsProcessPreview', 0);
-			$context->{answerHash} = $hash;
 
 			while (@_) {
 				my $wrongList = shift;
@@ -175,6 +174,7 @@ sub AnswerHints {
 					}
 				}
 			}
+			$context->{answerHash} = $hash;
 			return $ans;
 		},
 		@_
@@ -194,6 +194,9 @@ sub Compare {
 	$ans->{typeError}   = 0;
 	$ans->{ans_message} = $ans->{error_message} = "";
 	$ans->{score}       = 0;
+	my $context = $self->context;
+	my $hash    = $context->{answerHash};
+	$context->{answerHash} = $ans;
 
 	if ($self->address != $ans->{correct_value}->address) {
 		$ans->{correct_ans}     = $self->string;
@@ -208,6 +211,7 @@ sub Compare {
 	$self->cmp_preprocess($ans);
 	$self->cmp_equal($ans);
 	$self->cmp_postprocess($ans) if !$ans->{error_message} && !$ans->{typeError};
+	$context->{answerHash} = $hash;
 	return $ans->{score} >= 1;
 }
 


### PR DESCRIPTION
I was using answerHints.pl for an answer that should be like ln|x|, and wanted a special message if the student entered ln(x). I noticed the answer hint was given even when the student enters ln|x|. And even though the default setting for `checkCorrect` is 0.

It turned out that `checkCorrect` was only respected if the specified wrong answer was given as code, rather than given as a MathObject. So I adjusted the logic to wrap a check around the entire loop, checking if `checkCorrect` is 1 or if the score is less than 1. While doing this, it seemed a few other things should be checked outside of the loop as well. Namely, the check for `checkTypes`, and the check for if a prior message should be replaced.