### PR TITLE
Deny scripts for an npm package.

### DIFF
--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -41,5 +41,8 @@
 		"last 8 FirefoxAndroid versions",
 		"last 10 iOS versions",
 		"last 5 Opera versions"
-	]
+	],
+	"allowScripts": {
+		"@parcel/watcher": false
+	}
 }


### PR DESCRIPTION
Any time that a package has certain scripts defined (such as `install` or `postinstall`), npm now warns about them and tells you to "Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow."  Note that doing so just adds the section to the `package.json` file that you see in this pull request.

The package `@parcel/watcher` has an `install` script that rebuilds its distribution code if an environment variable is set. This script is harmless, but does not need to be run.