### PR TITLE
Change the extension used by `perltidy`.

### DIFF
--- a/bin/run-perltidy.pl
+++ b/bin/run-perltidy.pl
@@ -67,7 +67,7 @@ my $err = Perl::Tidy::perltidy(argv => \@args, dump_options => \%options);
 exit $err                                                if $err;
 die "The -pro option is not supported by this script.\n" if defined $options{profile};
 
-unshift(@args, '-bext=/') unless defined $options{'backup-file-extension'};
+unshift(@args, '-bext=/tidybak') unless defined $options{'backup-file-extension'};
 
 if (@files) {
 	for (@files) {


### PR DESCRIPTION
This is to address https://github.com/openwebwork/pg/issues/1018#issuecomment-4950123571.

The two settings that affect backups for `perltidy` are `-b` (or `--backup-and-modify-in-place`) and `-bext` (or `--backup-file-extension`).

The `-b` option is boolean and if given it means that a backup of the original Perl file will be created with the extension specified by the `-bext` option, and the original Perl file will be modified in place. This is currently set by default in the `.perltidyrc` file that we use. If this option is not given, then the original Perl file is never modified, and the result of running `perltidy` is saved in a new file with the extension `.tdy`.

The `-bext` option sets the file extension that is used when the `-b` option is set, and determines if the backup file should be kept.  The default value is `bak` which means the extension `.bak` is used and the backup will be kept.  If this is set to a value that does not include a forward slash, then its value will be used for the extension and the backup will be kept.  If the value is set to something that has a forward slash in it, then the backup will be created with that extension, but will be deleted if there are no errors. This is currently set by default in the `bin/run-perltidy.pl` script.

This changes the `-bext` value set by the `bin/run-perltidy.pl` to `/tidybak`.  That means that a backup file will be created with the extension `.tidybak`, but will be deleted if there are no errors.

This will fix @Alex-Jordan's issue because it will not touch any file with the `.bak` extension. Note that anyone that creates backups with the `.tidybak` extension will end up having the same problem, but the extension is chosen because no one really should be using that, and it should not conflict.