### PR TITLE
Add method to load texPackages and tikzLibraries to Plots 

### DIFF
--- a/lib/Plots/Plot.pm
+++ b/lib/Plots/Plot.pm
@@ -29,10 +29,12 @@ sub new {
 		axes            => Plots::Axes->new,
 		colors          => {},
 		data            => [],
+		texPackages     => [],
+		tikzLibraries   => []
 	}, $class;
 
 	# Besides for these core options, pass everything else to the Axes object.
-	for ('width', 'height', 'tex_size', 'rounded_corners') {
+	for ('width', 'height', 'tex_size', 'rounded_corners', 'texPackages', 'tikzLibraries') {
 		$self->{$_} = delete $options{$_} if $options{$_};
 	}
 	$self->axes->set(%options) if %options;

--- a/lib/Plots/Tikz.pm
+++ b/lib/Plots/Tikz.pm
@@ -19,8 +19,11 @@ sub new {
 	$image->svgMethod(eval('$main::envir{latexImageSVGMethod}')           // 'dvisvgm');
 	$image->convertOptions(eval('$main::envir{latexImageConvertOptions}') // { input => {}, output => {} });
 	$image->ext($plots->ext);
-	$image->tikzLibraries('arrows.meta,plotmarks,calc,spath3');
-	$image->texPackages(['pgfplots']);
+	$image->texPackages([ 'amsmath', 'pgfplots', @{ $plots->{texPackages} } ]);
+
+	my $tikzLibraries = 'arrows.meta,plotmarks,calc,spath3';
+	$tikzLibraries .= ',' . join(',', @{ $plots->{tikzLibraries} }) if @{ $plots->{tikzLibraries} };
+	$image->tikzLibraries($tikzLibraries);
 
 	# Set the pgfplots compatibility, add the pgfplots fillbetween library, define a save
 	# box that is used to wrap the axes in a nice rectangle frame with a white background, and redefine

--- a/macros/graph/plots.pl
+++ b/macros/graph/plots.pl
@@ -69,6 +69,19 @@ sharp corners will be used.  If this is set to C<1>, then rounded corners will
 be used. Note that this may not work well for images that have elements of the
 plot near or in the corners.
 
+=item texPackages
+
+This is an array reference of additional TeX packages to use when generating the
+TikZ output. By default this includes "amsmath" and "pgfplots". This is useful
+for adding packages for labels such as "cancel". See L<PGtikz.pl> for details
+on loading packages and options.
+
+=item tikzLibraries
+
+This is an array reference of additional TikZ libraries to include when generating
+the TikZ output. By default this includes "arrows.meta", "plotmarks", "calc",
+and "splath3".
+
 =back
 
 Add a function and other objects to the plot.


### PR DESCRIPTION
This adds two options to plots, `texPackages` and `tikzLibraries` to Plots, that can be used to add additional packages and libraries fro generating TikZ output. This also adds "amsmath" in the list of default packages that are loaded.