### PR TITLE
give feedback about variable potentially using wrong case

### DIFF
--- a/lib/Parser/Variable.pm
+++ b/lib/Parser/Variable.pm
@@ -26,6 +26,14 @@ sub new {
 			$ref->[3] = $ref->[2] + length($1);
 			$equation->Error([ "'%s' is not defined in this context", $1 ], $ref);
 		}
+		my ($iname) = grep {/^$name$/i} $equation->{context}->variables->variables;
+		$equation->Error(
+			[
+				"Variable '%s' is not defined in this context, but perhaps you mean '%s', which is defined",
+				$name, $iname
+			],
+			$ref
+		) if $iname;
 		$equation->Error([ "Variable '%s' is not defined in this context", $name ], $ref);
 	}
 	$equation->Error([ "Variable '%s' is not defined in this context", $name ], $ref)


### PR DESCRIPTION
Suppose a context has variable `x`, but not `X` (or vice versa). And a student enters an answer with `X` in it. The usual feedback message is `variable 'X' is not defined in this context`. The change here will recognize that a case change on `X` would make a valid variable, and adds a suggestion in the feedback message that maybe this is the student's issue.

An alternative I was considering is to replace all instances of  `variable '%s' is not defined in this context` with `variable '%s' is not defined in this context; only variables '%s' are defined in this context` where the second string is the actual list of the context's variables. Would that be better?

For that matter, is what I'm proposing here a bad idea for some reason I am overlooking? Do problems ever try to hide what constitutes a valid variable?