### PR TITLE
Rework the `MathJax.typesetPromise` usage.

### DIFF
--- a/htdocs/js/DragNDrop/dragndrop.js
+++ b/htdocs/js/DragNDrop/dragndrop.js
@@ -382,11 +382,7 @@
 			else bucketPool.bucketContainer.append(this.el);
 
 			// Typeset any math content that may be in the added html.
-			if (window.MathJax) {
-				window.MathJax.startup.promise = window.MathJax.startup.promise.then(() =>
-					window.MathJax.typesetPromise([this.el])
-				);
-			}
+			if (window.MathJax) window.MathJax.typesetPromise?.([this.el]);
 
 			const options = {
 				group: { name: bucketPool.answerName },

--- a/htdocs/js/DropDown/dropdown.js
+++ b/htdocs/js/DropDown/dropdown.js
@@ -28,8 +28,7 @@
 				dropdownBtn.textContent = option.dataset.content;
 				dropdownBtn.focus();
 
-				if (window.MathJax)
-					MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise([dropdownBtn]));
+				if (window.MathJax) MathJax.typesetPromise([dropdownBtn]);
 
 				// If any feedback popovers are open, then update their positions.
 				for (const popover of document.querySelectorAll('.ww-feedback-btn')) {

--- a/htdocs/js/DropDown/dropdown.js
+++ b/htdocs/js/DropDown/dropdown.js
@@ -28,7 +28,7 @@
 				dropdownBtn.textContent = option.dataset.content;
 				dropdownBtn.focus();
 
-				if (window.MathJax) MathJax.typesetPromise([dropdownBtn]);
+				if (window.MathJax) MathJax.typesetPromise?.([dropdownBtn]);
 
 				// If any feedback popovers are open, then update their positions.
 				for (const popover of document.querySelectorAll('.ww-feedback-btn')) {

--- a/htdocs/js/Essay/essay.js
+++ b/htdocs/js/Essay/essay.js
@@ -51,9 +51,9 @@
 					button.addEventListener(
 						'show.bs.popover',
 						() => {
-							MathJax.startup.promise = MathJax.startup.promise.then(() =>
-								MathJax.typesetPromise(['.popover-body'])
-							);
+							setTimeout(() => {
+								MathJax.typesetPromise([popover.tip]);
+							});
 						},
 						{ once: true }
 					);

--- a/htdocs/js/Essay/essay.js
+++ b/htdocs/js/Essay/essay.js
@@ -49,11 +49,9 @@
 				);
 				if (window.MathJax) {
 					button.addEventListener(
-						'show.bs.popover',
+						'inserted.bs.popover',
 						() => {
-							setTimeout(() => {
-								MathJax.typesetPromise([popover.tip]);
-							});
+							MathJax.typesetPromise([popover.tip]);
 						},
 						{ once: true }
 					);

--- a/htdocs/js/Essay/essay.js
+++ b/htdocs/js/Essay/essay.js
@@ -51,7 +51,7 @@
 					button.addEventListener(
 						'inserted.bs.popover',
 						() => {
-							MathJax.typesetPromise([popover.tip]);
+							MathJax.typesetPromise?.([popover.tip]);
 						},
 						{ once: true }
 					);

--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -13,7 +13,7 @@
 
 		feedbackBtn.addEventListener('inserted.bs.popover', () => {
 			// Render MathJax previews.
-			if (window.MathJax) MathJax.typesetPromise([feedbackPopover.tip]).then(() => feedbackPopover.update());
+			if (window.MathJax) MathJax.typesetPromise?.([feedbackPopover.tip]).then(() => feedbackPopover.update());
 
 			// Execute javascript in the answer preview.
 			feedbackPopover.tip?.querySelectorAll('script').forEach((origScript) => {

--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -11,20 +11,10 @@
 		});
 		feedbackPopovers.push(feedbackPopover);
 
-		// Render MathJax previews.
-		if (window.MathJax) {
-			feedbackBtn.addEventListener('show.bs.popover', () => {
-				// The feedbackPopover.tip element is not yet available to work with, but will be immediately after this
-				// event fires, since Bootstrap sets it later in the same method in which this event is triggered. So
-				// delay until it is with a timeout. Note that this still occurs earlier than the shown.bs.popover
-				// event, and so prevents visual motion as the MathJax content is typeset and the popover resizes.
-				setTimeout(() => {
-					MathJax.typesetPromise([feedbackPopover.tip]).then(() => feedbackPopover.update());
-				});
-			});
-		}
+		feedbackBtn.addEventListener('inserted.bs.popover', () => {
+			// Render MathJax previews.
+			if (window.MathJax) MathJax.typesetPromise([feedbackPopover.tip]).then(() => feedbackPopover.update());
 
-		feedbackBtn.addEventListener('shown.bs.popover', () => {
 			// Execute javascript in the answer preview.
 			feedbackPopover.tip?.querySelectorAll('script').forEach((origScript) => {
 				const newScript = document.createElement('script');

--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -14,9 +14,13 @@
 		// Render MathJax previews.
 		if (window.MathJax) {
 			feedbackBtn.addEventListener('show.bs.popover', () => {
-				MathJax.startup.promise = MathJax.startup.promise.then(() =>
-					MathJax.typesetPromise(['.popover-body']).then(() => feedbackPopover.update())
-				);
+				// The feedbackPopover.tip element is not yet available to work with, but will be immediately after this
+				// event fires, since Bootstrap sets it later in the same method in which this event is triggered. So
+				// delay until it is with a timeout. Note that this still occurs earlier than the shown.bs.popover
+				// event, and so prevents visual motion as the MathJax content is typeset and the popover resizes.
+				setTimeout(() => {
+					MathJax.typesetPromise([feedbackPopover.tip]).then(() => feedbackPopover.update());
+				});
 			});
 		}
 

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -702,11 +702,7 @@ window.graphTool = (containerId, options) => {
 						newContent.classList.add('gt-message-content');
 						setTimeout(() => newContent.classList.add('gt-message-content', 'gt-message-fade'));
 
-						if (window.MathJax) {
-							MathJax.startup.promise = MathJax.startup.promise.then(() =>
-								MathJax.typesetPromise([newContent])
-							);
-						}
+						if (window.MathJax) MathJax.typesetPromise([newContent]);
 					}
 
 					resolve();

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -702,7 +702,7 @@ window.graphTool = (containerId, options) => {
 						newContent.classList.add('gt-message-content');
 						setTimeout(() => newContent.classList.add('gt-message-content', 'gt-message-fade'));
 
-						if (window.MathJax) MathJax.typesetPromise([newContent]);
+						if (window.MathJax) MathJax.typesetPromise?.([newContent]);
 					}
 
 					resolve();

--- a/htdocs/js/Knowls/knowl.js
+++ b/htdocs/js/Knowls/knowl.js
@@ -89,9 +89,7 @@
 				setInnerHTML(knowlBody, knowl.dataset.knowlContents);
 
 				// If we are using MathJax, then render math content.
-				if (window.MathJax) {
-					MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise([knowlBody]));
-				}
+				if (window.MathJax) MathJax.typesetPromise?.([knowlBody]);
 			} else if (knowl.dataset.knowlUrl) {
 				// Retrieve url content.
 				fetch(knowl.dataset.knowlUrl)
@@ -104,11 +102,7 @@
 							setInnerHTML(knowlBody, data);
 						}
 						// If we are using MathJax, then render math content.
-						if (window.MathJax) {
-							MathJax.startup.promise = MathJax.startup.promise.then(() =>
-								MathJax.typesetPromise([knowlBody])
-							);
-						}
+						if (window.MathJax) MathJax.typesetPromise?.([knowlBody]);
 					})
 					.catch((err) => {
 						knowlBody.textContent = `ERROR: ${err}`;

--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -212,7 +212,9 @@
 
 			this.button.addEventListener('show.bs.popover', () => {
 				this.regenPreview();
-				MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise(['.popover']));
+				setTimeout(() => {
+					MathJax.typesetPromise([this.popover.tip]).then(() => feedbackPopover.update());
+				});
 			});
 
 			// Refresh math in the popover when there is a keyup in the input.

--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -215,7 +215,7 @@
 			});
 
 			this.button.addEventListener('inserted.bs.popover', () => {
-				MathJax.typesetPromise([this.popover.tip]);
+				MathJax.typesetPromise?.([this.popover.tip]);
 			});
 
 			// Refresh math in the popover when there is a keyup in the input.
@@ -286,7 +286,7 @@
 			if (this.renderingMode === 'LATEX') this.mviewer.textContent = `\\(${text}\\)`;
 			else this.mviewer.textContent = `\`${text}\``;
 
-			MathJax.typesetPromise([this.mviewer]);
+			MathJax.typesetPromise?.([this.mviewer]);
 		}
 
 		// Create a category from the locale js.  Each category is implemented using bootstraps tab feature.  The

--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -212,9 +212,10 @@
 
 			this.button.addEventListener('show.bs.popover', () => {
 				this.regenPreview();
-				setTimeout(() => {
-					MathJax.typesetPromise([this.popover.tip]).then(() => feedbackPopover.update());
-				});
+			});
+
+			this.button.addEventListener('inserted.bs.popover', () => {
+				MathJax.typesetPromise([this.popover.tip]);
 			});
 
 			// Refresh math in the popover when there is a keyup in the input.
@@ -285,7 +286,7 @@
 			if (this.renderingMode === 'LATEX') this.mviewer.textContent = `\\(${text}\\)`;
 			else this.mviewer.textContent = `\`${text}\``;
 
-			MathJax.startup.promise = MathJax.startup.promise.then(() => MathJax.typesetPromise([this.mviewer]));
+			MathJax.typesetPromise([this.mviewer]);
 		}
 
 		// Create a category from the locale js.  Each category is implemented using bootstraps tab feature.  The


### PR DESCRIPTION
The `MathJax.typesetPromise` calls no longer need to be passed through the `MathJax.startupPromise` according to @dpvc. See his comments on this in https://github.com/openwebwork/webwork2/issues/2955.

Also, make the `MathJax.typesetPromise` calls to typeset popover contents specific to the particular popover that needs to be typeset instead of typesetting all popovers in the page. This is not done in the way that @dpvc suggested because moving the typesetting from the `show.bs.popover` event to the `shown.bs.popover` event results in visual motion as the popover is typeset and possibly resized, and that is not desirable. Instead a timeout is used.  This works because Bootstrap creates the `popover.tip` element immediately after Bootstrap triggers the `show.bs.popover` event, and so when the timeout handler is executed it is available to work with. But that is still before the css transitions are complete which is when the `shown.bs.popover` event is triggered.

Note that in `htdocs/js/Knowls/knowl.js` and `htdocs/js/DragNDrop/dragndrop.js`, the `typesetPromise` method is often not yet defined on the `MathJax` object when those calls are made.  That is okay, because if it isn't yet defined, that means that MathJax is still typesetting the page, and gets those elements.  Generally the call is only needed for cases where those things are added to the page later.