### PR TITLE
Feedback button changes.

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -153,6 +153,10 @@
 			&.partially-correct::before {
 				content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='black' stroke='none'><path d='M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z'/><path d='M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z'/></svg>");
 			}
+
+			&.unknown::before {
+				content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 640'><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d='M528 320C528 205.1 434.9 112 320 112C205.1 112 112 205.1 112 320C112 434.9 205.1 528 320 528C434.9 528 528 434.9 528 320zM64 320C64 178.6 178.6 64 320 64C461.4 64 576 178.6 576 320C576 461.4 461.4 576 320 576C178.6 576 64 461.4 64 320zM320 240C302.3 240 288 254.3 288 272C288 285.3 277.3 296 264 296C250.7 296 240 285.3 240 272C240 227.8 275.8 192 320 192C364.2 192 400 227.8 400 272C400 319.2 364 339.2 344 346.5L344 350.3C344 363.6 333.3 374.3 320 374.3C306.7 374.3 296 363.6 296 350.3L296 342.2C296 321.7 310.8 307 326.1 302C332.5 299.9 339.3 296.5 344.3 291.7C348.6 287.5 352 281.7 352 272.1C352 254.4 337.7 240.1 320 240.1zM288 432C288 414.3 302.3 400 320 400C337.7 400 352 414.3 352 432C352 449.7 337.7 464 320 464C302.3 464 288 449.7 288 432z'/></svg>");
+			}
 		}
 
 		&.with-message::before {
@@ -163,7 +167,7 @@
 			left: 100%;
 			border: 1px solid black;
 			border-radius: 50%;
-			background-color: var(--bs-warning);
+			background-color: #ffc107;
 			padding: 0.25rem;
 			animation: flash-in 0.75s;
 
@@ -179,6 +183,75 @@
 				}
 			}
 		}
+	}
+
+	/* Feedback button colors. */
+	.btn-correct {
+		--bs-btn-color: #fff;
+		--bs-btn-bg: #198754;
+		--bs-btn-border-color: #198754;
+		--bs-btn-hover-color: #fff;
+		--bs-btn-hover-bg: #157347;
+		--bs-btn-hover-border-color: #146c43;
+		--bs-btn-focus-shadow-rgb: 60, 153, 110;
+		--bs-btn-active-color: #fff;
+		--bs-btn-active-bg: #146c43;
+		--bs-btn-active-border-color: #13653f;
+		--bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+		--bs-btn-disabled-color: #fff;
+		--bs-btn-disabled-bg: #198754;
+		--bs-btn-disabled-border-color: #198754;
+	}
+
+	.btn-incorrect {
+		--bs-btn-color: #fff;
+		--bs-btn-bg: #dc3545;
+		--bs-btn-border-color: #dc3545;
+		--bs-btn-hover-color: #fff;
+		--bs-btn-hover-bg: #bb2d3b;
+		--bs-btn-hover-border-color: #b02a37;
+		--bs-btn-focus-shadow-rgb: 225, 83, 97;
+		--bs-btn-active-color: #fff;
+		--bs-btn-active-bg: #b02a37;
+		--bs-btn-active-border-color: #a52834;
+		--bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+		--bs-btn-disabled-color: #fff;
+		--bs-btn-disabled-bg: #dc3545;
+		--bs-btn-disabled-border-color: #dc3545;
+	}
+
+	.btn-partially-correct {
+		--bs-btn-color: #000;
+		--bs-btn-bg: #ffc107;
+		--bs-btn-border-color: #ffc107;
+		--bs-btn-hover-color: #000;
+		--bs-btn-hover-bg: #ffca2c;
+		--bs-btn-hover-border-color: #ffc720;
+		--bs-btn-focus-shadow-rgb: 217, 164, 6;
+		--bs-btn-active-color: #000;
+		--bs-btn-active-bg: #ffcd39;
+		--bs-btn-active-border-color: #ffc720;
+		--bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+		--bs-btn-disabled-color: #000;
+		--bs-btn-disabled-bg: #ffc107;
+		--bs-btn-disabled-border-color: #ffc107;
+	}
+
+	.btn-preview {
+		--bs-btn-color: #fff;
+		--bs-btn-bg: #1a67ea;
+		--bs-btn-border-color: #1a67ea;
+		--bs-btn-hover-color: #fff;
+		--bs-btn-hover-bg: #1658c7;
+		--bs-btn-hover-border-color: #1552bb;
+		--bs-btn-focus-shadow-rgb: 60, 126, 237;
+		--bs-btn-active-color: #fff;
+		--bs-btn-active-bg: #1552bb;
+		--bs-btn-active-border-color: #144db0;
+		--bs-btn-active-shadow: inset 0 3px 5px #00000020;
+		--bs-btn-disabled-color: #fff;
+		--bs-btn-disabled-bg: #1a67ea;
+		--bs-btn-disabled-border-color: #1a67ea;
 	}
 
 	.radio-buttons-container,
