### PR TITLE
flash feedback message badges

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -164,6 +164,19 @@
 			border-radius: 50%;
 			background-color: var(--bs-warning);
 			padding: 0.25rem;
+			animation: flash-in 0.75s;
+
+			@keyframes flash-in {
+				0% {
+					filter: brightness(2);
+					padding: 0.25rem;
+				}
+
+				50% {
+					filter: brightness(2);
+					padding: 0.5rem;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This is an animation and may be controversial. Consider it an experiment.

I'm on a mission to see what can be done to get more students to realize the yellow badge means they should click to see feedback. There's a lot of not remembering this from the orientation. And a lot of just not visually registering that there's a yellow badge there. And/or not thinking that means something special.

So this change flares up the brightness of the badge when it first appears, and fades 1 second later to the normal brightness. I'm hoping to get students' attention, and have them realize "oh, maybe I should click this".

I kind of expect mixed reactions to an animation, for several good reasons. This is one place where I wouldn't mind having it.