### PR TITLE
Remove the internal debug messages.

### DIFF
--- a/lib/PGUtil.pm
+++ b/lib/PGUtil.pm
@@ -89,7 +89,7 @@ sub pretty_print_html {    # provides html output -- NOT a method
 	if (!$ref) {
 		return $r_input =~ s/</&lt;/gr;
 	} elsif (eval { %$r_input || 1 }) {
-		return '<div style="display:table;border:1px solid black;background-color:#fff;">'
+		return '<div style="display:table;border:1px solid black;background-color:#fff;color:#000;">'
 			. ($ref eq 'HASH'
 				? ''
 				: '<div style="'

--- a/lib/PGanswergroup.pm
+++ b/lib/PGanswergroup.pm
@@ -1,9 +1,11 @@
 package PGanswergroup;
-use Exporter;
+use parent qw(PGcore);    # This is so that PGresponsegroup objects can call the PGcore warning_message method.
+
+use strict;
+use warnings;
+
 use PGUtil qw(not_null);
 use PGresponsegroup;
-
-our @ISA = qw(PGcore);
 
 #############################################
 # An object which contains an answer label and
@@ -24,16 +26,14 @@ our @ISA = qw(PGcore);
 # use Tie: IxHash??? to create ordered hash? (see Perl Cookbook)
 
 sub new {
-	my $class = shift;
-	my $label = shift;
-	my $self  = {
+	my ($class, $label, %options) = @_;
+	my $self = {
 		ans_label => $label,
-		ans_eval  => undef,                          # usually an AnswerEvaluator, sometimes a CODE
-		response  => new PGresponsegroup($label),    # A PGresponse object which holds the responses
-													 # which make up the answer
+		ans_eval  => undef,                           # usually an AnswerEvaluator, sometimes a CODE
+		response  => PGresponsegroup->new($label),    # A PGresponse object which holds the responses
+													  # which make up the answer
 		active    => 1,    # whether this answer group is currently active (for multistate problems)
-
-		@_,
+		%options
 	};
 	bless $self, $class;
 	return $self;

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -10,8 +10,6 @@ BEGIN {
 	$ENV{PG_VERSION} = $PGcore::PG_VERSION || 'unknown';
 }
 
-our $internal_debug_messages = [];
-
 use PGanswergroup;
 use PGresponsegroup;
 use PGrandom;
@@ -418,7 +416,7 @@ sub new_ans_name {
 sub record_ans_name {
 	my ($self, $label, $value) = @_;
 
-	my $response_group = new PGresponsegroup($label, $label, $value);
+	my $response_group = PGresponsegroup->new($label, $label, $value);
 
 	if (ref($self->{PG_ANSWERS_HASH}{$label}) eq 'PGanswergroup') {
 		# This should really never happen.  Should this warn if it does?
@@ -732,15 +730,6 @@ To report the messages use:
 
 These are used in Problem.pm for example to report any errors.
 
-There is also
-
-	$PG->internal_debug_message()
-	$PG->get_internal_debug_message
-	$PG->clear_internal_debug_messages();
-
-There were times when things were buggy enough that only the internal_debug_message which are not saved
-inside the PGcore object would report.
-
 =cut
 
 sub debug_message {
@@ -761,21 +750,6 @@ sub warning_message {
 sub get_warning_messages {
 	my $self = shift;
 	$self->{WARNING_messages};
-}
-
-sub internal_debug_message {
-	my ($self, @str) = @_;
-	push @$internal_debug_messages, @str;
-}
-
-sub get_internal_debug_messages {
-	my $self = shift;
-	$internal_debug_messages;
-}
-
-sub clear_internal_debug_messages {
-	my $self = shift;
-	$internal_debug_messages = [];
 }
 
 sub DESTROY {

--- a/lib/PGresponsegroup.pm
+++ b/lib/PGresponsegroup.pm
@@ -22,11 +22,13 @@ use PGUtil qw(not_null);
 # Optionally append label/response pairs.
 sub new {
 	my ($class, $answergroup_label, @responses) = @_;
+	my $pg   = eval('$main::PG');
 	my $self = bless {
 		answergroup_label => $answergroup_label,    # enclosing answergroup that created this responsegroup
 		response_order    => [],                    # response labels
 		responses         => {},                    # response label/response value pair,
 													# value could be an arrayref in the case of radio or checkbox groups
+		WARNING_messages  => $pg->{WARNING_messages}
 	}, $class;
 	$self->append_responses(@responses);
 	return $self;
@@ -45,12 +47,11 @@ sub append_response {
 				? [ map { [ $_ => $response_value->{$_} ] } keys %$response_value ]
 				: $response_value;
 		} else {
-			$self->internal_debug_message(
-				"PGresponsegroup::append_response error: there is already an answer labeled $response_label",
-				caller(2), "\n");
+			$self->warning_message(
+				qq{PGresponsegroup::append_response error: There is already an answer labeled "$response_label".});
 		}
 	} else {
-		$self->internal_debug_message('PGresponsegroup::append_response error: undefined or empty response label');
+		$self->warning_message('PGresponsegroup::append_response error: Undefined or empty response label.');
 	}
 	return;
 }
@@ -82,13 +83,14 @@ sub replace_response {
 sub extend_response {
 	my ($self, $response_label, $new_value_key, $selected) = @_;
 
-	if (defined $self->{responses}{$response_label}) {
+	if (defined $response_label && defined $self->{responses}{$response_label}) {
 		my $response_value = $self->{responses}{$response_label};
 		$response_value //= [];
 
 		if (ref($response_value) !~ /^(HASH|ARRAY)$/) {
-			$self->internal_debug_message("PGresponsegroup::extend_response: error in extending response ",
-				ref($response_value), $response_value);
+			$self->warning_message('PGresponsegroup::extend_response error: Invalid value type "'
+					. (ref($response_value) || 'scalar')
+					. qq{" for $response_label.});
 			$response_value = [ [ $response_value => $selected ] ];
 		}
 
@@ -99,7 +101,12 @@ sub extend_response {
 		$self->{responses}{$response_label} = $response_value;
 		return $response_value;
 	} else {
-		$self->internal_debug_message("PGresponsegroup::extend_response: response label |$response_label| not defined");
+		if (defined $response_label) {
+			$self->warning_message(
+				qq{PGresponsegroup::extend_response error: Response label "$response_label" not defined.});
+		} else {
+			$self->warning_message('PGresponsegroup::extend_response error: Response label not provided.');
+		}
 		return;
 	}
 }

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -111,14 +111,13 @@ initializes variables and defines the problem environment.
 
 sub DOCUMENT {
 	# get environment
-	$rh_envir = \%envir;      #KLUDGE FIXME
-							  # warn "rh_envir is ",ref($rh_envir);
-	$PG       = new PGcore(
-		$rh_envir,            # can add key/value options to modify
-	);
-	$PG->clear_internal_debug_messages;
-	# initialize main:: variables
+	$rh_envir = \%envir;    #KLUDGE FIXME
 
+	$PG = new PGcore(
+		$rh_envir,          # can add key/value options to modify
+	);
+
+	# initialize main:: variables
 	$ANSWER_PREFIX             = $PG->{ANSWER_PREFIX};
 	$QUIZ_PREFIX               = $PG->{QUIZ_PREFIX};
 	$showPartialCorrectAnswers = $PG->{flags}->{showPartialCorrectAnswers};
@@ -620,7 +619,7 @@ sub NEW_ANS_ARRAY_NAME_EXTENSION {
 	}
 	my $ans_label         = $PG->new_ans_name();
 	my $element_ans_label = $PG->new_array_element_label($ans_label, $row_num, $col_num, vec_num => $vecnum);
-	my $response          = new PGresponsegroup($ans_label, $element_ans_label, undef);
+	my $response          = PGresponsegroup->new($ans_label, $element_ans_label, undef);
 	$PG->extend_ans_group($ans_label, $response);
 	return $element_ans_label;
 }
@@ -632,7 +631,7 @@ sub CLEAR_RESPONSES {
 		if (ref($responsegroup)) {
 			$responsegroup->clear;
 		} else {
-			$responsegroup = $PG->{PG_ANSWERS_HASH}{$ans_label}{response} = new PGresponsegroup($label);
+			$responsegroup = $PG->{PG_ANSWERS_HASH}{$ans_label}{response} = PGresponsegroup->new($ans_label);
 		}
 	}
 	return;


### PR DESCRIPTION
The only place this is used is for error messages in `lib/PGresponsegroup.pm`. That is now reworked to use the `PGcore::warning_message` method instead. The `internal_debug_messages` is just not needed anymore in addition to the `warning_message` and `debug_message` methods. Furthermore, it is inappropriately named. It has "debug" in the name, but is used for error messages, not debugging messages.

Note that this depends on https://github.com/openwebwork/webwork2/pull/2935 for webwork2 to work with this.