### PR TITLE
Enable disable toolbar width

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -527,6 +527,7 @@
 
 			const menuEl = document.createElement('ul');
 			menuEl.classList.add('dropdown-menu');
+			menuEl.style.setProperty('min-width', 'unset');
 			const li = document.createElement('li');
 			menuEl.append(li);
 			const action = document.createElement('a');


### PR DESCRIPTION
A bootstrap class that is used with the "Disable Toolbar" popover for the MQ editor has `min-width` set to something, and it makes excess whitespace following the "Disable Toolbar".

Before:


<img width="359" height="119" alt="Screenshot 2026-05-23 at 11 17 05 AM" src="https://github.com/user-attachments/assets/2cae4cb2-b2ce-4cec-b399-77cb86b85341" />


After:

<img width="359" height="119" alt="Screenshot 2026-05-23 at 11 16 57 AM" src="https://github.com/user-attachments/assets/b43a4d54-cae0-41e2-9a02-0854be063c77" />
