### PR TITLE
Suppress output from `dvisvgm` in `LaTeXImage.pm`.

### DIFF
--- a/lib/LaTeXImage.pm
+++ b/lib/LaTeXImage.pm
@@ -298,7 +298,7 @@ sub use_svgMethod {
 	# Validate svgMethod against known SVG converters to prevent command injection.
 	my $method = $self->svgMethod;
 	if ($method eq 'dvisvgm') {
-		system WeBWorK::PG::IO::externalCommand('dvisvgm'), "$working_dir/image.dvi", '--no-fonts',
+		system WeBWorK::PG::IO::externalCommand('dvisvgm'), "$working_dir/image.dvi", '--no-fonts', '--verbosity=0',
 			"--output=$working_dir/image.svg";
 	} elsif ($method eq 'pdf2svg') {
 		system WeBWorK::PG::IO::externalCommand('pdf2svg'), "$working_dir/image.pdf", "$working_dir/image.svg";


### PR DESCRIPTION
A side effect of #1397 is that output (stdout and stderr) from system calls is no longer suppressed. This was previously accomplished by piping the output to `/dev/null`.  However, since those system commands are no longer executed in a spawned shell, that cannot be done.

This suppresses the output generated by the execution of `dvisvgm` in `LaTeXImage.pm` by adding the flat `--verbosity=0`.  This is specific to this call, and errors or output from other system calls will still come through, but this one is particularly annoying since it occurs when the unit tests are run, and messes up the results output for the unit tests.