### PR TITLE
Fix the casing of the svg color `MediumAquamarine` in `StatisticalPlots.pl`.

### DIFF
--- a/macros/graph/StatisticalPlots.pl
+++ b/macros/graph/StatisticalPlots.pl
@@ -125,10 +125,10 @@ or a reference to a hash containing the name of a color palette
 (C<palette_name>) and number of colors to generate (C<num_colors>) (see L<COLOR
 PALETTES> for more information). If this is a reference to an array and the
 length of the array is smaller than the number of data values in the array
-referenced to by C<$data>, then the colors will be cycled.  
+referenced to by C<$data>, then the colors will be cycled.
 
-If C<fill_color> is included in the list of options, this will apply the same 
-color to each bar.  If neither C<fill_color> nor C<fill_colors> is included, 
+If C<fill_color> is included in the list of options, this will apply the same
+color to each bar.  If neither C<fill_color> nor C<fill_colors> is included,
 then the 'rainbow' palette will be used as default.
 
 For example,
@@ -845,7 +845,7 @@ sub color_palette {
 	if ($palette_name eq 'rainbow') {
 		return [ 'Violet', 'blue', 'green', 'yellow', 'orange', 'red' ];
 	} elsif ($palette_name eq 'greens') {
-		return [ 'Green', 'Olive', 'DarkGreen', 'LawnGreen', 'MediumAquaMarine', 'LimeGreen' ];
+		return [ 'Green', 'Olive', 'DarkGreen', 'LawnGreen', 'MediumAquamarine', 'LimeGreen' ];
 	} elsif ($palette_name eq 'blues') {
 		return [ 'Blue', 'MidnightBlue', 'MediumBlue', 'LightSkyBlue', 'DodgerBlue', 'DarkBlue', 'CornflowerBlue' ];
 	} elsif ($palette_name eq 'reds') {


### PR DESCRIPTION
Although JSXGraph is lenient with this, LaTeX and TikZ are not. So if you use the `greens` color palette you end up getting the stroke color for this color in TikZ output. but an aqua marine color for JSXGraph output.

Here is a MWE for testing this:

```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl', 'StatisticalPlots.pl', 'PGcourse.pl');

$barPlot = StatPlot(xmin => 0, xmax => 7, ymin => 0, ymax => 10);
$barPlot->add_barplot(
    [ 1 .. 6 ],
    [ 3, 6, 7, 8, 4, 1 ],
    fill_colors => { palette_name => 'greens' }
);

BEGIN_PGML
[<
    [<[@ $barPlot->image_type('Tikz'); @]* [!TikZ bar plot!]{$barPlot}{400}>]
    [<[@ $barPlot->image_type('JSXGraph'); @]* [!JSXGraph bar plot!]{$barPlot}{400}>]
>]{ [ class => 'd-flex gap-3 flex-wrap' ] }
END_PGML

ENDDOCUMENT();
```

I thought I had fixed all of these in my changes to #1374, but I seem to have missed this one.

It seems my editor's format on save also removed some spaces at the ends of lines in the POD that @pstaabp left in there.