### PR TITLE
Use strong and em instead of b and i tags for bold and italic.

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1613,13 +1613,13 @@ sub Break {"<br />\n"}
 sub Bold {
 	my $self = shift;
 	my $item = shift;
-	return '<b>' . $self->string($item) . '</b>';
+	return '<strong>' . $self->string($item) . '</strong>';
 }
 
 sub Italic {
 	my $self = shift;
 	my $item = shift;
-	return '<i>' . $self->string($item) . '</i>';
+	return '<em>' . $self->string($item) . '</em>';
 }
 
 our %openQuote  = ('"' => "&#x201C;", "'" => "&#x2018;");

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1319,8 +1319,8 @@ sub BBOLD   { MODES(TeX => '{\\bf ',       HTML => '<STRONG>',  PTX => '<alert>'
 sub EBOLD   { MODES(TeX => '}',            HTML => '</STRONG>', PTX => '</alert>'); }
 sub BLABEL  { MODES(TeX => '',             HTML => '<LABEL>',   PTX => ''); }
 sub ELABEL  { MODES(TeX => '',             HTML => '</LABEL>',  PTX => ''); }
-sub BITALIC { MODES(TeX => '{\\it ',       HTML => '<I>',       PTX => '<em>'); }
-sub EITALIC { MODES(TeX => '} ',           HTML => '</I>',      PTX => '</em>'); }
+sub BITALIC { MODES(TeX => '{\\it ',       HTML => '<em>',      PTX => '<em>'); }
+sub EITALIC { MODES(TeX => '} ',           HTML => '</em>',     PTX => '</em>'); }
 sub BUL     { MODES(TeX => '\\underline{', HTML => '<U>',       PTX => '<em>'); }
 sub EUL     { MODES(TeX => '}',            HTML => '</U>',      PTX => '</em>'); }
 


### PR DESCRIPTION
PGML should use strong and emphasis for bold and italic. This also updates `$BITALIC` and `$EITALIC` in PGbasicmacros.pl to use emphasis. The `$BBOLD` and `$EBOLD` variables were already using strong, so this also makes things consistent.