### PR TITLE
Clean up how the feedback reveal button works.

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -47,12 +47,17 @@
 			if (feedbackPopover.tip) feedbackPopover.tip.dataset.iframeHeight = '1';
 
 			const revealCorrectBtn = feedbackPopover.tip?.querySelector('.reveal-correct-btn');
-			if (revealCorrectBtn && feedbackPopover.correctRevealed) {
-				revealCorrectBtn.nextElementSibling?.classList.remove('d-none');
-				revealCorrectBtn.remove();
-			} else {
-				revealCorrectBtn?.addEventListener('click', () => {
-					feedbackPopover.correctRevealed = true;
+			if (revealCorrectBtn) {
+				const fragment = new DocumentFragment();
+				const container = document.createElement('div');
+				container.innerHTML = feedbackBtn.dataset.bsContent;
+				const button = container.querySelector('.reveal-correct-btn');
+				button?.nextElementSibling?.classList.remove('d-none');
+				button?.remove();
+				fragment.append(container);
+				const feedbackNoRevealBtn = fragment.firstElementChild.innerHTML;
+
+				revealCorrectBtn.addEventListener('click', () => {
 					revealCorrectBtn.classList.add('fade-out');
 					revealCorrectBtn.parentElement.classList.add('resize-transition');
 					revealCorrectBtn.parentElement.style.maxWidth = `${revealCorrectBtn.parentElement.offsetWidth}px`;
@@ -65,6 +70,12 @@
 						revealCorrectBtn.remove();
 						feedbackPopover.update();
 					});
+
+					feedbackBtn.addEventListener(
+						'hidden.bs.popover',
+						() => feedbackPopover.setContent({ '.popover-body': feedbackNoRevealBtn }),
+						{ once: true }
+					);
 				});
 			}
 		});


### PR DESCRIPTION
Instead of automatically hiding the reveal button every time the feedback popover is opened after the reveal button has been used for the first time, completely remove the reveal button from the popover content, and remove the `d-none` class from the `div` containing the correct answer.  Thus on subsequent loads the correct answer is shown cleanly.  Currently you can see the reveal button for a brief instant before it is removed.