### PR TITLE
Fix an issue with implied multiplication in the contextFraction.pl  macro.

### DIFF
--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -646,7 +646,15 @@ sub _check {
 #  operator we didn't otherwise subclass.
 #
 package context::Fraction::BOP::Space;
-our @ISA = ('context::Fraction::BOP::space');
+our @ISA = ('context::Fraction::Class', 'Parser::BOP');
+
+sub _check {
+	my $self    = shift;
+	my $context = $self->context;
+	$self->{bop} = $self->{def}{string};
+	$self->{def} = $context->{operators}{ $self->{bop} };
+	return $self->mutate->_check;
+}
 
 #################################################################################################
 #################################################################################################


### PR DESCRIPTION
The issue occurs with the following MWE:

```
DOCUMENT();
loadMacros(qw(PGstandard.pl MathObjects.pl contextUnits.pl contextFraction.pl));
Context(context::Units::extending('Fraction')->withUnitsFor('length'));
$a = Compute('2*3 cm');
ENDDOCUMENT();
```

Attempting to open the problem with the develop or main branch will consume all of your server's resources, and eventually the oomkiller will kill the process.

The changes in this pull request were suggested by @dpvc in an email communication between @Alex-Jordan, @dpvc, and myself.