### PR TITLE
Fix the drag and drop "Add Bucket" button.

### DIFF
--- a/htdocs/js/DragNDrop/dragndrop.js
+++ b/htdocs/js/DragNDrop/dragndrop.js
@@ -411,7 +411,7 @@
 			this.sortable = Sortable.create(this.ddList, options);
 		}
 
-		htmlBucket(label, removable, indices) {
+		htmlBucket(label, removable, indices = []) {
 			const bucketElement = document.createElement('div');
 			bucketElement.classList.add('dd-bucket');
 


### PR DESCRIPTION
I accidentally removed the default value for the `indices` argument to the `htmlBucket` function in #1394. That breaks the "Add Bucket" button because when it constructs a new `Bucket` there are no `indices`. This happened because I converted this JavaScript into TypeScript in a webpack built project for testing, and in the conversion back to JavaScript I deleted the typing that was added to the parameter, but was to aggressive in the deletion, and also deleted the default value.

For a basic problem to test with you can use:

```Perl
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'MathObjects.pl', 'draggableSubsets.pl');

$draggable = DraggableSubsets(
    [
        '\(e\)',  '\(r\)', '\(r^2\)', '\(s\)',
        '\(sr\)', '\(sr^2\)'
    ],
    [ [ 0, 3 ], [ 1, 4 ], [ 2, 5 ] ],
    DefaultSubsets => [
        {
            label     => 'Coset 1',
            indices   => [ 0 .. 3 ],
            removable => 0
        },
        {
            label     => 'Coset 2',
            indices   => [4],
            removable => 1
        },
        {
            label     => 'Coset 3',
            indices   => [5],
            removable => 1
        }
    ],
    BucketLabelFormat => 'Coset %s',
    AddButtonText     => 'Add Coset',
    RemoveButtonText  => 'Remove Coset',
);

BEGIN_PGML
Let [``G = D_3 = \{ e,r,r^2, s,sr,sr^2 \}``] be the Dihedral group of order
[`6`], where [`r`] is the counter-clockwise rotation by [`2\pi/3`], and [`s`] is
the reflection across the [`x`]-axis.

Partition [`G = D_3`] into *right* cosets of the subgroup [`H = \{ e, s \}`].
Give your result by dragging the following elements into separate buckets, each
corresponding to a coset.

[_]{$draggable}
END_PGML

ENDDOCUMENT();
```