### PR TITLE
Fix a bug with MathQuill options in the context flag before it is really an issue.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -994,7 +994,8 @@ sub ENDDOCUMENT {
 
 				if ($ansHash->{correct_value}) {
 					for (keys %{ $ansHash->{correct_value}->context->flag('mathQuillOpts') }) {
-						$mq_part_opts->{$_} = 0 unless defined $mq_part_opts->{$_};
+						$mq_part_opts->{$_} = $ansHash->{correct_value}->context->flag('mathQuillOpts')->{$_}
+							unless defined $mq_part_opts->{$_};
 					}
 				}
 


### PR DESCRIPTION
The current code passes on the option from the context as a hard coded zero instead of the actual option value from the context flag.  This works at this point because this is only used by the parserLogb.pl macro to make MathQuill not use the base change formula and the option value it is passing is zero.  However, in the future if a context ever wanted to enable a MathQuill feature then it wouldn't work.