### PR TITLE
Pg critic fixes for older perl

### DIFF
--- a/lib/WeBWorK/PG/Critic/Utils.pm
+++ b/lib/WeBWorK/PG/Critic/Utils.pm
@@ -62,7 +62,7 @@ use Scalar::Util        qw(blessed);
 use Mojo::Util          qw(md5_sum encode);
 use Env                 qw(PG_ROOT);
 
-use lib curfile->dirname->dirname->dirname->dirname->dirname->child('lib');
+use lib curfile->dirname->dirname->dirname->dirname->dirname->child('lib')->to_string;
 
 require Value;
 
@@ -84,7 +84,7 @@ sub main::Context()                  { return; }
 
 do "$PG_ROOT/macros/core/PGML.pl";
 
-sub walkPGMLTree ($block, $results //= {}) {
+sub walkPGMLTree ($block, $results) {
 	for my $item (@{ $block->{stack} }) {
 		next unless blessed $item && $item->isa('PGML::Block');
 		if ($item->{type} eq 'command') {


### PR DESCRIPTION
Using `//=` in signatures is a feature that is not available until version 5.28 of perl.  In this case that isn't needed since the `walkPGMLTree` is never called without that argument.

I am not entirely certain of why the added `to_string` is needed or why it works with newer versions of perl, but it causes an issue with older perl versions as well.

This fixes issue https://github.com/openwebwork/webwork2/issues/2978.