### PR TITLE
Revert `overflow-x: auto` on `.problem-content` divs.

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -12,7 +12,6 @@
 	border: 1px solid #e3e3e3;
 	border-radius: 4px;
 	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-	overflow-x: auto;
 
 	p {
 		margin-top: 1rem;


### PR DESCRIPTION
This was added in #1432, but is causing problems.  If an answer rule is contained in a `position: relative` parent, then the MathQuill toolbar ends up being positioned correctly, but is contained inside the `.problem-content` div, and so you need to scroll to the right to see it. Note that the `.ww-feedback-container` is `position: relative`.  So any answer inside a div with that class will have this issue.

An example problem for which the problem occurs is:

```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'parserMultiAnswer.pl', 'PGcourse.pl');

$ma = MultiAnswer(1, 2)->with(singleResult => 1);

BEGIN_PGML
[<
    Enter 1: [_]{$ma}{5}

    Enter 2: [_]{$ma}{5}
>]{ [ class => 'ww-feedback-container ww-fb-align-middle' ] }
END_PGML

ENDDOCUMENT();
```

Note that this is not a problem when using the problem editor, since the width of the `.problem-content` div is the same as its parent.  So this will need to be tested in an actual set.

For now the overflow is left for solutions and hints.  Those won't have answer rules, and thus will also not have the MathQuill toolbar issue.

So a different way to fix the issue with dark text overflowing into the dark region outside of the problem will need to be found.  Any ideas?