### PR TITLE
For the `plots.pl` macro HTML encode the aria description.

### DIFF
--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -499,7 +499,7 @@ sub init_graph {
 			const descriptionSpan = document.createElement('span');
 			descriptionSpan.id = `\${id}_description`;
 			descriptionSpan.classList.add('visually-hidden');
-			descriptionSpan.textContent = '${\($axes->style('aria_description'))}';
+			descriptionSpan.textContent = ${\(Mojo::JSON::encode_json($axes->style('aria_description')))};
 			board.containerObj.after(descriptionSpan);
 			board.containerObj.setAttribute('aria-describedby', descriptionSpan.id);
 			board.suspendUpdate();


### PR DESCRIPTION
This is to fix an issue reported by @somiaj in #1322 in which a apostrophe in the description causes invalid javascript to be generated.

This uses `Mojo::JSON::encode_json` to encode the text.  That is the same that it used before.
