### PR TITLE
don't try to remove a Matrix's only row (or only column)

### DIFF
--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -1502,6 +1502,7 @@ sub removeRow {
 	my @dim    = $self->dimensions;
 	my $degree = scalar @dim;
 	Value::Error("removeRow cannot be used on a Matrix of degree 1") if $degree == 1;
+	Value::Error("cannot remove a Matrix's only row")                if $dim[0] == 1;
 	my @indices = map { [ 1 .. $_ ] } @dim;
 	Value::Error("Can only remove rows 1 through $indices[0][-1]")
 		unless $r =~ /^\d+$/ && $r >= 1 && $r <= $indices[0][-1];
@@ -1529,6 +1530,7 @@ sub removeColumn {
 	my @dim    = $self->dimensions;
 	my $degree = scalar @dim;
 	Value::Error("removeColumn cannot be used on a Matrix of degree 1") if $degree == 1;
+	Value::Error("cannot remove a Matrix's only column")                if $dim[1] == 1;
 	my @indices = map { [ 1 .. $_ ] } @dim;
 	Value::Error("Can only remove columns 1 through $indices[1][-1]")
 		unless $r =~ /^\d+$/ && $r >= 1 && $r <= $indices[1][-1];

--- a/t/math_objects/matrix.t
+++ b/t/math_objects/matrix.t
@@ -334,6 +334,11 @@ subtest 'Remove row' => sub {
 	like dies {
 		$A->removeRow('a');
 	}, qr/Can only remove rows 1 through 4/, 'check that error is thrown for bad row specification';
+
+	my $D = Matrix([ [ 1, 2, 3 ] ]);
+	like dies {
+		$D->removeRow(1);
+	}, qr/cannot remove a Matrix's only row/, 'check that error is thrown for trying to remove the only row';
 };
 
 subtest 'Remove column' => sub {
@@ -362,6 +367,11 @@ subtest 'Remove column' => sub {
 	like dies {
 		$A->removeColumn('a');
 	}, qr/Can only remove columns 1 through 4/, 'check that error is thrown for bad column specification';
+
+	my $D = Matrix([1], [2], [3]);
+	like dies {
+		$D->removeColumn(1);
+	}, qr/cannot remove a Matrix's only column/, 'check that error is thrown for trying to remove the only column';
 };
 
 subtest 'Construct an identity matrix' => sub {


### PR DESCRIPTION
Without this PR, you can try to remove the only row of `[[1,2,3]]`, or the only column of `[[1],[2],[3]]`. It won't work, but the error message will be a bit cryptic, coming from the `subMatrix` method. It will say "Cannot use empty array reference for indices to keep".

This commit changes it so that `removeRow` and `removeColumn` catch that kind of thing earlier and give a direct message about it.