### PR TITLE
typos identified by github.com/crate-ci/typos

### DIFF
--- a/bin/perltidy-pg.pl
+++ b/bin/perltidy-pg.pl
@@ -19,7 +19,7 @@ perltidy documentation for details.
 
 Note that if the -pro=file option is not given, then this script will attempt to
 use the perltidy-pg.rc file in the PG bin directory for this option.  For this to
-work the the perltidy-pg.rc file in the PG bin directory must be readable.
+work the perltidy-pg.rc file in the PG bin directory must be readable.
 
 =cut
 

--- a/bin/pg-critic.pl
+++ b/bin/pg-critic.pl
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-pg-critic.pl - Command line interface to critque PG problem code.
+pg-critic.pl - Command line interface to critique PG problem code.
 
 =head1 SYNOPSIS
 

--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -14,8 +14,8 @@ Run perltidy on pg source files.
 
 =head1 OPTIONS
 
-For this script to work the the .perltidyrc file in the pg root directory
-must be readable.  Note that the pg root directory is automatically detected.
+For this script to work the .perltidyrc file in the pg root directory must be
+readable.  Note that the pg root directory is automatically detected.
 
 This script accepts all of the options that are accepted by perltidy.  See the
 perltidy documentation for details.

--- a/bin/update-localization-files
+++ b/bin/update-localization-files
@@ -6,7 +6,7 @@ function print_help_exit
 	printf " Update the pg.pot and language .po files with translation strings from the code.\n" >&2
 	printf "  options:\n" >&2
 	printf "    -p|--po-update  Update po files as well.  By default only the pg.pot file is updated.\n" >&2
-	printf "    -l|--langauge   Update the only given language in addition to updating the pg.pot file.\n" >&2
+	printf "    -l|--language   Update the only given language in addition to updating the pg.pot file.\n" >&2
 	printf "    -h|--help       Show this help.\n" >&2
 	exit 1
 }

--- a/conf/pg_config.dist.yml
+++ b/conf/pg_config.dist.yml
@@ -18,7 +18,7 @@ directories:
   OPL: /opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary
   Contrib: /opt/webwork/libraries/webwork-open-problem-library/Contrib
 
-  # The root PG location.  This will be set from the PG_ROOT environment variable, but can be overriden here.
+  # The root PG location.  This will be set from the PG_ROOT environment variable, but can be overridden here.
   root: $pg_root
 
   # Global temporary directory.  This location must be writable.
@@ -209,7 +209,7 @@ displayModeOptions:
 # PG modules to load
 # The first item of each list is the module file to load. The remaining items are additional packages to import that are
 # also contained in that file.
-# That is, if you wish to include a file MyModule.pm which containes the package MyModule and the additional packages
+# That is, if you wish to include a file MyModule.pm which contains the package MyModule and the additional packages
 # Dependency1 and Dependency2, then these should appear as [Mymodule, Dependency1, Dependency2].
 modules:
   - [Encode]

--- a/doc/MathObjectsAnswerCheckers.pod
+++ b/doc/MathObjectsAnswerCheckers.pod
@@ -7,7 +7,7 @@ use a single object to produce numeric values, TeX output, and answer
 strings from a single formula entry.  This avoids having to type a
 function three different ways (which makes maintaining a problem much
 harder).  Since MathObjects also includes vector and complex
-arthimetic, it is easier to work with these types of values as well.
+arithmetic, it is easier to work with these types of values as well.
 
 Secondly using MathObjects improves the processing of student input.
 This is accomplished through special answer checkers that are part of
@@ -670,7 +670,7 @@ student and correct answers to determine if the student list matches
 the correct list (regardless of order).
 
 When the C<checker> is called from the list checker, it has two
-additional paramters:
+additional parameters:
 
     checker => sub {
       my ($correct,$student,$ansHash,$nth,$value) = @_;
@@ -725,7 +725,7 @@ Note that in a C<list_checker> for a List object, you will have to do
 type checking yourself to check if the types of the entries are
 correct, since a list can consist of any type of elements.
 
-The C<list_checker> should return an array consisting of the nuber of
+The C<list_checker> should return an array consisting of the number of
 student entries that are correct followed by any error messages that
 should be displayed (each on a separate line in the messages section).
 
@@ -827,7 +827,7 @@ C<$n>$ when the answer is correct.
 More error checking might be desired, here.  For example, since a
 Union can be of Intervals or Sets, we might want to check that all the
 student's entries in the Union are actually intervals (the current
-version allows Sets).  Note thta because the
+version allows Sets).  Note that because the
 C<studentsMustReduceUnions> parameter is 1 by default, we don't have
 to check for disjoint intervals.  On the other hand, that flag also
 requires intervals to be merged into one if they could be, e.g.,

--- a/doc/UsingMathObjects.pod
+++ b/doc/UsingMathObjects.pod
@@ -95,7 +95,7 @@ name to S<C<< perlFunction >>> to get a named function to call:
     Formula('x^2 + 3')->perlFunction('f');
     $y = f(5);
 
-If the formula involves more than one variable, then the paramaters
+If the formula involves more than one variable, then the parameters
 should be given in alphabetical order.
 
     Formula('x^2 + y')->perlFunction('f');
@@ -193,7 +193,7 @@ automatically, when necessary.
 
 =item * vectors
 
