### PR TITLE
Remove partial credit note in avg_problem_grader.

### DIFF
--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -1077,9 +1077,6 @@ sub avg_problem_grader {
 
 	my %problem_result = (score => 0, errors => '', type => 'avg_problem_grader', msg => '');
 
-	$problem_result{msg} = eval('main::maketext("You can earn partial credit on this problem.")')
-		if keys %$answers > 1;
-
 	# Return unless answers have been submitted.
 	return (\%problem_result, $problem_state) unless $form_options{answers_submitted} == 1;
 

--- a/macros/core/PGanswermacros.pl
+++ b/macros/core/PGanswermacros.pl
@@ -1638,8 +1638,6 @@ sub avg_problem_grader {
 
 	my %problem_result = (score => 0, errors => '', type => 'avg_problem_grader', msg => '');
 
-	$problem_result{msg} = maketext('You can earn partial credit on this problem.') if keys %$answers > 1;
-
 	# Return unless answers have been submitted.
 	return (\%problem_result, $problem_state) unless $form_options{answers_submitted} == 1;
 


### PR DESCRIPTION
This note isn't that useful and can be misleading as it only is about number of answer blanks.