### PR TITLE
PGML::Format Refactoring

### DIFF
--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1292,7 +1292,7 @@ sub nl {
 	return $nl;
 }
 
-sub Escape { shift; shift }
+sub escape { shift; shift }
 
 sub Indent   { return "" }
 sub Align    { return "" }
@@ -1439,7 +1439,7 @@ sub Command {
 	my $item = $state->{item};
 	my $text = $self->{parser}->replaceCommand($item);
 	$text = PGML::LaTeX($text) if ($item->{hasStar} || 0) == 3;
-	$text = $self->Escape($text) unless $item->{hasStar};
+	$text = $self->escape($text) unless $item->{hasStar};
 	return $text;
 }
 
@@ -1448,7 +1448,7 @@ sub Variable {
 	my $item = $state->{item};
 	my $text = $self->{parser}->replaceVariable($item, $state->{block});
 	$text = PGML::LaTeX($text) if ($item->{hasStar} || 0) == 3;
-	$text = $self->Escape($text) unless $item->{hasStar};
+	$text = $self->escape($text) unless $item->{hasStar};
 	return $text;
 }
 
@@ -1456,7 +1456,7 @@ sub Text {
 	my ($self, $state) = @_;
 	my $text = $self->{parser}->replaceText($state->{item});
 	$text =~ s/^\n+// if substr($text, 0, 1) eq "\n" && $self->nl eq "";
-	return $self->Escape($text);
+	return $self->escape($text);
 }
 
 sub Image {
@@ -1486,7 +1486,7 @@ sub Image {
 package PGML::Format::html;
 our @ISA = ('PGML::Format');
 
-sub Escape {
+sub escape {
 	my ($self, $string) = @_;
 	return '' unless defined $string;
 	$string =~ s/&/\&amp;/g;
@@ -1647,7 +1647,7 @@ sub Rule {
 sub Verbatim {
 	my ($self, $state) = @_;
 	my $item = $state->{item};
-	my $text = $self->Escape($item->{text});
+	my $text = $self->escape($item->{text});
 	$text = "<code>$text</code>" if $item->{hasStar};
 	return $text;
 }
@@ -1702,7 +1702,7 @@ my %escape = (
 	'~'  => '{\ttfamily\char126}',
 );
 
-sub Escape {
+sub escape {
 	my ($self, $string) = @_;
 	return '' unless defined($string);
 	$string =~ s/(["\#\$%&<>\\^_\{|\}~])/$escape{$1}/eg;
@@ -1805,7 +1805,7 @@ sub Rule {
 sub Verbatim {
 	my ($self, $state) = @_;
 	my $item = $state->{item};
-	my $text = $self->Escape($item->{text});
+	my $text = $self->escape($item->{text});
 	$text = "{\\tt{}$text}" if $item->{hasStar};
 	return $text;
 }
@@ -1833,7 +1833,7 @@ sub Tag {
 package PGML::Format::ptx;
 our @ISA = ('PGML::Format');
 
-sub Escape {
+sub escape {
 	my ($self, $string) = @_;
 	return '' unless defined $string;
 	$string =~ s/&/&amp;/g;

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1270,7 +1270,7 @@ sub string {
 	my $stack = $block->{stack};
 	my @strings;
 	my $state = { block => $block, strings => \@strings, i => 0 };
-	while ($state->{i} <= $#$stack) {
+	while ($state->{i} < @$stack) {
 		$state->{item} = $stack->[ $state->{i}++ ];
 		$self->{nl}    = (!defined($strings[-1]) || $strings[-1] =~ m/\n$/ ? '' : "\n");
 		my $method = ucfirst($state->{item}{type});
@@ -1323,7 +1323,7 @@ sub Table {
 	my $table = [];
 	my $row   = [];
 	for my $cell (@{ $item->{stack} }) {
-		push(@$row, $self->Table($cell));
+		push(@$row, $self->Table({ item => $cell }));
 		if ($cell->{hasStar}) {
 			push(@$table, $row);
 			$row = [];

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1510,32 +1510,25 @@ sub Indent {
 		$bottom = '1em';
 		$state->{i}++;
 	}
-	return $self->nl . "<div style=\"margin:0 0 $bottom ${em}em\">\n" . $self->string($item) . $self->nl . "</div>\n";
+	return main::tag('div', style => "margin:0 0 $bottom ${em}em", $self->string($item));
 }
 
 sub Align {
 	my ($self, $state) = @_;
 	my $item = $state->{item};
-	return
-		$self->nl
-		. '<div style="text-align:'
-		. $item->{align}
-		. '; margin:0">' . "\n"
-		. $self->string($item)
-		. $self->nl
-		. "</div>\n";
+	return main::tag('div', style => "text-align:$item->{align};margin:0", $self->string($item));
 }
 
 our %bullet = (
-	bullet  => [ 'ul', 'list-style-type: disc;' ],
-	numeric => [ 'ol', 'list-style-type: decimal;' ],
-	alpha   => [ 'ol', 'list-style-type: lower-alpha;' ],
-	Alpha   => [ 'ol', 'list-style-type: upper-alpha;' ],
-	roman   => [ 'ol', 'list-style-type: lower-roman;' ],
-	Roman   => [ 'ol', 'list-style-type: upper-roman;' ],
-	disc    => [ 'ul', 'list-style-type: disc;' ],
-	circle  => [ 'ul', 'list-style-type: circle;' ],
-	square  => [ 'ul', 'list-style-type: square;' ],
+	bullet  => [ 'ul', 'list-style-type:disc;' ],
+	numeric => [ 'ol', 'list-style-type:decimal;' ],
+	alpha   => [ 'ol', 'list-style-type:lower-alpha;' ],
+	Alpha   => [ 'ol', 'list-style-type:upper-alpha;' ],
+	roman   => [ 'ol', 'list-style-type:lower-roman;' ],
+	Roman   => [ 'ol', 'list-style-type:upper-roman;' ],
+	disc    => [ 'ul', 'list-style-type:disc;' ],
+	circle  => [ 'ul', 'list-style-type:circle;' ],
+	square  => [ 'ul', 'list-style-type:square;' ],
 );
 
 sub List {
@@ -1548,34 +1541,33 @@ sub List {
 		$margin = '0 0 1em';
 		$state->{i}++;
 	}
-	return $self->nl
-		. main::tag(
-			$list->[0],
-			style => "margin:$margin;padding-left:2.25em;$list->[1]",
-			$self->string($item) . $self->nl
-		);
+	return main::tag($list->[0], style => "margin:$margin;padding-left:2.25em;$list->[1]", $self->string($item));
 }
 
 sub Bullet {
 	my ($self, $state) = @_;
 	my $next = $state->{block}{stack}[ $state->{i} ];
+	my $style;
 	if (defined $next && $next->{type} eq 'par') {
 		$state->{i}++;
-		return $self->nl . '<li style="margin-bottom:1em">' . $self->string($state->{item}) . "</li>\n";
+		$style = 'margin-bottom:1em';
 	}
-	return $self->nl . '<li>' . $self->string($state->{item}) . "</li>\n";
+	return main::tag('li', $style ? (style => $style) : (), $self->string($state->{item}));
 }
 
 sub Code {
 	my ($self, $state) = @_;
-	my $item  = $state->{item};
-	my $class = ($item->{class} ? ' class="' . $item->{class} . '"' : "");
-	return $self->nl . '<pre style="margin:0"><code' . $class . '>' . $self->string($item) . "</code></pre>\n";
+	my $item = $state->{item};
+	return main::tag(
+		'pre',
+		style => 'margin:0',
+		main::tag('code', $item->{class} ? (class => $item->{class}) : (), $self->string($item))
+	);
 }
 
 sub Pre {
 	my ($self, $state) = @_;
-	return $self->nl . '<pre style="margin:0"><code>' . $self->string($state->{item}) . "</code></pre>\n";
+	return main::tag('pre', style => 'margin:0', main::tag('code', $self->string($state->{item})));
 }
 
 sub Heading {
@@ -1585,24 +1577,24 @@ sub Heading {
 	my $text = $self->string($item);
 	$text =~ s/^ +| +$//gm;
 	$text =~ s! +(<br />)!$1!g;
-	return '<h' . $n . ' style="margin:0">' . $text . "</h$n>\n";
+	return main::tag("h$n", style => 'margin:0', $text);
 }
 
 sub Par {
 	my ($self, $state) = @_;
-	return $self->nl . '<div style="margin-top:1em"></div>' . "\n";
+	return main::tag('div', style => 'margin-top:1em', '');
 }
 
-sub Break {"<br />\n"}
+sub Break {'<br />'}
 
 sub Bold {
 	my ($self, $state) = @_;
-	return '<strong>' . $self->string($state->{item}) . '</strong>';
+	return main::tag('strong', $self->string($state->{item}));
 }
 
 sub Italic {
 	my ($self, $state) = @_;
-	return '<em>' . $self->string($state->{item}) . '</em>';
+	return main::tag('em', $self->string($state->{item}));
 }
 
 our %openQuote  = ('"' => "&#x201C;", "'" => "&#x2018;");
@@ -1631,24 +1623,23 @@ sub Rule {
 		$height = $item->{size};
 		$height .= 'px' if ($height =~ /^\d*\.?\d+$/);
 	}
-	return $self->nl
-		. main::tag(
+	return main::tag(
+		'div',
+		main::tag(
 			'div',
+			style => "width:$width;display:inline-block;margin:0.3em auto",
 			main::tag(
-				'div',
-				style => "width:$width; display:inline-block; margin:0.3em auto",
-				main::tag(
-					'hr', style => "width:$width; height:$height; background-color:currentColor; margin:0.3em auto;"
-				)
+				'hr', style => "width:$width;height:$height;background-color:currentColor;margin:0.3em auto;"
 			)
-		);
+		)
+	);
 }
 
 sub Verbatim {
 	my ($self, $state) = @_;
 	my $item = $state->{item};
 	my $text = $self->escape($item->{text});
-	$text = "<code>$text</code>" if $item->{hasStar};
+	$text = main::tag('code', $text) if $item->{hasStar};
 	return $text;
 }
 

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1270,7 +1270,7 @@ sub string {
 	my $stack = $block->{stack};
 	my $state = { strings => [], i => 0 };
 	while ($state->{i} <= $#$stack) {
-		my $item   = $self->{item} = $stack->[ $state->{i}++ ];
+		my $item   = $stack->[ $state->{i}++ ];
 		my $method = ucfirst($item->{type});
 		$self->{nl} = (!defined($state->{strings}[-1]) || $state->{strings}[-1] =~ m/\n$/ ? '' : "\n");
 		if (Value::can($self, $method)) {

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1635,7 +1635,7 @@ sub Rule {
 		. main::tag(
 			'div',
 			main::tag(
-				'span',
+				'div',
 				style => "width:$width; display:inline-block; margin:0.3em auto",
 				main::tag(
 					'hr', style => "width:$width; height:$height; background-color:currentColor; margin:0.3em auto;"

--- a/macros/core/PGML.pl
+++ b/macros/core/PGML.pl
@@ -1576,7 +1576,7 @@ sub Heading {
 	my $n    = $item->{n};
 	my $text = $self->string($item);
 	$text =~ s/^ +| +$//gm;
-	$text =~ s! +(<br />)!$1!g;
+	$text =~ s! +(<br>)!$1!g;
 	return main::tag("h$n", style => 'margin:0', $text);
 }
 
@@ -1585,7 +1585,7 @@ sub Par {
 	return main::tag('div', style => 'margin-top:1em', '');
 }
 
-sub Break {'<br />'}
+sub Break {'<br>'}
 
 sub Bold {
 	my ($self, $state) = @_;

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -21,8 +21,8 @@ is($pg->{post_header_text}, '', 'post_header_text is empty');
 is(
 	$pg->{body_text},
 	qq{<div class="PGML">\n}
-		. qq{Enter a value for <script type="math/tex">\\pi</script>.\n}
-		. qq{<div style="margin-top:1em"></div>\n}
+		. qq{Enter a value for <script type="math/tex">\\pi</script>.}
+		. qq{<div style="margin-top:1em"></div>}
 		. qq{<div class="text-nowrap d-inline">}
 		. qq{<input aria-label="answer 1 " autocapitalize="off" autocomplete="off" class="codeshard" }
 		. qq{dir="auto" id="AnSwEr0001" name="AnSwEr0001" size="5" spellcheck="false" type="text" value="3.14159">}


### PR DESCRIPTION
Refactor the PGML::Format package, which includes changing how it is used, and cleaning up HTML output (including fixing some invalid HTML issues).

+ Refactors how the methods to format the different PGML::Format item methods are called. Instead of using
an odd syntax for switch/cases, `/foo/ && do { ....; last }`, just convert the item `type` into a method name and test if that method exists. Also all item methods are sent the same input, a `state` hash which includes the data they need to determine what output to produce.

+ Fix some issues with invalid HTML, this means that the margin created by `par` blocks are now applied
to the previous list, list item, or indent div, instead of creating an empty div. Also fixed an issue where an `hr` tag was inside a `span` tag.

+ Remove newlines and extra spaces from HTML output. These are extra characters that don't need to be sent to the client.

+ Use `main::tag` to create the HTML tags used in the HTML output.

Based on the code from @dpvc in #1355 and in the review of this PR.