### PR TITLE
Use `isa` to determine if a given image is a `Plots::Plot`, `WWPlot`, or `LaTeXImage`.

### DIFF
--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2923,7 +2923,7 @@ sub image {
 			);
 			next;
 		}
-		if (ref $image_item eq 'Plots::Plot' || ref $image_item eq 'Plots::StatPlot') {
+		if (eval { $image_item->isa('Plots::Plot') }) {
 			# Update image attributes as needed.
 			$image_item->{width}    = $width    if $out_options{width};
 			$image_item->{height}   = $height   if $out_options{height};
@@ -2942,7 +2942,9 @@ sub image {
 			$width_ratio   = 0.001 * $image_item->{tex_size};
 		}
 		$image_item = insertGraph($image_item)
-			if (grep { ref $image_item eq $_ } ('WWPlot', 'Plots::Plot', 'Plots::StatPlot', 'PGlateximage', 'PGtikz'));
+			if grep {
+				eval { $image_item->isa($_) }
+			} ('WWPlot', 'Plots::Plot', 'LaTeXImage');
 		my $imageURL = alias($image_item) // '';
 		$imageURL = ($envir{use_site_prefix}) ? $envir{use_site_prefix} . $imageURL : $imageURL;
 		my $id  = $main::PG->getUniqueName('img');


### PR DESCRIPTION
This simplifies the checks in the `PGbasicmacros.pl` `image` method that determine if an image is an instance of a `Plots::Plot`, `WWPlot`, or `LaTeXImage` package and makes it so that any future package that derives from one of those will work without further modification to the `image` method. This uses the `isa` method wrapped in an `eval`.  So if something is not blessed, the `isa` call will throw an exception, but the `eval` catches the exception and ignores it returning false.

This is technically not quite as good as using `blessed $image_item && $image_item->isa('Package::Name')`, but here should be fine.  The one case that this will now throw an exception for that the `Scalar::Util::blessed` method would fix is if `$image_item` is a literal package name that satisfies the `isa` call. For example if someone were to call `image(WWPlot)` or `image('WWPlot')`. That will now throw an uncaught exception, since `WWPlot->isa('WWPlot')` will not throw an exception here and will return true.  So the `insertGraph` method will be called with the package name `WWPlot`, and that code will throw the exception because it cannot work with the `WWPlot` package name. That should not be a real problem though, since no one should do that. Without this pull request that still wouldn't work, but it would only give the warning "The file name "WWPlot" does not have an extension. Every file name used as an argument to alias must have an extension. The permissible extensions are .gif, .jpg, .png, .svg, .pdf, .mp4, .mpg, .ogg, .webm, .css, .js, .nb, .csv, .tgz, and .html," but the problem would still render.  The same would happen for any package name that derives from one of `WWPlot`, `Plots::Plot`, or `LaTeXImage`.