### PR TITLE
Fix invalid html for ans_array answers.

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -555,57 +555,57 @@ sub format_matrix_HTML {
 	my ($rows, $cols) = (scalar(@{$array}), scalar(@{ $array->[0] }));
 	my $HTML  = "";
 	my $class = 'class="ans_array_cell"';
-	my $cell  = "display:table-cell;vertical-align:middle;";
+	my $cell  = "display:table-cell;vertical-align:middle;text-align:center;";
 	my $pad   = "padding:4px 0;";
-	if   ($sep) { $sep = '<span class="ans_array_sep" style="' . $cell . 'padding:0 2px">' . $sep . '</span>' }
-	else        { $sep = '<span class="ans_array_sep" style="' . $cell . 'width:8px"></span>' }
-	$sep = '</span>' . $sep . '<span ' . $class . ' style="' . $cell . $pad . '">';
+	if   ($sep) { $sep = '<div class="ans_array_sep" style="' . $cell . 'padding:0 2px">' . $sep . '</div>' }
+	else        { $sep = '<div class="ans_array_sep" style="' . $cell . 'width:8px"></div>' }
+	$sep = '</div>' . $sep . '<div ' . $class . ' style="' . $cell . $pad . '">';
 
 	if ($options{top_labels}) {
 		$HTML .=
-			'<span style="display:table-row"><span '
+			'<div style="display:table-row"><div '
 			. $class
 			. ' style="'
 			. $cell
 			. $pad . '">'
 			. join($sep, @{ $options{top_labels} })
-			. '</span></span>';
+			. '</div></div>';
 	}
 	foreach my $i (0 .. $rows - 1) {
 		$HTML .=
-			'<span style="display:table-row"><span '
+			'<div style="display:table-row"><div '
 			. $class
 			. ' style="'
 			. $cell
 			. $pad . '">'
 			. join($sep, EVALUATE(@{ $array->[$i] }))
-			. '</span></span>';
+			. '</div></div>';
 	}
-	$HTML  = '<span class="ans_array_table" style="display:inline-table; vertical-align:middle">' . $HTML . '</span>';
+	$HTML  = '<div class="ans_array_table" style="display:inline-table; vertical-align:middle">' . $HTML . '</div>';
 	$open  = $self->format_delimiter($open,  $rows, $options{tth_delims});
 	$close = $self->format_delimiter($close, $rows, $options{tth_delims});
 	if ($open ne '' || $close ne '') {
 		my $delim = "display:inline-block; vertical-align:middle;";
 		$HTML =
-			'<span class="ans_array_open" style="'
+			'<div class="ans_array_open" style="'
 			. $delim
 			. ' margin-right:4px">'
 			. $open
-			. '</span>'
+			. '</div>'
 			. $HTML
-			. '<span class="ans_array_close" style="'
+			. '<div class="ans_array_close" style="'
 			. $delim
 			. ' margin-left:4px">'
 			. $close
-			. '</span>';
+			. '</div>';
 	}
-	return '<span class="ans_array" style="display:inline-block;vertical-align:.5ex"'
+	return '<div class="ans_array" style="display:inline-block;vertical-align:.5ex"'
 		. ($options{ans_last_name}
 			? qq{ data-feedback-insert-element="$options{ans_last_name}" data-feedback-insert-method="append_content"}
 			: '')
 		. '>'
 		. $HTML
-		. '</span>';
+		. '</div>';
 }
 
 sub EVALUATE {


### PR DESCRIPTION
The `format_matrix_HTML` method uses `span` tags to format the html output for matrices. This is a problem when that is used to format the output for an `ans_array` answer because the answer inputs inside now are wrapped in `div` tags (so that the feedback button works in a valid html way).  So this just switches to using `div`s instead.  This doesn't change the result at all since the containg array layout div already has `display:inline-block` set.

There is one minor tweak to the style.  I added `text-align:center;` to the cells.  This just looks better in about all of the cases that I have observed. Note that this is also consistent with when these objects are displayed in math mode via MathJax or as an image with the image display mode.

Note that method is used ans_array matrix, vector, and point answer rules, as well as the "Entered" feedback preview of the student answer for those answers. It also affects the "textual" correct answer, but that actually isn't used for anything anymore.