### PR TITLE
Fix numeric values for CheckboxLists.

### DIFF
--- a/macros/parsers/parserCheckboxList.pl
+++ b/macros/parsers/parserCheckboxList.pl
@@ -255,7 +255,7 @@ sub new {
 	$self->getCheckedChoices($self->{checked});
 
 	$context->strings->add(map { ($self->{values}[$_] => {}) } (0 .. ($self->{n} - 1)));
-	$_ = Value::makeValue($_, context => $context) for @{ $self->data };
+	$_ = $context->Package('String')->make($context, $_) for @{ $self->data };
 
 	return $self;
 }


### PR DESCRIPTION
For the following MWE the correct answer is not accepted as correct:

```perl
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'parserCheckboxList.pl', 'PGcourse.pl');

$checkList = CheckboxList(
    [ 50, 51, 52, 53 ], [0],
    labels => 'ABC',
    values => [ 50, 51, 52, 53 ]
);

BEGIN_PGML
Select [`50`].

[_]{$checkList}
END_PGML

ENDDOCUMENT();
```

The problem is that the only correct answer 50 is turned into a `Value::Real` instead of a `Value::String`.  However, the student answer is parsed into a `Value::String`, and then the types don't match and it is marked incorrect.

To fix this explicitly construct the correct answers as strings.