### PR TITLE
Perltidy update

### DIFF
--- a/.github/workflows/check-formats.yml
+++ b/.github/workflows/check-formats.yml
@@ -18,9 +18,9 @@ jobs:
       image: perl:5.38
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy@20240903
+        run: cpanm -n Perl::Tidy@20260204
       - name: Run perltidy
         shell: bash
         run: |
@@ -33,11 +33,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install Dependencies
         run: cd htdocs && npm ci --ignore-scripts
       - name: Check formatting with prettier

--- a/.github/workflows/generate-and-publish-docs.yml
+++ b/.github/workflows/generate-and-publish-docs.yml
@@ -24,7 +24,7 @@ jobs:
             libpod-parser-perl
 
       - name: Checkout pg code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: pg
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout PG code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Ubuntu dependencies
         run: |

--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -48,8 +48,8 @@ use Mojo::File qw(curfile);
 
 my $pg_root = curfile->dirname->dirname;
 
-die "Version 20240903 of perltidy is required for this script.\nThe installed version is $Perl::Tidy::VERSION.\n"
-	unless $Perl::Tidy::VERSION == 20240903;
+die "Version 20260204 of perltidy is required for this script.\nThe installed version is $Perl::Tidy::VERSION.\n"
+	unless $Perl::Tidy::VERSION == 20260204;
 die "The .perltidyrc file in the pg root directory is not readable.\n"
 	unless -r "$pg_root/.perltidyrc";
 

--- a/docker/pg.Dockerfile
+++ b/docker/pg.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
@@ -20,8 +20,8 @@ RUN apt-get update \
 		liblocale-maketext-lexicon-perl \
 		libmojolicious-perl \
 		libtest-mockobject-perl \
-		libtest2-suite-perl \
 		libtie-ixhash-perl \
+		libtypes-serialiser-perl \
 		libuuid-tiny-perl \
 		libyaml-libyaml-perl \
 		make \

