### PR TITLE
Allow plotting Fy = 0 in plots.

### DIFF
--- a/lib/Plots/Data.pm
+++ b/lib/Plots/Data.pm
@@ -225,7 +225,7 @@ sub set_function {
 		$f->{"x$key"} = $options{$key};
 		delete $options{$key};
 	}
-	return unless $f->{Fy};
+	return unless $f->{Fy} ne '';
 
 	$f->{Fx}          = $self->get_math_object($f->{Fx}, $f->{xvar}, $f->{yvar});
 	$f->{Fy}          = $self->get_math_object($f->{Fy}, $f->{xvar}, $f->{yvar});


### PR DESCRIPTION
Since 0 returns false, the logic to ensure Fy was defined was incorrect, and needs to check Fy is not the empty string.

This could be a hotfix as it breaks plotting the zero function or vector fields in which Fy is set equal to zero.