### PR TITLE
Update the MathQuill version to pull in some fixes (hotfix).

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "pg.javascript_package_manager",
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@openwebwork/mathquill": "^0.11.0",
+				"@openwebwork/mathquill": "^0.11.1",
 				"jsxgraph": "^1.10.1",
 				"jszip": "^3.10.1",
 				"jszip-utils": "^0.1.0",
@@ -85,9 +85,9 @@
 			}
 		},
 		"node_modules/@openwebwork/mathquill": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0.tgz",
-			"integrity": "sha512-w5AlhsnreqCFYePP2V8Ve/hxA8KZvYmyHD5uehCD07PDp/HiL3DSo4mtAyLV7pWTXUoPVLFdnZK/WmrSYs+UdQ==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.1.tgz",
+			"integrity": "sha512-NLmu+AQ8i4bXX6Zuv5YMOkxhLsZisIW9pB0OvIIajVtAIsUu9ES7aG5Bhq823Ohc9xxA+2S7YrtmRaiDbp+GKA==",
 			"license": "MPL-2.0"
 		},
 		"node_modules/@trysound/sax": {
@@ -1748,9 +1748,9 @@
 			}
 		},
 		"@openwebwork/mathquill": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.0.tgz",
-			"integrity": "sha512-w5AlhsnreqCFYePP2V8Ve/hxA8KZvYmyHD5uehCD07PDp/HiL3DSo4mtAyLV7pWTXUoPVLFdnZK/WmrSYs+UdQ=="
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.1.tgz",
+			"integrity": "sha512-NLmu+AQ8i4bXX6Zuv5YMOkxhLsZisIW9pB0OvIIajVtAIsUu9ES7aG5Bhq823Ohc9xxA+2S7YrtmRaiDbp+GKA=="
 		},
 		"@trysound/sax": {
 			"version": "0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
 	},
 	"dependencies": {
-		"@openwebwork/mathquill": "^0.11.0",
+		"@openwebwork/mathquill": "^0.11.1",
 		"jsxgraph": "^1.10.1",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",


### PR DESCRIPTION
https://github.com/openwebwork/mathquill/pull/39 and https://github.com/openwebwork/mathquill/pull/40 have been merged and a new version of @openwebwork/mathquill have been merged.  This updates to the newly published version that includes those fixes.