--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -151,7 +151,7 @@ sub HTML {
 	$self->{JS}             //= '';
 	$plots->{extra_js_code} //= '';
 
-	return <<~ "END_HTML";
+	return <<~"END_HTML";
 		$divs
 		<script>
 		(async () => {
@@ -460,7 +460,7 @@ sub add_multipath {
 	$self->{JS} .= "];\n";
 
 	if ($plotOptions) {
-		$self->{JS} .= <<~ "END_JS";
+		$self->{JS} .= <<~"END_JS";
 			const curve_$curve_name = board.create('curve', [[], []], $plotOptions);
 			curve_$curve_name.updateDataArray = function () {
 				this.dataX = [].concat(...$curve_parts_name.map((c) => c.points.map((p) => p.usrCoords[1]))$start_x);
@@ -469,7 +469,7 @@ sub add_multipath {
 			END_JS
 	}
 	if ($fillOptions) {
-		$self->{JS} .= <<~ "END_JS";
+		$self->{JS} .= <<~"END_JS";
 			const fill_$curve_name = board.create('curve', [[], []], $fillOptions);
 			fill_$curve_name.updateDataArray = function () {
 				this.dataX = [].concat(...$curve_parts_name.map((c) => c.points.map((p) => p.usrCoords[1])));

--- a/lib/Plots/Tikz.pm
+++ b/lib/Plots/Tikz.pm
@@ -32,7 +32,7 @@ sub new {
 	# than the pgfplots defaults, but is consistent with where JSXGraph places them, and is better than what pgplots
 	# does.  Axis tick labels are textual elements that should be in front of the things that are drawn and together
 	# with the "axis descriptions".
-	$image->addToPreamble( <<~ 'END_PREAMBLE');
+	$image->addToPreamble(<<~'END_PREAMBLE');
 		\usepgfplotslibrary{fillbetween}
 		\newsavebox{\axesBox}
 		\pgfplotsset{
@@ -330,7 +330,7 @@ sub generate_axes {
 	# The savebox only actually saves the main layer.  All other layers are actually drawn when the savebox is saved.
 	# So clipping of anything drawn on any other layer has to be done when things are drawn on the other layers.  The
 	# axisclippath is used for this. The main layer is clipped at the end when the savebox is used.
-	my $tikzCode = <<~ "END_TIKZ";
+	my $tikzCode = <<~"END_TIKZ";
 		\\pgfplotsset{set layers=${\($axes->style('axis_on_top') ? 'axis on top' : 'standard')}}%
 		$grid_color_def
 		\\savebox{\\axesBox}{
@@ -378,7 +378,7 @@ sub generate_axes {
 	$tikzCode .= $plotContents;
 	$tikzCode .= $plots->{extra_tikz_code} if $plots->{extra_tikz_code};
 
-	$tikzCode .= <<~ "END_TIKZ";
+	$tikzCode .= <<~"END_TIKZ";
 			\\end{axis}
 		}
 		\\pgfresetboundingbox

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1490,7 +1490,7 @@ sub ENDDOCUMENT {
 					'',
 					map {
 						'<li>' . knowlLink($_, value => pretty_print($PG->{PG_alias}{resource_list}{$_})) . '</li>'
-					}
+						}
 						sort keys %{ $PG->{PG_alias}{resource_list} }
 					)
 					. '</ul>'

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -3225,7 +3225,7 @@ sub tag {
 		' ',
 		map {
 			($_ =~ s/_/-/gr) . (defined $attributes{$_} ? ('="' . encode_pg_and_html($attributes{$_})) . '"' : '')
-		}
+			}
 			keys %attributes
 	);
 

--- a/macros/graph/AppletObjects.pl
+++ b/macros/graph/AppletObjects.pl
@@ -149,7 +149,7 @@ our @ISA = qw(PGApplet);
 sub new {
 	my $class = shift;
 	$class->SUPER::new(
-		objectText => << 'END_OBJECT_TEXT',
+		objectText => <<'END_OBJECT_TEXT',
 <div id="$appletName"
 	data-id="$appletName"
 	data-width="$width"

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -1168,7 +1168,7 @@ sub generateHTMLAnswerGraph {
 		$html . ($options{longDescription} =~ s/LONG-DESCRIPTION-ID/${ans_name}_${idSuffix}_details/r)
 	) if $options{longDescription};
 
-	return $html . main::tag('script', <<~ "END_SCRIPT");
+	return $html . main::tag('script', <<~"END_SCRIPT");
 		(() => {
 			const initialize = () => {
 				graphTool('${ans_name}_$idSuffix', {

--- a/t/math_objects/matrix.t
+++ b/t/math_objects/matrix.t
@@ -476,8 +476,8 @@ subtest 'Multiply matrices' => sub {
 	my $prod1 = Matrix([ [ -8, 2, -6 ], [ -17, 8, -15 ], [ -26, 14, -24 ] ]);
 	my $C     = Matrix([ [ 1, -5, -2, -5 ],   [ 0, -5, 5, -4 ],     [ 4, 1, -1, 1 ] ]);
 	my $prod2 = Matrix([ [ 13, -12, 5, -10 ], [ 28, -39, 11, -34 ], [ 43, -66, 17, -58 ] ]);
-	ok $A*$B == $prod1, 'Checking the product of two 3 by 3 matrices';
-	ok $A*$C == $prod2, 'Checking the product of a 3 by 3 and 3 by 4 matrix';
+	ok $A * $B == $prod1, 'Checking the product of two 3 by 3 matrices';
+	ok $A * $C == $prod2, 'Checking the product of a 3 by 3 and 3 by 4 matrix';
 
 	like dies { $C * $A }, qr/Matrices of dimensions \d+x\d+ and \d+x\d+ can't be multiplied/,
 		'Test that multiplying row matrices of incompatible dimsensions throws an error';
@@ -486,15 +486,16 @@ subtest 'Multiply matrices' => sub {
 
 	my $row   = Matrix(1,  2,  3);
 	my $prod3 = Matrix(14, 32, 50);
-	ok $A*$row == $prod3, 'Multiply a 3 by 3 matrix and a row matrix of length 3 (the row is promoted to a matrix)';
+	ok $A * $row == $prod3,
+		'Multiply a 3 by 3 matrix and a row matrix of length 3 (the row is promoted to a matrix)';
 
 	my $col   = Matrix([ [1],  [2],  [3] ]);
 	my $prod4 = Matrix([ [14], [32], [50] ]);
-	ok $A*$col == $prod4, 'Multiply a 3 by 3 matrix and a column matrix of length 3';
+	ok $A * $col == $prod4, 'Multiply a 3 by 3 matrix and a column matrix of length 3';
 
 	my $v     = Vector(1,  2,  3);
 	my $prod5 = Vector(14, 32, 50);
-	ok $A*$v == $prod5, 'Multiply a 3 by 3 matrix and a vector of length 3';
+	ok $A * $v == $prod5, 'Multiply a 3 by 3 matrix and a vector of length 3';
 };
 
 subtest 'Construct an elementary matrix' => sub {

--- a/t/pg_problems/source.t
+++ b/t/pg_problems/source.t
@@ -7,7 +7,7 @@ use Test2::V0;
 
 use WeBWorK::PG;
 
-my $source = << 'END_SOURCE';
+my $source = <<'END_SOURCE';
 DOCUMENT();
 
 loadMacros('PGstandard.pl', 'MathObjects.pl', 'PGML.pl', 'PGcourse.pl');

--- a/t/tikz_test/tikz_image.t
+++ b/t/tikz_test/tikz_image.t
@@ -12,7 +12,7 @@ use LaTeXImage;
 loadMacros('PGtikz.pl');
 
 my $drawing = createTikZImage();
-$drawing->tex(<< 'END_TIKZ');
+$drawing->tex(<<'END_TIKZ');
 \draw (-4,0) -- (4,0);
 \draw (0,-2) -- (0,2);
 \draw (0,0) circle[radius=1.5];


### PR DESCRIPTION
Update to `perltidy` version 20260204.

Developers will need to install and use this version to match the workflow.

Also update Github workflows to use node 24, and the actions in the workflows to their newest versions. For now these are still running on Ubuntu 24.04, since an official runner image for Ubuntu 26.04 has not been released yet.  Also because there is a runner image, but some of the rserve unit tests are failing with it.  Note that the rserve tests are passing on my locak machine running Ubuntu 26.

The docker test build is updated to use Ubuntu 26.04.  The rserve tests also are passing with this build.

The first commit in this pull request sets everything up and makes the other changes noted above.  The second commit perltidies the perl files in the code base.