### PR TITLE
Fix the legacyFraction.pl init method. (hotfix of #1342)

### DIFF
--- a/macros/contexts/legacyFraction.pl
+++ b/macros/contexts/legacyFraction.pl
@@ -223,7 +223,7 @@ error.
 
 =cut
 
-sub _contextFraction_init { context::Fraction::Init() }
+sub _legacyFraction_init { context::Fraction::Init() }
 
 ###########################################################################
 


### PR DESCRIPTION
This causes the macro to fail to load.