### PR TITLE
pretty versions of some units in math mode

### DIFF
--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -781,7 +781,7 @@ sub addUnit {
 		$constants->add(
 			$name => {
 				value      => context::Units::Unit->new($name => $unit),
-				TeX        => "\\text{$name}",
+				TeX        => '\\text{' . pretty($name) . '}',
 				isUnit     => 1,
 				isConstant => 1
 			}
@@ -793,6 +793,27 @@ sub addUnit {
 		$self->addUnitAliases($unit);
 	}
 	return $self;
+}
+
+sub pretty {
+	my $name       = shift;
+	my %prettyName = (
+		angstrom => "\x{00C5}",
+		deg      => "\x{00B0}",
+		degC     => "\x{2103}",
+		degF     => "\x{00B0}F",
+		degK     => "\x{212A}",
+		ohm      => "\x{2126}",
+		kohm     => "k\x{2126}",
+		Mohm     => "M\x{2126}",
+		uC       => "\x{00B5}C",
+		uF       => "\x{00B5}F",
+		um       => "\x{00B5}m",
+		uN       => "\x{00B5}N",
+		us       => "\x{00B5}s",
+		uSv      => "\x{00B5}Sv",
+	);
+	return defined $prettyName{$name} ? $prettyName{$name} : $name;
 }
 
 #
@@ -1315,7 +1336,7 @@ sub cmp_postprocess {
 #
 sub string {
 	my ($self, $equation, $open, $close, $precedence) = @_;
-	my $string = $self->stringFor('nunits', 'dunits', $self->{order});
+	my $string = context::Units::Context::pretty($self->stringFor('nunits', 'dunits', $self->{order}));
 	$string = '(' . $string . ')' if $string =~ m![ /]! && defined($precedence) && $precedence > 2.9;
 	return $string;
 }
@@ -1502,7 +1523,7 @@ sub uString { (shift)->unit->uString(shift) }
 sub string {
 	my ($self, $equation, $open, $close, $precedence) = @_;
 	my $unit   = $self->unit;
-	my $u      = $unit->stringFor('nunits', 'dunits', $unit->{order}, 0, 1);
+	my $u      = context::Units::Context::pretty($unit->stringFor('nunits', 'dunits', $unit->{order}, 0, 1));
 	my $string = $self->number->string;
 	$string .= substr($u, 0, 1) eq '/' ? $u : " $u";
 	$string = '(' . $string . ')' if defined($precedence) && $precedence > 1;

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -1525,9 +1525,15 @@ sub string {
 	my $unit   = $self->unit;
 	my $u      = context::Units::Context::pretty($unit->stringFor('nunits', 'dunits', $unit->{order}, 0, 1));
 	my $string = $self->number->string;
-	$string .= substr($u, 0, 1) eq '/' ? $u : " $u";
+	$string .= substr($u, 0, 1) eq '/' || noSeparator($u) ? $u : " $u";
 	$string = '(' . $string . ')' if defined($precedence) && $precedence > 1;
 	return $string;
+}
+
+sub noSeparator {
+	my $u = shift;
+	return 1 if ($u =~ /^(\x{00B0}|\x{2103}|\x{00B0}F)$/);
+	return 0;
 }
 
 #
@@ -1541,7 +1547,7 @@ sub TeX {
 	if (substr($u, 0, 1) eq '/') {
 		$tex = "\\frac{$tex}{" . $unit->raiseUnit(-1, 1)->with(negativePowers => {})->TeX . '}';
 	} else {
-		$tex .= '\\,' . $unit->TeX;
+		$tex .= (noSeparator($unit) ? '' : '\\,') . $unit->TeX;
 	}
 	$tex = '(' . $tex . ')' if defined($precedence) && $precedence > 1;
 	return $tex;


### PR DESCRIPTION
This sort of addresses #503, except by way of the newer `contextUnits.pl`. Each of the supported units from `Units.pm` that has a special unicode character will now print that way, if the unit is being used in math mode. Test with the problem below. It all looks fine in HTML. In hardcopy, we must be careful that the default font we use has glyphs for these characters. This is why two characters are used for degrees Fahrenheit, but a single character can be used for degrees Celsius. Also if someone switched away from xelatex over to pdflatex, these won't work. I'm unsure if we support not using xelatex.

Test with:
```
DOCUMENT();
loadMacros(qw(PGstandard.pl PGML.pl contextUnits.pl));

Context("Units")->withUnitsFor('length', 'temperature', 'angles', 'time', 'force', 'electricity', 'radiation');

$thickness = Compute('70 um');
$boils = Compute('100 degC');
$freezes = Compute('32 degF');
$zero = Compute('0 degK');
$pi = Compute('180 deg');
$us = Compute('us');
$angstrom = Compute('angstrom');
$bacterium = Compute('0.01 uN');
$charge = Compute('1 uC');
$farad = Compute('1 uF');
$ohm = Compute('ohm');
$kohm = Compute('kohm');
$Mohm = Compute('Mohm');
$uSv = Compute('uSv');

BEGIN_PGML
The thickness of a human hair is about [$thickness], or [`[$thickness]`].  
Water boils at [$boils], or [`[$boils]`].  
Water freezes at [$freezes], or [`[$freezes]`].  
Absolute zero is [$zero], or [`[$zero]`].  
[`\pi`] is [$pi], or [`[$pi]`].  
A very short unit of time is a [$us], or [`[$us]`].  
A very short distance is an [$angstrom], or [`[$angstrom]`].  
A bacterium has weight [$bacterium], or [`[$bacterium]`].  
A very small charge is a [$charge], or [`[$charge]`].  
A very small unit of capacitance is a [$farad], or [`[$farad]`].  
[$ohm], [$kohm], [$Mohm], or [`[$ohm]`], [`[$kohm]`], [`[$Mohm]`]  
[$uSv] or [`[$uSv]`]
END_PGML

ENDDOCUMENT();
```