### PR TITLE
Use same context when creating a new context::Fraction::Parser::Number (Hotfix of 1338)

### DIFF
--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -781,7 +781,7 @@ our @ISA = ('context::Fraction::Class', 'Parser::Number');
 
 sub new {
 	my $self = shift;
-	my $num  = &{ $self->super('new') }($self, @_);
+	my $num  = &{ $self->super('new', $_[0]->context) }($self, @_);
 	$num->setExtensionClass('INTEGER') if $num->{value_string} =~ m/^[-+]?[0-9]+$/;
 	return $num->mutate;
 }


### PR DESCRIPTION
When creating a context::Fraction::Parser::Number, use the same context as the original object instead of the current context.

This fixes issue #1337 with checking if an object created in the fraction context is equal to a number after the context has changed. This fix is by @dpvc.