### PR TITLE
RREF typo

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -621,7 +621,7 @@ sub isRREF {
 		}
 	} else {
 		for my $row (@{ $self->{data} }) {
-			return 0 unless $row->isREF;
+			return 0 unless $row->isRREF;
 		}
 	}
 	return 1;


### PR DESCRIPTION
This is a typo or copy-paste error. The `isRREF` method should be recursively calling itself, not calling the `isREF` method.