### PR TITLE
Fix a minor html validity issue with the plots.pl macro.

### DIFF
--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -42,7 +42,7 @@ sub HTML {
 
 	my $divs =
 		qq!<div id="jsxgraph-plot-$self->{name}" !
-		. qq!class="jxgbox plots-jsxgraph$imageviewClass$roundedCornersClass"$tabindex!
+		. qq!class="jxgbox plots-jsxgraph$imageviewClass$roundedCornersClass"$tabindex !
 		. qq!style="width: ${width}px; height: ${height}px;"$aria_details></div>!;
 	$divs = qq!<div class="image-container">$divs$details</div>! if $details;
 


### PR DESCRIPTION
A missing space in the JSXGraph.pm package causes the `div` for the JSXGraph image to have invalid attributes. It turns out this is fixed by the `Mojo::DOM` xml parsing that occurs in the `post_process_content` phase of the translator, and even if that doesn't fix it most browsers handle this okay, but HTML validation doesn't like it.  In any case, it should be fixed.