@@ -256,7 +329,7 @@
 	.popover-header {
 		text-align: center;
 		cursor: pointer;
-		--bs-popover-header-bg: var(--bs-info);
+		--bs-popover-header-bg: #1a67ea;
 		--bs-popover-header-color: white;
 
 		.btn-close {
@@ -268,21 +341,22 @@
 
 	&.correct {
 		.popover-header {
-			--bs-popover-header-bg: var(--bs-success);
+			--bs-popover-header-bg: #198754;
 			--bs-popover-header-color: white;
 		}
 	}
 
 	&.incorrect {
 		.popover-header {
-			--bs-popover-header-bg: var(--bs-danger);
+			--bs-popover-header-bg: #dc3545;
 			--bs-popover-header-color: white;
 		}
 	}
 
-	&.partially-correct {
+	&.partially-correct,
+	&.unknown {
 		.popover-header {
-			--bs-popover-header-bg: var(--bs-warning);
+			--bs-popover-header-bg: #ffc107;
 			--bs-popover-header-color: black;
 		}
 	}

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -845,8 +845,12 @@ the type of submission.
 
 =item *
 
-C<btnClass>: This is the bootstrap button class added to the feedback button.
-By default it is "btn-info", "btn-success", "btn-danger", or "btn-warning"
+C<btnClass>: This is the button class added to the feedback button. These are
+based on bootstrap button styles, but are custom styles for the feedback
+buttons to allow clients to theme the bootstrap buttons without changing the
+feedback styles. By default it is "btn-preview" (coppied from btn-info),
+"btn-correct" (coppied from btn-success), "btn-incorrect" (coppied from
+btn-danger), or "btn-partially-correct" (coppied from btn-warning)
 depending on the status of the answer and the type of submission.
 
 =item *
@@ -1059,7 +1063,7 @@ sub ENDDOCUMENT {
 				my %options = (
 					resultTitle      => maketext('Answer Preview'),
 					resultClass      => '',
-					btnClass         => 'btn-info',
+					btnClass         => 'btn-preview',
 					btnAddClass      => 'ms-2',
 					feedbackElements => Mojo::Collection->new,
 					insertElement    => undef,
@@ -1108,15 +1112,28 @@ sub ENDDOCUMENT {
 					} elsif ($answerScore >= 1) {
 						$options{resultTitle} = maketext('Correct');
 						$options{resultClass} = 'correct';
-						$options{btnClass}    = 'btn-success';
+						$options{btnClass}    = 'btn-correct';
 					} elsif ($answerScore == 0) {
 						$options{resultTitle} = maketext('Incorrect');
 						$options{resultClass} = 'incorrect';
-						$options{btnClass}    = 'btn-danger';
+						$options{btnClass}    = 'btn-incorrect';
 					} else {
 						$options{resultTitle} = maketext('[_1]% correct', round($answerScore * 100));
 						$options{resultClass} = 'partially-correct';
-						$options{btnClass}    = 'btn-warning';
+						$options{btnClass}    = 'btn-partially-correct';
+					}
+				} elsif ($rh_envir->{showAttemptResults} && !$PG->{flags}{showPartialCorrectAnswers}) {
+					# Partially correct feedback is not being shown, but this is not a preview, so make the
+					# feedback look different than a preview. If the problem score is zero, everything is
+					# incorrect, so mark the whole problem as incorrect. Otherwise mark it as unknown correctness.
+					if ($problemResult->{score}) {
+						$options{resultTitle} = maketext('Unknown');
+						$options{resultClass} = 'unknown';
+						$options{btnClass}    = 'btn-partially-correct';
+					} else {
+						$options{resultTitle} = maketext('Incorrect');
+						$options{resultClass} = 'incorrect';
+						$options{btnClass}    = 'btn-incorrect';
 					}
 				}
 

--- a/macros/core/PGessaymacros.pl
+++ b/macros/core/PGessaymacros.pl
@@ -67,7 +67,7 @@ sub essay_cmp {
 
 			$options->{resultClass}      = '';
 			$options->{insertMethod}     = 'append_content';
-			$options->{btnClass}         = 'btn-info';
+			$options->{btnClass}         = 'btn-preview';
 			$options->{btnAddClass}      = '';
 			$options->{wrapPreviewInTex} = 0;
 			$options->{showEntered}      = 0;                  # Suppress output of the feedback entered answer.


### PR DESCRIPTION
I am using this PR as a discussion (so it is a draft). I'm unsure what others will think of these changes, but this is to address two issues I have with the feedback buttons. I have attempted to implement suggested changes to address the issues.

The first is themes can change the feedback button colors since they are using the bootstrap color classes. This may not be desirable that the feedback buttons match the webwork button colors, so new classes are created for the feedback buttons that can be themed independently of the bootstrap classes.

The second is when `$showPartialCorrectAnswers=0` and the student didn't get the problem correct, the feedback looks like a "Preview Answers" and it confuses students as they think they hit "Preview Answers" and not "Submit Answer" button. This makes it so the feedback has its own look for this case. It uses the yellow color for partially correct, a title of "Unknown" (I think something better could be used here to indicate it is unknown if the answer is correct or incorrect) and a question mark in a circle as the icon (my question mark needs to be improved, I had trouble finding a good SVG question mark).