### PR TITLE
add cancel package to pg.sty

### DIFF
--- a/assets/tex/pg.sty
+++ b/assets/tex/pg.sty
@@ -8,6 +8,7 @@
 \usepackage[table]{xcolor}                                                        % niceTables.pl
 \usepackage{multicol}                                                             % DragNDrop.pm
 \usepackage[version=4]{mhchem}                                                    % chemistry macros
+\usepackage{cancel}                                                               % cancel strikethrough macros
 
 % some packages need to be handled differently for xelatex vs pdflatex
 \usepackage{iftex}


### PR DESCRIPTION
This addresses https://github.com/openwebwork/webwork2/issues/2840. There it is suggested to add the `cancel` package to `webwork2.sty`, but I think `pg.sty` is the appropriate place.

I think this is a reasonable LaTeX package to add be default.