### PR TITLE
change Round function to use sprintf and combat machine rounding error

### DIFF
--- a/macros/core/PGauxiliaryFunctions.pl
+++ b/macros/core/PGauxiliaryFunctions.pl
@@ -175,12 +175,29 @@ Example:
 
     Round(1.789,2) returns 1.79
 
+This macro assumes an input x having lots of consecutive 9s such as 1.4999999999999997 is already
+the result of machine rounding error, and was meant to be 1.5. And so will round up to 2, not down
+to 1. Do not use this macro if a problem might work with honest numbers like 1.4999999999999997
+and need to round it.
+
 =cut
 
-# Round contributed bt Mark Schmitt 3-6-03
 sub Round {
-	if    (@_ == 1) { $_[0] > 0 ? int $_[0] + 0.5                      : int $_[0] - 0.5 }
-	elsif (@_ == 2) { $_[0] > 0 ? Round($_[0] * 10**$_[1]) / 10**$_[1] : Round($_[0] * 10**$_[1]) / 10**$_[1] }
+	my ($x, $n) = @_;
+	$n = 0 unless $n;
+	my $e = (split(/E/, sprintf("%E", $x)))[1] + 0;     # exponent for $x
+	my $s = ($x < 0 ? -1 : 1);                          # the sign of $x
+	my $N = $e + $n;                                    # number of digits to retain
+	$x += $s * 10**($e - 15);                           # adjust for repeated 9s
+	return sprintf("%.${N}E", $x) + 0 unless $N < 0;    # round the adjusted value
+
+	# For zero original digits, we add a digit just above the first one
+	# in $x, round that, then remove the added digit, getting 0 if $x
+	# didn't round up, or 1 in the proper place if it did.  This means
+	# that 0.005 rounds to .01, for example, when 2 digits are requested.
+
+	my $d = $s * 10**($e + 1);
+	return sprintf("%.0E", $x + $d) - $d;
 }
 
 =head2 lcm

--- a/t/macros/pgaux.t
+++ b/t/macros/pgaux.t
@@ -61,7 +61,8 @@ subtest 'round and Round functions' => sub {
 
 	is(Round(15.793, -1), 20, "Round to -1 digits (nearest 10)");
 
-	is(Round(134.49999999999997, 0), 134.0, 'Round a number with decimals close to 0.5');
+	is(Round(134.49999999999997, 0), 135.0, 'Round a number with decimals close to 0.5');
+	is(Round(1.4999999999999991, 0), 2.0,   'Round another number with decimals close to 0.5');
 	is(Round(1.49999999999991,   0), 1.0,   'Round another number with decimals close to 0.5');
 	is(Round(0.01499999999991,   2), 0.01,  'Round a number close to 0.005 to 2 digits');
 };


### PR DESCRIPTION
This may be controversial, and I will close it in a heartbeat if other developers don't like it. But it's to address #403.

The philosophy is that if we have a number like `134.49999999999997` it was *probably* supposed to be `134.5` and should round up to `135`. So we add an extremely small amount (`numZeroLevelTolDefault`) before doing the rounding.

Of course the risk is that the number really was supposed to be `134.49999999999997`, and really should round down. It is hard for me to come up with a scenario where you'd really be working with a number like this *and* need to round it.

To test, this problem gives different results before and after this commit:
```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl));

$x = 3.3625/0.025;
$rounded = Round($x,0);

TEXT("When you round $x you get $rounded.");
ENDDOCUMENT();
```