### PR TITLE
Harden system calls plus.

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -271,12 +271,18 @@ sub draw {
 
 sub use_svgMethod {
 	my ($self, $working_dir) = @_;
-	if ($self->svgMethod eq 'dvisvgm') {
-		system WeBWorK::PG::IO::externalCommand('dvisvgm')
-			. " $working_dir/image.dvi --no-fonts --output=$working_dir/image.svg > /dev/null 2>&1";
+
+	# Validate svgMethod against known SVG converters to prevent command injection.
+	my $method = $self->svgMethod;
+	if ($method eq 'dvisvgm') {
+		my $cmd = WeBWorK::PG::IO::externalCommand('dvisvgm');
+		system {$cmd} $cmd, "$working_dir/image.dvi", '--no-fonts', "--output=$working_dir/image.svg";
+	} elsif ($method eq 'pdf2svg') {
+		my $cmd = WeBWorK::PG::IO::externalCommand('pdf2svg');
+		system {$cmd} $cmd, "$working_dir/image.pdf", "$working_dir/image.svg";
 	} else {
-		system WeBWorK::PG::IO::externalCommand($self->svgMethod)
-			. " $working_dir/image.pdf $working_dir/image.svg > /dev/null 2>&1";
+		warn "Unknown svgMethod '$method'. Must be 'dvisvgm' or 'pdf2svg'.";
+		return;
 	}
 	warn "Failed to generate svg file." unless -r "$working_dir/image.svg";
 
@@ -285,11 +291,24 @@ sub use_svgMethod {
 
 sub use_convert {
 	my ($self, $working_dir, $ext) = @_;
-	system WeBWorK::PG::IO::externalCommand('convert')
-		. join('', map { " -$_ " . $self->convertOptions->{input}->{$_} } (keys %{ $self->convertOptions->{input} }))
-		. " $working_dir/image.pdf"
-		. join('', map { " -$_ " . $self->convertOptions->{output}->{$_} } (keys %{ $self->convertOptions->{output} }))
-		. " $working_dir/image.$ext > /dev/null 2>&1";
+
+	# Validate convertOptions keys and values to prevent shell injection.
+	# Only alphanumeric option names and simple values are permitted.
+	my @args;
+	for my $phase (qw(input output)) {
+		my $opts = $self->convertOptions->{$phase} // {};
+		for my $key (keys %$opts) {
+			warn("Invalid convert option name: $key"), next unless $key =~ /^[a-zA-Z][a-zA-Z0-9\-]*$/;
+			my $val = $opts->{$key};
+			warn("Invalid convert option value for $key"), next unless defined $val && $val =~ /^[a-zA-Z0-9.\-+:x%]+$/;
+			push @args, "-$key", $val;
+		}
+		push @args, "$working_dir/image.pdf" if $phase eq 'input';
+	}
+	push @args, "$working_dir/image.$ext";
+
+	my $convert = WeBWorK::PG::IO::externalCommand('convert');
+	system {$convert} $convert, @args;
 	warn "Failed to generate $ext file." unless -r "$working_dir/image.$ext";
 
 	return;

--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -36,6 +36,29 @@ sub new {
 			# be passed to the command line in the system call it is used in.
 			if ($field eq 'ext') {
 				$data->{ext} = $value if $value && ($value =~ /^(png|gif|svg|pdf|tgz)$/);
+			} elsif ($field eq 'convertOptions') {
+				if (ref $value eq 'HASH') {
+					# Validate convertOptions keys and values to prevent shell injection.
+					# Only alphanumeric option names and simple values are permitted.
+					my $options = { input => {}, output => {} };
+					for my $phase (keys %$options) {
+						next unless ref $value->{$phase} eq 'HASH';
+						for my $key (keys %{ $value->{$phase} }) {
+							unless ($key =~ /^[a-zA-Z][a-zA-Z0-9\-]*$/) {
+								warn "Invalid convert option name: $key";
+								next;
+							}
+							unless (defined $value->{$phase}{$key}
+								&& $value->{$phase}{$key} =~ /^[a-zA-Z0-9.\-+:x%]+$/)
+							{
+								warn "Invalid convert option value for $key";
+								next;
+							}
+							$options->{$phase}{$key} = $value->{$phase}{$key};
+						}
+					}
+					$data->{convertOptions} = $options;
+				}
 			} else {
 				$data->{$field} = $value;
 			}
@@ -275,11 +298,10 @@ sub use_svgMethod {
 	# Validate svgMethod against known SVG converters to prevent command injection.
 	my $method = $self->svgMethod;
 	if ($method eq 'dvisvgm') {
-		my $cmd = WeBWorK::PG::IO::externalCommand('dvisvgm');
-		system {$cmd} $cmd, "$working_dir/image.dvi", '--no-fonts', "--output=$working_dir/image.svg";
+		system WeBWorK::PG::IO::externalCommand('dvisvgm'), "$working_dir/image.dvi", '--no-fonts',
+			"--output=$working_dir/image.svg";
 	} elsif ($method eq 'pdf2svg') {
-		my $cmd = WeBWorK::PG::IO::externalCommand('pdf2svg');
-		system {$cmd} $cmd, "$working_dir/image.pdf", "$working_dir/image.svg";
+		system WeBWorK::PG::IO::externalCommand('pdf2svg'), "$working_dir/image.pdf", "$working_dir/image.svg";
 	} else {
 		warn "Unknown svgMethod '$method'. Must be 'dvisvgm' or 'pdf2svg'.";
 		return;
@@ -292,23 +314,12 @@ sub use_svgMethod {
 sub use_convert {
 	my ($self, $working_dir, $ext) = @_;
 
-	# Validate convertOptions keys and values to prevent shell injection.
-	# Only alphanumeric option names and simple values are permitted.
-	my @args;
-	for my $phase (qw(input output)) {
-		my $opts = $self->convertOptions->{$phase} // {};
-		for my $key (keys %$opts) {
-			warn("Invalid convert option name: $key"), next unless $key =~ /^[a-zA-Z][a-zA-Z0-9\-]*$/;
-			my $val = $opts->{$key};
-			warn("Invalid convert option value for $key"), next unless defined $val && $val =~ /^[a-zA-Z0-9.\-+:x%]+$/;
-			push @args, "-$key", $val;
-		}
-		push @args, "$working_dir/image.pdf" if $phase eq 'input';
-	}
-	push @args, "$working_dir/image.$ext";
-
-	my $convert = WeBWorK::PG::IO::externalCommand('convert');
-	system {$convert} $convert, @args;
+	my $convertOptions = $self->convertOptions;
+	system WeBWorK::PG::IO::externalCommand('convert'),
+		(map { ("-$_" => $convertOptions->{input}{$_}) } keys %{ $convertOptions->{input} }),
+		"$working_dir/image.pdf",
+		(map { ("-$_" => $convertOptions->{output}{$_}) } keys %{ $convertOptions->{output} }),
+		"$working_dir/image.$ext";
 	warn "Failed to generate $ext file." unless -r "$working_dir/image.$ext";
 
 	return;

--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -270,7 +270,7 @@ sub convert_file_to_png_for_tex {
 	$self->debug_message('convert filePath ', $sourceFilePath, "\n");
 
 	my $conversion_command = WeBWorK::PG::IO::externalCommand('convert');
-	my $returnCode         = system "$conversion_command '${sourceFilePath}[0]' $targetFilePath";
+	my $returnCode         = system {$conversion_command} $conversion_command, "${sourceFilePath}[0]", $targetFilePath;
 	if ($returnCode || !-e $targetFilePath) {
 		$resource_object->warning_message(
 			qq{Failed to convert "$sourceFilePath" to "$targetFilePath" using "$conversion_command": $!});

--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -238,17 +238,27 @@ sub create_link_to_tmp_file {
 	my $linkPath = $self->surePathToTmpFile($link);
 
 	if (-e $resource_object->path) {
-		if (-e $linkPath) {
-			# Destroy the old link.
-			unlink($linkPath) or $self->warning_message(qq{Unable to unlink alias file at "$linkPath".});
-		}
+		if (WeBWorK::PG::IO::path_is_subdir(
+			$resource_object->path, $WeBWorK::PG::IO::pg_envir->{directories}{permitted_read_dir}, 1
+		))
+		{
+			if (-e $linkPath) {
+				# Destroy the old link.
+				unlink($linkPath) or $self->warning_message(qq{Unable to unlink alias file at "$linkPath".});
+			}
 
-		# Create a new link, and the URI to this link.
-		if (symlink($resource_object->path, $linkPath)) {
-			$resource_object->uri(($self->{tempURL} =~ s|/$||r) . "/$link");
+			# Create a new link, and the URI to this link.
+			if (symlink($resource_object->path, $linkPath)) {
+				$resource_object->uri(($self->{tempURL} =~ s|/$||r) . "/$link");
+			} else {
+				$self->warning_message(
+					qq{The macro alias cannot create a link from "$linkPath"  to "} . $resource_object->path . '"');
+			}
 		} else {
-			$self->warning_message(
-				qq{The macro alias cannot create a link from "$linkPath"  to "} . $resource_object->path . '"');
+			$self->warning_message('Unable to create link to the file "'
+					. $resource_object->path . '" '
+					. 'because it is an unsafe path.');
+
 		}
 	} else {
 		$self->warning_message('Cannot find the file: "'
@@ -270,7 +280,7 @@ sub convert_file_to_png_for_tex {
 	$self->debug_message('convert filePath ', $sourceFilePath, "\n");
 
 	my $conversion_command = WeBWorK::PG::IO::externalCommand('convert');
-	my $returnCode         = system {$conversion_command} $conversion_command, "${sourceFilePath}[0]", $targetFilePath;
+	my $returnCode         = system $conversion_command, "${sourceFilePath}[0]", $targetFilePath;
 	if ($returnCode || !-e $targetFilePath) {
 		$resource_object->warning_message(
 			qq{Failed to convert "$sourceFilePath" to "$targetFilePath" using "$conversion_command": $!});

--- a/lib/WeBWorK/PG/IO.pm
+++ b/lib/WeBWorK/PG/IO.pm
@@ -316,17 +316,40 @@ sub externalCommand {
 # Isolate the call to the sage server in case we have to jazz it up.
 sub query_sage_server {
 	my ($python, $url, $accepted_tos, $setSeed, $webworkfunc, $debug, $curlCommand) = @_;
-	my $sagecall =
-		qq{$curlCommand -i -k -sS -L }
-		. qq{--data-urlencode "accepted_tos=${accepted_tos}" }
-		. qq{--data-urlencode 'user_expressions={"WEBWORK":"_webwork_safe_json(WEBWORK)"}' }
-		. qq{--data-urlencode "code=${setSeed}${webworkfunc}$python" $url};
 
-	my $output = `$sagecall`;
+	# Validate url to prevent shell injection — must look like a URL.
+	if ($url && $url !~ m{^https?://[^\s;|&`\$]+$}) {
+		warn "query_sage_server: invalid url rejected: $url";
+		return;
+	}
+
+	# Use system LIST form via open-pipe to capture output without shell interpolation.
+	my @cmd = (
+		$curlCommand,                                                 '-i',
+		'-k',                                                         '-sS',
+		'-L',                                                         '--data-urlencode',
+		"accepted_tos=$accepted_tos",                                 '--data-urlencode',
+		'user_expressions={"WEBWORK":"_webwork_safe_json(WEBWORK)"}', '--data-urlencode',
+		"code=${setSeed}${webworkfunc}$python",                       $url // (),
+	);
+
 	if ($debug) {
 		warn "debug is turned on in IO.pm. ";
-		warn "\n\nIO::query_sage_server(): SAGE CALL: ", $sagecall, "\n\n";
-		warn "\n\nRETURN from sage call \n",             $output,   "\n\n";
+		warn "\n\nIO::query_sage_server(): SAGE CMD: ", join(' ', @cmd), "\n\n";
+	}
+
+	my $output = '';
+	if (open(my $pipe, '-|', @cmd)) {
+		local $/;
+		$output = <$pipe>;
+		close $pipe;
+	} else {
+		warn "query_sage_server: failed to execute curl: $!";
+		return;
+	}
+
+	if ($debug) {
+		warn "\n\nRETURN from sage call \n", $output, "\n\n";
 		warn "\n\n END SAGE CALL";
 	}
 


### PR DESCRIPTION
This does the things that I asked @drdrew42 to address in #1392. Since @drdrew42 seems to not have time to deal with that (due to the lack of response to my comments) I am opening this pull request.
This also addresses the fourth security vulnerability that @drdrew42 mentioned in the Slack securityresponseteam channel. Basically, it only allows symlinks to be created to a file that is in the `$WeBWorK::PG::IO::pg_envir->{directories}{permitted_read_dir}`.
    
That does allow following symlinks, so for webwork2 that includes anything in or linked to in the course directory. That means OPL static image files will work, or files in the `webwork2/assets/pg/Student_Orientation` directory (for example). One case that was allowed before that this doesn't allow is a file in the `webwork2/htdocs/images` directory. I don't really see a need to allow those files though.
    
For the standalone renderer that is the root directory of the standalone renderer app (by default).
    
This could be considered for a hotfix as @drdrew42 mentioned in #1392.