### PR TITLE
fully close most HTML tags in niceTables

### DIFF
--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -1514,8 +1514,7 @@ sub tag {
 		$return .= $inner;
 		$return .= "$separator</$name>";
 	} else {
-		$return .= '>' unless ($main::displayMode eq 'PTX');
-		$return .= '/>' if ($main::displayMode eq 'PTX');
+		$return .= ($main::displayMode eq 'PTX') ? '/>' : $name =~ /^(br|col|hr|img|input)$/ ? '>' : "></$name>";
 	}
 	return $return;
 }


### PR DESCRIPTION
This addresses #1182. If the `tag` function is making an HTML tag and there is no content, close it like `<div></div>`. Only for a few exceptional tags, close it like `<br>`. The list of exceptional tags is not complete, but the ones left out are not reasonably going to arise in niceTables. In fact, I'm not sure the ones I listed will arise form niceTables either, but it's harmless to list them.