### PR TITLE
Update @openwebwork/mathquill to the latest version.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -290,6 +290,23 @@
 			);
 		}
 
+		if (cfgOptions.includeIonButtons) {
+			answerQuill.mathField.options.addToolbarButtons([
+				{
+					id: 'positiveion',
+					latex: '\\positiveion',
+					tooltip: 'postitive ion',
+					icon: '\\text{ }^{\\text{ }+}'
+				},
+				{
+					id: 'negativeion',
+					latex: '\\negativeion',
+					tooltip: 'negative ion',
+					icon: '\\text{ }^{\\text{ }-}'
+				}
+			]);
+		}
+
 		window.answerQuills[answerLabel] = answerQuill;
 
 		if (latexEntryMode) return;

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "pg.javascript_package_manager",
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@openwebwork/mathquill": "^0.11.4",
+				"@openwebwork/mathquill": "^0.11.5",
 				"jsxgraph": "^1.12.2",
 				"jszip": "^3.10.1",
 				"jszip-utils": "^0.1.0",
@@ -84,9 +84,9 @@
 			}
 		},
 		"node_modules/@openwebwork/mathquill": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.4.tgz",
-			"integrity": "sha512-JI3MrHEyANUw+hp6SFvWPGO9gZodpaW+R0zpJKR8sPbTOiktgwjYMCusjjRbq1cqVHvP+Vc3A9Ee3bYFA6i43g==",
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/@openwebwork/mathquill/-/mathquill-0.11.5.tgz",
+			"integrity": "sha512-hX0aj8FayJnwpTYWHTDY/2j4OvYXDoUJIsLtciwCqB7isI7/gEdefWvtQle3UWXD/H7XpBtEZXEoVjc7zmn42Q==",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"bootstrap": "^5.3.8"

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"prettier-check": "prettier --ignore-path=../.gitignore --check \"**/*.{js,css,scss,html}\" \"../**/*.dist.yml\""
 	},
 	"dependencies": {
-		"@openwebwork/mathquill": "^0.11.4",
+		"@openwebwork/mathquill": "^0.11.5",
 		"jsxgraph": "^1.12.2",
 		"jszip": "^3.10.1",
 		"jszip-utils": "^0.1.0",

--- a/macros/contexts/contextReaction.pl
+++ b/macros/contexts/contextReaction.pl
@@ -311,6 +311,7 @@ sub Init {
 		acceptMolecularForm     => 0,
 		compareMolecular        => 0,
 		keepElementOrder        => 1,
+		mathQuillOpts           => { includeIonButtons => 1 }
 	);
 	$context->{parser}{Number}   = 'context::Reaction::Number';
 	$context->{parser}{Variable} = 'context::Reaction::Variable';


### PR DESCRIPTION
This includes the ion button commands added by @drdrew42.

Also add an `includeIonButtons` option for the MathQuill toolbar.  This option is set by default for any answer in the `Reaction` context from the `contextReaction.pl` macro. The option is only used locally by the `mqeditory.js` code, and is actually ignored by the MathQuill code.