### PR TITLE
Fix a typo in `mqeditor.js`.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -279,7 +279,7 @@
 		answerQuill.textarea = answerQuill.querySelector('textarea');
 
 		if (!cfgOptions.logsChangeBase) {
-			answerQuill.mathField.options.addToolbarButton(
+			answerQuill.mathField.options.addToolbarButtons(
 				{
 					id: 'subscript',
 					latex: '_',


### PR DESCRIPTION
There is no `addToolbarButton` method.  It is `addToolbarButtons`. This was caused when I changed the MathQuill api, but forgot to change this.

As a result, if an answer uses `parserLogb.pl` the `subscript` button is not added to the toolbar, and a console log error occurs when this non-existent method is called.

For a problem to test this with you could use:

```PG
DOCUMENT();

loadMacros(qw(PGstandard.pl PGML.pl parserLogb.pl));

Parser::Logb->Enable;
$n = logb(3, 5);

BEGIN_PGML
Enter [`\log_3(5)`]: [_]{$n}{5}
END_PGML

ENDDOCUMENT();
```