### PR TITLE
Update MathQuill to version 0.11.2 with the MathFunction copy/paste fix.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "pg.javascript_package_manager",
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@openwebwork/mathquill": "^0.11.1",
+				"@openwebwork/mathquill": "^0.11.2",
 				"jsxgraph": "^1.12.2",
 				"jszip": "^3.10.1",
 				"jszip-utils": "^0.1.0",
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@openwebwork/mathquill": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.1.tgz",
-			"integrity": "sha512-NLmu+AQ8i4bXX6Zuv5YMOkxhLsZisIW9pB0OvIIajVtAIsUu9ES7aG5Bhq823Ohc9xxA+2S7YrtmRaiDbp+GKA==",
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.2.tgz",
+			"integrity": "sha512-xMqyP4KDcNI23aVROloFbfqxeW5Hlm6rsdIuTPQOhu/TgEy5KCBpP3tsYBhaXdc2VmGgSbYZKN3fOTemwYELNg==",
 			"license": "MPL-2.0"
 		},
 		"node_modules/@parcel/watcher": {
@@ -2117,9 +2117,9 @@
 			}
 		},
 		"@openwebwork/mathquill": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.1.tgz",
-			"integrity": "sha512-NLmu+AQ8i4bXX6Zuv5YMOkxhLsZisIW9pB0OvIIajVtAIsUu9ES7aG5Bhq823Ohc9xxA+2S7YrtmRaiDbp+GKA=="
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.2.tgz",
+			"integrity": "sha512-xMqyP4KDcNI23aVROloFbfqxeW5Hlm6rsdIuTPQOhu/TgEy5KCBpP3tsYBhaXdc2VmGgSbYZKN3fOTemwYELNg=="
 		},
 		"@parcel/watcher": {
 			"version": "2.5.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
 	},
 	"dependencies": {
-		"@openwebwork/mathquill": "^0.11.1",
+		"@openwebwork/mathquill": "^0.11.2",
 		"jsxgraph": "^1.12.2",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",


### PR DESCRIPTION
Now that https://github.com/openwebwork/mathquill/pull/44 has been merged and published, update PG to use it.