### PR TITLE
Fix `drawZero` for JSXGraph output of the plots macro.

### DIFF
--- a/htdocs/js/Plots/plots.js
+++ b/htdocs/js/Plots/plots.js
@@ -347,8 +347,8 @@ const PGplots = {
 									!options.yAxis?.visible ||
 									(options.yAxis.location === 'center' && (options.yAxis.position ?? 0) != 0) ||
 									((options.yAxis.location === 'left' || options.yAxis.location === 'box') &&
-										(options.yAxis.min ?? -5) != 0) ||
-									(options.yAxis.location === 'right' && (options.yAxis.max ?? 5) != 0)
+										(options.xAxis.min ?? -5) != 0) ||
+									(options.yAxis.location === 'right' && (options.xAxis.max ?? 5) != 0)
 										? true
 										: false,
 								insertTicks: false,
@@ -446,8 +446,8 @@ const PGplots = {
 									!options.xAxis?.visible ||
 									(options.xAxis.location === 'middle' && (options.xAxis.position ?? 0) != 0) ||
 									((options.xAxis.location === 'bottom' || options.xAxis.location === 'box') &&
-										(options.xAxis.min ?? -5) != 0) ||
-									(options.xAxis.location === 'top' && (options.xAxis.max ?? 5) != 0)
+										(options.yAxis.min ?? -5) != 0) ||
+									(options.xAxis.location === 'top' && (options.yAxis.max ?? 5) != 0)
 										? true
 										: false,
 								insertTicks: false,


### PR DESCRIPTION
Currently if the y axis location is 'left' (or 'box'), or 'right', then the determination that zero is drawn is made by checking that the y axis min or max value.  That is incorrect.  It should be checking the x axis min or max value.  The point is that if the y axis is passing through x = 0, then zero should not be drawn, and otherwise it should be.

Similarly, the y axis `drawZero` determination is fixed.

You can test this with the following problem code:

```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'plots.pl', 'PGcourse.pl');

$graph = Plot(
    xmin           => -2,
    xmax           => 10,
    xtick_distance => 1,
    xminor         => 0,
    xlocation      => 'bottom',
    ymin           => 0,
    ymax           => 10,
    ytick_distance => 1,
    yminor         => 0,
    ylocation      => 'left'
);

BEGIN_PGML
[!graph!]{$graph}{500}
END_PGML

ENDDOCUMENT();
```

With that example and the develop branch the zero on the x-axis is incorrectly not drawn in JSXGraph output.  With this branch it is drawn as it should be. Note that in TikZ output the zero is drawn with this example. So this makes the two output formats consistent.