### PR TITLE
Force some things to be displayed in the light color scheme.

### DIFF
--- a/htdocs/js/ImageView/imageview.js
+++ b/htdocs/js/ImageView/imageview.js
@@ -31,6 +31,12 @@
 		modal.setAttribute('aria-label', 'image view dialog');
 		modal.tabIndex = -1;
 
+		// Force the dialog into light mode. This is needed for a webwork2 page in dark mode since the dialog is outside
+		// of the problem content.  At least until PG is updated to honor dark mode. Further discussion on this will
+		// also be needed at that time since many images have transparent backgrounds that will not work with a dark
+		// background.
+		modal.dataset.bsTheme = 'light';
+
 		const dialog = document.createElement('div');
 		dialog.classList.add('modal-dialog');
 

--- a/htdocs/js/Knowls/knowl.js
+++ b/htdocs/js/Knowls/knowl.js
@@ -24,6 +24,10 @@
 			knowl.knowlModal.setAttribute('aria-labelledby', `${knowl.knowlModal.id}-title`);
 			knowl.knowlModal.setAttribute('aria-hidden', 'true');
 
+			// Force the dialog into light mode. This is needed for a webwork2 page in dark mode since the dialog is
+			// outside of the problem content.  At least until PG and the help files are updated to honor dark mode.
+			knowl.knowlModal.dataset.bsTheme = 'light';
+
 			const knowlDialog = document.createElement('div');
 			knowlDialog.classList.add(
 				'knowl-dialog',

--- a/htdocs/js/Scaffold/scaffold.scss
+++ b/htdocs/js/Scaffold/scaffold.scss
@@ -15,6 +15,13 @@
 				min-width: 1.25rem;
 				font-weight: bold;
 			}
+
+			// Force the accordion button to a dark color so that it has sufficient contrast even if the page is in dark
+			// mode. Bootstrap wants to use the dark mode color for this if the page is in dark mode.
+			&::after {
+				--bs-accordion-btn-icon: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%23212529' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='m2 5 6 6 6-6'/%3E%3C/svg%3E");
+				--bs-accordion-btn-active-icon: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%23001436' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='m2 5 6 6 6-6'/%3E%3C/svg%3E");
+			}
 		}
 
 		&.cannotopen > button.accordion-button::after {


### PR DESCRIPTION
The image view and knowl dialogs need to be forced into light mode. These dialogs are injected outside of the problem content div in webwork2, and so by default will display in the mode of the page. So the data-bs-theme attribute needs to be set to "light" to prevent that.

Many PG images have transparent backgrounds and so will not work with a dark background.  Furthermore, the image view and knowl dialog styles themself are not set up to honor dark mode.

Note that there is another modal dialog for the `quickMatrixEntry.pl` macro (in the `htdocs/js/QuickMatrixEntry/quickMatrixEntry.js` file), but for now I have left that and allowed it to go into dark mode.  That dialog works fine with dark mode already.  It could be forced to light mode for consistency though.  Although, does anyone actually use this?

Also ensure that the accordion buttons for scaffolds are dark so that they have sufficient contrast against the blue or green accordion header background color.  Bootstrap wants to use the page text color for this, and if the primary color is light (for instance with the math4-yellow theme), that does not work.

These changes are needed for https://github.com/openwebwork/webwork2/pull/2894.