### PR TITLE
Add horizontal overflow to `.problem-content` divs and solution and hint bodies.

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -12,6 +12,7 @@
 	border: 1px solid #e3e3e3;
 	border-radius: 4px;
 	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+	overflow-x: auto;
 
 	p {
 		margin-top: 1rem;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -961,7 +961,7 @@ sub SOLUTION {
 					. tag(
 						'div',
 						class => 'accordion-collapse collapse',
-						tag('div', class => 'accordion-body', $solution_body)
+						tag('div', class => 'accordion-body overflow-x-auto', $solution_body)
 					)
 			)
 		));
@@ -1003,7 +1003,7 @@ sub HINT {
 					. tag(
 						'div',
 						class => 'accordion-collapse collapse',
-						tag('div', class => 'accordion-body', $hint_body)
+						tag('div', class => 'accordion-body overflow-x-auto', $hint_body)
 					)
 			)
 		));


### PR DESCRIPTION
If the problem text or the content of a solution or hint is too wide, then it overflows the problem boundaries.  This is a problem when the page is in dark mode, because the problem is not and so the text is dark, yet the main page background is also dark.  This results in black text on a black background for the text that overflows the `.problem-content` div.

Adding `overflow-x: auto` makes the content scroll horizontally as needed if the text is too wide, and so the text is still contained within the light background of the problem.

Note that adding the overflow to solutions and hints is perhaps not needed since the `.problem-content` div has it.  The text overflows the solution or hint if it is too wide, but the problem content is scrollable, and so it is contained within the light background. However, it is still ugly when the content overflows the solution or hint, and it is better if it scrolls on its own.

For a basic test problem, you can use:
```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl');

BEGIN_PGML
[```
    \int \frac{4x^4 + 5x^3 + 110x^2 + 128x + 175}{x^3 + 25x} \,dx
    = \int 4x + 5 + \frac{7}{x} + \frac{3x+3}{x^2 + 25} \,dx
    = \int 4x + 5 + \frac{7}{x} + \frac{3x}{x^2 + 25} + \frac{3}{x^2 + 25} \,dx
    = 2x^2 + 5x + 7\ln\left(\left|x\right|\right) + \frac{3}{2}\ln\left(x^2 + 25\right) + \frac{3}{5}\tan^{-1}\left(\frac{x}{5}\right) + C.
```]
END_PGML

BEGIN_PGML_SOLUTION
[```
    \int \frac{4x^4 + 5x^3 + 110x^2 + 128x + 175}{x^3 + 25x} \,dx
    = \int 4x + 5 + \frac{7}{x} + \frac{3x+3}{x^2 + 25} \,dx
    = \int 4x + 5 + \frac{7}{x} + \frac{3x}{x^2 + 25} + \frac{3}{x^2 + 25} \,dx
    = 2x^2 + 5x + 7\ln\left(\left|x\right|\right) + \frac{3}{2}\ln\left(x^2 + 25\right) + \frac{3}{5}\tan^{-1}\left(\frac{x}{5}\right) + C.
```]
END_PGML_SOLUTION

ENDDOCUMENT();
```

Note that in the actual problem that came from an `aligned` environment is used, and it is not nearly so wide.  It does fit in okay on a wider screen.  However, if the screen is not so wide (such as on a mobile device), then it is a problem.  I don't think that you can do much better with this to make it narrower either.