### PR TITLE
Revert JSXGraph back to version 1.10.1.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@openwebwork/mathquill": "^0.11.1",
-				"jsxgraph": "^1.11.1",
+				"jsxgraph": "^1.10.1",
 				"jszip": "^3.10.1",
 				"jszip-utils": "^0.1.0",
 				"plotly.js-dist-min": "^3.1.0",
@@ -1026,13 +1026,10 @@
 			"license": "MIT"
 		},
 		"node_modules/jsxgraph": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.11.1.tgz",
-			"integrity": "sha512-0UdVqQPrKiHH29QZq0goaJvJ6eAAHln00/9urKyiTgqqFWA0xX4/akUbaz9N5cmdh8fQ6NPSwMe43TbeAWQfXA==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.10.1.tgz",
+			"integrity": "sha512-N7WQmjeiiGKiJPr4iGUHgf8uRazOo9qaGLjX/tLWvrup67FUVD4eEctSLO1HuNcOSthwl16aTc692TKf/vZxNw==",
 			"license": "(MIT OR LGPL-3.0-or-later)",
-			"dependencies": {
-				"jsxgraph": "^1.11.0-beta2"
-			},
 			"engines": {
 				"node": ">=0.6.0"
 			}
@@ -2622,12 +2619,9 @@
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"jsxgraph": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.11.1.tgz",
-			"integrity": "sha512-0UdVqQPrKiHH29QZq0goaJvJ6eAAHln00/9urKyiTgqqFWA0xX4/akUbaz9N5cmdh8fQ6NPSwMe43TbeAWQfXA==",
-			"requires": {
-				"jsxgraph": "^1.11.0-beta2"
-			}
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-1.10.1.tgz",
+			"integrity": "sha512-N7WQmjeiiGKiJPr4iGUHgf8uRazOo9qaGLjX/tLWvrup67FUVD4eEctSLO1HuNcOSthwl16aTc692TKf/vZxNw=="
 		},
 		"jszip": {
 			"version": "3.10.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@openwebwork/mathquill": "^0.11.1",
-		"jsxgraph": "^1.11.1",
+		"jsxgraph": "^1.10.1",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",
 		"plotly.js-dist-min": "^3.1.0",


### PR DESCRIPTION
Something has changed in version 1.11.1 that is messing up the tab order when using the tab key to change focus between points in the graph and such.  I will need to update the keyboard handling code in the graphtool to fix this.  So for now this reverts back to version 1.10.1 for which the current graphtool code still works.

I will try to get this fixed an update back to 1.11.1 before the next release.