### PR TITLE
Fix the enter key behavior for MathQuill inputs.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -281,12 +281,17 @@
 				answerQuill.toolbar?.remove();
 				delete answerQuill.toolbar;
 
-				// For ww2 homework, depends on $pg{options}{enterKey}
+				// For ww2 homework if the enter_key_submit button is found, then use that.
+				// This Depends on $pg{options}{enterKey}.
 				const enterKeySubmit = document.getElementById('enter_key_submit');
-				if (enterKeySubmit) enterKeySubmit.click();
-				else document.getElementById('previewAnswers_id')?.click();
-				// For gateway quizzes, always the preview button
+				if (enterKeySubmit) {
+					enterKeySubmit.click();
+					return;
+				}
+				// If the enter_key_submit button is not found (it will not be present in tests),
+				// then use the preview button.
 				document.querySelector('input[name=previewAnswers]')?.click();
+
 				// For ww3
 				const previewButtonId = answerQuill.textarea
 					.closest('[name=problemMainForm]')


### PR DESCRIPTION
The code looks for the `enter_key_submit` submit button in the DOM, and if that is found then it clicks it.  However, it doesn't return after that, but continues on the the later code in the method none of which should occur if that button is found.  The later code executes the "gateway quiz" fallback which clicks the submit button with the name "previewAnswers".  However, there is also a button with that name in homework.

The behavior is different in different browsers with this.  In Firefox the first button clicked seems to be what is in effect.  However, in Google Chrome the second button clicked is in effect.  So the desired behavior occurs in Firefox, but not in Google Chrome.

What needs to happen is that if the `enter_key_submit` input is found, then that should be clicked, and the method should return.  There is no need for the fallback click of the submit button with the id `previewAnswers_id` otherwise.  Instead just click the submit button with the name `previewAnswers` which is present in both homework sets and tests.

I certainly thing that this should be a hotfix.