### PR TITLE
Fix the aria label for the zoom out button of the imageview dialog.

### DIFF
--- a/htdocs/js/ImageView/imageview.js
+++ b/htdocs/js/ImageView/imageview.js
@@ -48,7 +48,7 @@
 
 		const zoomInButton = document.createElement('button');
 		zoomInButton.type = 'button';
-		zoomInButton.classList.add('btn', 'btn-outline-secondary', 'btn-sm', 'zoom-in');
+		zoomInButton.classList.add('btn', 'btn-outline-secondary', 'btn-sm');
 		zoomInButton.setAttribute('aria-label', 'zoom in');
 
 		const zoomInSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -80,8 +80,8 @@
 
 		const zoomOutButton = document.createElement('button');
 		zoomOutButton.type = 'button';
-		zoomOutButton.classList.add('btn', 'btn-outline-secondary', 'btn-sm', 'zoom-in');
-		zoomOutButton.setAttribute('aria-label', 'zoom in');
+		zoomOutButton.classList.add('btn', 'btn-outline-secondary', 'btn-sm');
+		zoomOutButton.setAttribute('aria-label', 'zoom out');
 
 		const zoomOutSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 		zoomOutSVG.setAttribute('width', 16);


### PR DESCRIPTION
Testing things with the screen reader revealed this.  The zoom out button has the same aria label as the zoom in button.  This was probably a cut and paste error.

Also remove the `zoom-in` class on both that is not needed or used for either.