-A vetor is represented C<< <a,b,c> >> or C<a i + b j + c k> (when used
+A vector is represented C<< <a,b,c> >> or C<a i + b j + c k> (when used
 in vector context).  As with points, vectors can have any number of
 coordinates.  For example, C<< <1,0,0> >>, C<< <-1,3> >>, C<< <x,1-x> >>,
 etc.
@@ -341,7 +341,7 @@ so you can use:
 to produce a TeX version of the vector, just as you can with formulas.
 
 There are several "constant" functions that generate common constant
-values.  These include C<pi>, C<i>, C<j>, C<k> and C<Infininty>.  you
+values.  These include C<pi>, C<i>, C<j>, C<k> and C<Infinity>.  you
 can use these in perl expressions as though they were their actual
 values:
 
@@ -368,7 +368,7 @@ interpretation is used, you specify a parser I<context>.
 
 The context controls what operations and functions are defined in the
 parser, what variables and constants to allow, how to interpret
-various paretheses, and so on.  Changing the context can completely
+various parentheses, and so on.  Changing the context can completely
 change the way a formula is interpreted.
 
 There are several predefined contexts: S<C<< Numeric >>>, S<C<<
@@ -435,7 +435,7 @@ used for variables above.  The command
 
     $M = $constant->constants->get('M');
 
-will return the value of the consant C<M>.  (See the
+will return the value of the constant C<M>.  (See the
 F<pg/lib/Value/Context/Data.pm> file for more information on the methods
 you can call for the various types of context data.)
 

--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -265,7 +265,7 @@ The entry $rh_ans->{error_flag} is set to "FLAG".
 
 The catch_error and clear_error methods use this entry.
 
-message is a descriptive message for the end user, defining what error occured.
+message is a descriptive message for the end user, defining what error occurred.
 
 =head3 catch_error
 

--- a/lib/AnswerHash.pm
+++ b/lib/AnswerHash.pm
@@ -597,7 +597,7 @@ sub evaluate {
 	eval(q!main::DEBUG_MESSAGE( `<h4>final result: </h4>`, pretty_print($rh_ans,'html'))!)
 		if defined($self->{debug})
 		and $self->{debug} > 0;
-	# re-refrence $rh_ans;
+	# re-reference $rh_ans;
 	$self->{rh_ans} = $rh_ans;
 	$rh_ans;
 }

--- a/lib/AnswerIO.pm
+++ b/lib/AnswerIO.pm
@@ -30,7 +30,7 @@ use strict;
 sub saveAnswerToFile {
 	my $logFileID = shift;
 	my $string    = shift;
-	# We want to allow acces only to predetermined files
+	# We want to allow access only to predetermined files
 	# We accomplish this by translating legal IDs into a file name
 
 	my $rh_allowableFiles = {

--- a/lib/Applet.pm
+++ b/lib/Applet.pm
@@ -265,7 +265,7 @@ The applets initialization method is as follows:
 
 =head3 Submit sequence
 
-When the WW question submit button is pressed the form containing the WW question calles the
+When the WW question submit button is pressed the form containing the WW question calls the
 JavaScript "submitAction()" which then asks each of the applets on the page to perform its
 submit action which consists of
 

--- a/lib/ChoiceList.pm
+++ b/lib/ChoiceList.pm
@@ -351,7 +351,7 @@ sub cmp {
 	return @answers;
 }
 
-#Match and Select return references to arrays while Multiple justs returns a string
+#Match and Select return references to arrays while Multiple just returns a string
 #so Match and Select use ra_correct_ans while Multiple uses correct_ans
 sub correct_ans {
 	warn "Match and/or Select do not use correct_ans.\nYou should use ra_correct_ans instead.";
@@ -419,7 +419,7 @@ sub getRandoms {
 	my @remaining = complement([ 0 .. $N - 1 ], [@fixed_choices]);
 
 	my @slice = @fixed_choices;
-	push(@slice, @remaining[ $self->NchooseK(scalar(@remaining), $K) ]);    #slice of remaing choices
+	push(@slice, @remaining[ $self->NchooseK(scalar(@remaining), $K) ]);    #slice of remaining choices
 	@slice = @slice[ $self->NchooseK(scalar(@slice), scalar(@slice)) ];     #randomize the slice (the questions)
 
 	#shuffle will be used to randomize the answers a second time (so they don't coincide with the questions)
@@ -454,8 +454,8 @@ sub makeLast {
 
 	push(@{ $self->{selected_a} }, @input);
 	$self->condense();    #make sure that the user has not accidentally forced a duplicate answer
-						  #note: condense was changed to eliminate the first occurence of a duplicate
-						  #instead of the last occurence so that it could be used in this case and
+						  #note: condense was changed to eliminate the first occurrence of a duplicate
+						  #instead of the last occurrence so that it could be used in this case and
 						  #would not negate the fact that one of the answers needs to be at the end
 }
 
@@ -526,7 +526,7 @@ sub condense {
 				}
 
 				#because we just changed the element that $outer points to
-				#we need to run throught the loop to make sure that the new value at $outer has
+				#we need to run through the loop to make sure that the new value at $outer has
 				#no duplicates as well
 				#This means that we don't want to increment either counter (and we need to reset $inner)
 				$repeat = 1;

--- a/lib/Chromatic.pm
+++ b/lib/Chromatic.pm
@@ -355,7 +355,7 @@ sub matrix_graph {
 	return @matrix;
 }
 
-# $graph input is a string adjacency matrix with rows terminted with semicolons
+# $graph input is a string adjacency matrix with rows terminated with semicolons
 # and entries of each row separated by a space.
 sub ChromNum {
 	my $graph = shift;

--- a/lib/Complex1.pm
+++ b/lib/Complex1.pm
@@ -164,7 +164,7 @@ sub cplx {
 	my ($re, $im) = @_;
 	return $package->make(defined $re ? $re : 0, defined $im ? $im : 0);
 }
-# cplx adn cplxe changed by MEG
+# cplx and cplxe changed by MEG
 #
 # cplxe
 #

--- a/lib/Distributions.pm
+++ b/lib/Distributions.pm
@@ -551,8 +551,8 @@ Statistics::Distributions - Perl module for calculating probabilities and critic
 
 =head1 DESCRIPTION
 
-This Perl module calulates percentage points (6 significant digits) of the u (standard normal) distribution, 
-the student's t distribution, the chi-square distribution and the F distribution. 
+This Perl module calculates percentage points (6 significant digits) of the u (standard normal) distribution,
+the student's t distribution, the chi-square distribution and the F distribution.
 
 It can also calculate the upper probability (6 significant digits) of the u (standard normal), 
 the chi-square, the t and the F distribution.
@@ -567,7 +567,7 @@ If you are interested in more precise algorithms you could look at:
 =head1 AUTHOR
 
 Michael Kospach, mike.perl@gmx.at
-Nice formating, simplification and bug repair by Matthias Trautner Kromann, mtk@id.cbs.dk 
+Nice formatting, simplification and bug repair by Matthias Trautner Kromann, mtk@id.cbs.dk
 
 =cut
 

--- a/lib/Fraction.pm
+++ b/lib/Fraction.pm
@@ -44,7 +44,7 @@ Other methods
 =head1 SYNOPSIS
 
 The fraction object stores two variables, numerator and denominator.  The basic
-arithmatic methods listed above can be performed on a fraction, and it can return its own
+arithmetic methods listed above can be performed on a fraction, and it can return its own
 scalar value for use with functions expecting a scalar (ie, sqrt($frac->scalar) ).
 
 =cut

--- a/lib/Fraction.pm
+++ b/lib/Fraction.pm
@@ -2,7 +2,7 @@
 #
 # Fraction object
 # Keeps track of two variables- numerator and denominator.
-# Has subroutines for basic arithmatic functions, for anything
+# Has subroutines for basic arithmetic functions, for anything
 # more complicated, it can return a scalar value of
 # numerator/denominator.
 # VS 7/20/2000
@@ -387,7 +387,7 @@ sub print_inline {
 # Internal Methods
 
 # Least Common Multiple
-# Used in arithmatic methods to convert two fractions to common denominator
+# Used in arithmetic methods to convert two fractions to common denominator
 # takes in two scalar values and returns their lcm
 sub lcm {
 	my $self = shift;
@@ -418,7 +418,7 @@ sub lcm {
 sub gcd {
 
 	my $self = shift;
-	my $a    = abs(shift);    #absolute values because this will yeild the same gcd,
+	my $a    = abs(shift);    #absolute values because this will yield the same gcd,
 	my $b    = abs(shift);    #but allows use of the mod operation
 
 	if ($a < $b) {

--- a/lib/Fun.pm
+++ b/lib/Fun.pm
@@ -77,7 +77,7 @@ domain of the function object is set to the domain of the graph.
 
 =item	$fn = new Fun ( x_rule_ref, y_rule_ref );
 
-A parametric function object is created where the subroutines refered to by x_rule_ref and y_rule_ref define
+A parametric function object is created where the subroutines referred to by x_rule_ref and y_rule_ref define
 the x and y outputs in terms of the input t.
 
 =item	$fn = new Fun ( x_rule_ref, y_rule_ref, graph_ref );
@@ -87,7 +87,7 @@ of the function object is not adjusted.  The domain's default value is (-1, 1).
 
 =back
 
-=head2 Properites
+=head2 Properties
 
 	All of the properties are set using the construction $new_value = $fn->property($new_value)
 	and read using $current_value = $fn->property()

--- a/lib/Label.pm
+++ b/lib/Label.pm
@@ -87,7 +87,7 @@ sub _initialize {
 		elsif ($j eq 'center')   { $self->lr_nudge(-(length($self->str)) / 2); }
 		elsif ($j eq 'middle')   { $self->tb_nudge(-0.5); }
 		elsif ($j eq 'vertical') { $self->orientation($j); }
-		#there are only five avialble fonts: http://search.cpan.org/~rurban/GD-2.68/lib/GD.pm#Font_Utilities
+		#there are only five available fonts: http://search.cpan.org/~rurban/GD-2.68/lib/GD.pm#Font_Utilities
 		elsif ($j eq 'small') { $self->font(GD::gdSmallFont); }
 		elsif ($j eq 'large') { $self->font(GD::gdLargeFont); }
 		elsif ($j eq 'tiny')  { $self->font(GD::gdTinyFont); }

--- a/lib/Label.pm
+++ b/lib/Label.pm
@@ -22,7 +22,7 @@ This module defines labels for the graph objects (WWPlot).
     $label1 = new Label($x_value, $y_value, $label_string, $label_color, @options)
     $options is an array with (*'d defaults)
         - one of 'left'*, 'center', 'right' (horizontal alignment)
-        - one of 'bottom', 'center', 'top'* (verical alignment)
+        - one of 'bottom', 'center', 'top'* (vertical alignment)
         - one of 'horizontal'*, 'vertical' (orientation)
         - one of 'small', 'large', 'mediumbold'*, 'tiny', 'giant' (which gd font to use)
     Note the alignment specifications are relative to the English reading of the string,

--- a/lib/List.pm
+++ b/lib/List.pm
@@ -351,7 +351,7 @@ sub cmp {
 	return @answers;
 }
 
-#Match and Select return references to arrays while Multiple justs returns a string
+#Match and Select return references to arrays while Multiple just returns a string
 #so Match and Select use ra_correct_ans while Multiple uses correct_ans
 sub correct_ans {
 	warn "Match and/or Select do not use correct_ans.\nYou should use ra_correct_ans instead.";
@@ -419,7 +419,7 @@ sub getRandoms {
 	my @remaining = complement([ 0 .. $N - 1 ], [@fixed_choices]);
 
 	my @slice = @fixed_choices;
-	push(@slice, @remaining[ $self->NchooseK(scalar(@remaining), $K) ]);    #slice of remaing choices
+	push(@slice, @remaining[ $self->NchooseK(scalar(@remaining), $K) ]);    #slice of remaining choices
 	@slice = @slice[ $self->NchooseK(scalar(@slice), scalar(@slice)) ];     #randomize the slice (the questions)
 
 	#shuffle will be used to randomize the answers a second time (so they don't coincide with the questions)
@@ -454,8 +454,8 @@ sub makeLast {
 
 	push(@{ $self->{selected_a} }, @input);
 	$self->condense();    #make sure that the user has not accidentally forced a duplicate answer
-						  #note: condense was changed to eliminate the first occurence of a duplicate
-						  #instead of the last occurence so that it could be used in this case and
+						  #note: condense was changed to eliminate the first occurrence of a duplicate
+						  #instead of the last occurrence so that it could be used in this case and
 						  #would not negate the fact that one of the answers needs to be at the end
 }
 
@@ -529,7 +529,7 @@ sub condense {
 				}
 
 				#because we just changed the element that $outer points to
-				#we need to run throught the loop to make sure that the new value at $outer has
+				#we need to run through the loop to make sure that the new value at $outer has
 				#no duplicates as well
 				#This means that we don't want to increment either counter (and we need to reset $inner)
 				$repeat = 1;
@@ -575,7 +575,7 @@ sub condense {
 #     my $out = '';
 #     if ( not ref($r_input) ) {
 #     	$out = $r_input;    # not a reference
-#     } elsif ("$r_input" =~/hash/i ) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_iput).
+#     } elsif ("$r_input" =~/hash/i ) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_input).
 # 	    local($^W) = 0;
 # 		$out .= "$r_input " ."<TABLE border = \"2\" cellpadding = \"3\" BGCOLOR = \"#FFFFFF\">";
 # 		foreach my $key (sort keys %$r_input ) {

--- a/lib/Matrix.pm
+++ b/lib/Matrix.pm
@@ -456,7 +456,7 @@ sub decompose_LR {
 	my ($swap);
 	my ($temp);
 	my $rh_options = $matrix->[$MatrixReal1::OPTION_ENTRY];
-	#    FIXEME Why won't this work on non-square matrices?
+	#    FIXME: Why won't this work on non-square matrices?
 	#    croak "MatrixReal1::decompose_LR(): matrix is not quadratic"
 	#      unless ($rows == $cols);
 	#    croak "MatrixReal1::decompose_LR(): matrix has more rows than columns"

--- a/lib/Matrix.pm
+++ b/lib/Matrix.pm
@@ -106,7 +106,7 @@ sub R {
 	$R_matrix;
 }
 
-sub PL {    # use this permuation on the left PL*L*R*PR =M
+sub PL {    # use this permutation on the left PL*L*R*PR =M
 	my $matrix    = shift;
 	my $rows      = $matrix->[1];
 	my $cols      = $rows;
@@ -117,7 +117,7 @@ sub PL {    # use this permuation on the left PL*L*R*PR =M
 	$PL_matrix;
 }
 
-sub PR {    # use this permuation on the right PL*L*R*PR =M
+sub PR {    # use this permutation on the right PL*L*R*PR =M
 	my $matrix    = shift;
 	my $cols      = $matrix->[2];
 	my $rows      = $cols;
@@ -384,7 +384,7 @@ sub copy {
 }
 ###################################################################
 
-# MEG added 6/25/03 to accomodate complex entries
+# MEG added 6/25/03 to accommodate complex entries
 
 =head2 conj
 

--- a/lib/MatrixReal1.pm
+++ b/lib/MatrixReal1.pm
@@ -3226,7 +3226,7 @@ The primary property of an eigenvalue I<l> and an eigenvector
 B<x> is of course that: B<M> * B<x> = I<l> * B<x>.
 
 The method uses a Householder reduction to tridiagonal form
-followed by a QL algoritm with implicit shifts on this
+followed by a QL algorithm with implicit shifts on this
 tridiagonal. (The tridiagonal matrix is kept internally
 in a compact form in this routine to save memory.)
 In fact, this routine wraps the householder() and
@@ -3246,7 +3246,7 @@ the I<n> by I<n> real I<symmetric> matrix B<M> contained
 in $matrix to tridiagonal form.
 On output, B<T> is a symmetric tridiagonal matrix (only
 diagonal and off-diagonal elements are non-zero) and B<Q>
-is an I<orthogonal> matrix performing the tranformation
+is an I<orthogonal> matrix performing the transformation
 between B<M> and B<T> (C<$M == $Q * $T * ~$Q>).
 
 =item *
@@ -3385,7 +3385,7 @@ Example:
 
 Boolean test
 
-Tests wether there is at least one non-zero element in the matrix.
+Tests whether there is at least one non-zero element in the matrix.
 
 Example:
 
@@ -3395,7 +3395,7 @@ Example:
 
 Negated boolean test
 
-Tests wether the matrix contains only zero's.
+Tests whether the matrix contains only zero's.
 
 Examples:
 

--- a/lib/PGalias.pm
+++ b/lib/PGalias.pm
@@ -78,7 +78,7 @@ sub make_alias {
 		$ext = $1;
 	} else {
 		$self->warning_message(qq{The file name "$aux_file_id" does not have an extension. }
-				. 'Every file name used as an argument to alias must have an extension. The permissable extensions are '
+				. 'Every file name used as an argument to alias must have an extension. The permissible extensions are '
 				. '.gif, .jpg, .png, .svg, .pdf, .mp4, .mpg, .ogg, .webm, .css, .js, .nb, .csv, .tgz, and .html.');
 		return;
 	}

--- a/lib/PGanswergroup.pm
+++ b/lib/PGanswergroup.pm
@@ -104,7 +104,7 @@ sub insert {    # add new values to PGanswergroup keys preserve existing values
 	$self;
 }
 
-sub replace {    # add new values ot PGanswergroup, overwriting existing values when duplicated
+sub replace {    # add new values to PGanswergroup, overwriting existing values when duplicated
 	my $self = shift;
 	my @in   = @_;
 	my %hash = ();

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -152,7 +152,7 @@ named answer is associated with its answer blank by name.
 =item *
 
 "Extra" answers: Names of answer blanks that do not have a 1-to-1
-correspondance to an answer evaluator. For example, in matrix problems, there
+correspondence to an answer evaluator. For example, in matrix problems, there
 will be several input fields that correspond to the same answer evaluator.
 
 =back
@@ -163,7 +163,7 @@ This file is automatically loaded into the namespace of every PG problem. The
 macros within can then be called to define the structure of the problem.
 
 DOCUMENT() should be the first executable statement in any problem. It
-initializes vriables and defines the problem environment.
+initializes variables and defines the problem environment.
 
 ENDDOCUMENT() must be the last executable statement in any problem. It packs
 up the results of problem processing for delivery back to WeBWorK.

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -522,7 +522,7 @@ sub encode_base64 ($;$) {
 }
 
 #####
-#  This macro encodes HTML, EV3, and PGML special caracters using html codes
+#  This macro encodes HTML, EV3, and PGML special characters using html codes
 #  This should be done for any variable which contains student input and is
 #  printed to a screen or interpreted by EV3.
 

--- a/lib/PGloadfiles.pm
+++ b/lib/PGloadfiles.pm
@@ -39,7 +39,7 @@ modifying existing macros.
 I<Modifying macros is for users with some experience.>
 
 Modifying existing macros might break other standard macros or problems which
-depend on the unmodified behavior of these macors so do this with great caution.
+depend on the unmodified behavior of these macros so do this with great caution.
 In addition problems which use new macros defined in these files or which depend
 on the modified behavior of existing macros will not work in other courses
 unless the macros are also transferred to the new course.  It helps to document

--- a/lib/PGresponsegroup.pm
+++ b/lib/PGresponsegroup.pm
@@ -78,7 +78,7 @@ sub replace_response {
 }
 
 # Extend the response to an array for this response label entry.  This is used for check boxes and radio buttons.  This
-# converts the reponse value into an array of label/value pairs if it is a hash to begin with.  Otherwise it just adds a
+# converts the response value into an array of label/value pairs if it is a hash to begin with.  Otherwise it just adds a
 # label/value pair to the existing array.
 sub extend_response {
 	my ($self, $response_label, $new_value_key, $selected) = @_;

--- a/lib/Parser.pm
+++ b/lib/Parser.pm
@@ -6,7 +6,7 @@ no strict "refs";
 BEGIN {
 	#
 	#  Map class names to packages (added to Context, and
-	#  can be overriden to customize the parser)
+	#  can be overridden to customize the parser)
 	#
 	our $class = { Formula => 'Value::Formula' };
 
@@ -274,7 +274,7 @@ sub pushBlankOperand {
 #          Apply it to the top operand
 #        Otherwise (binary operator)
 #          Convert the space operator to explicit multiplication
-#          Save the opertor on the stack
+#          Save the operator on the stack
 #      Otherwise, (top is not an operand)
 #        If the operator is an explicit one or the top is a function
 #          Call Op again to report the error, or to apply
@@ -713,7 +713,7 @@ sub eval {
 
 ##################################################
 #
-#  Removes redundent items (like x+-y, 0+x and 1*x, etc)
+#  Removes redundant items (like x+-y, 0+x and 1*x, etc)
 #  using the provided flags
 #
 sub reduce {

--- a/lib/Parser/BOP.pm
+++ b/lib/Parser/BOP.pm
@@ -60,7 +60,7 @@ sub _check { }
 ##################################################
 
 #
-#  Evaluate the left and right operands and peform the
+#  Evaluate the left and right operands and perform the
 #  required operation on the results.
 #
 sub eval {

--- a/lib/Parser/BOP/equality.pm
+++ b/lib/Parser/BOP/equality.pm
@@ -32,7 +32,7 @@ sub _eval {
 }
 
 #
-#  Remove redundent minuses
+#  Remove redundant minuses
 #
 sub _reduce {
 	my $self     = shift;

--- a/lib/Parser/BOP/underscore.pm
+++ b/lib/Parser/BOP/underscore.pm
@@ -48,7 +48,7 @@ sub _eval {
 
 #
 #  If the right-hand side is constant and the left is a list
-#    extact the given coordinate(s).  Return empty lists
+#    extract the given coordinate(s).  Return empty lists
 #    if we run past the end of the coordinates.  Return
 #    a simpler extraction if a portion of the extraction
 #    can be performed.

--- a/lib/Parser/Context/Variables.pm
+++ b/lib/Parser/Context/Variables.pm
@@ -8,7 +8,7 @@ our @ISA = qw(Value::Context::Data);
 
 #
 #  The named types for variables
-#    (you can use arbitary types by supplying an
+#    (you can use arbitrary types by supplying an
 #     instance of the type rather than a name)
 #
 our %type = (

--- a/lib/Parser/Function.pm
+++ b/lib/Parser/Function.pm
@@ -287,7 +287,7 @@ sub getVariables {
 #
 #  Produce the string form.
 #
-#  Put parentheses around the funciton call if
+#  Put parentheses around the function call if
 #    the function call is on the left of the parent operation
 #    and the precedence of the parent is higher than function call
 #    (e.g., powers, etc.)

--- a/lib/Parser/Legacy/LimitedComplex.pm
+++ b/lib/Parser/Legacy/LimitedComplex.pm
@@ -233,7 +233,7 @@ package Parser::Legacy::LimitedComplex;
 
 my $context = $Parser::Context::Default::context{Complex}->copy;
 $Parser::Context::Default::context{LimitedComplex} = $context;
-$context->{name} = "LimtedComplex";
+$context->{name} = "LimitedComplex";
 
 #
 #  Override operator classes
@@ -270,7 +270,7 @@ $context->flags->set(complex_format => 'either');
 $context = $context->copy;
 $Parser::Context::Default::context{'LimitedComplex-cartesian'} = $context;
 $context->flags->set(complex_format => 'cartesian');
-$context->{name} = "LimtedComplex-cartesian";
+$context->{name} = "LimitedComplex-cartesian";
 
 ##################################################
 
@@ -278,14 +278,14 @@ $context = $context->copy;
 $Parser::Context::Default::context{'LimitedComplex-cartesian-strict'} = $context;
 $context->flags->set(strict_numeric => 1);
 $context->functions->disable('All');
-$context->{name} = "LimtedComplex-cartesian-strinct";
+$context->{name} = "LimitedComplex-cartesian-strinct";
 
 ##################################################
 
 $context = $Parser::Context::Default::context{'LimitedComplex'}->copy;
 $Parser::Context::Default::context{'LimitedComplex-polar'} = $context;
 $context->flags->set(complex_format => 'polar');
-$context->{name} = "LimtedComplex-polar";
+$context->{name} = "LimitedComplex-polar";
 
 ##################################################
 
@@ -293,7 +293,7 @@ $context = $context->copy;
 $Parser::Context::Default::context{'LimitedComplex-polar-strict'} = $context;
 $context->flags->set(strict_numeric => 1);
 $context->functions->disable('All');
-$context->{name} = "LimtedComplex-polar-strict";
+$context->{name} = "LimitedComplex-polar-strict";
 
 ##################################################
 
@@ -301,7 +301,7 @@ $context = $Parser::Context::Default::context{'LimitedComplex'}->copy;
 $Parser::Context::Default::context{'LimitedComplex-strict'} = $context;
 $context->flags->set(strict_numeric => 1);
 $context->functions->disable('All');
-$context->{name} = "LimtedComplex-strict";
+$context->{name} = "LimitedComplex-strict";
 
 ##################################################
 

--- a/lib/Parser/Legacy/LimitedNumeric.pm
+++ b/lib/Parser/Legacy/LimitedNumeric.pm
@@ -7,7 +7,7 @@
 #  and one for fractions of integers.  Select them using
 #  one of the following commands:
 #
-#      Context("LimiteNumeric");
+#      Context("LimitedNumeric");
 #      Context("LimitedNumeric-Fraction");
 #
 #  There is also a third version, which is a strict fraction

--- a/lib/Parser/Legacy/NumberWithUnits.pm
+++ b/lib/Parser/Legacy/NumberWithUnits.pm
@@ -7,7 +7,7 @@
 
 package Parser::Legacy::ObjectWithUnits;
 
-# Refrences to problem specific copies of %Units::fundamental_units
+# References to problem specific copies of %Units::fundamental_units
 # and %Units::known_units.  These should be passed to any Units function call.
 # They are set by the initializeUnits sub
 my $fundamental_units = '';

--- a/lib/Parser/Legacy/PGcomplexmacros.pl
+++ b/lib/Parser/Legacy/PGcomplexmacros.pl
@@ -67,7 +67,7 @@ my $number = '([+-]?)(?=\d|\.\d)\d*(\.\d*)?(E([+-]?\d+))?';
  #				functions. The default display method is cartesian, for all methods, but if
  #				the student answer is polar, even in part, then their answer will be displayed
  #				that way.
- #	'strict_polar'		This is still under developement. The idea is to check to make sure that there
+ #	'strict_polar'		This is still under development. The idea is to check to make sure that there
  #				only a single term in front of the e and after it... but the method does not
  #				check to make sure that the i is in the exponent, nor does it handle cases
  #				where the polar has e** coefficients.
@@ -286,7 +286,7 @@ sub original_cplx_cmp {
 	#  error checking, but that was removed in version 1.9 and it had been commented out
 	#  prior to that because it was always producing errors.  This is because $correct_num_answer
 	#  usually is somethine like "1+4i", which will produce a "missing operation before 'i'"
-	#  error, and "1-i" wil produce an "amiguous use of '-i' resolved as '-&i'" message.
+	#  error, and "1-i" will produce an "ambiguous use of '-i' resolved as '-&i'" message.
 	#  You probably need a call to check_syntax and the other filters that are used on
 	#  the student answer first. (Unless the item is already a reference to a Complex,
 	#  in which canse you should just accept it.)
@@ -414,12 +414,12 @@ sub compare_cplx {
  #
  #	Checks a comma separated string of  items against an array of evaluators.
  #	For example this is useful for checking all of the complex roots of an equation.
- #	Each student answer must be evaluated as correct by a DISTINCT answer evalutor.
+ #	Each student answer must be evaluated as correct by a DISTINCT answer evaluator.
  #
  #	This answer checker will only work reliably if each answer checker corresponds
  #	to a distinct correct answer.  For example if one answer checker requires
  #	any positive number, and the second requires the answer 1, then 1,2 might
- #	be judged incorrect since 1, satisifes the first answer checker, but 2 doesn't
+ #	be judged incorrect since 1, satisfies the first answer checker, but 2 doesn't
  #	satisfy the second.  2,1 would work however. Avoid this type of use!!
  #
  #	Including backtracking to fit the answers as best possible to each answer evaluator
@@ -517,7 +517,7 @@ sub cplx_constants {
 
 =cut
 
-# Output is text displaying the complex numver in "e to the i theta" form. The
+# Output is text displaying the complex number in "e to the i theta" form. The
 # formats for the argument theta is determined by the option C<theta_format> and the
 # format for the modulus is determined by the C<r_format> option.
 
@@ -650,8 +650,8 @@ sub is_a_numeric_polar {
 	}
 }
 
-#this subroutine mearly captures what is before and after the "e**" it does not verify that the "i" is there, or in the
-#exponent this must eventually be addresed
+#this subroutine merely captures what is before and after the "e**" it does not verify that the "i" is there, or in the
+#exponent this must eventually be addressed
 sub is_a_polar {
 	my ($num, %options) = @_;
 	my $process_ans_hash = (ref($num) eq 'AnswerHash') ? 1 : 0;
@@ -689,9 +689,9 @@ sub is_a_polar {
 
 =head4 single_term()
 
- #	This subroutine takes in a string, which is a mathematical expresion, and determines whether or not
+ #	This subroutine takes in a string, which is a mathematical expression, and determines whether or not
  #	it is a single term. This is accoplished using a stack. Open parenthesis pluses and minuses are all
- #	added onto the stack, and when a closed parenthesis is reached, the stack is popped untill the open
+ #	added onto the stack, and when a closed parenthesis is reached, the stack is popped until the open
  #	parenthesis is found. If the original was a single term, the stack should be empty after
  #	evaluation. If there is anything left ( + or - ) then false is returned.
  #	Of course, the unary operator "-" must be handled... if it is a unary operator, and not a regular -

--- a/lib/Plots/Axes.pm
+++ b/lib/Plots/Axes.pm
@@ -63,7 +63,7 @@ It is also possible to get multiple options for both axes using the get method, 
 a reference to a hash of requested keys, such as:
 
     $bounds = $plot->axes->get('xmin', 'xmax', 'ymin', 'ymax');
-    # The following is equivlant to $plot->axes->grid
+    # The following is equivalent to $plot->axes->grid
     $grid = $plot->axes->get('xmajor', 'xminor', 'xtick_delta', 'ymajor', 'yminor', 'ytick_delta');
 
 It is also possible to get the bounds as an array in the order xmin, ymin, xmax, ymax

--- a/lib/Rserve.pm
+++ b/lib/Rserve.pm
@@ -121,7 +121,7 @@ use constant {
 	CMD_attachSession    => 0x032,    # session key : -
 
 	# control commands (since 0.6-0) - passed on to the master process */
-	# Note: currently all control commands are asychronous, i.e. RESP_OK indicates that the command was enqueued in the
+	# Note: currently all control commands are asynchronous, i.e. RESP_OK indicates that the command was enqueued in the
 	# master pipe, but there is no guarantee that it will be processed. Moreover non-forked connections (e.g. the
 	# default debug setup) don't process any control commands until the current client connection is closed so the
 	# connection issuing the control command will never see its result.
@@ -131,7 +131,7 @@ use constant {
 	CMD_ctrlShutdown => 0x44,    # - : -
 
 	# 'internal' commands (since 0.1-9)
-	CMD_setBufferSize => 0x081,    # [int sendBufSize] this commad allow clients to request bigger buffer sizes if
+	CMD_setBufferSize => 0x081,    # [int sendBufSize] this command allow clients to request bigger buffer sizes if
 								   # large data is to be transported from Rserve to the client. (incoming buffer is
 								   # resized automatically)
 	CMD_setEncoding   => 0x082,    # string (one of "native","latin1","utf8") : -; since 0.5-3

--- a/lib/Rserve/REXP.pm
+++ b/lib/Rserve/REXP.pm
@@ -170,6 +170,6 @@ C<L<base::inherits|http://stat.ethz.ch/R-manual/R-patched/library/base/html/clas
 =head1 OVERLOADS
 
 C<REXP> overloads the stringification, C<eq> and C<ne> methods. Subclasses
-further specialize for their types if necesssary.
+further specialize for their types if necessary.
 
 =cut

--- a/lib/Rserve/REXP/Expression.pm
+++ b/lib/Rserve/REXP/Expression.pm
@@ -26,7 +26,7 @@ Rserve::REXP::Expression - an R expression vector
 
     use Rserve::REXP::Expression
 
-    # Representation of the R call C<expresson(1 + 2))>:
+    # Representation of the R call C<expression(1 + 2))>:
     my $vec = Rserve::REXP::Expression->new([
         Rserve::REXP::Language->new([
             Rserve::REXP::Symbol->new('+'),

--- a/lib/Select.pm
+++ b/lib/Select.pm
@@ -75,7 +75,7 @@ receive a sub-set of those questions by using choose.
 =head2 Usage
 
 
-=head3 Regualar Select List
+=head3 Regular Select List
 
 
 Create a select list using the new_select_list call.

--- a/lib/Units.pm
+++ b/lib/Units.pm
@@ -96,7 +96,7 @@ our %known_units = (
 		rad     => 1,
 		aliases => [ "\x{00B0}", 'degree', 'degrees' ]
 	},
-	sr => {     # steradian, a mesure of solid angle
+	sr => {     # steradian, a measure of solid angle
 		factor => 1,
 		rad    => 2
 	},

--- a/lib/Value.pm
+++ b/lib/Value.pm
@@ -351,7 +351,7 @@ Usage:
 
     Value->Package(name[,noerror]])
 
-Returns the package name for the specificied Value object class
+Returns the package name for the specified Value object class
 (as specified by the context's {value} hash, or "Value::name").
 
 =cut

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -1292,7 +1292,7 @@ Usage:
     $interval = Interval("(1,2]");
     $interval = Interval('(',1,2,']');
 
-    ANS($inteval->cmp);
+    ANS($interval->cmp);
 
 compareOptions and default values:
 

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -689,7 +689,7 @@ sub format_delimiter_tth {
 #  based on these, and keep track of error messages.
 #
 
-my @ans_cmp_defaults = (showCoodinateHints => 0, checker => sub {0});
+my @ans_cmp_defaults = (showCoordinateHints => 0, checker => sub {0});
 
 sub ans_collect {
 	my $self   = shift;

--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -949,7 +949,7 @@ sub cmp {
 }
 
 #
-#  Adjust student preview and anser strings so they display properly
+#  Adjust student preview and answer strings so they display properly
 #
 sub cmp_preprocess {
 	my $self = shift;
@@ -1575,7 +1575,7 @@ sub cmp_equal {
 	$ans->{showPartialCorrectAnswers} = $self->getPG('$showPartialCorrectAnswers');
 
 	#
-	#  get the paramaters
+	#  get the parameters
 	#
 	my $showHints         = getOption($ans, 'showHints');
 	my $showLengthHints   = getOption($ans, 'showLengthHints');

--- a/lib/Value/Context.pm
+++ b/lib/Value/Context.pm
@@ -96,7 +96,7 @@ sub copy {
 }
 
 #
-#  Returns the package name for the specificied Value object class
+#  Returns the package name for the specified Value object class
 #  (as specified by the context's {value} hash, or "Value::name").
 #
 sub Package {

--- a/lib/Value/Interval.pm
+++ b/lib/Value/Interval.pm
@@ -204,7 +204,7 @@ sub sub {
 #
 #  Subtract an interval from another
 #    (returns the resulting interval(s), set
-#     or nothing for emtpy set)
+#     or nothing for empty set)
 #
 sub subIntervalInterval {
 	my ($l, $r) = @_;

--- a/lib/Value/Matrix.pm
+++ b/lib/Value/Matrix.pm
@@ -1442,7 +1442,7 @@ sub subMatrix {
 		if (ref $ind[$i] eq 'ARRAY') {
 			push @indices, $ind[$i];
 		} else {
-			# check that $ind[$i] is an integer in the appopriate range
+			# check that $ind[$i] is an integer in the appropriate range
 			Value::Error("The input $ind[$i] is not a valid index")
 				unless $ind[$i] =~ /^\d+$/ && $ind[$i] >= 0 && $ind[$i] <= $dim[$i];
 			push @indices, [ grep { $_ != $ind[$i] } (1 .. $dim[$i]) ];

--- a/lib/Value/Real.pm
+++ b/lib/Value/Real.pm
@@ -101,7 +101,7 @@ sub power {
 	my $x = $l->{data}[0]**$r->{data}[0];
 	return $self->inherit($other)->make($x) unless lc($x) eq 'nan' or lc($x) eq '-nan';
 	Value::Error("Can't raise a negative number to a non-integer power") if ($l->{data}[0] < 0);
-	Value::Error("Result of exponention is not a number");
+	Value::Error("Result of exponentiation is not a number");
 }
 
 sub modulo {

--- a/lib/Value/Vector.pm
+++ b/lib/Value/Vector.pm
@@ -55,7 +55,7 @@ sub new {
 }
 
 #
-#  Try to promote arbitary data to a vector
+#  Try to promote arbitrary data to a vector
 #
 sub promote {
 	my $self    = shift;

--- a/lib/VectorField.pm
+++ b/lib/VectorField.pm
@@ -42,7 +42,7 @@ The graph_ref must come last.
 
 =item	$vf = new VectorField ( dx_rule_ref, dy_rule_ref );
 
-A vector field object is created where the subroutines refered to by dx_rule_ref and dy_rule_ref define
+A vector field object is created where the subroutines referred to by dx_rule_ref and dy_rule_ref define
 the x and y components of the vector field at (x,y).  Both subroutines must be functions of two variables.
 
 =item	$vf = new VectorField ( x_rule_ref, y_rule_ref, graph_ref );
@@ -52,7 +52,7 @@ of the vector field object is set to the domain of the graph. The graph_ref must
 
 =back
 
-=head2 Properites
+=head2 Properties
 
 	All of the properties are set using the construction $new_value = $vf->property($new_value)
 	and read using $current_value = $vf->property()

--- a/lib/WWPlot.pm
+++ b/lib/WWPlot.pm
@@ -68,20 +68,20 @@ while
 
 	@functions = $graph->fn();
 
-will give a list of the current functions (similary for labels and stamps).
+will give a list of the current functions (similarly for labels and stamps).
 
 Either of the  commands
 
 	$graph->fn('reset');
 	$graph->fn('erase');
 
-will erase the array containing the functions and similary for the label and stamps arrays.
+will erase the array containing the functions and similarly for the label and stamps arrays.
 
 
 =item h_axis, v_axis
 
 	$h_axis_coordinate = $graph -> h_axis();
-	$new_axis    =       $grpah -> h_axis($new_axis);
+	$new_axis    =       $graph -> h_axis($new_axis);
 
 Respectively read and set the vertical coordinate value in real world coordinates where the
 horizontal axis intersects the vertical one.  The same construction reads and sets the coordinate
@@ -100,7 +100,7 @@ $tick1, etc are the real world coordinate values for each of the tick marks.
 	@h_grid = $graph -> h_grid();
 	@h_grid = $graph -> h_grid( $grid1, $grid2, $grid3, $grid4   );
 
-reads and sets the verical coordinates for the horizontal grid lines.  The values
+reads and sets the vertical coordinates for the horizontal grid lines.  The values
 $grid1, etc are the real world coordinate values where the horizontal grid meets the
 vertical axis.
 

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -354,7 +354,7 @@ sourceFilePath
 =item sourceFilePath (string)
 
 Location of the pg problem file to render.  It must either be provided with an
-absoute path, or a path relative to the given templateDirectory.
+absolute path, or a path relative to the given templateDirectory.
 
 =item templateDirectory (string, default: '')
 
@@ -602,7 +602,7 @@ These options are still used in some places in PG (mostly by macros that will
 eventually be deprecated and removed), but eventually that will all be fixed and
 these will no longer be needed.  Note that webwork2 still needs to pass the
 courseName so the relevant course values (course html directories and urls) can
-be optained from the WeBWorK::CourseEnvironment.
+be obtained from the WeBWorK::CourseEnvironment.
 
 =back
 

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -107,7 +107,7 @@ sub convertToPGML {
 			while ($row && $row !~ /\);\s*$/) {
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
-				# This only adds the row if there is something relevent to the left of a #
+				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
 			# Split by commas and pull out the quotes.

--- a/lib/WeBWorK/PG/Environment.pm
+++ b/lib/WeBWorK/PG/Environment.pm
@@ -17,7 +17,7 @@ The configuration is initially loaded from
 $ENV{PG_ROOT}/conf/pg_config.dist.yml.  If it is desired to change the default
 values, then copy the $ENV{PG_ROOT}/conf/pg_config.dist.yml to
 $ENV{PG_ROOT}/conf/pg_config.yml, and make changes in the copy.  The default
-values will be overriden with the changed values in the copy.  Note that invalid
+values will be overridden with the changed values in the copy.  Note that invalid
 values added to the copy will cause a warning to be issued.
 
 If the WeBWorK::CourseEnvironment module is found, then the configuration

--- a/lib/WeBWorK/PG/Environment.pm
+++ b/lib/WeBWorK/PG/Environment.pm
@@ -65,7 +65,7 @@ sub new ($invocant, $courseName = '___') {
 
 	# Override pg settings and things needed by WeBWorK::PG::IO with settings from the course environment.  Pick and
 	# choose the important values from the webwork2 course environment.  Some values in the PG configuration are not
-	# overriden.  These are the values that are used in the WeBWorK::PG and WeBWorK::PG::IO.  Note that in WeBWorK::PG
+	# overridden.  These are the values that are used in the WeBWorK::PG and WeBWorK::PG::IO.  Note that in WeBWorK::PG
 	# most values for the translator environment are taken from the options passed in, and the values in the pg
 	# environment are used for the default values.
 	if (defined $ce) {

--- a/lib/WeBWorK/PG/EquationCache.pm
+++ b/lib/WeBWorK/PG/EquationCache.pm
@@ -13,7 +13,7 @@ WeBWorK::PG::EquationCache - create and cache images of TeX equations.
 
 WeBWorK::PG::EquationCache maintains a list of unique identifiers for TeX
 strings. The unique identifier is based on an MD5 hash of the TeX string, and a
-sequence number. Before calcuating the MD5 hash of a TeX string, all whitespace
+sequence number. Before calculating the MD5 hash of a TeX string, all whitespace
 is removed.
 
 =head2 FILE FORMAT

--- a/lib/WeBWorK/PG/Tidy.pm
+++ b/lib/WeBWorK/PG/Tidy.pm
@@ -81,7 +81,7 @@ my $postfilter = sub {
 	$evalString =~ s/(.*)->tex\(<<END_LATEX_IMAGE\);/$1->BEGIN_LATEX_IMAGE/g;
 
 	# Care is needed to reverse the preprocessing here.
-	# First in all occurences of an odd number of backslashes the last backslash is replaced with two tildes.
+	# First in all occurrences of an odd number of backslashes the last backslash is replaced with two tildes.
 	$evalString =~ s/(?<!\\) \\ ((?:\\{2})*) (?!\\)/$1~~/gx;
 	# Then all pairs of backslashes are replaced with a single backslash.
 	$evalString =~ s/\\\\/\\/g;

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -477,7 +477,7 @@ Specifically the following are allowed:
     time
         - Gives the current Unix time.
     atan, sin, cos, exp, log, sqrt
-        - Arithemetic commands.  More are defined in PGauxiliaryFunctions.pl
+        - Arithmetic commands.  More are defined in PGauxiliaryFunctions.pl
 
 The following are specifically not allowed:
 

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -13,7 +13,7 @@ WeBWorK::PG::Translator - Evaluate PG code and evaluate answers safely
 
     $pt->source_string($source);             # provide the source string for the problem
                                              # or
-    $pt->source_file($sourceFilePath);       # provide the proble file containing the source
+    $pt->source_file($sourceFilePath);       # provide the problem file containing the source
 
     # Load the unprotected macro files.
     # These files are evaluated with the Safe compartment wide open.

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -7,7 +7,7 @@ PG.pl - Provides core Program Generation Language functionality.
 
 In a PG problem:
 
-    DOCUMENT();             # should be the first statment in the problem
+    DOCUMENT();             # should be the first statement in the problem
 
     loadMacros(.....);      # (optional) load other macro files if needed.
 
@@ -20,7 +20,7 @@ In a PG problem:
                             # It is defined in PGbasicmacros.pl.
     );
 
-    ANS(answer_evalutors);  # see PGanswermacros.pl for examples of answer evaluatiors.
+    ANS(answer_evaluators); # see PGanswermacros.pl for examples of answer evaluatiors.
 
     ENDDOCUMENT()           # must be the last statement in the problem
 
@@ -412,7 +412,7 @@ sub sageReturnedFail {
 
 =head2 NAMED_ANS
 
-Associates answer names with answer evaluators.  If the given anwer name has a
+Associates answer names with answer evaluators.  If the given answer name has a
 response group in the PG_ANSWERS_HASH, then the evaluator is added to that
 response group.  Otherwise the name and evaluator are added to the hash of
 explicitly named answer evaluators.  They will be paired with exlplicitly
@@ -551,7 +551,7 @@ sub persistent_data {
 }
 
 # The store_persistent_data, update_persistent_data, and get_persistent_data methods are deprecated and are only still
-# here for backward compatability. Use the persistent_data method instead which can do everything these three methods
+# here for backward compatibility. Use the persistent_data method instead which can do everything these three methods
 # can do. Note that if you use the persistent_data method, then you will need to join the values as strings if you want
 # that. Even better pass the persistent_data method an array reference containing the values so you can avoid the hassle
 # of splitting the values when they are retrieved.
@@ -846,9 +846,9 @@ the type of submission.
 C<btnClass>: This is the button class added to the feedback button. These are
 based on bootstrap button styles, but are custom styles for the feedback
 buttons to allow clients to theme the bootstrap buttons without changing the
-feedback styles. By default it is "btn-preview" (coppied from btn-info),
-"btn-correct" (coppied from btn-success), "btn-incorrect" (coppied from
-btn-danger), or "btn-partially-correct" (coppied from btn-warning)
+feedback styles. By default it is "btn-preview" (copied from btn-info),
+"btn-correct" (copied from btn-success), "btn-incorrect" (copied from
+btn-danger), or "btn-partially-correct" (copied from btn-warning)
 depending on the status of the answer and the type of submission.
 
 =item *
@@ -1796,7 +1796,7 @@ against misspelling an option and is generally what is desired for most filters.
 
 Occasionally one wants to write a filter which accepts a long list of options,
 not all of which are known in advance, but only uses a subset of the options
-provided. In this case, setting C<allow_unkown_options> to 1 prevents the error
+provided. In this case, setting C<allow_unknown_options> to 1 prevents the error
 from being signaled.
 
 =cut

--- a/macros/answers/PGasu.pl
+++ b/macros/answers/PGasu.pl
@@ -452,7 +452,7 @@ the problem:
 
     $ENV{'partial_weights'} = [.2,.2,.2,.3];
 
-This will soon be superceded by a better grader.
+This will soon be superseded by a better grader.
 
 =cut
 

--- a/macros/answers/PGfunctionevaluators.pl
+++ b/macros/answers/PGfunctionevaluators.pl
@@ -30,7 +30,7 @@ evaluators for use in common situations which feature a simplified syntax.
 
 BEGIN { strict->import; }
 
-# Until we get the PG cacheing business sorted out, we need to use
+# Until we get the PG caching business sorted out, we need to use
 # PG_restricted_eval to get the correct values for some(?) PG environment
 # variables. We do this once here and place the values in lexicals for later
 # access.

--- a/macros/answers/PGfunctionevaluators.pl
+++ b/macros/answers/PGfunctionevaluators.pl
@@ -653,7 +653,7 @@ sub FUNCTION_CMP {
 		my $s = ($n != 1) ? "s" : "";
 		foreach my $p (@{$testPoints}) {
 			$p = [$p] unless ref($p) eq 'ARRAY';
-			warn "Test point (" . join(',', @{$p}) . ") should have $n coordiante$s"
+			warn "Test point (" . join(',', @{$p}) . ") should have $n coordinate$s"
 				unless scalar(@{$p}) == $n;
 		}
 	}

--- a/macros/answers/PGfunctionevaluators.pl
+++ b/macros/answers/PGfunctionevaluators.pl
@@ -126,7 +126,7 @@ qualify as correct. In other words, a student answer is correct when
 
     abs(studentAnswer - correctAnswer) <= abs(.01*relTol*correctAnswer)
 
-tol and relTol are mutually exclusive. reltol is also accpeted as a synonym for
+tol and relTol are mutually exclusive. reltol is also accepted as a synonym for
 relTol.
 
 =item zeroLevel, zeroLevelTol
@@ -169,7 +169,7 @@ single variable. Hence, the following are equivalent:
 	var=>['t']
 	var=>'t'
 
-vars is recognied as a synonym for var. The default is a single variable, x.
+vars is recognized as a synonym for var. The default is a single variable, x.
 
 =item limits
 

--- a/macros/answers/PGnumericevaluators.pl
+++ b/macros/answers/PGnumericevaluators.pl
@@ -48,7 +48,7 @@ recommended that you use the MathObjects cmp() methods directly if possible.
 
 BEGIN { strict->import; }
 
-# Until we get the PG cacheing business sorted out, we need to use
+# Until we get the PG caching business sorted out, we need to use
 # PG_restricted_eval to get the correct values for some(?) PG environment
 # variables. We do this once here and place the values in lexicals for later
 # access.
@@ -257,7 +257,7 @@ sub num_cmp {
 	my %out_options;
 
 #########################################################################
-	# Retain this first check for backword compatibility.  Allows input of the form
+	# Retain this first check for backward compatibility.  Allows input of the form
 	# num_cmp($ans, 1, '%0.5f') but warns against it
 #########################################################################
 	my %known_options = (
@@ -419,7 +419,7 @@ sub num_cmp {
 	return (wantarray) ? @output_list : $output_list[0];
 }
 
-#legacy code for compatability purposes
+#legacy code for compatibility purposes
 sub num_rel_cmp {    # compare numbers
 	std_num_cmp(@_);
 }
@@ -929,7 +929,7 @@ This function is deprecated. Use num_cmp with the units option instead:
 ##			zeroLevel	--	if the correct answer is this close to zero, then zeroLevelTol applies
 ##			zeroLevelTol	--	absolute tolerance to allow when correct answer is close to zero
 
-# This mode is depricated.  send input through num_cmp -- it can handle units.
+# This mode is deprecated.  send input through num_cmp -- it can handle units.
 
 sub numerical_compare_with_units {
 	my $correct_answer = shift;    # the answer is a string which	includes both the numerical answer and the units.
@@ -994,7 +994,7 @@ sub NUM_CMP {    # low level numeric compare (now uses Parser)
 		if $correctAnswer =~ m/e/ && Value::isNumber($correctAnswer);
 
 	#
-	#  Get an apppropriate context based on the mode
+	#  Get an appropriate context based on the mode
 	#
 	my $context;
 	for ($mode) {
@@ -1232,7 +1232,7 @@ sub ORIGINAL_NUM_CMP {    # low level	numeric	compare
 
 ###############################################################################
 	# We'll leave these next lines out for now, so that the evaluated versions of the student's and professor's
-	# can be displayed in the answer message.  This may still cause a few anomolies when strings are used
+	# can be displayed in the answer message.  This may still cause a few anomalies when strings are used
 	#
 ###############################################################################
 

--- a/macros/answers/PGnumericevaluators.pl
+++ b/macros/answers/PGnumericevaluators.pl
@@ -135,7 +135,7 @@ formatting syntax is the same as Perl uses for the sprintf() function. Format
 strings are of the form '%m.nx' or '%m.nx#', where m and n are described below,
 and x is a formatter.
 
-Esentially, m is the minimum length of the field (make this negative to
+Essentially, m is the minimum length of the field (make this negative to
 left-justify). Note that the decimal point counts as a character when
 determining the field width. If m begins with a zero, the number will be padded
 with zeros instead of spaces to fit the field.
@@ -189,7 +189,7 @@ correct when
 
     abs(studentAnswer - correctAnswer) <= abs(.01*relTol*correctAnswer)
 
-tol and relTol are mutually exclusive. reltol is also accpeted as a synonym for
+tol and relTol are mutually exclusive. reltol is also accepted as a synonym for
 relTol.
 
 =item zeroLevel, zeroLevelTol
@@ -427,7 +427,7 @@ sub num_rel_cmp {    # compare numbers
 =head1 "mode"_num_cmp() functions
 
 There are 16 functions that provide simplified interfaces to num_cmp(). They are
-organized into four groups, based on the number of answers accpeted (single or
+organized into four groups, based on the number of answers accepted (single or
 list) and whether relative or absolute tolerances are used. Each group contains
 four functions, one for each evaluation mode. See the mode option to num_cmp()
 above for details about each mode.
@@ -463,7 +463,7 @@ to num_cmp(), above.
     ANS(frac_num_cmp_list($relTol, $format, @answerList));
 
 This group of functions produces answer evaluators for a list of correct answers
-using relative tolerances. $relTol and $format are equivelent to the
+using relative tolerances. $relTol and $format are equivalent to the
 identically-named options to num_cmp() above. @answerList must contain one or
 more correct answers. A list of answer evaluators is returned, one for each
 answer provided in @answerList. All answer returned evaluators will use the
@@ -489,7 +489,7 @@ to num_cmp(), above.
     ANS(frac_num_cmp_abs_list($absTol, $format, @answerList));
 
 This group of functions produces answer evaluators for a list of correct answers
-using absolute tolerances. $absTol and $format are equivelent to the
+using absolute tolerances. $absTol and $format are equivalent to the
 identically-named options to num_cmp() above. @answerList must contain one or
 more correct answers. A list of answer evaluators is returned, one for each
 answer provided in @answerList. All answer returned evaluators will use the

--- a/macros/answers/PGstringevaluators.pl
+++ b/macros/answers/PGstringevaluators.pl
@@ -217,7 +217,7 @@ checked for. If these strings are found in the argument list, it is assumed that
 
 A reference to an array of filter names, to be applied to both the correct
 answer and the student's answer before doing string comparison. Supported
-filters are listed above. filter is avaliable as a synonym for filters.
+filters are listed above. filter is available as a synonym for filters.
 
 =item debug
 

--- a/macros/answers/answerHints.pl
+++ b/macros/answers/answerHints.pl
@@ -24,7 +24,7 @@ answer, the student's answer, and the answer hash, and returns
 displayed.  (See the examples below.)
 
 The right-hand side can be either the message string itself, or
-a referrence to an array where the first element is the message
+a reference to an array where the first element is the message
 string, and the remaining elements are name-value pairs that
 set options for the message.  These can include:
 
@@ -38,7 +38,7 @@ Default: 0
 
 =item C<S<< replaceMessage => 0 or 1 >>>
 
-1 means it's OK to repalce any
+1 means it's OK to replace any
 message that is already in place
 in the answer hash.
 Default: 0
@@ -54,7 +54,7 @@ Default: 1
 
 1 means process student answers even
 during answer previews.  Usually, no
-hints are given durring previews, but
+hints are given during previews, but
 only when answers are checked or submitted.
 The default can be controlled on an individual
 message basis, or by adding

--- a/macros/answers/answerVariableList.pl
+++ b/macros/answers/answerVariableList.pl
@@ -83,7 +83,7 @@ sub variable_cmp {
 
     addVariables(@vars)
 
-Adds each string in @vars as a varible to the current context.
+Adds each string in @vars as a variable to the current context.
 
 =cut
 

--- a/macros/answers/extraAnswerEvaluators.pl
+++ b/macros/answers/extraAnswerEvaluators.pl
@@ -409,7 +409,7 @@ sub interval_cmp {
 =head2 number_list_cmp
 
 Checks an answer which is a comma-separated list of numbers.  The actual
-numbers are fed to num_cmp, so all of the flexibilty of num_cmp carries
+numbers are fed to num_cmp, so all of the flexibility of num_cmp carries
 over (values can be expressions to be evaluated).  For example,
 
 	number_list_cmp("1, -2")
@@ -428,7 +428,7 @@ to use cplx_cmp instead:
 In cases where you set complex=>'ok', be sure the problem file loads
 PGcomplexmacros.pl.
 
-Optional arguements for num_cmp (resp. cplx_cmp) can be used as well,
+Optional arguments for num_cmp (resp. cplx_cmp) can be used as well,
 such as
 
 	number_list_cmp("cos(3), sqrt(111)", relTol => 3)
@@ -444,7 +444,7 @@ will mark "none" wrong, but not generate an error.  On the other hand,
 
 will mark "none" as correct.
 
-One can also specify optionnal arguments for Parser's List checker: showHints,
+One can also specify optional arguments for Parser's List checker: showHints,
 partialCredit, and showLengthHints, as in:
 
 	number_list_cmp("cos(3), sqrt(111)", partialCredit=>1)

--- a/macros/answers/extraAnswerEvaluators.pl
+++ b/macros/answers/extraAnswerEvaluators.pl
@@ -324,7 +324,7 @@ sub interval_cmp {
 	my $ans_type = '';                        # set to List, Union, or String below
 
 	#
-	#  Get an apppropriate context based on the mode
+	#  Get an appropriate context based on the mode
 	#
 	my $oldContext = Context();
 	my $context    = mode2context($mode, %opts);
@@ -464,7 +464,7 @@ sub number_list_cmp {
 	my %options = (debug => $num_params{debug});
 
 	#
-	#  Get an apppropriate context based on the mode
+	#  Get an appropriate context based on the mode
 	#
 	my $oldContext = Context();
 	my $context    = mode2context($mode, %num_params);

--- a/macros/answers/unorderedAnswer.pl
+++ b/macros/answers/unorderedAnswer.pl
@@ -25,7 +25,7 @@ sub _unorderedAnswer_init { };    # don't reload this file
 
 Collect a group of answer checkers for use with answers that can be given
 in any order.  If C<N> answer checkers are given, then the last C<N> answer
-rules will be used.  It is beter to use named rules and C<UNORDERED_NAMED_ANS>
+rules will be used.  It is better to use named rules and C<UNORDERED_NAMED_ANS>
 below.  Otherwise, be sure to use C<UNORDERED_ANS> right after the answer
 rules for the answers you want to compare.
 

--- a/macros/contexts/contextAlternateDecimal.pl
+++ b/macros/contexts/contextAlternateDecimal.pl
@@ -75,7 +75,7 @@ different values.  For example.
     );
 
 would allow students to enter decimals in either format, but all
-numebrs would be displayed in standard form.
+numbers would be displayed in standard form.
 
 
 =head2 LISTS IN ALTERNATE FORMAT
@@ -92,7 +92,7 @@ Note that the comma is still available for use as a separator, but
 this makes things like C<3,2,1> tricky, because it is not clear if
 this is 3.2 followed by 1, or 3.2 times .1, or the list of 3, 2, and
 1.  To help make this unambiguous, numbers that use a comma as decimal
-inidcator must have a digit on both sides of the comma.  So one tenth
+indicator must have a digit on both sides of the comma.  So one tenth
 would have to be entered as C<0,1> not just C<,1> (but you can still
 enter C<.1>.  Similarly, You must enter C<3,0> or just C<3> rather
 than C<3,>, even though C<3.> is acceptable.

--- a/macros/contexts/contextAlternateIntervals.pl
+++ b/macros/contexts/contextAlternateIntervals.pl
@@ -244,7 +244,7 @@ sub Open {
 #
 #  We need to modify the test for formInterval to NOT check the number
 #  of entries so that better error messages are produced, and to handle
-#  multiple close delimiters.  These are both in teh "operand" branch,
+#  multiple close delimiters.  These are both in the "operand" branch,
 #  so do the original for all the choices, and copy that branch here,
 #  with our modifications.
 #

--- a/macros/contexts/contextArbitraryString.pl
+++ b/macros/contexts/contextArbitraryString.pl
@@ -33,7 +33,7 @@ the student answer to match the correct one exactly (spacing and
 case are significant), then you don't have to use a custom checker.
 But if you want, for example, to collapse multiple white-space, or
 trim leading and trailing blanks, or treat upper- and lower-case
-letters as quivalent, then you will need to provide your own
+letters as equivalent, then you will need to provide your own
 checker that does that.
 
 This context handles multi-line answers properly.  If your answers

--- a/macros/contexts/contextBaseN.pl
+++ b/macros/contexts/contextBaseN.pl
@@ -11,7 +11,7 @@ greater than or equal to 2.  The numbers will be stored internally in decimal, t
 and shown in the chosen base.
 
 The original purpose for this is simple conversion and operations in another base, however
-it is not limited to this. In addition, basic integer arithemetic (+,-,*,/,%,^) are available for these numbers.
+it is not limited to this. In addition, basic integer arithmetic (+,-,*,/,%,^) are available for these numbers.
 Division is defined in an integer sense.
 
 To use a non-decimal base MathObject, first load the contextBaseN.pl file:

--- a/macros/contexts/contextBoolean.pl
+++ b/macros/contexts/contextBoolean.pl
@@ -417,14 +417,14 @@ sub perl {
 	return "($result ? context::Boolean->T : context::Boolean->F)";
 }
 
-# remove once UOP::string passses 'same' as second argument
+# remove once UOP::string passes 'same' as second argument
 sub string {
 	my ($self, $precedence, $showparens, $position, $outerRight) = @_;
 	$showparens = "same" if !($position // '') && !($showparens // '');
 	return $self->SUPER::string($precedence, $showparens, $position, $outerRight);
 }
 
-# remove once UOP::TeX passses 'same' as second argument
+# remove once UOP::TeX passes 'same' as second argument
 sub TeX {
 	my ($self, $precedence, $showparens, $position, $outerRight) = @_;
 	$showparens = "same" if !($position // '') && !($showparens // '');

--- a/macros/contexts/contextBoolean.pl
+++ b/macros/contexts/contextBoolean.pl
@@ -83,7 +83,7 @@ are the only manner by which an expression will evaluate operations to the right
 
     $a = Compute("T or T and F"); # $a == F
 
-The C<oxan> setting priortizes C<or> < C<xor> < C<and> < C<not>.
+The C<oxan> setting prioritizes C<or> < C<xor> < C<and> < C<not>.
 
     Context()->setPrecedence('oxan');
     $b = Compute("T or T and F"); # $b == T

--- a/macros/contexts/contextComplexJ.pl
+++ b/macros/contexts/contextComplexJ.pl
@@ -62,7 +62,7 @@ different values.  For example.
     );
 
 would allow students to enter complex numbers in either format, but
-all numebrs would be displayed in standard form.
+all numbers would be displayed in standard form.
 
 
 =head2 SETTING THE ALTERNATE FORM AS THE DEFAULT

--- a/macros/contexts/contextCongruence.pl
+++ b/macros/contexts/contextCongruence.pl
@@ -160,7 +160,7 @@ sub compare {
 	} elsif ($requireAllSolutions) {
 		return $allSolutions->compare($r);
 	} else {
-		# check both all solutons and general solution
+		# check both all solutions and general solution
 		return 0 if $allSolutions->compare($r) == 0;
 		return $generalSolution->compare($r);
 	}

--- a/macros/contexts/contextCongruence.pl
+++ b/macros/contexts/contextCongruence.pl
@@ -16,7 +16,7 @@ allows both types of solutions, C<Context("Congruence-General-Solution")>, which
 requires the general solution, and C<Context("Congruence-All-Solutions")>, which
 requires all solutions to be entered.
 
-Congruences must be created with three paramters (a, b, m) from ax ≡ b (mod m).
+Congruences must be created with three parameters (a, b, m) from ax ≡ b (mod m).
 
     loadMacros("contextCongruence.pl");
 

--- a/macros/contexts/contextCurrency.pl
+++ b/macros/contexts/contextCurrency.pl
@@ -32,7 +32,7 @@ more than one way to write the currency).  For example:
     Context("Currency")->currency->addSymbol("dollars","dollar");
 
 would accept '$12,345.67' or '12.50 dollars' or '1 dollar' as
-acceptable values.  Note that if the symbol cantains any
+acceptable values.  Note that if the symbol contains any
 alphabetic characters, it is expected to come at the end of the
 number (as in the examples above) and if the symbol has only
 non-alphabetic characters, it comes before it.  You can change

--- a/macros/contexts/contextForm.pl
+++ b/macros/contexts/contextForm.pl
@@ -8,10 +8,10 @@ arithmetic.
 
 This context distinguishes between "forms" of an expression by using bizarro
 arithmetic.  For example, the answer could be "(x+1)(x+2)". Bizarro arithmetic always has
-commutative and associative addidition and multiplication, so it would be OK
+commutative and associative addition and multiplication, so it would be OK
 to answer with "(2+x)(x+1)".
 
-But this context initally only uses bizarro with multiplication and division.
+But this context initially only uses bizarro with multiplication and division.
 So "x^2+3x+2" will not evaluate to the same as "(x+1)(x+2)".
 
 The reverse works as well: the answer could be "x^2+3x+2" and "(x+1)(x+2)"

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -1012,7 +1012,7 @@ sub power {
 	}
 	return $self->inherit($other)->make($x, $y) unless $x eq 'nan' || $y eq 'nan';
 	Value::Error("Can't raise a negative number to a non-integer power") if $a * $b < 0;
-	Value::Error("Result of exponention is not a number");
+	Value::Error("Result of exponentiation is not a number");
 }
 
 sub compare {

--- a/macros/contexts/contextFraction.pl
+++ b/macros/contexts/contextFraction.pl
@@ -149,7 +149,7 @@ are created.  The default is to reduce fractions (except when
 C<studentsMustReduceFractions> is set), so C<Compute("4/6")> would
 produce the fraction C<2/3>.  To leave fractions unreduced, set C<S<<
 reduceFractions => 0 >>>.  The C<LimitedFraction> and
-C<LimiteProperFraction> contexts have C<studentsMustReduceFractions>
+C<LimitedProperFraction> contexts have C<studentsMustReduceFractions>
 set, so C<reduceFractions> is unset automatically for students, but
 not for correct answers, so C<Fraction(2,4)> would still produce
 C<1/2>, even though C<2/4> would not be allowed in a student answer.
@@ -207,7 +207,7 @@ C<requirePureFractions> and C<requireProperFractions> to 1.
 
 =item S<C<< fractionTolerance >>>
 
-Thie determines the tolerance to use when comparing a fraction to a
+This determines the tolerance to use when comparing a fraction to a
 real number.  The fraction will be converted to a real, and then this
 is used as the tolerance in a relative-tolerance comparison of the two
 reals.  The default is 1E-10, meaning the decimal must match to

--- a/macros/contexts/contextInequalities.pl
+++ b/macros/contexts/contextInequalities.pl
@@ -74,7 +74,7 @@ For example:
     $I0 = Compute("1 < x <= 2");       # the inequality 1 < x <= 2
     $I1 = Interval($I0);               # the interval (1,2]
 
-Note that ineqaulities and inervals can be compared and combined
+Note that inequalities and intervals can be compared and combined
 regardless of the format, so C<$I0 == $I1> is true in either example
 above.
 

--- a/macros/contexts/contextLimitedPolynomial.pl
+++ b/macros/contexts/contextLimitedPolynomial.pl
@@ -236,7 +236,7 @@ sub checkPolynomial {
 
 sub checkStrict {
 	my $self = shift;
-	$self->Error("You can only use '%s' between coefficents and variables in a simplified polynomial", $self->{bop});
+	$self->Error("You can only use '%s' between coefficients and variables in a simplified polynomial", $self->{bop});
 }
 
 ##############################################

--- a/macros/contexts/contextOrdering.pl
+++ b/macros/contexts/contextOrdering.pl
@@ -233,11 +233,11 @@ sub TeX {
 #
 #  This is the Value object used to implement the list That represents
 #  one ordering operation.  It is simply a normal Value::List with the
-#  operator as the first entry and the two operands as the remaing
-#  entries in the list.  The new() method is overriden to make binary
+#  operator as the first entry and the two operands as the remaining
+#  entries in the list.  The new() method is overridden to make binary
 #  trees of equal operators into flat sorted lists.  We override the
 #  List string and TeX methods so that they print correctly as binary
-#  operators.  The cmp_equal method is overriden to make sure the that
+#  operators.  The cmp_equal method is overridden to make sure the that
 #  the lists are treated as a unit during answer checking.  There is
 #  also a routine for adding letters to the object's context.
 #

--- a/macros/contexts/contextPercent.pl
+++ b/macros/contexts/contextPercent.pl
@@ -49,7 +49,7 @@ In this way, C<n%> is treated essentially as C<(n/100)>.
 
 You can enforce more restrictive rules using the C<LimitedPercent> or
 C<LimitedPercent-strict> contexts.  The first of these allows
-operations within the number that preceeds the percent sign, but does
+operations within the number that precedes the percent sign, but does
 not allow you to combine percentages with real numbers or other
 percentages.  In this way, C<(5+5)%> is legal, but C<5% + 5%> is not.
 
@@ -119,7 +119,7 @@ This determines whether students are allowed to enter decimals beyond
 the number given by the C<decimalPlaces> flag.  If set to 0 (the
 default for the C<Percent>, C<Percent-strict>, and C<LimitedPercent>
 contexts), any number of decimals are allowed (but the C<tolerance>
-determines what values are meaningfull), while if set to 1 (the
+determines what values are meaningful), while if set to 1 (the
 default for the C<LimitedPercent-strict> context), students are not
 allowed to enter more than the required number of decimals and receive
 a warning if they do.

--- a/macros/contexts/contextPermutation.pl
+++ b/macros/contexts/contextPermutation.pl
@@ -540,7 +540,7 @@ sub _check {
 
 #
 #  Evaluate by forming a list if this is acting as a comma,
-#  othewise take a product (Value object will take care of things).
+#  otherwise take a product (Value object will take care of things).
 #
 sub _eval {
 	my $self = shift;

--- a/macros/contexts/contextPermutation.pl
+++ b/macros/contexts/contextPermutation.pl
@@ -19,7 +19,7 @@ contextPermutation.pl - Provides contexts that allow the entry of cycles and per
 
     $P4 = Compute("(1 2 3)^2");        # square a cycle
     $P5 = Compute("((1 2)(3 4))^2");   # square a permutation
-    $I = Comptue("(1 2 3)^-1");        # inverse
+    $I = Compute("(1 2 3)^-1");        # inverse
 
     $L = Compute("(1 2),(1 3 2)");     # list of permutations
 

--- a/macros/contexts/contextPermutationUBC.pl
+++ b/macros/contexts/contextPermutationUBC.pl
@@ -11,7 +11,7 @@ The entries in a cycle are separated by spaces and enclosed in
 parentheses.  Cycles are multiplied by juxtaposition.  A permutation
 can be multiplied on the left by a number in order to obtain the
 result of that number under the action of the permutation.
-Exponentiation is alos allowed (as described below).
+Exponentiation is also allowed (as described below).
 
 There are three contexts included here: C<Context("Permutation")>, which
 allows permutations in any form, C<Context("Permutation-Strict")>, which
@@ -35,7 +35,7 @@ are written in canonical form (as described below).
 
     $P4 = Compute("(1 2 3)^2");        # square a cycle
     $P5 = Compute("((1 2)(3 4))^2");   # square a permutation
-    $I = Comptue("(1 2 3)^-1");        # inverse
+    $I = Compute("(1 2 3)^-1");        # inverse
 
     $L = Compute("(1 2),(1 3 2)");     # list of permutations
 

--- a/macros/contexts/contextPermutationUBC.pl
+++ b/macros/contexts/contextPermutationUBC.pl
@@ -603,7 +603,7 @@ sub _check {
 
 #
 #  Evaluate by forming a list if this is acting as a comma,
-#  othewise take a product (Value object will take care of things).
+#  otherwise take a product (Value object will take care of things).
 #
 sub _eval {
 	my $self = shift;

--- a/macros/contexts/contextPiecewiseFunction.pl
+++ b/macros/contexts/contextPiecewiseFunction.pl
@@ -30,7 +30,7 @@ unpaired final formula, it represents the "otherwise" portion
 of the function (the formula to use of the input is not in
 any of the given intervals).
 
-Note that you can use Inveral, Set, or Union objects in place of
+Note that you can use Interval, Set, or Union objects in place of
 the intervals in the specification of a piecewise function.
 
 The PiecewiseFunction object TeXifies using a LaTeX "cases"

--- a/macros/contexts/contextPiecewiseFunction.pl
+++ b/macros/contexts/contextPiecewiseFunction.pl
@@ -345,7 +345,7 @@ sub _eval {
 #  This implements the "in" operator as in inequality.
 #  We inherit all the inequality methods, and simply
 #  need to handle the string and TeX output.  The
-#  underlying type is still an Inerval.
+#  underlying type is still an Interval.
 #
 package PiecewiseFunction::Interval;
 our @ISA = ("Inequalities::Interval");

--- a/macros/contexts/contextPolynomialFactors.pl
+++ b/macros/contexts/contextPolynomialFactors.pl
@@ -223,7 +223,7 @@ sub cmp_postprocess { }
 ##############################################
 
 package PolynomialFactors;
-our @ISA = ('LimitedPolynomal');
+our @ISA = ('LimitedPolynomial');
 
 sub markFactor {
 	my $self = shift;

--- a/macros/contexts/contextPolynomialFactors.pl
+++ b/macros/contexts/contextPolynomialFactors.pl
@@ -130,7 +130,7 @@ sub checkFactors {
 
 sub checkStrict {
 	my $self = shift;
-	$self->Error("You can only use '%s' between coefficents and variables or between factors", $self->{bop});
+	$self->Error("You can only use '%s' between coefficients and variables or between factors", $self->{bop});
 }
 
 ##############################################

--- a/macros/contexts/contextScientificNotation.pl
+++ b/macros/contexts/contextScientificNotation.pl
@@ -197,7 +197,7 @@ our @ISA = qw(Parser::BOP);
 
 #
 #  Check that the operand types are compatible, and give
-#  approrpiate error messages if not.  (We have to work
+#  appropriate error messages if not.  (We have to work
 #  hard to make a good message about the number of
 #  decimal digits required.)
 #

--- a/macros/contexts/contextTF.pl
+++ b/macros/contexts/contextTF.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-contextTF.pl - Imlements contexts for true/false problems.
+contextTF.pl - Implements contexts for true/false problems.
 
 =head1 DESCRIPTION
 

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -1028,7 +1028,7 @@ sub new {
 			dunits         => {},
 			nfunds         => $nfunds,
 			dfunds         => $dfunds,
-			isConsant      => 1,
+			isConstant     => 1,
 		},
 		$class
 	);

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -2123,8 +2123,8 @@ sub _call {
 #  Differentiate a function with a number-with-units as an argument.
 #
 #  Get the argument as a Formula.
-#  If the the argument is an angle, get its quantity (which includes
-#    the unit factor) and differentiate that.
+#  If the argument is an angle, get its quantity (which includes the unit factor)
+#    and differentiate that.
 #  Otherwise, remove the unit from the function call and differentiate that.
 #
 sub D {

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -293,7 +293,7 @@ a particular setting, without the need for a quantity.
 =head2 Working with numbers with units
 
 Because units and numbers with units are full-fledged MathObjects, you
-can do computations with them, just as with other MathObejcts.  For
+can do computations with them, just as with other MathObjects.  For
 example, you can do
 
     $n = Compute("3 m + 10 cm");
@@ -475,7 +475,7 @@ correct answer is given as C<m s^-2>, then C<m/s^2> is also marked as
 correct.  When C<< exactUnits => 1 >> is set, however, in addition to
 using the units in the same order, the student's answer must use the
 same form (either fraction or negative power) for units in the
-denominator, and will only get the C<particalCredit> value for using
+denominator, and will only get the C<partialCredit> value for using
 the other form.
 
 Answers that are numbers with units are treated in a similar manner,

--- a/macros/contexts/legacyFraction.pl
+++ b/macros/contexts/legacyFraction.pl
@@ -482,7 +482,7 @@ sub _eval {
 
 #
 #  If the implied multiplication represents a proper fraction with a
-#  preceeding integer, then switch to the proper fraction operator
+#  preceding integer, then switch to the proper fraction operator
 #  (for proper handling of string() and TeX() calls), otherwise,
 #  convert the object to a standard multiplication.
 #

--- a/macros/contexts/legacyFraction.pl
+++ b/macros/contexts/legacyFraction.pl
@@ -10,7 +10,7 @@ keeps the numerator and denominator separate.  It provides methods for
 reducing the fractions, and for allowing fractions with a whole-number
 preceding it, as in C<4 1/2> for "four and one half".  The answer
 checker can require that students reduce their results, and there are
-contexts that don't allow entery of decimal values (only fractions),
+contexts that don't allow entry of decimal values (only fractions),
 and that don't allow any operators or functions (other than division
 and negation).
 
@@ -47,7 +47,7 @@ must enter a whole number or a fraction in this context.  It is also
 permissible to enter a whole number WITH a fraction, as in C<2 1/2> for
 "two and one half", or C<5/2>.
 
-The fourth is the same as LimiteFraction, but students must enter proper
+The fourth is the same as LimitedFraction, but students must enter proper
 fractions, and results are shown as proper fractions.
 
 You can use the C<Compute()> function to generate fraction objects, or
@@ -149,7 +149,7 @@ C<Fraction> and C<Fraction-NoDecimals> contexts, but 1 in C<LimitedFraction>.
 =item S<C<< allowMixedNumbers >>>
 
 This determines whether a space between a whole number and a fraction
-is interpretted as implicit multiplication (as it usually would be in
+is interpreted as implicit multiplication (as it usually would be in
 WeBWorK), or as addition, allowing "4 1/2" to mean "4 and 1/2".  By
 default, it acts as multiplication in the Fraction and
 C<Fraction-NoDecimals> contexts, and as addition in C<LimitedFraction>.  If
@@ -182,7 +182,7 @@ C<requirePureFractions> to 1.
 
 This determines whether fractions MUST be entered as pure fractions
 rather than mixed numbers.  If C<allowMixedNumbers> is also set, then
-mixed numbers will be properly interpretted, but will produce a
+mixed numbers will be properly interpreted, but will produce a
 warning message and be marked incorrect; that is, C<2 3/4> would be
 recognized as C<2+3/4> rather than C<2*3/4>, but would generate a message
 indicating that mixed numbers are not allowed.  This flag is off by

--- a/macros/contexts/legacyFraction.pl
+++ b/macros/contexts/legacyFraction.pl
@@ -854,7 +854,7 @@ sub power {
 	}
 	return $self->inherit($other)->make($x, $y) unless $x eq 'nan' || $y eq 'nan';
 	Value::Error("Can't raise a negative number to a non-integer power") if $a * $b < 0;
-	Value::Error("Result of exponention is not a number");
+	Value::Error("Result of exponentiation is not a number");
 }
 
 sub compare {

--- a/macros/core/PGanswermacros.pl
+++ b/macros/core/PGanswermacros.pl
@@ -116,7 +116,7 @@ show a typeset view on the answer on the preview page. For a student answer of
 
 BEGIN { strict->import; }
 
-# Until we get the PG cacheing business sorted out, we need to use
+# Until we get the PG caching business sorted out, we need to use
 # PG_restricted_eval to get the correct values for some(?) PG environment
 # variables. We do this once here and place the values in lexicals for later
 # access.
@@ -222,7 +222,7 @@ sub get_var_array {
 }
 
 ## Internal routine that converts limits into the standard array of arrays format
-##	Some of the cases are probably unneccessary, but better safe than sorry
+##	Some of the cases are probably unnecessary, but better safe than sorry
 ##
 ## IN:	one of the following:
 ##			an undefined value (i.e., no limits were specified)
@@ -615,7 +615,7 @@ sub is_zero_array {
 		'stdin'        => 'ra_differences',
 		'stdout'       => 'score',
 	);
-	#intialize
+	#initialize
 	$rh_ans->{_filter_name} = $options{_filter_name};
 
 	my $array = $rh_ans->{ $options{stdin} };    # default ra_differences
@@ -697,11 +697,11 @@ sub best_approx_parameters {
 	my %options = @_;
 	set_default_options(
 		\%options,
-		'_filter_name'          => 'best_approx_paramters',
+		'_filter_name'          => 'best_approx_parameters',
 		'allow_unknown_options' => 1,
 	);
 	my $errors = undef;
-	# This subroutine for the determining the coefficents of the parameters at a given point
+	# This subroutine for the determining the coefficients of the parameters at a given point
 	# is pretty specialized, so it is included here as a sub-subroutine.
 	my $determine_param_coeffs = sub {
 		my ($rf_fun, $ra_variables, $dim_of_params_space, %options) = @_;
@@ -1297,7 +1297,7 @@ sub check_strings {
 
 # OVERVIEW of reminder of function:
 # if answer is correct, return correct.  (adjust score to 1)
-# if answer is incorect:
+# if answer is incorrect:
 #	1) determine if the answer is sensible.  if it is, return incorrect.
 #	2) if the answer is not sensible (and incorrect), then return an error message indicating so.
 # no matter what:  throw a 'STRING' error to skip numerical evaluations.  (error flag skips remainder of pre_filters and evaluators)
@@ -1722,7 +1722,7 @@ This can be very useful for printing out messages about objects while debugging
 #     if ( not ref($r_input) ) {
 #     	$out = $r_input if defined $r_input;    # not a reference
 #     	$out =~ s/</&lt;/g  ;  # protect for HTML output
-#     } elsif ("$r_input" =~/hash/i) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_iput).
+#     } elsif ("$r_input" =~/hash/i) {  # this will pick up objects whose '$self' is hash and so works better than ref($r_input).
 # 	    local($^W) = 0;
 #
 # 		$out .= "$r_input " ."<TABLE border = \"2\" cellpadding = \"3\" BGCOLOR = \"#FFFFFF\">";

--- a/macros/core/PGanswermacros.pl
+++ b/macros/core/PGanswermacros.pl
@@ -463,7 +463,7 @@ sub std_num_filter {
 
 Assumes the {student_ans} field is a numerical  array, and applies BOTH check_syntax and std_num_filter
 to each element of the array.  Does it's best to generate sensible error messages for syntax errors.
-A typical error message displayed in {studnet_ans} might be ( 56, error message, -4).
+A typical error message displayed in {student_ans} might be ( 56, error message, -4).
 
 =cut
 
@@ -660,7 +660,7 @@ The parameters for the comparison function which best approximates the test_func
 in the field {ra_parameters}.
 
 
-The last $dim_of_parms_space variables are assumed to be parameters, and it is also
+The last $dim_of_params_space variables are assumed to be parameters, and it is also
 assumed that the function \&comparison_fun
 depends linearly on these variables.  This function finds the  values for these parameters which minimizes the
 Euclidean distance (L2 distance) between the test function and the comparison function and the test points specified
@@ -1110,7 +1110,7 @@ sub phase_pi {
 	$rh_ans;
 }
 
-=head4 C<is_an_arithemetic_expression>
+=head4 C<is_an_arithmetic_expression>
 
 =cut
 

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1485,7 +1485,7 @@ sub processDivSpanOptions {
 
 		# A space is used to separate class names
 
-		# The offical W3C documentation allows class names to follow a far more general
+		# The official W3C documentation allows class names to follow a far more general
 		# grammar, but this is not being permitted here at present.
 		# See: https://www.w3.org/TR/css-syntax-3/#token-diagrams
 
@@ -1524,7 +1524,7 @@ sub processDivSpanOptions {
 
 		$StyleVal = $options{style};
 
-		# Mininal cleanup for safety
+		# Minimal cleanup for safety
 		$StyleVal =~ s/["']//g;    # Drop quotes
 		if ($StyleVal eq $options{style}) {
 			# no quotes, so now drop other characters we consider invalid
@@ -2187,7 +2187,7 @@ sub PTX_cleanup {
 		#move PTX warnings from the beginning of inside a p to just before the p.
 		$string =~ s/<p>(<!\-\- PTX:WARNING.*?-->)/$1\n<p>/g;
 
-		#remove doulbe p's we may have created
+		#remove double p's we may have created
 		$string =~ s/<p><p>/<p>/g;
 		$string =~ s/<\/p><\/p>/<\/p>/g;
 

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1864,7 +1864,7 @@ sub old_safe_ev {
 	my ($out, $PG_eval_errors, $PG_full_error_report) = PG_restricted_eval($in);
 	if ($PG_eval_errors) {
 		my @errorLines = split("\n", $PG_eval_errors);
-		warn "There is an error occuring inside evaluation brackets \\{ ...code... \\}\n"
+		warn "There is an error occurring inside evaluation brackets \\{ ...code... \\}\n"
 			. "somewhere in an EV2, EV3, or BEGIN_TEXT block.\n"
 			. "Code evaluated:\n$in\n"
 			. "Errors:\n"
@@ -1988,7 +1988,7 @@ sub EV3 {
 		$string =~ s/</&lt;/g;
 		$string =~ s/>/&gt;/g;
 		$evaluated_string =
-			"<PRE>$PAR % ERROR in $0:EV3, PGbasicmacros.pl: $PAR % There is an error occuring in the following code:$BR $string $BR % $BR % $errorLines[0]\n % $errorLines[1]$BR % $BR % $BR </PRE> ";
+			"<PRE>$PAR % ERROR in $0:EV3, PGbasicmacros.pl: $PAR % There is an error occurring in the following code:$BR $string $BR % $BR % $errorLines[0]\n % $errorLines[1]$BR % $BR % $BR </PRE> ";
 		$@ = "";
 	}
 	$string = $evaluated_string;
@@ -2008,7 +2008,7 @@ sub EV4 {
 			$string =~ s/>/&gt;/g;
 			$evaluated_string =
 				"<PRE>$PAR % ERROR in $0:EV3, PGbasicmacros.pl:"
-				. "$PAR % There is an error occuring in the following code:$BR "
+				. "$PAR % There is an error occurring in the following code:$BR "
 				. "$string $BR % $BR % $errorLines[0]\n % $errorLines[1]$BR "
 				. "% $BR % $BR </PRE> ";
 		}
@@ -2423,7 +2423,7 @@ only used by PreTeXt.
 
 Example usage:
 
-    knowlLink('Click Me', title => 'Fascinating Contents', value => 'Here are my facinating contents.');
+    knowlLink('Click Me', title => 'Fascinating Contents', value => 'Here are my fascinating contents.');
     knowlLink('Help Me', title => 'Help Contents', url => 'https://my.domain.edu/helpfile-contents');
 
 =cut

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -790,7 +790,7 @@ Creates an array of answer blanks and passes it to display_matrix which returns
 text which represents the matrix in TeX format used in math display mode. Answers
 are then passed back to whatever answer evaluators you write at the end of the problem.
 (note, if you have an m x n matrix, you will need mn answer evaluators, and they will be
-returned to the evaluaters starting in the top left hand corner and proceed to the left
+returned to the evaluators starting in the top left hand corner and proceed to the left
 and then at the end moving down one row, just as you would read them.)
 
 The options are passed on to display_matrix.
@@ -1043,7 +1043,7 @@ Takes the text to be lines of a comment to be shown only
 in the Library Browser below the rendered problem.
 
 The function COMMENT stores the needed html in the variable
-pgComment, which gets transfered to the flag 'comment' in PG_FLAGS.
+pgComment, which gets transferred to the flag 'comment' in PG_FLAGS.
 
 =cut
 
@@ -1387,7 +1387,7 @@ sub APOS    { MODES(TeX => "'",       HTML => "'",                     PTX => "\
 
 =head2 SPAN and DIV macros
 
-These are functions primarly meant to add
+These are functions primarily meant to add
 HTML block level DIV or inline SPAN
 tags and the relevant closing tags for HTML output.
 
@@ -1656,7 +1656,7 @@ See C<EV3> below for details on the processing.
 
 =head3 EV3
 
-        TEXT(EV3("This is a formulat \( \int_0^5 x^2 \, dx \) ");
+        TEXT(EV3("This is a formula \( \int_0^5 x^2 \, dx \) ");
         TEXT(EV3(@text));
 
         TEXT(EV3(<<'END_TEXT'));
@@ -1670,7 +1670,7 @@ The single quotes around END_TEXT mean that no automatic interpolation of variab
 Using EV3 with strings which have been evaluated by double quotes may lead to unexpected results.
 
 The evaluation macro E3 first evaluates perl code inside the braces:  C<\{  code \}>.
-Any perl statment can be put inside the braces.  The
+Any perl statement can be put inside the braces.  The
 result of the evaluation (i.e. the last statement evaluated) replaces the C<\{ code \}> construction.
 
 Next interpolation of all variables (e.g. C<$var or @array> ) is performed.
@@ -1790,7 +1790,7 @@ Two additional legacy formatting constructions are also supported:
 
 C<!{$c:%0.3f} > will give a number with 3 decimal places and a negative
 sign if the number is negative, no sign if the number is positive.  Since this is
-identical to the behavior of C<{$c:%0.3f}> the use of this syntax is depricated.
+identical to the behavior of C<{$c:%0.3f}> the use of this syntax is deprecated.
 
 C<?{$c:%0.3f}> determines the sign and prints it
 whether the number is positive or negative.  You can use this
@@ -2623,7 +2623,7 @@ sub PGsort {
 
 Usage:
 
-    lex_sort(@list);   # outputs list in lexigraphic (alphabetical) order
+    lex_sort(@list);   # outputs list in lexicographic (alphabetical) order
     num_sort(@list);   # outputs list in numerical order
     uniq( @list);      # outputs a list with no duplicates.  Order is unspecified.
 
@@ -2657,7 +2657,7 @@ Usage:
     row(@dataelements)
     endtable()
 
-Example of useage:
+Example of usage:
 
     BEGIN_TEXT
         This problem tests calculating new functions from old ones:$BR

--- a/macros/core/Parser.pl
+++ b/macros/core/Parser.pl
@@ -71,7 +71,7 @@ C<original_formula> field, and can be obtained by
 
 if needed later in the problem.
 
-If the formula is contstant-valued, C<Compute()> will return the value
+If the formula is constant-valued, C<Compute()> will return the value
 of the formula rather than the formula itself.  Again, in this case, the
 original can be obtained from the C<original_formula> property.
 

--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -167,7 +167,7 @@ With the default C<can_open> and C<is_open> settings, the first
 section will be open automatically when the problem is first viewed,
 but if you have material to read (or even answers to give) prior to
 the first section, you might want the first section to be closed, and
-have the student open it by hand before anwering the questions.  In
+have the student open it by hand before answering the questions.  In
 this case, set this value to 0 (it is 1 by default).
 
 =item C<< preview_can_change_state => 0 or 1 >>
@@ -245,7 +245,7 @@ you to override the defaults for a particular section.  In particular,
 you can provide a subroutine that determines when the section can or
 should be open.
 
-Note that values like C<$showPartialCorrectAnswers> and the isntalled
+Note that values like C<$showPartialCorrectAnswers> and the installed
 grader are global to the whole problem, so can't be set individually
 on a per section basis.  Also note that the answers aren't checked
 until the end of the problem, so any changes you make to the

--- a/macros/core/scaffold.pl
+++ b/macros/core/scaffold.pl
@@ -539,7 +539,7 @@ sub add_container {
 		# Scaffold to consider the score to be 1. This is used by PGessaymacros.pl.
 		# Also, if answers are being previewed and the preview_can_change_state option is 0, then use the scores saved
 		# in the persistent data hash form the last answer submission (if there is no data for an answer, then the
-		# anwser is considered blank).
+		# answer is considered blank).
 		for (@{ $self->{ans_names} }) {
 			next unless defined $PG_ANSWERS_HASH->{$_};
 			$scaffold->{scores}{$_} = $scaffoldScores->{$_} =

--- a/macros/deprecated/Alfredmacros.pl
+++ b/macros/deprecated/Alfredmacros.pl
@@ -235,7 +235,7 @@ sub Snxy() {
 ### width  - change the width of the answer blanks. defaults to 3.
 ### lowerwidth  - change the width of the lower answer blank. defaults to width
 ### upperwidth  - change the width of the upper answer blank. defaults to width.
-### upper - the uppper limit of integration, does not have to be an answer blank, defaults to answer blank with width "width"
+### upper - the upper limit of integration, does not have to be an answer blank, defaults to answer blank with width "width"
 ### lower - the lower limit of integration, does not have to be an answer blank,  defaults to answer blank with width "width"
 ### limits - boolean, if 1 puts the limits of integration above and below the integral symbol, if 0 puts them after the integral symbol.
 ###          default is 1.
@@ -250,7 +250,7 @@ sub Snxy() {
 ###
 ### This example prints out a double integral, the first integral with answer blanks with width 10, the second integral
 ### has 0 for the lower limit of integration and an answer blank with width 5 for the upper limit of integration.
-### The default limits of integratin are answer blanks with width 3, in this case the default width was overridden to 5
+### The default limits of integration are answer blanks with width 3, in this case the default width was overridden to 5
 ### and the default lower limit was changed to a zero.
 ###   \{BeginTable(center=>0).
 ###      Row([tableintegral(width=>10,limits=>'\(0\)'),tableintegral(width=>5,lower=>'\(0\)',limits=>0),

--- a/macros/deprecated/CanvasObject.pl
+++ b/macros/deprecated/CanvasObject.pl
@@ -241,7 +241,7 @@ EOF
 #
 # 	my $base64_initialState     = '';  # encode_base64($self->initialState);
 # 	main::RECORD_FORM_LABEL($appletStateName);            #this insures that the state will be saved from one invocation to the next
-# 	                                                      # FIXME -- with PGcore the persistant data mechanism can be used instead
+# 	                                                      # FIXME -- with PGcore the persistent data mechanism can be used instead
 #     my $answer_value = '<xml></xml>';
 #
 # 	##########################

--- a/macros/deprecated/CofIdaho_macros.pl
+++ b/macros/deprecated/CofIdaho_macros.pl
@@ -366,7 +366,7 @@ sub FactoringEvaluator {
 	my @vars = @_;
 
 	my $format_ans = $ans;
-	$format_ans =~ s/\*/ /g;                              #Remove any astrix
+	$format_ans =~ s/\*/ /g;                              #Remove any asterisk
 	$format_ans =~ s/[\(]/,\(/g;                          #Put in the delimiter ,
 	if ($format_ans =~ /^,/) { $format_ans =~ s/,//; }    #Remove any leading comma
 	my @factors = split(/[,]/, $format_ans);              #Split off the terms
@@ -414,7 +414,7 @@ sub FactoringEvaluator {
 
 		if ($ans_hash->{score} == 1) {
 			my $format_student_ans = $student_ans;
-			$format_student_ans =~ s/[\*]/ /g;                                    #Remove any astrix
+			$format_student_ans =~ s/[\*]/ /g;                                    #Remove any asterisk
 			$format_student_ans =~ s/[\(]/,\(/g;                                  #Put in the delimiter ,
 			if ($format_student_ans =~ /^,/) { $format_student_ans =~ s/,//; }    #Remove leading commas
 			my @student_factors = split(/[,]/, $format_student_ans);              #Split off the terms
@@ -476,7 +476,7 @@ sub StrictFactoringEvaluator {
 	my @vars = @_;
 
 	my $format_ans = $ans;
-	$format_ans =~ s/[\*]//g;                             #Remove any astrix
+	$format_ans =~ s/[\*]//g;                             #Remove any asterisk
 	$format_ans =~ s/[\(]/,\(/g;                          #Put in the delimiter ,
 	if ($format_ans =~ /^,/) { $format_ans =~ s/,//; }    #Remove any leading commas
 	my @factors = split(/[,]/, $format_ans);              #Split off the terms
@@ -504,7 +504,7 @@ sub StrictFactoringEvaluator {
 
 		if ($ans_hash->{score} == 1) {    #Check factors
 			my $format_student_ans = $student_ans;
-			$format_student_ans =~ s/[\*]//g;                                     #Remove any astrix
+			$format_student_ans =~ s/[\*]//g;                                     #Remove any asterisk
 			$format_student_ans =~ s/[\(]/,\(/g;                                  #Put in the delimiter ,
 			if ($format_student_ans =~ /^,/) { $format_student_ans =~ s/,//; }    #Remove any leading commas
 			my @student_factors = split(/[,]/, $format_student_ans);              #Split off the terms

--- a/macros/deprecated/CofIdaho_macros.pl
+++ b/macros/deprecated/CofIdaho_macros.pl
@@ -7,7 +7,7 @@ CofIdaho_macros.pl - Extra macros for Intermediate Algebra problems at The Colle
 
 macros by R Cruz -- The College of Idaho
 
-=head1 Format the instuctor answer
+=head1 Format the instructor answer
 
 
 1) SimplifyExponents: Formats an expression without negative exponents
@@ -63,7 +63,7 @@ macros by R Cruz -- The College of Idaho
    Note: Answers must be of the form: (poly)/(poly)
 
 9) ReduceFraction: Returns a string that represents a reduced fraction.
-   To use: $a = SimplifyFraction(numerator expression,denominator espression);
+   To use: $a = SimplifyFraction(numerator expression,denominator expression);
 =cut
 
 ###################################################################

--- a/macros/deprecated/Dartmouthmacros.pl
+++ b/macros/deprecated/Dartmouthmacros.pl
@@ -79,7 +79,7 @@ sub vector_diff {
 
 ## Compute the length of a vector
 sub vec_length {
-	## Put the paramaters passed into an array of values
+	## Put the parameters passed into an array of values
 	my @vector = @_;
 
 	## Initialize maximum value to first element
@@ -137,7 +137,7 @@ sub cross_product {
 
 ## Compute the maximum value in a list
 #sub max {
-#    ## Put the paramters passed into an array of values
+#    ## Put the parameters passed into an array of values
 #    my @values = @_;
 #
 #    ## Initialize maximum value to first element
@@ -155,7 +155,7 @@ sub cross_product {
 
 ## Compute the minimum value in a list
 #sub min {
-#    ## Put the paramters passed into an array of values
+#    ## Put the parameters passed into an array of values
 #    my @values = @_;
 #
 #    ## Initialize minimum value to first element

--- a/macros/deprecated/PGcomplexmacros.pl
+++ b/macros/deprecated/PGcomplexmacros.pl
@@ -52,7 +52,7 @@ my $number = '([+-]?)(?=\d|\.\d)\d*(\.\d*)?(E([+-]?\d+))?';
  #				functions. The default display method is cartesian, for all methods, but if
  #				the student answer is polar, even in part, then their answer will be displayed
  #				that way.
- #	'strict_polar'		This is still under developement. The idea is to check to make sure that there
+ #	'strict_polar'		This is still under development. The idea is to check to make sure that there
  #				only a single term in front of the e and after it... but the method does not
  #				check to make sure that the i is in the exponent, nor does it handle cases
  #				where the polar has e** coefficients.
@@ -123,7 +123,7 @@ sub cplx_cmp {
 	#  error checking, but that was removed in version 1.9 and it had been commented out
 	#  prior to that because it was always producing errors.  This is because $correct_num_answer
 	#  usually is somethine like "1+4i", which will produce a "missing operation before 'i'"
-	#  error, and "1-i" wil produce an "amiguous use of '-i' resolved as '-&i'" message.
+	#  error, and "1-i" will produce an "ambiguous use of '-i' resolved as '-&i'" message.
 	#  You probably need a call to check_syntax and the other filters that are used on
 	#  the student answer first. (Unless the item is already a reference to a Complex,
 	#  in which canse you should just accept it.)
@@ -252,12 +252,12 @@ sub compare_cplx {
  #
  #	Checks a comma separated string of  items against an array of evaluators.
  #	For example this is useful for checking all of the complex roots of an equation.
- #	Each student answer must be evaluated as correct by a DISTINCT answer evalutor.
+ #	Each student answer must be evaluated as correct by a DISTINCT answer evaluator.
  #
  #	This answer checker will only work reliably if each answer checker corresponds
  #	to a distinct correct answer.  For example if one answer checker requires
  #	any positive number, and the second requires the answer 1, then 1,2 might
- #	be judged incorrect since 1, satisifes the first answer checker, but 2 doesn't
+ #	be judged incorrect since 1, satisfies the first answer checker, but 2 doesn't
  #	satisfy the second.  2,1 would work however. Avoid this type of use!!
  #
  #	Including backtracking to fit the answers as best possible to each answer evaluator
@@ -355,7 +355,7 @@ sub cplx_constants {
 
 =cut
 
-# Output is text displaying the complex numver in "e to the i theta" form. The
+# Output is text displaying the complex number in "e to the i theta" form. The
 # formats for the argument theta is determined by the option C<theta_format> and the
 # format for the modulus is determined by the C<r_format> option.
 
@@ -488,8 +488,8 @@ sub is_a_numeric_polar {
 	}
 }
 
-#this subroutine mearly captures what is before and after the "e**" it does not verify that the "i" is there, or in the
-#exponent this must eventually be addresed
+#this subroutine merely captures what is before and after the "e**" it does not verify that the "i" is there, or in the
+#exponent this must eventually be addressed
 sub is_a_polar {
 	my ($num, %options) = @_;
 	my $process_ans_hash = (ref($num) eq 'AnswerHash') ? 1 : 0;
@@ -527,9 +527,9 @@ sub is_a_polar {
 
 =head2 single_term()
 
- #	This subroutine takes in a string, which is a mathematical expresion, and determines whether or not
+ #	This subroutine takes in a string, which is a mathematical expression, and determines whether or not
  #	it is a single term. This is accoplished using a stack. Open parenthesis pluses and minuses are all
- #	added onto the stack, and when a closed parenthesis is reached, the stack is popped untill the open
+ #	added onto the stack, and when a closed parenthesis is reached, the stack is popped until the open
  #	parenthesis is found. If the original was a single term, the stack should be empty after
  #	evaluation. If there is anything left ( + or - ) then false is returned.
  #	Of course, the unary operator "-" must be handled... if it is a unary operator, and not a regular -

--- a/macros/deprecated/PGsequentialmacros.pl
+++ b/macros/deprecated/PGsequentialmacros.pl
@@ -55,7 +55,7 @@ The basic sequential problem structure:
 	listVariables();
 
 Lists all variables submitted in the problem form and all variables in the
-the Problem environment.  This is used for debugging.
+Problem environment.  This is used for debugging.
 
 =cut
 

--- a/macros/deprecated/PGtextevaluators.pl
+++ b/macros/deprecated/PGtextevaluators.pl
@@ -21,7 +21,7 @@ questionnaires.
 
 =head1 DESCRIPTION
 
-This file contians macros for handling questionnaires. Questionnaires can
+This file contains macros for handling questionnaires. Questionnaires can
 consist of textual answers and radio buttons, and responses are reported
 via email.
 

--- a/macros/deprecated/PGtextevaluators.pl
+++ b/macros/deprecated/PGtextevaluators.pl
@@ -29,7 +29,7 @@ via email.
 
 BEGIN { strict->import; }
 
-# Until we get the PG cacheing business sorted out, we need to use
+# Until we get the PG caching business sorted out, we need to use
 # PG_restricted_eval to get the correct values for some(?) PG environment
 # variables. We do this once here and place the values in lexicals for later
 # access.

--- a/macros/deprecated/compoundProblem.pl
+++ b/macros/deprecated/compoundProblem.pl
@@ -146,7 +146,7 @@ sub _compoundProblem_init { };    # don't reload this file
 #
 #    $cp->part                   Returns the part the student is working on.
 #    $cp->part(n)                Sets the part to be part n, as long as the
-#                                student has finished the preceeding parts.
+#                                student has finished the preceding parts.
 #                                If not, the part is set to the highest
 #                                one the student hasn't completed, and he
 #                                can work up to the given part.  (The

--- a/macros/deprecated/compoundProblem5.pl
+++ b/macros/deprecated/compoundProblem5.pl
@@ -153,7 +153,7 @@ C<SECTION_PGML_SOLUTION()> to create it.  E.g.,
     When you add 1 to 1 you get 2.
     END_SOLUTION
 
-Normally, a solution will be tied to the section that preceeded it,
+Normally, a solution will be tied to the section that preceded it,
 but if you want to put all your solutions at the end, for example, you
 can pass options the solution macros that tell it the section to
 attach to:

--- a/macros/deprecated/littleneck.pl
+++ b/macros/deprecated/littleneck.pl
@@ -162,7 +162,7 @@ sub sqrt_simplify {
 	if (($number == int($number)) && ($number > 0)) {
 		$perfsqr = 1;
 		#*************************************************************************************
-		#   Check all perfect squares up to the max and store the hightest one that divides
+		#   Check all perfect squares up to the max and store the highest one that divides
 		#*************************************************************************************
 		for ($i = 2; $i * $i <= $number; $i++) {
 			$sqr = $i * $i;

--- a/macros/deprecated/problemRandomize.pl
+++ b/macros/deprecated/problemRandomize.pl
@@ -384,7 +384,7 @@ sub grader {
 	}
 	if (!$result->{msg}) {
 		# hack to remove unwanted "<b>Note: </b>" from the problem
-		#  (it is inserted automatically by Problem.pm when {msg} is non-emtpy).
+		#  (it is inserted automatically by Problem.pm when {msg} is non-empty).
 		$result->{msg} .=
 			'<script>var bb = document.getElementsByTagName("b");' . 'bb[bb.length-1].style.display="none"</script>';
 	}

--- a/macros/deprecated/problemRandomize.pl
+++ b/macros/deprecated/problemRandomize.pl
@@ -95,7 +95,7 @@ Note that the problem will store the new problem seed only if the student can
 submit saved answers (i.e., only before the due date).  After the due date,
 the student can get new versions, but the problem will revert to the original
 version when they come back to the problem later.  Since the default is only
-to allow reseeding afer the due date, the reseeding will not be sticky by default.
+to allow reseeding after the due date, the reseeding will not be sticky by default.
 Hardcopy ALWAYS produces the original version of the problem, regardless of
 the seed saved by the student.
 

--- a/macros/deprecated/unionMacros.pl
+++ b/macros/deprecated/unionMacros.pl
@@ -94,7 +94,7 @@ $ESUB = HTML('</SUB>', '}$');
 $BBR = HTML('<BR>');
 
 #
-#  Broser-only \displaystyle
+#  Browser-only \displaystyle
 #
 $DISPLAY = MODES(
 	TeX      => '',
@@ -127,7 +127,7 @@ sub JAVASCRIPT_PROBLEM {
 }
 
 #
-#  Modify a polynomial to remove coeficients of 1, -1 and 0
+#  Modify a polynomial to remove coefficients of 1, -1 and 0
 #  The polynomial can be a multivariable one.  The parameters
 #  following the formula itself are the names of the variables
 #  for the formula.  Any number can be provided, and the default

--- a/macros/graph/AppletObjects.pl
+++ b/macros/graph/AppletObjects.pl
@@ -229,7 +229,7 @@ END_OBJECT_TEXT
 
     $applet->header(<<END_HEADER);
     <script>
-        // The applet name is passed to this function, although it is not really neccessary to
+        // The applet name is passed to this function, although it is not really necessary to
         // check it, as the method will only be called for this applet.  The applet name is only
         // provided for backwards compatibility.
         function myUniqueAppletOnInit(appletName) {

--- a/macros/graph/LiveGraphicsVectorField2D.pl
+++ b/macros/graph/LiveGraphicsVectorField2D.pl
@@ -83,7 +83,7 @@ Color of vectors shown in the slope field.
 
 =item C<< vectorscale => 0.2 >>
 
-Multiplier that determines the lentgh of vectors shown in the slope field.
+Multiplier that determines the length of vectors shown in the slope field.
 
 =item C<< vectorthickness => 0.001 >>
 

--- a/macros/graph/LiveGraphicsVectorField3D.pl
+++ b/macros/graph/LiveGraphicsVectorField3D.pl
@@ -110,7 +110,7 @@ Color of vectors shown in the slope field.
 
 =item C<< vectorscale => 0.2 >>
 
-Multiplier that determines the lentgh of vectors shown in the slope field.
+Multiplier that determines the length of vectors shown in the slope field.
 
 =item C<< vectorthickness => 0.001 >>
 

--- a/macros/graph/PGanalyzeGraph.pl
+++ b/macros/graph/PGanalyzeGraph.pl
@@ -72,7 +72,7 @@ sub detect_intervals {
 	my ($left_x, $right_x);
 
 	########
-	# Combine adjacent intervals with the same properites
+	# Combine adjacent intervals with the same properties
 	########
 	foreach my $item (@intervals) {
 		if (defined $prev_slope) {

--- a/macros/graph/PGgraphmacros.pl
+++ b/macros/graph/PGgraphmacros.pl
@@ -384,7 +384,7 @@ See the documentation in F<PGcore.pl> for the latest details.
 
 =cut
 
-=head2  'Circle' lables
+=head2  'Circle' labels
 
 Usage:
 

--- a/macros/graph/PGlateximage.pl
+++ b/macros/graph/PGlateximage.pl
@@ -70,7 +70,7 @@ LaTeXImage object return by createLaTeXImage to generate the desired image.
                                and 'pdf'.  The default is an 'svg' image.  You
                                should determine if an 'svg' image works well with
                                the LaTeX code that you utilize.  If not, then use
-                               this method to change the exension to 'png' or
+                               this method to change the extension to 'png' or
                                'gif'.
 
                                This macro sets the extension to 'pdf' when a

--- a/macros/graph/PGnauGraphics.pl
+++ b/macros/graph/PGnauGraphics.pl
@@ -37,7 +37,7 @@ sub Plot {
 #Name: checkbox_table
 #Input: [values list], [answer list i.e. 1,0,1,0]
 #Optional Input: border => n - width of border in table (default = 0)
-#		 tex_size => n - control size of tex output for pictures (defualt = 10 * 95 / # of columns)
+#		 tex_size => n - control size of tex output for pictures (default = 10 * 95 / # of columns)
 #		 geometry =>[r,c] -  the number of rows and columns desired in the table (default = 2,2)
 #		 labels => [@list] - a list of labels that appear beside the checkboxes. (default is blank)
 #		 [..] - other answer lists, included as many as desired.  Note the lists must use the same
@@ -181,7 +181,7 @@ sub checkbox_table {
 #Name: radio_table
 #Input: [values list], [answer list i.e. 1,0,1,0]
 #Optional Input: border => n - width of border in table (default = 0)
-#		 tex_size => n - control size of tex output for pictures (defualt = 10 * 95 / # of columns)
+#		 tex_size => n - control size of tex output for pictures (default = 10 * 95 / # of columns)
 #		 geometry =>[r,c] -  the number of rows and columns desired in the table (default = 2,2)
 #		 labels => [@list] - a list of labels that appear beside the radio buttons. (default is blank)
 #		 [..] - other answer lists, included as many as desired.  Note the lists must use the same

--- a/macros/graph/PGstatisticsGraphMacros.pl
+++ b/macros/graph/PGstatisticsGraphMacros.pl
@@ -58,7 +58,7 @@ See F<PGbasicmacros> for definitions of C<image> and C<caption>
 #   $graph = init_statistics_graph(axes=>[0,0.0],ticks=>[10]);
 #   $bounds = add_boxplot($graph,{"outliers"=>1});
 #   # or #
-#   $bounds = add_histogram($graph,10,1);  # add a histogram with 10 bins and a multipler of 1.
+#   $bounds = add_histogram($graph,10,1);  # add a histogram with 10 bins and a multiplier of 1.
 #                                          # The multiplier is for the height of the frequencies.
 #                                          # ex: if the multiplier is 2 the graph is twice as tall
 #

--- a/macros/graph/PGtikz.pl
+++ b/macros/graph/PGtikz.pl
@@ -69,7 +69,7 @@ LaTeXImage object return by createTikZImage to generate the desired image.
                                and 'pdf'.  The default is an 'svg' image.  You
                                should determine if an 'svg' image works well with
                                the TikZ code that you utilize.  If not, then use
-                               this method to change the exension to 'png' or
+                               this method to change the extension to 'png' or
                                'gif'.
 
                                This macro sets the extension to 'pdf' when a

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -45,7 +45,7 @@ The following types of graph objects can be graphed:
     lines                           (GraphTool::GraphObject::Line)
     circles                         (GraphTool::GraphObject::Circle)
     parabolas                       (GraphTool::GraphObject::Parabola)
-    quadratics                      (GraphTool::GraphObject::Qudratic)
+    quadratics                      (GraphTool::GraphObject::Quadratic)
     cubics                          (GraphTool::GraphObject::Cubic)
     intervals                       (GraphTool::GraphObject::Interval)
     sine waves                      (GraphTool::GraphObject::SineWave)

--- a/macros/graph/parserGraphTool.pl
+++ b/macros/graph/parserGraphTool.pl
@@ -1808,7 +1808,7 @@ sub new {
 	$self->{isLine} = abs($self->{a}) < 0.000001;
 
 	if ($self->{isLine}) {
-		# Colinear points
+		# Collinear points
 		$self->{a}        = 1;
 		$self->{function} = sub { return ($y2 - $y1) / ($x2 - $x1) * ($_[0] - $x1) + $y1; };
 	} else {
@@ -1924,7 +1924,7 @@ sub new {
 	$self->{degree} = abs($self->{c3}) < 0.000001 && abs($c2) < 0.000001 ? 1 : abs($self->{c3}) < 0.000001 ? 2 : 3;
 
 	if ($self->{degree} == 1) {
-		# Colinear points
+		# Collinear points
 		$self->{c3}       = 1;
 		$self->{function} = sub { return ($y2 - $y1) / ($x2 - $x1) * ($_[0] - $x1) + $y1; };
 	} elsif ($self->{degree} == 2) {

--- a/macros/graph/plotly3D.pl
+++ b/macros/graph/plotly3D.pl
@@ -374,7 +374,7 @@ sub TeX {
 	if ($self->{image}) {
 		$out .= &main::image($self->{image}, tex_size => 950);
 	} else {
-		$out .= '3D image not avaialble. You must view it online.';
+		$out .= '3D image not available. You must view it online.';
 	}
 	$out .= "\n\\end{minipage}}\n";
 
@@ -492,7 +492,7 @@ sub genPoints {
 	} elsif ($type eq 'perl') {
 		$self->buildArray;
 	} else {
-		Value::Error("Unkown plot type: $type\n");
+		Value::Error("Unknown plot type: $type\n");
 	}
 }
 

--- a/macros/graph/plotly3D.pl
+++ b/macros/graph/plotly3D.pl
@@ -300,7 +300,7 @@ Put (1) or don't put (0) a border around image in TeX output.
 Add a JavaScript scene configuration dictionary to the plotly layout.
 This can be used to configure various aspects of the plot, such as
 the aspect ratio, and view range of the 3D axes. The scene is a string
-which contains a JavaScript dictonary to pass to plotly. Example:
+which contains a JavaScript dictionary to pass to plotly. Example:
 
   scene => 'aspectmode: "manual",'
          . 'aspectratio: {x: 1, y: 1, z: 1},'

--- a/macros/math/LinearProgramming.pl
+++ b/macros/math/LinearProgramming.pl
@@ -57,7 +57,7 @@ will have the same result as the example above.
 
 # perform a pivot operation
 # lp_pivot([[1,2,3],...,[4,5,6]], row, col, fractionmode)
-# row and col indecies start at 0
+# row and col indices start at 0
 # ^function lp_pivot
 sub lp_pivot {
 	my $a_ref = shift;

--- a/macros/math/PGdiffeqmacros.pl
+++ b/macros/math/PGdiffeqmacros.pl
@@ -140,7 +140,7 @@ sub diffop {
 =cut
 
 sub rad {
-	# initalize primes
+	# initialize primes
 	my @p = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29);
 	my ($a, $b, $c) = @_;
 	my $s = "0";
@@ -345,7 +345,7 @@ sub ivy {
 		$answer = "($c1) *$rr1 + ($c2)*t *$rr2";
 	}
 
-	# if the descriminant is negative, then the roots are imaginary.
+	# if the discriminant is negative, then the roots are imaginary.
 	# recall, e^x where x=a+ib then e^x = (e^a)*cos(bt) + (e^a)*sin(bt).
 	if ($d < 0) {
 # y(t) = me^(-Bt/(2A))*cos(t*sqrt(4AC-B*B)/(2A))+(2An+Bm)*sqrt(4AC-B*B)/(4AC-B*B)*e^(-Bt/(2A))*sin(t*sqrt(4AC-B*B)/(2A))

--- a/macros/math/PGmatrixmacros.pl
+++ b/macros/math/PGmatrixmacros.pl
@@ -116,7 +116,7 @@ sub display_matrix {
 	if (ref($ra_matrix) eq 'Value::Matrix') {
 		$ra_matrix = $ra_matrix->wwMatrix->array_ref;    # translate
 	}
-	if (ref($ra_matrix) eq 'Matrix') {                   #handle Real::Matrix1 type matrices: #FIXME deprectated
+	if (ref($ra_matrix) eq 'Matrix') {                   #handle Real::Matrix1 type matrices: #FIXME deprecated
 		($numRows, $numCols) = $ra_matrix->dim();
 		for (my $i = 0; $i < $numRows; $i++) {
 			$myRows[$i] = [];

--- a/macros/math/PGmatrixmacros.pl
+++ b/macros/math/PGmatrixmacros.pl
@@ -285,14 +285,14 @@ sub dm_mat_left {
 		or $main::displayMode eq 'HTML')
 	{
 		$out .= "$brh<tr valign=\"center\"><td nowrap=\"nowrap\" align=\"left\" rowspan=\"$numrows\">$erh";
-		$out .= dm_image_delimeter($numrows, $opts{'left'});
+		$out .= dm_image_delimiter($numrows, $opts{'left'});
 		#               $out .= "$brh<td><table border=0  cellspacing=5>\n$erh";
 		return $out;
 	}
 	# Mode is now tth
 
 	$out .= "<tr valign=\"center\"><td nowrap=\"nowrap\" align=\"left\" rowspan=\"$numrows\">";
-	$out .= dm_tth_delimeter($numrows, $opts{'left'});
+	$out .= dm_tth_delimiter($numrows, $opts{'left'});
 	#       $out .= "<td><table border=0  cellspacing=5>\n";
 	return $out;
 }
@@ -315,13 +315,13 @@ sub dm_mat_right {
 	{
 		$out .= "$brh<td nowrap=\"nowrap\" align=\"right\" rowspan=\"$numrows\">$erh";
 
-		$out .= dm_image_delimeter($numrows, $opts{'right'});
+		$out .= dm_image_delimiter($numrows, $opts{'right'});
 		return $out;
 	}
 
 	#       $out .= "</table>";
 	$out .= '<td nowrap="nowrap" align="left" rowspan="' . $numrows . '2">';
-	$out .= dm_tth_delimeter($numrows, $opts{'right'});
+	$out .= dm_tth_delimiter($numrows, $opts{'right'});
 	$out .= '</td>';
 	return $out;
 }
@@ -351,7 +351,7 @@ sub dm_end_matrix {
 }
 
 # Make an image of a big delimiter for a matrix
-sub dm_image_delimeter {
+sub dm_image_delimiter {
 	my $numRows = shift;
 	my $char    = shift;
 	my ($out, $j);
@@ -374,8 +374,8 @@ sub dm_image_delimeter {
 }
 
 # Basically uses a table of special characters and simple
-# recipe to produce big delimeters a la tth mode
-sub dm_tth_delimeter {
+# recipe to produce big delimiters a la tth mode
+sub dm_tth_delimiter {
 	my $numRows = shift;
 	my $char    = shift;
 
@@ -390,7 +390,7 @@ sub dm_tth_delimeter {
 	elsif ($char eq "]") { ($top, $mid, $bot, $extra) = ('ù', 'ú', 'û', 'ú'); }
 	elsif ($char eq "{") { ($top, $mid, $bot, $extra) = ('ì', 'ï', 'î', 'í'); }
 	elsif ($char eq "}") { ($top, $mid, $bot, $extra) = ('ü', 'ï', 'þ', 'ý'); }
-	else                 { warn "Unknown delimiter in dm_tth_delimeter"; }
+	else                 { warn "Unknown delimiter in dm_tth_delimiter"; }
 
 	# old version
 	#       $out = '<td nowrap="nowrap" align="left"><font face="symbol">';
@@ -463,13 +463,13 @@ sub dm_mat_row {
 			if ($myalign eq "|" or $myalign eq "d") {
 				if ($opts{'isfirst'} && $main::displayMode ne 'HTML_tth') {
 					$out .= $brh . '<td rowspan="' . $opts{'isfirst'} . '">' . $erh;
-					$out .= dm_image_delimeter($opts{'isfirst'} - 1, $myalign);
+					$out .= dm_image_delimiter($opts{'isfirst'} - 1, $myalign);
 				} elsif ($main::displayMode eq 'HTML_tth') {
 					if ($myalign eq "d") {    # dashed line in tth mode
 						$out .= '<td> | </td>';
 					} elsif ($opts{'isfirst'}) {    # solid line in tth mode
 						$out .= '<td rowspan="' . $opts{'isfirst'} . '"<table border="0"><tr>';
-						$out .= dm_tth_delimeter($opts{'isfirst'} - 1, "|");
+						$out .= dm_tth_delimiter($opts{'isfirst'} - 1, "|");
 						$out .= '</td></tr></table>';
 					}
 				}

--- a/macros/math/PGmorematrixmacros.pl
+++ b/macros/math/PGmorematrixmacros.pl
@@ -172,7 +172,7 @@ sub linear_combo {
 # These should be compared to similar subroutines made later in
 # MatrixCheckers.pl
 
-=head1 COMARISON FUNCTIONS
+=head1 COMPARISON FUNCTIONS
 
 =head2 basis_cmp
 
@@ -193,7 +193,7 @@ ANS( basis_cmp( vectors_as_array_ref_in_array_ref, options_hash ) );
                                  to zero
 
         debug           --  if set to 1, provides verbose listing of
-                                hash entries throughout fliters.
+                                hash entries throughout filters.
 
         help        --  'none' (default) (is quiet on all errors)
                     'dim' (Tells student if wrong number of vectors are entered)

--- a/macros/math/PGmorematrixmacros.pl
+++ b/macros/math/PGmorematrixmacros.pl
@@ -483,8 +483,8 @@ sub vec_list_string {
 						}
 					} else {
 
-						# This parser code was origianally taken from PGanswermacros::check_syntax
-						# but parts of it needed to be slighty modified for this context
+						# This parser code was originally taken from PGanswermacros::check_syntax
+						# but parts of it needed to be slightly modified for this context
 						my $parser = new AlgParserWithImplicitExpand;
 						my $ret    = $parser->parse($entry);            #for use with loops
 
@@ -588,7 +588,7 @@ sub ans_array_filter {
 	#   assign_option_aliases( \%opt,
 	#     );
 	set_default_options(\%options, _filter_name => 'ans_array_filter',);
-#   $rh_ans->{ans_label} =~ /$ArRaY(\d+)\[\d+,\d+,\d+\]/;  # CHANGE made to accomodate HTML 4.01 standards for name attribute
+#   $rh_ans->{ans_label} =~ /$ArRaY(\d+)\[\d+,\d+,\d+\]/;  # CHANGE made to accommodate HTML 4.01 standards for name attribute
 	$rh_ans->{ans_label} =~ /$ArRaY(\d+)\_\_\d+\-\d+\-\d+\_\_/;
 	my $ans_num = $1;
 	my @keys    = grep /$ArRaY$ans_num/, keys(%{$main::inputs_ref});
@@ -619,8 +619,8 @@ sub ans_array_filter {
 			for ($k = 0; $k < scalar(@{ $array[$i][$j] }); $k++) {
 				my $entry = $array[$i][$j][$k];
 				$entry = math_constants($entry);
-				# This parser code was origianally taken from PGanswermacros::check_syntax
-				# but parts of it needed to be slighty modified for this context
+				# This parser code was originally taken from PGanswermacros::check_syntax
+				# but parts of it needed to be slightly modified for this context
 				my $parser = new AlgParserWithImplicitExpand;
 				my $ret    = $parser->parse($entry);            #for use with loops
 

--- a/macros/math/PGnauGraphtheory.pl
+++ b/macros/math/PGnauGraphtheory.pl
@@ -1535,7 +1535,7 @@ sub GRwheel_size {
 #Name: GRcompletebipartite_size_size
 #Input: Size for upper and size for lower bipartite graph
 #Output: A picture of a bipartite graph with size and
-#	 size labels on top and bottem (and no labels).
+#	 size labels on top and bottom (and no labels).
 ######################################
 sub GRcompletebipartite_size_size {
 	my ($m, $n) = @_;

--- a/macros/math/PGnauScheduling.pl
+++ b/macros/math/PGnauScheduling.pl
@@ -232,7 +232,7 @@ sub ListProc {
 		@machine_info,        @these_dones
 	);
 
-	#intialize and setup
+	#initialize and setup
 	#####################################################
 	@coordinates_weights = split ",", $coordinates;
 	$i                   = 0;
@@ -274,7 +274,7 @@ sub ListProc {
 		$dependence_count[ $connections[$j] ]++;
 		$j += 2;
 	}
-	# done intializing
+	# done initializing
 	##########################################
 	$time       = 0;
 	$done       = 0;
@@ -290,7 +290,7 @@ sub ListProc {
 				if ($ready[$j] == $i) { $onlist = 1; }
 				$j++;
 			}
-			# check readyness against current dependencies
+			# check readiness against current dependencies
 			if (!$onlist && $dependence_count[$i] == 0) {
 				unshift @ready, $i;
 				pop @ready;
@@ -559,7 +559,7 @@ sub CritList {
 		$temp_word
 	);
 
-	#intialize and setup
+	#initialize and setup
 	#####################################################
 	@coordinates_weights       = split ",", $coordinates;
 	@these_coordinates_weights = @coordinates_weights;
@@ -577,7 +577,7 @@ sub CritList {
 	$task_count       = scalar @weights;
 	@connection_array = split ",", $connections;
 	$priority_list    = "";
-	# end intialize and setup
+	# end initialize and setup
 	#####################################################
 	$scheduled_count = 0;
 	while ($scheduled_count < $task_count) {
@@ -645,7 +645,7 @@ sub CritPath {
 		$independent
 	);
 
-	#intialize and setup
+	#initialize and setup
 	#####################################################
 	@coordinates_weights = split ",", $coordinates;
 	$i                   = 0;
@@ -661,7 +661,7 @@ sub CritPath {
 	@connection_array = split ",", $connections;
 	$i                = 0;
 	while ($i < scalar @connection_array) { $connection_array[$i]--; $i++; }
-	# end intialize and setup
+	# end initialize and setup
 	#####################################################
 
 	# find all possible starting vertices ...

--- a/macros/math/PGnauStats.pl
+++ b/macros/math/PGnauStats.pl
@@ -1055,7 +1055,7 @@ sub DrawNormalDist {
 	);
 
 	###########################
-	# begin intialize and setup
+	# begin initialize and setup
 	# initialize to default
 	# check for options
 	while (@opt) {

--- a/macros/math/PGstatisticsmacros.pl
+++ b/macros/math/PGstatisticsmacros.pl
@@ -124,7 +124,7 @@ Usage:
 
     stats_mean(@data);
 
-Computes the artihmetic mean of a list of numbers, data. You may also pass the numbers individually.
+Computes the arithmetic mean of a list of numbers, data. You may also pass the numbers individually.
 
 =cut
 
@@ -501,7 +501,7 @@ Example:
 This routine will generate num random results. The distribution is in
 the given array.  Each element in the array is itself an array.  The
 first value in the array is the probability.  The second value in the
-array is the value assocated with the probability.
+array is the value associated with the probability.
 
 
 =cut

--- a/macros/math/PGstatisticsmacros.pl
+++ b/macros/math/PGstatisticsmacros.pl
@@ -284,7 +284,7 @@ Generates N exponentially distributed random numbers with the given parameter, l
 
 sub exprand {    # generate exponentially dist. numbers  Exp(x,lambda)
 				 # exprand(lambda,N,digits)
-				 # Generates N random numbers. The distribution is exponetially
+				 # Generates N random numbers. The distribution is exponentially
 				 # distributed with parameter lambda.  The value of 'digits' gives the
 				 # number of decimal places to return.
 	my ($lambda, $N, $digits) = @_;
@@ -511,7 +511,7 @@ sub discreterand {    # generate random, values based on a given table
 					  # Generates num random results. The distribution is in the given array.
 					  # Each element in the array is itself an array.
 					  # The first value in the array is the probability.
-					  # The second value in the array is the value assocated with the probability.
+					  # The second value in the array is the value associated with the probability.
 
 	my $num   = shift;    # Number of values to generate
 	my @table = @_;       # Table of arrays with the probabilities and values.
@@ -1141,14 +1141,14 @@ Usage:
 
     %freq = frequencies(@theData)
 
-Finds the factors in the data set and calculates the frequency of occurance for each factor.
+Finds the factors in the data set and calculates the frequency of occurrence for each factor.
 Returns a hash whose keys are the factors and the associated values are the frequencies.
 
 =cut
 
 sub frequencies {
 	#   %freq = frequencies(@theData)
-	#   returns a hash whos keys are the factors and the associated values are the frequencies.
+	#   returns a hash whose keys are the factors and the associated values are the frequencies.
 
 	# Get the data that is passed to me and put it all in one array.
 	my (@data_list) = @_;

--- a/macros/math/SimpleGraph.pl
+++ b/macros/math/SimpleGraph.pl
@@ -2789,7 +2789,7 @@ flag before constructing the C<Edge> or C<EdgeSet>.  For example, by calling
         map { $_ => { isVertex => 1, caseSensitive => 1 } } 'A' .. 'F'
     );
 
-If it is prefered that the vertices not be case sensitive, then remove
+If it is preferred that the vertices not be case sensitive, then remove
 C<< caseSensitive => 1 >> from the above call.
 
 If the vertices in the C<Edge> or C<EdgeSet> belong to a C<GraphTheory::SimpleGraph>

--- a/macros/math/bizarroArithmetic.pl
+++ b/macros/math/bizarroArithmetic.pl
@@ -84,7 +84,7 @@ will be rejected, as will
 
 package bizarro;
 
-#This f just stretches complex numbers by a positve real that
+#This f just stretches complex numbers by a positive real that
 #depends in a nontrivial away on the magnitude of z
 sub f {
 	my $z = shift;

--- a/macros/math/draggableProof.pl
+++ b/macros/math/draggableProof.pl
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-draggableProof.pl - Allows the contructions of problems with draggable statements for proofs.
+draggableProof.pl - Allows the constructions of problems with draggable statements for proofs.
 
 =head1 DESCRIPTION
 

--- a/macros/math/tableau.pl
+++ b/macros/math/tableau.pl
@@ -75,7 +75,7 @@ Note: it is important to include the () at the end of tableauEquivalence
 
 tableauEquivalence compares two matrices up to
 reshuffling the rows and multiplying each row by a constant.
-It is equivalent up to multiplying on the left by a permuation matrix
+It is equivalent up to multiplying on the left by a permutation matrix
 or a (non-uniformly constant) diagonal matrix.
 It is appropriate for comparing augmented matrices representing a system of equations
 since the order of the equations is unimportant.  This applies to tableaus for
@@ -589,7 +589,7 @@ sub objective_row {
 		Parameters: () or (list)
 		Returns:  A MathObjectMatrix
 
-	Useage:
+	Usage:
 		$MathObjectmatrix = $self->current_tableau
 		$MathObjectmatrix = $self->current_tableau(3,4) #updates basis to (3,4)
 
@@ -1225,7 +1225,7 @@ These are specialized routines used in the simplex method
 
 		@array = $self->primal2dual(2,3,4)
 
-Maps LOP column indices to dual LOP indicies (basis of complementary slack property)
+Maps LOP column indices to dual LOP indices (basis of complementary slack property)
 
 
 =cut
@@ -1234,7 +1234,7 @@ Maps LOP column indices to dual LOP indicies (basis of complementary slack prope
 
 		@array = $self->dual2primal(2,3,4)
 
-Maps dual LOP column indices to primal LOP indicies (basis of complementary slack property).
+Maps dual LOP column indices to primal LOP indices (basis of complementary slack property).
 Inverse of primal2dual method.
 
 

--- a/macros/misc/PCCmacros.pl
+++ b/macros/misc/PCCmacros.pl
@@ -755,7 +755,7 @@ sub radicalListCheck {
 		#
 		#  Check that the student's answer is an assignment (or whatever the right type)
 		#
-		my $assingmentMessageGiven = 0;
+		my $assignmentMessageGiven = 0;
 		my $nosolutionMessageGiven = 0;
 		if (defined($p)) {
 			if ($p eq "no real solutions") {
@@ -763,7 +763,7 @@ sub radicalListCheck {
 				$nosolutionMessageGiven = 1;
 			} elsif ($p->type ne "Assignment") {
 				push(@errors, "Your $ith entry should be written $var=_____");
-				$assingmentMessageGiven = 1;
+				$assignmentMessageGiven = 1;
 			}
 		}
 
@@ -819,9 +819,9 @@ sub radicalListCheck {
 				}
 			}
 			push(@errors, "Your $ith solution is not correct")
-				if (!$numericallyCorrect and ($n > 1) and !$assingmentMessageGiven);
+				if (!$numericallyCorrect and ($n > 1) and !$assignmentMessageGiven);
 			push(@errors, "Your solution is not correct")
-				if (!$numericallyCorrect and ($n == 1) and !$assingmentMessageGiven and !$nosolutionMessageGiven);
+				if (!$numericallyCorrect and ($n == 1) and !$assignmentMessageGiven and !$nosolutionMessageGiven);
 		}
 	}
 

--- a/macros/misc/randomPerson.pl
+++ b/macros/misc/randomPerson.pl
@@ -52,7 +52,7 @@ C<theirs> (with or without capitalization) will select the correct subject, obje
 possession, possessive forms of the pronoun.  Also, note that C<go> is one of a
 few special verbs with irregular conjugation.
 
-If you would like multiple people to be randomly choosen with unique names, use
+If you would like multiple people to be randomly chosen with unique names, use
 
     @persons = randomPerson(n => 4);
 

--- a/macros/parsers/parserAssignment.pl
+++ b/macros/parsers/parserAssignment.pl
@@ -379,7 +379,7 @@ sub cmp_class {
 sub showClass { cmp_class(@_) }
 
 #
-#  Convert varaible names to those used in the correct answer, if the
+#  Convert variable names to those used in the correct answer, if the
 #  student answer uses different ones
 #
 sub compare {

--- a/macros/parsers/parserCustomization.pl
+++ b/macros/parsers/parserCustomization.pl
@@ -16,7 +16,7 @@ vectors) by using:
     $context{Vector}->parens->remove('<');
 
 To allow vectors to be entered with parens (and displayed with
-parens) rather than angle-brakets, use
+parens) rather than angle-brackets, use
 
     $context{Vector} = Parser::Context->getCopy("Vector");
     $context{Vector}->{cmpDefaults}{Vector} = {promotePoints => 1};

--- a/macros/parsers/parserFormulaWithUnits.pl
+++ b/macros/parsers/parserFormulaWithUnits.pl
@@ -39,14 +39,14 @@ is three meters.  (See Units.pm for examples).
 
 Finally, the newUnit option can also be an array ref containing any number of
 new units to add.  A common reason for doing this would be to add the plural
-version of the unit as an equilvalent unit.  E.G.
+version of the unit as an equivalent unit.  E.G.
 
     $newUnits = ['apple',{name=>'apples',conversion=>{factor=>1,apple=>1}}];
     $a = FormulaWithUnits("3x apples",{newUnit=>$newUnits});
 
 In this case both 3x apple and 3x apples would be accepted as answers.
 
-Note:  English pluralization is suprisingly hard, so WeBWorK will make no
+Note:  English pluralization is surprisingly hard, so WeBWorK will make no
 attempt to display a grammerically correct result.
 
 =head1 SEE ALSO

--- a/macros/parsers/parserImplicitEquation.pl
+++ b/macros/parsers/parserImplicitEquation.pl
@@ -190,7 +190,7 @@ sub Init {
 		BisectionCutoff              => 40,
 	);
 
-	main::Context("ImplicitEquation");    ### FIXEME:  probably should require author to set this explicitly
+	main::Context("ImplicitEquation");    ### FIXME:  probably should require author to set this explicitly
 
 	main::PG_restricted_eval('sub ImplicitEquation {ImplicitEquation->new(@_)}');
 }

--- a/macros/parsers/parserMultiAnswer.pl
+++ b/macros/parsers/parserMultiAnswer.pl
@@ -525,8 +525,8 @@ answer is equal to its correct answer (using the overloaded C<==> operator). If 
 the checker returns an array of 0s and 1s listing which answers are correct giving partial credit.
 If C<< partialCredit => 0 >>, the checker only returns 1 if all answers are correct, otherwise returns 0.
 
-Note that C<< $multi_ans->{scores} >> will be set to a reference to an array containing the the
-scores from evaluating the individual answers and can be used inside the C<checker> routine.
+Note that C<< $multi_ans->{scores} >> will be set to a reference to an array containing the scores
+from evaluating the individual answers and can be used inside the C<checker> routine.
 
 =head2 partialCredit
 
@@ -556,8 +556,8 @@ Specifies whether the types of the student and instructor's answers must match a
 if C<< checkTypes => 'compatible' >> then the student answers only need to be compatible with the
 instructor answers in the sense that they parse into objects that can be compared to the instructor
 answers. If C<< checkTypes => 1 >> then the types of the student answers must match the types of the
-instructor answers exactly. Otherwise no type checking is done other than the the usual type-match
-error checking (in which case, you should check the types before you use the data). Default: 1.
+instructor answers exactly. Otherwise no type checking is done other than the usual type-match error
+checking (in which case, you should check the types before you use the data). Default: 1.
 Note that if the default checker is used, i.e., if C<checker> is not set, then C<< checkTypes => 1 >>
 is the same as C<< checkTypes => 'compatible' >>.
 

--- a/macros/parsers/parserNumberWithUnits.pl
+++ b/macros/parsers/parserNumberWithUnits.pl
@@ -37,14 +37,14 @@ is three meters.  (See Units.pm for examples).
 
 Finally, the newUnit option can also be an array ref containing any number of
 new units to add.  A common reason for doing this would be to add the plural
-version of the unit as an equilvalent unit.  E.G.
+version of the unit as an equivalent unit.  E.G.
 
     $newUnits = ['apple',{name=>'apples',conversion=>{factor=>1,apple=>1}}];
     $a = NumberWithUnits("3 apples",{newUnit=>$newUnits});
 
 In this case both 3 apple and 3 apples would be considered correct.
 
-Note:  English pluralization is suprisingly hard, so WeBWorK will make no
+Note:  English pluralization is surprisingly hard, so WeBWorK will make no
 attempt to display a grammerically correct result.
 
 =head1 SEE ALSO

--- a/macros/parsers/parserOneOf.pl
+++ b/macros/parsers/parserOneOf.pl
@@ -1,7 +1,7 @@
 
 =head1 NAME
 
-parserOneOf.pl - Implements a MathObject that allows students to entery any
+parserOneOf.pl - Implements a MathObject that allows students to enter any
                  one of several possible right answers.
 
 =head1 DESCRIPTION

--- a/macros/parsers/parserPopUp.pl
+++ b/macros/parsers/parserPopUp.pl
@@ -17,11 +17,11 @@ To create a PopUp, DropDown, or DropDownTF  object, use
     $truefalse = DropDownTF(correct, options);
 
 where "choices" are the items in the drop-down list, "correct" is the
-the correct answer for the group (or its index, with 0 being the
-first one), and options are chosen from among those listed below.  If
-the correct answer is a number, it is interpreted as an index, even
-if the array of choices are also numbers.  (See the C<noindex> below
-for more details.)
+correct answer for the group (or its index, with 0 being the first
+one), and options are chosen from among those listed below.  If the
+correct answer is a number, it is interpreted as an index, even if the
+array of choices are also numbers.  (See the C<noindex> below for more
+details.)
 
 Note that drop-down menus cannot contain mathematical notation, only
 plain text. This is because the browser's native menus are used, and

--- a/macros/parsers/parserRadioMultiAnswer.pl
+++ b/macros/parsers/parserRadioMultiAnswer.pl
@@ -155,8 +155,8 @@ Specifies whether the types of the student and instructor's answers must match a
 if C<< checkTypes => 'compatible' >> then the student answers only need to be compatible with the
 instructor answers in the sense that they parse into objects that can be compared to the instructor
 answers. If C<< checkTypes => 1 >> then the types of the student answers must match the types of the
-instructor answers exactly. Otherwise no type checking is done other than the the usual type-match
-error checking (in which case, you should check the types before you use the data). Default: 1.
+instructor answers exactly. Otherwise no type checking is done other than the usual type-match error
+checking (in which case, you should check the types before you use the data). Default: 1.
 Note that if the default checker is used, i.e., if C<checker> is not set, then C<< checkTypes => 1 >>
 is the same as C<< checkTypes => 'compatible' >>.
 

--- a/macros/parsers/parserSolutionFor.pl
+++ b/macros/parsers/parserSolutionFor.pl
@@ -2,7 +2,7 @@
 =head1 NAME
 
 parserSolutionFor.pl - An answer checker that checks if a student's answer
-satisifies an implicit equation.
+satisfies an implicit equation.
 
 =head1 DESCRIPTION
 
@@ -10,7 +10,7 @@ This is a Parser class that implements an answer checker that
 checks if a student's answer satisfies an implicit equation.
 We define a SolutionFor object class that lets you specify an
 equality that the student answer must satisfy, and a point that
-DOES satify the equation.  The overloaded == operator will
+DOES satisfy the equation.  The overloaded == operator will
 check if a given point satisfies the given equality.
 
 Use SolutionFor(equality,point[,options]) to create a SolutionFor object.

--- a/macros/parsers/parserSolutionFor.pl
+++ b/macros/parsers/parserSolutionFor.pl
@@ -151,7 +151,7 @@ sub compare {
 #
 #  Set up a new context that is a copy of the current one, but
 #  has the equality operator defined, and the SolutionFor object
-#  prededence set so that comparisons with points or numbers will
+#  precedence set so that comparisons with points or numbers will
 #  be promoted to comparisons with the SolutionFor
 #
 sub getContext {

--- a/macros/ui/PGchoicemacros.pl
+++ b/macros/ui/PGchoicemacros.pl
@@ -92,7 +92,7 @@ defaults. It is equivalent to:
 
     $ml = new Match(random(1,2000,1), ~~&std_print_q, ~~&std_print_a);
 
-The first argument is the seed for the match list (choosen at random between 1
+The first argument is the seed for the match list (chosen at random between 1
 and 2000 in the example above). The next two arguments are references to the
 print subroutines used to print the questions and the answers. Other printing
 methods can be used instead of the standard ones. An example of how to do this
@@ -119,7 +119,7 @@ defaults. It is equivalent to:
     $sl = new Select(random(1,2000,1), ~~&std_print_q, ~~&std_print_a);
 
 The parameters to the C<Select> constructor are the same as those for the Match
-constrcutor described above under C<new_match_list()>.
+constructor described above under C<new_match_list()>.
 
 See the documentation for the C<Select> class to see how to use this object to
 create a true/false question.
@@ -168,7 +168,7 @@ a number possible answers, only one of which can be chosen. It is equivalent to:
     $mc = new Multiple(random(1,2000,1), ~~&std_print_q, ~~&radio_print_a);
 
 The parameters to the C<Multiple> constructor are the same as those for the Match
-constrcutor described above under C<new_match_list()>.
+constructor described above under C<new_match_list()>.
 
 =cut
 

--- a/macros/ui/PGinfo.pl
+++ b/macros/ui/PGinfo.pl
@@ -15,7 +15,7 @@ loadMacros("MathObjects.pl");
 Usage: 	listVariables();
 
 Prints all variables submitted in the problem form and all variables in the
-the Problem environment and all of the flag variables in Context().
+Problem environment and all of the flag variables in Context().
 This is used for debugging and to determine the current
 context for the problem.
 

--- a/macros/ui/alignedChoice.pl
+++ b/macros/ui/alignedChoice.pl
@@ -70,7 +70,7 @@ sub aligned_print_q {
 
 ######################################################################
 #
-#  Genarate a new AlignedList object
+#  Generate a new AlignedList object
 #
 #     $al = new_aligned_list(options)
 #

--- a/macros/ui/niceTables.pl
+++ b/macros/ui/niceTables.pl
@@ -778,7 +778,7 @@ sub Rows {
 		my $html     = $row;
 
 		# establish if this row has certain things
-		# when declared mulltiple times, last non-falsy values are used
+		# when declared multiple times, last non-falsy values are used
 		my $bottom    = 0;
 		my $top       = 0;
 		my $rowcolor  = '';
@@ -808,7 +808,7 @@ sub Rows {
 					&& ($bottom || $tableOpts->{horizontalrules}));
 
 			# do cells in this row have a top or bottom border?
-			# although a propery of cells, LaTeX makes us do this at the row level
+			# although a property of cells, LaTeX makes us do this at the row level
 			for my $x (@$rowArray) {
 				$row = prefix($row, hrule($booktabs, 'cmid', $x->{top}) . "{$x->{leftcol}-$x->{rightcol}}", ' ')
 					if ($i == 0 && $x->{top});
@@ -1587,7 +1587,7 @@ sub getWidthPercent {
 		$unit = $2;
 	}
 	my %convert_to_pt = (
-		# units with related absolute defintions
+		# units with related absolute definitions
 		# the following are as TeX defines them
 		pt => 1,
 		pc => 12,

--- a/macros/ui/problemPanic.pl
+++ b/macros/ui/problemPanic.pl
@@ -99,14 +99,14 @@ Panic::GradWithPenalty command is issued.
 sub _problemPanic_init { Panic::Init() }
 
 #
-#  The packge to contain the routines and data for the Panic buttons
+#  The package to contain the routines and data for the Panic buttons
 #
 package Panic;
 
 my $isTeX       = 0;      # true in hardcopy mode
 my $allowReset  = 0;      # true if a professor is viewing the problem
 my $buttonCount = 0;      # number of panic buttons displayed so far
-my @penalty     = (0);    # accummulated penalty values
+my @penalty     = (0);    # accumulated penalty values
 my $grader;               # problem's original grader
 
 #

--- a/macros/ui/problemPanic.pl
+++ b/macros/ui/problemPanic.pl
@@ -89,7 +89,7 @@ To allow the grading penalties to work, you must include the command
 
     Panic::GradeWithPenalty();
 
-in order to install the panic-button grader.  You should do this afer
+in order to install the panic-button grader.  You should do this after
 setting the grader that you want to use for the problem itself, as the
 panic grader will use the one that is installed at the time the
 Panic::GradWithPenalty command is issued.

--- a/t/README.md
+++ b/t/README.md
@@ -31,8 +31,8 @@ Best practice is to create a directory for each module being tested and
 group similar tests together in separate files with a descriptive name,
 such as **t/units/** for testing the **Units.pm** module.
 
-Formal unit tests are located in the the `macros` and `contexts` directories
-that are designed to test the pg macros and contexts respectively.
+Formal unit tests are located in the `macros` and `contexts` directories that
+are designed to test the pg macros and contexts respectively.
 
 ## Running the tests
 

--- a/t/contexts/toltype_digits.t
+++ b/t/contexts/toltype_digits.t
@@ -16,7 +16,7 @@ loadMacros('PGstandard.pl', 'MathObjects.pl');
 my $ctx = Context('Numeric');
 my $pi  = Real('pi');
 
-subtest 'set tolTrunction to 1' => sub {
+subtest 'set tolTruncation to 1' => sub {
 	$ctx->flags->set(tolType => 'digits', tolerance => 3, tolTruncation => 1);
 
 	is check_score($pi, Compute('3.14')),  1, 'toltype digits: pi is 3.14';
@@ -26,7 +26,7 @@ subtest 'set tolTrunction to 1' => sub {
 	is check_score($pi, Compute('3.15')),  0, 'toltype digits: pi is not 3.15';
 };
 
-subtest 'set tolTrunction to 0' => sub {
+subtest 'set tolTruncation to 0' => sub {
 	$ctx->flags->set(tolType => 'digits', tolerance => 3, tolTruncation => 0);
 
 	is check_score($pi, Compute('3.14')),  1, 'toltype digits: pi is 3.14';

--- a/t/contexts/trig_degrees.t
+++ b/t/contexts/trig_degrees.t
@@ -18,7 +18,7 @@ my $ctx = Context('TrigDegrees');
 ok(Value::isContext($ctx), 'trig degrees: check context');
 
 ok my $cos60      = Compute('cos(60)'),           'Call Compute';
-ok my $eval_cos60 = $cos60->cmp->evaluate('1/2'), 'evalute an answer to cos(60)';
+ok my $eval_cos60 = $cos60->cmp->evaluate('1/2'), 'evaluate an answer to cos(60)';
 
 is $eval_cos60, hash {
 	field type          => 'Value (Real)';

--- a/t/math_objects/matrix.t
+++ b/t/math_objects/matrix.t
@@ -248,24 +248,24 @@ subtest 'Replace a value' => sub {
 subtest 'Submatrix' => sub {
 	my $A = Matrix([ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11, 12 ]);
 	is $A->subMatrix([ 2 .. 3 ], [ 2 .. 4 ])->TeX, Matrix([ 6, 7, 8 ], [ 10, 11, 12 ])->TeX,
-		'Submatrix from specifing rows/cols to keep';
+		'Submatrix from specifying rows/cols to keep';
 	is $A->subMatrix(2, 3)->TeX, Matrix([ 1, 2, 4 ], [ 9, 10, 12 ])->TeX,
-		'Submatrix from specifing row/col to remove';
+		'Submatrix from specifying row/col to remove';
 	is $A->subMatrix([1], 0)->TeX, Matrix([ [ 1, 2, 3, 4 ] ])->TeX,
-		'Submatrix from specifing rows/cols with mixed syntax';
+		'Submatrix from specifying rows/cols with mixed syntax';
 	is $A->subMatrix([ 3, 1, 2 ], [ 1, 4, 2 ])->TeX, Matrix([ 9, 12, 10 ], [ 1, 4, 2 ], [ 5, 8, 6 ])->TeX,
 		'Submatrix from permuting rows and columns, droppping one column';
 
 	my $B = Matrix(2, 4, 6, 8);
 	is $B->subMatrix([ 1, 3 ])->TeX, Matrix(2, 6)->TeX,
-		'Submatrix of degree 1 matrix from specifing entries to keep';
-	is $B->subMatrix(2)->TeX, Matrix(2, 6, 8)->TeX, 'Submatrix of degree 1 matrix from specifing entry to remove';
+		'Submatrix of degree 1 matrix from specifying entries to keep';
+	is $B->subMatrix(2)->TeX, Matrix(2, 6, 8)->TeX, 'Submatrix of degree 1 matrix from specifying entry to remove';
 
 	my $C = Matrix([ [ 1, 2, 3 ], [ 4, 5, 6 ] ], [ [ 7, 8, 9 ], [ 10, 11, 12 ] ]);
 	is $C->subMatrix(0, 1, [ 1, 3 ])->TeX, Matrix([ [ 4, 6 ] ], [ [ 10, 12 ] ])->TeX,
-		'Submatrix of degree 3 matrix from specifing indices to keep';
+		'Submatrix of degree 3 matrix from specifying indices to keep';
 	is $C->subMatrix(1, 2, 3)->TeX, Matrix([ [ [ 7, 8 ] ] ])->TeX,
-		'Submatrix of degree 3 matrix from specifing indices to remove';
+		'Submatrix of degree 3 matrix from specifying indices to remove';
 
 	like dies {
 		$A->subMatrix(1, 1, 1);
@@ -385,7 +385,7 @@ subtest 'Construct an identity matrix' => sub {
 
 subtest 'Construct a permutation matrix' => sub {
 	my $P1 = Value::Matrix->P(3, [ 1, 2, 3 ]);
-	is $P1->TeX, Matrix([ [ 0, 0, 1 ], [ 1, 0, 0 ], [ 0, 1, 0 ] ])->TeX, 'Create permuation matrix on cycle (123)';
+	is $P1->TeX, Matrix([ [ 0, 0, 1 ], [ 1, 0, 0 ], [ 0, 1, 0 ] ])->TeX, 'Create permutation matrix on cycle (123)';
 
 	my $P2 = Value::Matrix->P(6, [ 1, 3 ], [ 2, 4, 6 ]);
 	is $P2->TeX,

--- a/t/rserve/rexp-unknown.t
+++ b/t/rserve/rexp-unknown.t
@@ -11,7 +11,7 @@ use lib "$ENV{PG_ROOT}/lib";
 use Rserve::REXP::Unknown;
 
 ok my $unk = Rserve::REXP::Unknown->new(sexptype => 42), 'new unknown';
-isa_ok $unk, [ 'Rserve::REXP::Unknown', 'Rserve::REXP' ], 'unkown has correct class classes';
+isa_ok $unk, [ 'Rserve::REXP::Unknown', 'Rserve::REXP' ], 'unknown has correct class classes';
 
 is($unk, $unk, 'self equality');
 

--- a/t/units/basic_parser.t
+++ b/t/units/basic_parser.t
@@ -192,7 +192,7 @@ subtest 'Check possible answers compared to the formula 0.009 x^2 T' => sub {
 	is check_score($correct, '0 x^2 T*m/angstrom'),        0, '0 x^2 T*m/angstrom is incorrect';
 };
 
-subtest 'Check possible answers compared to the the number 1 amu' => sub {
+subtest 'Check possible answers compared to the number 1 amu' => sub {
 	my $correct = NumberWithUnits('1 amu');
 
 	is check_score($correct, '1 amu'),                 1, '1 amu is correct';

--- a/tutorial/sample-problems/Algebra/AlgebraicFractionAnswer.pg
+++ b/tutorial/sample-problems/Algebra/AlgebraicFractionAnswer.pg
@@ -102,7 +102,7 @@ $multians = MultiAnswer($num, $den)->with(
 #: The fraction answer is created using a `LayoutTable` from
 #: PODLINK('niceTables.pl') via its `PGML` syntax. A `LayoutTable` is started
 #: with `[#` and is ended with `#]*`. Options for the table are set in braces
-#: after the ending `#]*`. Cells of the table are started wtih `[.` and ended
+#: after the ending `#]*`. Cells of the table are started with `[.` and ended
 #: with `.]`. Options for a cell (some of which apply to the row as a whole)
 #: are set in braces after the cell's ending `.]`. Rows of the table are ended
 #: by a starred cell. For example `[. ... .]*`. Note that the second cell of

--- a/tutorial/sample-problems/Arithmetic/UnitConversion.pg
+++ b/tutorial/sample-problems/Arithmetic/UnitConversion.pg
@@ -34,7 +34,7 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'contextUnits.pl', 'PGcourse.pl');
 #: requested unit.
 #:
 #: The second part below is a different conversion question, so the line
-#: `Context('Units')->withUnitsFor('length', 'time');` resets the contxt with
+#: `Context('Units')->withUnitsFor('length', 'time');` resets the context with
 #: a new set of units.
 Context('Units')->withUnitsFor('volume');
 

--- a/tutorial/sample-problems/DiffCalc/AnswerWithUnits.pg
+++ b/tutorial/sample-problems/DiffCalc/AnswerWithUnits.pg
@@ -30,7 +30,7 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'contextUnits.pl', 'PGcourse.pl');
 #:
 #: Then, assign the unit "seconds" to the variable `t`.
 #:
-#: Use the differentiation operator `->D('t')` to compute the derivated, and the
+#: Use the differentiation operator `->D('t')` to compute the derivative, and the
 #: evaluation method `->eval()` to evaluate it as a function. All of these will
 #: now have the expect units.
 Context('Units')->withUnitsFor('length', 'time')->variables->are(t => 'Real');

--- a/tutorial/sample-problems/IntegralCalc/RiemannSumPlot.pg
+++ b/tutorial/sample-problems/IntegralCalc/RiemannSumPlot.pg
@@ -25,7 +25,7 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'plots.pl', 'PGcourse.pl');
 #:% section = setup
 #: For this problem, we make a Riemann Sum plot by plotting the function $y=x^3+3$
 #: and the midpoint rectangles.  Each of these objects is created separately and added
-#: to the the plot.
+#: to the plot.
 #:
 #: Create a Plot object with the given plotting window and other axis properties. The
 #: function is made in this case as a MathObject.  With `$plot->add_function`, the function

--- a/tutorial/sample-problems/ProblemTechniques/AskSage.pg
+++ b/tutorial/sample-problems/ProblemTechniques/AskSage.pg
@@ -37,8 +37,8 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'PGcourse.pl');
 #: the `sageReturnedFail` method. If that is true, then the Sage cell server
 #: query failed. In that case set fallback values for the variables needed in
 #: the problem so that a workable problem is rendered in this case. If the call
-#: succeeded the the Sage `WEBWORK` dictionary will be decoded into the
-#: `webwork` hash key of the reply.
+#: succeeded the Sage `WEBWORK` dictionary will be decoded into the `webwork`
+#: hash key of the reply.
 #:
 #: Note that by default `AskSage` queries the public Sage cell service at
 #: https://sagecell.sagemath.org/service. However, that site no longer accepts

--- a/tutorial/sample-problems/VectorCalc/VectorLineSegment1.pg
+++ b/tutorial/sample-problems/VectorCalc/VectorLineSegment1.pg
@@ -32,7 +32,7 @@ loadMacros(
 );
 
 #:% section = setup
-#: Create a `MutiAnswer` object that is used to evaluate the student's vector
+#: Create a `MultiAnswer` object that is used to evaluate the student's vector
 #: equation at the starting and ending times provided by the student. For
 #: example, both of the student answers `<4, 0> + t<-4, 2>` for `t` between `0`
 #: and `1`, and `<4,0> + t<-2,1>` for t between `0` and `2` will be marked

--- a/tutorial/templates/index.html
+++ b/tutorial/templates/index.html
@@ -115,7 +115,7 @@
 								<span class="h4">PG POD</span>
 							</div>
 							<div>
-								Documentation from source code for PG modules and macro files (Plain Old Documenation).
+								Documentation from source code for PG modules and macro files (Plain Old Documentation).
 							</div>
 						</a>
 						<a


### PR DESCRIPTION
This is a massive collection of typo corrections after I used `github.com/crate-ci/typos`. Note that it had some false positives, and I examined each one of these to avoid the false positives.

Most of these are in code comments and POD.

A small number of these actually correct a meaningful typo in code.

An even smaller number of these correct some typo in a variable or method name. In those cases, I checked that nothing else was relying on the bad variable/method name.