### PR TITLE
Pgml convert improvements revised

### DIFF
--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -78,7 +78,7 @@ sub convertFile ($filename) {
 	my $pg_source = $path->slurp;
 	my $result    = convertToPGML($pg_source);
 	if (ref($result) eq 'HASH' && $result->{errors}) {
-		warn "Error parsing $filename. " . $result->{errors} . "\n";
+		warn "Error parsing $filename. " . $result->{errors};
 		return;
 	}
 

--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -83,7 +83,7 @@ sub convertFile ($filename) {
 	}
 
 	# Copy the original file to a backup and then write the file.
-	my $new_path    = $backup ? $path : Mojo::File->new($filename =~ s/\.pg/.$suffix/r);
+	my $new_path    = $backup ? $path : Mojo::File->new($filename =~ s/\.pg/.$suffix\.pg/r);
 	my $backup_file = $filename =~ s/\.pg$/.pg.bak/r;
 	$path->copy_to($backup_file) if $backup;
 	$new_path->spurt($result->{pgmlCode});

--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -70,14 +70,18 @@ sub convertFile ($filename) {
 	my $path = Mojo::File->new($filename);
 	die "The file: $filename does not exist or is not readable" unless -r $path;
 
-	my $pg_source        = $path->slurp;
-	my $converted_source = convertToPGML($pg_source);
+	my $pg_source = $path->slurp;
+	my $result    = convertToPGML($pg_source);
+	if (ref($result) eq 'HASH' && $result->{errors}) {
+		warn "Error parsing $filename. " . $result->{errors};
+		return;
+	}
 
 	# copy the original file to a backup and then write the file
 	my $new_path    = $backup ? $path : Mojo::File->new($filename =~ s/\.pg/.$suffix/r);
 	my $backup_file = $filename =~ s/\.pg$/.pg.bak/r;
 	$path->copy_to($backup_file) if $backup;
-	$new_path->spurt($converted_source);
+	$new_path->spurt($result->{pgmlCode});
 	print "Writing converted file to $new_path\n"      if $verbose;
 	print "Backing up original file to $backup_file\n" if $verbose && $backup;
 }

--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -78,7 +78,7 @@ sub convertFile ($filename) {
 	my $pg_source = $path->slurp;
 	my $result    = convertToPGML($pg_source);
 	if (ref($result) eq 'HASH' && $result->{errors}) {
-		warn "Error parsing $filename. " . $result->{errors};
+		warn "Error parsing $filename. " . $result->{errors} . "\n";
 		return;
 	}
 

--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -10,10 +10,11 @@ convert-to-pgml.pl -- Convert pg problem with non-pgml structure to PGML structu
 
 Options:
 
-    -b|--backup         Create a backup of the original file before converting.
-    -s|--suffix=s       Suffix for the converted files. Default is 'pgml'.
-    -v|--verbose        Print verbose output.
-    -h|--help           Show the help message.
+    -b|--backup               Create a backup of the original file before converting.
+    -e|--extension-prefix=s   Extension prefix for the converted files. Default is 'pgml'.
+    -p|--output-path=s        Output directory in which to save the converted problem files.
+    -v|--verbose              Print verbose output.
+    -h|--help                 Show the help message.
 
 
 =head1 DESCRIPTION
@@ -24,35 +25,52 @@ BEGIN_SOLUTION/END_SOLUTION.
 
 Within each block, the following are converted:  math modes to their PGML version,
 $BR and $PAR to line breaks or empty lines, C<$HR> to C<--->, bold and italics pairs,
-any variables of the form C<$var> to C<[$var]>, scripts from \{ \} to [@ @], and C<ans_rule>
-to the form C<[_]{}>
+any variables of the form C<$var> to C<[$var]>, scripts from \{ \} to [@ @], and
+C<< $var->ans_rule() >> to the form C<[_]{$var}>.
+
+A bare C<ans_rule()> call with no answer object cannot be paired with its C<ANS>
+call reliably from the source alone, so it is left as a raw Perl call inside a
+C<[@ @]> block instead of being converted to a C<[_]{}> answer blank. C<ANS>
+commands are never modified or commented out; pairing them with converted or
+unconverted answer rules is left entirely to manual review.
 
 Many code features that are no longer needed are removed including
 C<TEXT(beginproblem())>, C<< Context()->texStrings; >> and C<< Context()->normalStrings; >>.
-Any C<ANS> commands are commented out.
 
 The C<loadMacros> command is parsed, the C<PGML.pl> is included and C<MathObjects.pl>
 is removed (because it is loaded by C<PGML.pl>) and C<PGcourse.pl> is added to the
 end of the list.
 
 Note: many of the features are converted correctly, but there may be errors
-after the conversion.  Generally after using this script, the PGML style answers
-will need to have their corresponding variable added.
+after the conversion.  Generally after using this script, the answer rules and
+answer evaluators will need to be reviewed and paired up by hand.
 
 =head2 OPTIONS
 
-The option C<-b> or C<--backup> will create a C<.bak> file with the original code and
-replace the current file with the converted code.
+The option C<-b> or C<--backup> will create a C<.bak> file with the original
+code and replace the current file with the converted code.
 
-The option C<-s xyz> or C<--suffix=xyz> will convert the code and write the results in a file
-with the given suffix C<xyz> appended to the file name.  If this is not given
-C<pgml> is used. If the C<-b> flag is used, this option will be ignored.
+The option C<-e xyz> or C<--extension-prefix=xyz> will convert the code and
+write the results in a file with the given extension prefix C<xyz> before the
+C<.pg> extension.  If this is not given C<pgml> is used. So, for example, with
+the default value of this option, if the file C<problemFile.pg> is converted,
+the file C<problemFile.pgml.pg> will be written.  If the C<-b> flag is used,
+this option will be ignored.
+
+The option C<-p path> or C<--output-path=path> is the location to save the
+converted problem files to.  If this option is not provided, then the converted
+files will be saved in the same directory as the original file. Note that if
+this option is used, then the C<-b> or C<--backup> and C<-e> or
+C<--extension-prefix> options are ignored unless the path chosen by this option
+is the directory containing the original problem file. Also note that if this
+option is used, then files in the provided output path will be unconditionally
+overwritten unless the file happens to be the original input file.
 
 =cut
 
 use Mojo::Base -signatures;
 
-use Mojo::File qw(curfile);
+use Mojo::File qw(path curfile);
 use Getopt::Long;
 use Pod::Usage;
 
@@ -61,34 +79,45 @@ use lib curfile->dirname->dirname . '/lib';
 use WeBWorK::PG::ConvertToPGML qw(convertToPGML);
 
 GetOptions(
-	'b|backup'   => \my $backup,
-	's|suffix=s' => \my $suffix,
-	'v|verbose'  => \my $verbose,
-	'h|help'     => \my $show_help
+	'b|backup'             => \my $backup,
+	'e|extension-prefix=s' => \my $extensionPrefix,
+	'p|output-path=s'      => \my $outputPath,
+	'v|verbose'            => \my $verbose,
+	'h|help'               => \my $show_help
 );
 pod2usage(2) if $show_help || @ARGV == 0;
 
-$suffix //= 'pgml';
+$extensionPrefix //= 'pgml';
 convertFile($_) for (grep { $_ =~ /\.pg$/ } @ARGV);
 
 sub convertFile ($filename) {
-	my $path = Mojo::File->new($filename);
-	die "The file: $filename does not exist or is not readable" unless -r $path;
+	my $path = path($filename);
+	die "The file: $filename does not exist or is not readable.\n" unless -r $path;
 
 	my $pg_source = $path->slurp;
 	my $result    = convertToPGML($pg_source);
-	if (ref($result) eq 'HASH' && $result->{errors}) {
-		warn "Error parsing $filename. " . $result->{errors} . "\n";
+	if ($result->{error}) {
+		warn "Error parsing $filename. " . $result->{error} . "\n";
+		return;
+	}
+
+	# If --output-path is given and is not the directory the original file is in, then write to that location.
+	die qq{The output path "$outputPath" does not exist or is not a directory.\n}
+		if $outputPath && !-d $outputPath;
+	if ($outputPath && path($outputPath)->realpath ne $path->dirname->realpath) {
+		my $new_path = path($outputPath, $path->basename);
+		$new_path->spurt($result->{pgmlCode});
+		say "Writing converted file to $new_path" if $verbose;
 		return;
 	}
 
 	# Copy the original file to a backup and then write the file.
-	my $new_path    = $backup ? $path : Mojo::File->new($filename =~ s/\.pg/.$suffix\.pg/r);
+	my $new_path    = $backup ? $path : path($filename =~ s/\.pg/.$extensionPrefix.pg/r);
 	my $backup_file = $filename =~ s/\.pg$/.pg.bak/r;
 	$path->copy_to($backup_file) if $backup;
 	$new_path->spurt($result->{pgmlCode});
-	print "Writing converted file to $new_path\n"      if $verbose;
-	print "Backing up original file to $backup_file\n" if $verbose && $backup;
+	say "Writing converted file to $new_path"      if $verbose;
+	say "Backing up original file to $backup_file" if $verbose && $backup;
 }
 
 1;

--- a/bin/convert-to-pgml.pl
+++ b/bin/convert-to-pgml.pl
@@ -8,6 +8,14 @@ convert-to-pgml.pl -- Convert pg problem with non-pgml structure to PGML structu
 
     convert-to-pgml -b -s pgml file1.pg file2.pg ...
 
+Options:
+
+    -b|--backup         Create a backup of the original file before converting.
+    -s|--suffix=s       Suffix for the converted files. Default is 'pgml'.
+    -v|--verbose        Print verbose output.
+    -h|--help           Show the help message.
+
+
 =head1 DESCRIPTION
 
 This converts each pg file to PGML formatting.  In particular, text blocks are
@@ -20,14 +28,14 @@ any variables of the form C<$var> to C<[$var]>, scripts from \{ \} to [@ @], and
 to the form C<[_]{}>
 
 Many code features that are no longer needed are removed including
-C<TEXT(beginproblem())>, C<<Context()->texStrings;>> and C<<Context()->normalStrings;>>.
+C<TEXT(beginproblem())>, C<< Context()->texStrings; >> and C<< Context()->normalStrings; >>.
 Any C<ANS> commands are commented out.
 
 The C<loadMacros> command is parsed, the C<PGML.pl> is included and C<MathObjects.pl>
 is removed (because it is loaded by C<PGML.pl>) and C<PGcourse.pl> is added to the
 end of the list.
 
-Note: many of the features are converted correctly, but often there will be errors
+Note: many of the features are converted correctly, but there may be errors
 after the conversion.  Generally after using this script, the PGML style answers
 will need to have their corresponding variable added.
 
@@ -42,28 +50,25 @@ C<pgml> is used. If the C<-b> flag is used, this option will be ignored.
 
 =cut
 
-use strict;
-use warnings;
-use experimental 'signatures';
+use Mojo::Base -signatures;
 
 use Mojo::File qw(curfile);
 use Getopt::Long;
+use Pod::Usage;
 
 use lib curfile->dirname->dirname . '/lib';
 
 use WeBWorK::PG::ConvertToPGML qw(convertToPGML);
 
-my $backup  = 0;
-my $verbose = 0;
-my $suffix  = 'pgml';
-
 GetOptions(
-	"b|backup"   => \$backup,
-	"s|suffix=s" => \$suffix,
-	"v|verbose"  => \$verbose,
+	'b|backup'   => \my $backup,
+	's|suffix=s' => \my $suffix,
+	'v|verbose'  => \my $verbose,
+	'h|help'     => \my $show_help
 );
+pod2usage(2) if $show_help || @ARGV == 0;
 
-die 'arguments must have a list of pg files' unless @ARGV > 0;
+$suffix //= 'pgml';
 convertFile($_) for (grep { $_ =~ /\.pg$/ } @ARGV);
 
 sub convertFile ($filename) {
@@ -73,11 +78,11 @@ sub convertFile ($filename) {
 	my $pg_source = $path->slurp;
 	my $result    = convertToPGML($pg_source);
 	if (ref($result) eq 'HASH' && $result->{errors}) {
-		warn "Error parsing $filename. " . $result->{errors};
+		warn "Error parsing $filename. " . $result->{errors} . "\n";
 		return;
 	}
 
-	# copy the original file to a backup and then write the file
+	# Copy the original file to a backup and then write the file.
 	my $new_path    = $backup ? $path : Mojo::File->new($filename =~ s/\.pg/.$suffix/r);
 	my $backup_file = $filename =~ s/\.pg$/.pg.bak/r;
 	$path->copy_to($backup_file) if $backup;

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -70,11 +70,20 @@ This returns a string that is the converted input string.
 
 =cut
 
+use Mojo::Util qw(dumper);
+
 # This stores the answers inside of ANS and related functions.
 my @ans_list;
 
 sub convertToPGML {
 	my ($pg_source) = @_;
+
+	print dumper ($pg_source);
+
+	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement.
+	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
+
+	return $pg_source if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/ && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
 
 	# First get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
@@ -101,29 +110,48 @@ sub convertToPGML {
 		} elsif ($in_pgml_block) {
 			push(@pgml_block, $row);
 		} elsif ($row =~ /loadMacros\(/) {
-			# Parse the macros, which may be on multiple rows.
-			# Remove comments within loadMacros block (should we keep them?)
-			my $macros = $row;
-			while ($row && $row !~ /\);\s*$/) {
+			# Parse the macros, which may be on multiple rows and may be in a qw block.
+			my $macros = '';
+			while (1) {
+				# Remove comments within loadMacros block (should we keep them?)
+				$row =~ s/#.*$//;
+				$macros .= $row;
+				last if ($row =~ /(.*)\);/);
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
 				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
-			# Split by commas and pull out the quotes.
-			my @macros =
-				grep { $_ !~ /^#/ }
-				grep {
-					$_ !~
-					/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
-				}
-				map {s/['"\s]//gr}
-				split(/\s*,\s*/, $macros =~ s/loadMacros\((.*)\)\;$/$1/r);
 
-			push(@all_lines,
-				'loadMacros('
-					. join(', ', map {"'$_'"} ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl'))
-					. ');');
+			my @macros = ();
+			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
+
+			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
+			# loadMacros(qw{macro1.pl macro2.pl});
+			if ($macros =~ /loadMacros\((qw(.))?(.*?)(.)?\)/ms) {
+				($qw_start, $qw_end) = ($2, $4);
+				@macros =
+					grep {
+						$_
+						&& $_ !~
+						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
+					}
+					map {s/['"]//gr} split(/\s+|\s*,\s*/, $3);
+
+				# Remove any duplicates:
+				my %seen;
+				@macros = grep { !$seen{$_}++ } @macros;
+			} else {
+				warn 'The loadMacros statement in this file could not be processed.';
+			}
+
+			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
+
+			if ($qw_start) {
+				push(@all_lines, "loadMacros(qw$qw_start\n\t" . join("\n\t", @macros) . "\n$qw_end);");
+			} else {
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');');
+			}
 		} else {
 			push(@all_lines, cleanUpCode($row));
 		}

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -76,12 +76,17 @@ my @ans_list;
 sub convertToPGML {
 	my ($pg_source) = @_;
 
-	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement.
+	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement,
 	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
 
-	return $pg_source if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/ && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
+	return { pgmlCode => $pg_source }
+		if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/m && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
 
-	# First get a list of all of the ANS, LABELED_ANS, etc. in the problem.
+	# Return an error if the loadMacros isn't in the form loadMacros( ... );
+	return { errors => "The loadMacros command cannot be parsed.", pgmlCode => $pg_source }
+		unless $pg_source =~ /loadMacros\((.*?)\)\s*;/m;
+
+	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
 
 	my @pgml_block;
@@ -108,19 +113,20 @@ sub convertToPGML {
 		} elsif ($row =~ /loadMacros\(/) {
 			# Parse the macros, which may be on multiple rows and may be in a qw block.
 			my $macros          = '';
-			my $num_macro_lines = 0; # store the number of lines in the loadMacro so the output is similar to the input.
-			while (1) {
+			my $num_macro_lines = 1; # store the number of lines in the loadMacro so the output is similar to the input.
+			while ($row !~ /\)\s*;/) {
 				# Remove comments within loadMacros block (should we keep them?)
 				$row =~ s/#.*$//;
 				$macros .= $row;
-				last if ($row =~ /(.*)\);/);
 				++$num_macro_lines;
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
 				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
-			my @macros = ();
+			$macros .= $row;
+
+			my @macros;
 			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
 
 			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
@@ -146,7 +152,7 @@ sub convertToPGML {
 					grep {
 						$_
 						&& $_ !~
-						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
+						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
 					}
 					map {s/['"]//gr} @macros;
 
@@ -154,7 +160,10 @@ sub convertToPGML {
 				my %seen;
 				@macros = grep { !$seen{$_}++ } @macros;
 			} else {
-				warn 'The loadMacros statement in this file could not be processed.';
+				return {
+					errors   => 'The loadMacros command cannot be processed.',
+					pgmlCode => $pg_source
+				};
 			}
 
 			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
@@ -165,10 +174,10 @@ sub convertToPGML {
 					push(@all_lines, "\t$_") for (@macros);
 					push(@all_lines, "$qw_end);");
 				} else {
-					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);");
+					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);", '');
 				}
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');');
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');', '');
 			}
 		} else {
 			push(@all_lines, cleanUpCode($row));

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -70,13 +70,22 @@ This returns a string that is the converted input string.
 
 =cut
 
+use Mojo::Util qw(dumper);
+
 # This stores the answers inside of ANS and related functions.
 my @ans_list;
 
 sub convertToPGML {
 	my ($pg_source) = @_;
 
-	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
+	print dumper ($pg_source);
+
+	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement.
+	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
+
+	return $pg_source if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/ && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
+
+	# First get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
 
 	my @pgml_block;
@@ -102,46 +111,46 @@ sub convertToPGML {
 			push(@pgml_block, $row);
 		} elsif ($row =~ /loadMacros\(/) {
 			# Parse the macros, which may be on multiple rows and may be in a qw block.
-			my $macros          = '';
-			my $num_macro_lines = 1; # store the number of lines in the loadMacro so the output is similar to the input.
-			while ($row !~ /\)\s*;/) {
+			my $macros = '';
+			while (1) {
 				# Remove comments within loadMacros block (should we keep them?)
 				$row =~ s/#.*$//;
 				$macros .= $row;
-				++$num_macro_lines;
+				last if ($row =~ /(.*)\);/);
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
 				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
-			$macros .= $row;
 
-			my $load_macros_block = parseLoadMacros($macros);
+			my @macros = ();
+			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
 
-			# If PGML.pl is a macro and there are no BEGIN_TEXT/HINT/SOLUTION blocks
-			# return the original source.
-			return { pgmlCode => $pg_source }
-				if (!defined($load_macros_block->{errors})
-					&& grep { $_ eq 'PGML.pl' } @{ $load_macros_block->{macros} }
-					&& $pg_source !~ /^\s*BEGIN_(TEXT|HINT|SOLUTION)/m);
+			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
+			# loadMacros(qw{macro1.pl macro2.pl});
+			if ($macros =~ /loadMacros\((qw(.))?(.*?)(.)?\)/ms) {
+				($qw_start, $qw_end) = ($2, $4);
+				@macros =
+					grep {
+						$_
+						&& $_ !~
+						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
+					}
+					map {s/['"]//gr} split(/\s+|\s*,\s*/, $3);
 
-			return { errors => $load_macros_block->{errors}, pgmlCode => $pg_source } if ($load_macros_block->{errors});
-
-			if ($load_macros_block->{qw_start}) {
-				if ($num_macro_lines > 1) {    # put each macro on a separate line
-					push(@all_lines, 'loadMacros(qw' . $load_macros_block->{qw_start});
-					push(@all_lines, "\t$_") for (@{ $load_macros_block->{macros} });
-					push(@all_lines, $load_macros_block->{qw_end} . ');');
-				} else {
-					push(@all_lines,
-						'loadMacros(qw'
-							. $load_macros_block->{qw_start}
-							. join(' ', @{ $load_macros_block->{macros} })
-							. $load_macros_block->{qw_end} . ');',
-						'');
-				}
+				# Remove any duplicates:
+				my %seen;
+				@macros = grep { !$seen{$_}++ } @macros;
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @{ $load_macros_block->{macros} }) . ');', '');
+				warn 'The loadMacros statement in this file could not be processed.';
+			}
+
+			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
+
+			if ($qw_start) {
+				push(@all_lines, "loadMacros(qw$qw_start\n\t" . join("\n\t", @macros) . "\n$qw_end);");
+			} else {
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');');
 			}
 		} else {
 			push(@all_lines, cleanUpCode($row));

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -57,7 +57,7 @@ use parent qw(Exporter);
 use strict;
 use warnings;
 
-our @EXPORT = qw(convertToPGML);
+our @EXPORT_OK = qw(convertToPGML);
 
 =head2 convertToPGML
 
@@ -75,16 +75,6 @@ my @ans_list;
 
 sub convertToPGML {
 	my ($pg_source) = @_;
-
-	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement,
-	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
-
-	return { pgmlCode => $pg_source }
-		if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/m && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
-
-	# Return an error if the loadMacros isn't in the form loadMacros( ... );
-	return { errors => "The loadMacros command cannot be parsed.", pgmlCode => $pg_source }
-		unless $pg_source =~ /loadMacros\((.*?)\)\s*;/m;
 
 	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
@@ -126,58 +116,32 @@ sub convertToPGML {
 			}
 			$macros .= $row;
 
-			my @macros;
-			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
+			my $load_macros_block = parseLoadMacros($macros);
 
-			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
-			# loadMacros(qw{macro1.pl macro2.pl});
-			if ($macros =~ /loadMacros\((.*?)\);/ms) {
-				my @macro_str = split(/\s*,\s*/, $1);
+			# If PGML.pl is a macro and there are no BEGIN_TEXT/HINT/SOLUTION blocks
+			# return the original source.
+			return { pgmlCode => $pg_source }
+				if (!defined($load_macros_block->{errors})
+					&& grep { $_ eq 'PGML.pl' } @{ $load_macros_block->{macros} }
+					&& $pg_source !~ /^\s*BEGIN_(TEXT|HINT|SOLUTION)/m);
 
-				for my $str (@macro_str) {
-					if ($str =~ /^qw(.)/) {
-						my $qw_matches = { '{' => '}', '(' => ')', '[' => ']', '/' => '/', '|' => '|' };
-						$qw_start = $1;
-						$qw_end   = $qw_matches->{$qw_start};
+			return { errors => $load_macros_block->{errors}, pgmlCode => $pg_source } if ($load_macros_block->{errors});
 
-						if ($str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/) {
-							push(@macros, split(/\s+/, $1));
-						}
-					} else {
-						push(@macros, $str);
-					}
-				}
-
-				@macros =
-					grep {
-						$_
-						&& $_ !~
-						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
-					}
-					map {s/['"]//gr} @macros;
-
-				# Remove any duplicates:
-				my %seen;
-				@macros = grep { !$seen{$_}++ } @macros;
-			} else {
-				return {
-					errors   => 'The loadMacros command cannot be processed.',
-					pgmlCode => $pg_source
-				};
-			}
-
-			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
-
-			if ($qw_start) {
+			if ($load_macros_block->{qw_start}) {
 				if ($num_macro_lines > 1) {    # put each macro on a separate line
-					push(@all_lines, "loadMacros(qw$qw_start");
-					push(@all_lines, "\t$_") for (@macros);
-					push(@all_lines, "$qw_end);");
+					push(@all_lines, 'loadMacros(qw' . $load_macros_block->{qw_start});
+					push(@all_lines, "\t$_") for (@{ $load_macros_block->{macros} });
+					push(@all_lines, $load_macros_block->{qw_end} . ');');
 				} else {
-					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);", '');
+					push(@all_lines,
+						'loadMacros(qw'
+							. $load_macros_block->{qw_start}
+							. join(' ', @{ $load_macros_block->{macros} })
+							. $load_macros_block->{qw_end} . ');',
+						'');
 				}
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');', '');
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @{ $load_macros_block->{macros} }) . ');', '');
 			}
 		} else {
 			push(@all_lines, cleanUpCode($row));
@@ -193,6 +157,56 @@ sub convertToPGML {
 		}
 	}
 	return { pgmlCode => join "\n", @all_lines };
+}
+
+sub parseLoadMacros {
+	my ($macros) = @_;
+
+	my $error_string = 'The loadMacros statement could not be parsed. Check for syntax errors.';
+
+	return { errors => $error_string }
+		if $macros =~ /loadMacros\(.*?\)(.*?);/s && $1 !~ /^\s*$/m;
+
+	my @macros;
+	my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
+	my $qw_matches = { '{' => '}', '(' => ')', '[' => ']', '/' => '/', '|' => '|' };
+
+	# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
+	# loadMacros(qw{macro1.pl macro2.pl});
+	if ($macros =~ /loadMacros\((.*?)\);/ms) {
+		my @macro_str = split(/\s*,\s*/, $1);
+
+		for my $str (@macro_str) {
+			if ($str =~ /^qw(.)/) {
+				$qw_start = $1;
+				$qw_end   = $qw_matches->{$qw_start};
+				push(@macros, split(/\s+/, $1)) if $str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/;
+			} else {
+				push(@macros, $str);
+			}
+		}
+
+		@macros =
+			grep {
+				$_
+				&& $_ !~
+				/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
+			}
+			map {s/['"]//gr} @macros;
+
+		# Remove any duplicates:
+		my %seen;
+		@macros = grep { !$seen{$_}++ } @macros;
+	} else {
+		return { errors => $error_string };
+	}
+
+	@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
+	return {
+		qw_start => $qw_start,
+		qw_end   => $qw_end,
+		macros   => \@macros
+	};
 }
 
 # This subroutine converts a block (passed in as an array ref of strings) to
@@ -269,12 +283,12 @@ sub convertPGMLBlock {
 		}
 
 		# After many other variables have been replaced, replace the variables in the PGML block.
-		# However if not in a {}, assumed to be in an answer blank.
+		# If a variable is inside [_]{}, like '[_]{$a}', then leave it alone.
 		if (my @matches = $row =~ /\$[\w\_]+/g) {
-			for my $m (@matches) {
-				$m =~ s/\$/\\\$/;
-				# Wrap variables in [].  Handle arrays, hashes, array refs and hashrefs.
-				$row =~ s/(?<!\]{)($m+(\[\d+\])?((->)?\{.*?\})?)/[$1]/;
+			my %seen;
+			for my $m (grep { !$seen{$_}++ } @matches) {
+				# $row =~ s/(?<!\{)(\Q$m\E)(?!\})/[$1]/g;
+				$row =~ s/\[_+\]\{\Q$m\E\}(*SKIP)(*F)|(\Q$m\E)/[$1]/g;
 			}
 		}
 

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -13,13 +13,17 @@ This script does a number of conversions:
 
 =item *
 
-Update the loadMacros call to include C<PGML.pl>, eliminate C<MathObject.pl> (since it is loaded by C<PGML.pl>)
-and adds C<PGcourse.pl> to the end of the list.
+Update the loadMacros call to include C<PGML.pl>, eliminate C<MathObjects.pl>
+and C<niceTables.pl> (since they are loaded by C<PGML.pl>) and adds
+C<PGcourse.pl> to the end of the list.
 
 =item *
 
-Coverts C<BEGIN_TEXT>/C<END_TEXT> (and older versions of this), C<BEGIN_SOLUTION>/C<END_SOLUTION>,
-C<BEGIN_HINT>/C<END_HINT> to their newer C<BEGIN_PGML> blocks.
+Coverts C<BEGIN_TEXT>/C<END_TEXT>, C<BEGIN_SOLUTION>/C<END_SOLUTION>,
+C<BEGIN_HINT>/C<END_HINT>, and the older
+C<TEXT(EV2(<<TERM));>/C<SOLUTION(EV3(<<TERM));>/C<HINT(EV2(<<TERM));> heredoc
+forms (with C<TERM> being any terminator the problem author chose) to their
+newer C<BEGIN_PGML> blocks.
 
 =item *
 
@@ -35,7 +39,9 @@ Convert variables to the interpolated C<[$var]> PGML style.
 
 =item *
 
-Convert some of the answer rules to newer PGML style.
+Leave answer rules and answer evaluators as they were, as ordinary Perl code
+inside a C<[@ @]> block. Pairing them up and converting them to PGML answer
+blanks is left entirely to manual review.
 
 =item *
 
@@ -57,56 +63,99 @@ use parent qw(Exporter);
 use strict;
 use warnings;
 
+use PPI;
+
+require WeBWorK::PG::Translator;
+
 our @EXPORT_OK = qw(convertToPGML);
 
 =head2 convertToPGML
 
 This subroutine converts the file that is passed in as a multi-line string and
-assumed to be an older-style PG file with BEGIN_TEXT/END_TEXT, BEGIN_SOLUTION/END_SOLUTION,
-and BEGIN_HINT/END_HINT blocks.
+assumed to be an older-style PG file with BEGIN_TEXT/END_TEXT,
+BEGIN_SOLUTION/END_SOLUTION, and BEGIN_HINT/END_HINT blocks.
 
-The input is expected to be a string containing the source of the pg file to be converted.
-This returns a string that is the converted input string.
+The input is expected to be a string containing the source of the pg file to be
+converted.  This returns a string that is the converted input string.
 
 =cut
 
-# This stores the answers inside of ANS and related functions.
-my @ans_list;
+# Matches the start of any old-style BEGIN_TEXT/HINT/SOLUTION content block, or TEXT(EV2(<<TERM)); /
+# SOLUTION(EV3(<<'TERM')); / HINT(EV2(<<"TERM")); forms. TERM is whatever bareword the problem author chose as the
+# heredoc or nowdoc terminator. It is captured here, and used by the main loop below to find the matching end-of-block
+# row. The EVn form is sometimes seen called with an explicit & sigil, e.g. &SOLUTION(EV3(<<'EOT'));, which is tolerated
+# here too. The BEGIN_TEXT/HINT/SOLUTION line itself must have nothing but horizontal whitespace before it and nothing
+# but horizontal whitespace and/or semicolons after it just as in translation, so a line that would not actually be
+# treated as BEGIN_TEXT in translation is not treated as one here either. This is shared between the main conversion
+# loop and the "is this already converted" check so the two can't drift out of sync.
+my $OLD_BLOCK_START_RE = qr/
+	^\h*BEGIN_(?<beginKind>TEXT|HINT|SOLUTION)[\h;]*$ |
+	&?(?:TEXT|HINT|SOLUTION)\s*\(\s*EV[23]\s*\(\s*<<\s*(?<termQuote>['"]?)(?<term>\w+)\k<termQuote>\s*\)\s*\)\s*;?
+/xm;
+
+# Maps a bracket-style quote-like delimiter to its closing character.
+my %QUOTE_LIKE_CLOSE = ('(' => ')', '{' => '}', '[' => ']', '<' => '>');
+
+# Returns an error message if $pg_source is not structurally well-formed Perl once translated, or undef if it is. This
+# uses PPI, and does not actually compile or execute the code which would be a security vulnerability. PPI is a
+# heuristic parser rather than a full Perl grammar, so it is not a perfect substitute for actually compiling or
+# executing the file, but it reliably flags the kind of gross structural breakage (unbalanced quotes/braces/parens, an
+# unterminated heredoc, a truncated statement) this check is for.
+sub checkPGSyntax {
+	my ($pg_source) = @_;
+	my $translated = WeBWorK::PG::Translator::default_preprocess_code($pg_source);
+
+	my $document = PPI::Document->new(\$translated);
+	return 'The file could not be parsed by PPI: ' . PPI::Document->errstr unless $document;
+
+	my @unclosed = grep { !defined $_->finish } @{ $document->find('PPI::Structure') || [] };
+	return 'The file contains an unclosed ' . $unclosed[0]->braces . ' delimiter.' if @unclosed;
+
+	return;
+}
 
 sub convertToPGML {
 	my ($pg_source) = @_;
 
-	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
-	@ans_list = getANS($pg_source);
+	# Check the source syntax and stop before attempting the conversion if there are syntax errors, rather than risk
+	# silently producing a mangled result from source that was already broken to begin with.
+	if (my $compileError = checkPGSyntax($pg_source)) {
+		return {
+			error    => "The file could not be converted because it does not compile: $compileError",
+			pgmlCode => $pg_source
+		};
+	}
 
 	my @pgml_block;
 	my $in_pgml_block = 0;
+	my $block_end_re;
 	my @all_lines;
 
 	my @rows = split(/\n/, $pg_source);
 
 	while (@rows) {
 		my $row = shift @rows;
-		if ($row =~ /BEGIN_(TEXT|HINT|SOLUTION)/
-			|| $row =~ /SOLUTION\(EV3\(<<\'END_SOLUTION\'\)\);/
-			|| $row =~ /TEXT\(EV2\(<<EOT\)\)/)
-		{
+		if (!$in_pgml_block && $row =~ $OLD_BLOCK_START_RE) {
 			push(@pgml_block, $row);
 			$in_pgml_block = 1;
-		} elsif ($row =~ /END_(TEXT|HINT|SOLUTION)|EOT/) {
+			# BEGIN_TEXT/HINT/SOLUTION is closed by the matching END_ keyword, allowing the same horizontal
+			# whitespace/semicolons that are allowed in translation and nothing else. The EV2/EV3 heredoc forms are
+			# closed by a line consisting of just the captured terminator, and the terminator must be alone on the line
+			# with no whitespace at all, since translation does not strip that.
+			$block_end_re = defined $+{term} ? qr/^\Q$+{term}\E$/ : qr/^\h*END_\Q$+{beginKind}\E[\h;]*$/;
+		} elsif ($in_pgml_block && $row =~ $block_end_re) {
 			push(@pgml_block, $row);
 			$in_pgml_block = 0;
 			push(@all_lines, @{ convertPGMLBlock(\@pgml_block) });
 			@pgml_block = ();
 		} elsif ($in_pgml_block) {
 			push(@pgml_block, $row);
-		} elsif ($row =~ /loadMacros\(/) {
+		} elsif ($row !~ /^\s*#/ && $row =~ /loadMacros\(/) {
 			# Parse the macros, which may be on multiple rows and may be in a qw block.
 			my $macros          = '';
-			my $num_macro_lines = 1; # store the number of lines in the loadMacro so the output is similar to the input.
+			my $num_macro_lines = 1; # Store the number of lines in the loadMacro so the output is similar to the input.
 			while ($row !~ /\)\s*;/) {
-				# Remove comments within loadMacros block (should we keep them?)
-				$macros .= $row =~ s/#.*$//r;
+				$macros .= "$row\n";
 				++$num_macro_lines;
 				$row = shift @rows;
 			}
@@ -114,16 +163,44 @@ sub convertToPGML {
 
 			my $load_macros_block = parseLoadMacros($macros);
 
-			# If PGML.pl is a macro and there are no BEGIN_TEXT/HINT/SOLUTION blocks
-			# return the original source.
+			# If the original loadMacros call already listed PGML.pl and there are no old-style content blocks,
+			# this file has already been converted.  So return the original source unchanged.
 			return { pgmlCode => $pg_source }
-				if (!defined($load_macros_block->{errors})
-					&& grep { $_ eq 'PGML.pl' } @{ $load_macros_block->{macros} }
-					&& $pg_source !~ /^\s*BEGIN_(TEXT|HINT|SOLUTION)/m);
+				if (!defined($load_macros_block->{error})
+					&& $load_macros_block->{already_had_pgml}
+					&& $pg_source !~ $OLD_BLOCK_START_RE);
 
-			return { errors => $load_macros_block->{errors}, pgmlCode => $pg_source } if ($load_macros_block->{errors});
+			return { error => $load_macros_block->{error}, pgmlCode => $pg_source } if ($load_macros_block->{error});
 
-			if ($load_macros_block->{qw_start}) {
+			# Only a comment that trailed a macro which survived filtering, deduplication, and reordering is kept.  See
+			# parseLoadMacros for how that is determined. Anything else (a comment on a macro that was dropped, a whole
+			# commented-out line, a comment after the closing sign) has no macro left to sit next to in the rebuilt
+			# call, so it is dropped rather than relocated somewhere that would misattribute it.
+			my %comments_to_keep;
+			for my $name (@{ $load_macros_block->{macros} }) {
+				my $lines = $load_macros_block->{macro_comments}{$name};
+				$comments_to_keep{$name} = $lines if $lines && @$lines;
+			}
+
+			if (%comments_to_keep) {
+				# qw(...) has no comment syntax of its own, so this uses the quoted, one-macro-per-line form
+				# regardless of how the original was written, since that is the only way to keep a comment
+				# attached to the right line.
+				push(@all_lines, 'loadMacros(');
+				my @names = @{ $load_macros_block->{macros} };
+				for my $i (0 .. $#names) {
+					my $name  = $names[$i];
+					my $comma = $i < $#names ? ',' : '';
+					if ($comments_to_keep{$name}) {
+						my @commentLines = @{ $comments_to_keep{$name} };
+						push(@all_lines, "\t'$name'$comma " . shift(@commentLines));
+						push(@all_lines, "\t\t$_") for @commentLines;
+					} else {
+						push(@all_lines, "\t'$name'$comma");
+					}
+				}
+				push(@all_lines, ');');
+			} elsif ($load_macros_block->{qw_start}) {
 				if ($num_macro_lines > 1) {    # put each macro on a separate line
 					push(@all_lines, 'loadMacros(qw' . $load_macros_block->{qw_start});
 					push(@all_lines, "\t$_") for (@{ $load_macros_block->{macros} });
@@ -133,26 +210,74 @@ sub convertToPGML {
 						'loadMacros(qw'
 							. $load_macros_block->{qw_start}
 							. join(' ', @{ $load_macros_block->{macros} })
-							. $load_macros_block->{qw_end} . ');',
-						'');
+							. $load_macros_block->{qw_end}
+							. ');');
 				}
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @{ $load_macros_block->{macros} }) . ');', '');
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @{ $load_macros_block->{macros} }) . ');');
 			}
+			push(@all_lines, '');
 		} else {
 			push(@all_lines, cleanUpCode($row));
 		}
 	}
 
-	# remove blank lines if there are more than one.
+	# Remove blank lines if there are more than one.
 	my @empty_lines = grep { $all_lines[$_] =~ /^\s*$/ } (0 .. $#all_lines);
 
-	for (my $n = $#empty_lines; $n >= 1; $n--) {
+	for (my $n = $#empty_lines; $n >= 1; --$n) {
 		if ($empty_lines[$n] == $empty_lines[ $n - 1 ] + 1) {
 			splice(@all_lines, $empty_lines[$n], 1);
 		}
 	}
-	return { pgmlCode => join "\n", @all_lines };
+
+	return { pgmlCode => join("\n", @all_lines) };
+}
+
+# Splits $row into a code part and a trailing # comment, skipping over any quote-like content first so a # inside a
+# quoted string is not mistaken for the start of one. Returns (code, comment); comment is undef if $row had none.
+# The comment keeps its leading #.
+sub splitTrailingComment {
+	my ($row) = @_;
+	my $pos   = 0;
+	my $len   = length($row);
+	while ($pos < $len) {
+		my $next = skipQuoteLike($row, $pos);
+		if (defined $next) {
+			$pos = $next;
+			next;
+		}
+		return (substr($row, 0, $pos), substr($row, $pos)) if substr($row, $pos, 1) eq '#';
+		++$pos;
+	}
+	return ($row, undef);
+}
+
+# Returns the content of $str trimmed of surrounding whitespace with one layer of Perl string quoting removed, or undef
+# if it is not actually quoted at all. This handles the quote forms '...', "...", q(...), q{...}, qq(...), etc.
+# (qw(...) is handled separately in parseLoadMacros, since it expands to multiple items, not one.)
+sub matchQuotedString {
+	my ($str) = @_;
+	$str =~ s/^\s+|\s+$//g;
+
+	return $2 if $str =~ /^(['"])(.*)\1$/s;
+
+	if ($str =~ /^q{1,2}\s*(\S)/) {
+		my $openDelim  = $1;
+		my $closeDelim = $QUOTE_LIKE_CLOSE{$openDelim} // $openDelim;
+		return $1 if $str =~ /^q{1,2}\s*\Q$openDelim\E(.*)\Q$closeDelim\E$/s;
+	}
+
+	return;
+}
+
+# Strips one layer of Perl string quoting from a single loadMacros list item to obtain the bare macro filename, but
+# falls back to the trimmed item unchanged if it was not actually quoted.
+sub unquoteMacroItem {
+	my ($str) = @_;
+	$str =~ s/^\s+|\s+$//g;
+	my $inner = matchQuotedString($str);
+	return defined $inner ? $inner : $str;
 }
 
 sub parseLoadMacros {
@@ -160,54 +285,95 @@ sub parseLoadMacros {
 
 	my $error_string = 'The loadMacros statement could not be parsed. Check for syntax errors.';
 
-	return { errors => $error_string }
-		if $macros =~ /loadMacros\(.*?\)(.*?);/s && $1 !~ /^\s*$/m;
+	return { error => $error_string } unless $macros =~ /loadMacros\s*\(/;
+	my $openParen = $+[0] - 1;
+
+	# Find the matching closing parenthesis for a `loadMacros(` call. Anything after the `;` other than a comment
+	# means this was not really a bare loadMacros(...); statement.
+	my $closeParen = matchingDelimiter($macros, $openParen);
+	return { error => $error_string }
+		unless defined $closeParen && substr($macros, $closeParen + 1) =~ /^\s*;\s*(?:#.*)?$/;
+
+	my $inner = substr($macros, $openParen + 1, $closeParen - $openParen - 1);
 
 	my @macros;
-	my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
-	my $qw_matches = { '{' => '}', '(' => ')', '[' => ']', '/' => '/', '|' => '|' };
+	my ($qw_start, $qw_end);    # The characters if the loadMacros has a qw block.
+	my $already_had_pgml;       # Whether the original loadMacros call already listed PGML.pl.
 
-	# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
-	# loadMacros(qw{macro1.pl macro2.pl});
-	if ($macros =~ /loadMacros\(\s*(.*?)\s*\);/ms) {
-		my @macro_str = split(/\s*,\s*/, $1);
-
-		for my $str (@macro_str) {
-			if ($str =~ /^qw(.)/) {
-				$qw_start = $1;
-				$qw_end   = $qw_matches->{$qw_start};
-				push(@macros, split(/\s+/, $1)) if $str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/;
-			} else {
-				push(@macros, $str);
-			}
+	# The following can parse loadMacros in the form `loadMacros('macro1.pl', 'macro2.pl');`,
+	# `loadMacros(q(macro1.pl));`, or `loadMacros(qw{macro1.pl macro2.pl});` including qw blocks mixed with other quoted
+	# forms. A list item that is not a qw(...) block and not actually a quoted string is treated as a parse error.
+	for my $str (splitTopLevelArgs($inner)) {
+		if ($str =~ /^qw(.)/) {
+			$qw_start = $1;
+			$qw_end   = $QUOTE_LIKE_CLOSE{$qw_start} // $qw_start;
+			push(@macros, split(/\s+/, $1)) if $str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/;
+		} else {
+			my $name = matchQuotedString($str);
+			return { error => $error_string } unless defined $name;
+			push(@macros, $name);
 		}
-
-		@macros =
-			grep {
-				$_
-				&& $_ !~ /(PGstandard|
-					PGML|
-					PGauxiliaryFunctions|
-					PGbasicmacros|
-					PGanswermacros|
-					MathObjects|
-					PGcourse|
-					AnswerFormatHelp).pl/x
-			}
-			map {s/['"]//gr} @macros;
-
-		# Remove any duplicates:
-		my %seen;
-		@macros = grep { !$seen{$_}++ } @macros;
-	} else {
-		return { errors => $error_string };
 	}
+
+	# Collect any comment trailing each macro's own line, keeping it with that macro so it can be kept only if the
+	# macro itself survives filtering below. A comment-only line is treated as continuing the comment on the line
+	# right before it, but only if that line had a comment of its own to continue - a comment-only line right
+	# after a macro with no comment (e.g. a whole commented-out macro entry a couple of lines down from the last
+	# real comment) is not attributed to that earlier macro. This still cannot reliably tell an intentional
+	# continuation apart from an unrelated comment that happens to immediately follow one, so it is a best effort.
+	# A line with a qw(...) block is not attributed to any one macro in it, since qw() has no comment syntax of
+	# its own to preserve one inline anyway.
+	my %macro_comments;
+	my $currentMacro;
+	my $chaining = 0;
+	for my $line (split /\n/, $inner) {
+		my ($code, $comment) = splitTrailingComment($line);
+		if ($code =~ /\S/) {
+			my @items = splitTopLevelArgs($code);
+			$currentMacro = @items && $items[-1] !~ /^qw/ ? unquoteMacroItem($items[-1]) : undef;
+			if (defined $comment) {
+				push(@{ $macro_comments{$currentMacro} }, $comment) if defined $currentMacro;
+				$chaining = 1;
+			} else {
+				$chaining = 0;
+			}
+		} elsif (defined $comment && $chaining) {
+			push(@{ $macro_comments{$currentMacro} }, $comment) if defined $currentMacro;
+		} else {
+			$chaining = 0;
+		}
+	}
+
+	# Determine if the *original* loadMacros call already listed PGML.pl before it is added unconditionally below.
+	# This is used by the caller to decide whether this file has already been converted.
+	$already_had_pgml = !!(grep { $_ eq 'PGML.pl' } @macros);
+
+	@macros =
+		grep {
+			$_ && $_ !~ /(
+			AnswerFormatHelp |
+			MathObjects |
+			niceTables |
+			PGML |
+			PGanswermacros |
+			PGauxiliaryFunctions |
+			PGbasicmacros |
+			PGcourse |
+			PGstandard
+			).pl/x
+		} @macros;
+
+	# Remove any duplicates:
+	my %seen;
+	@macros = grep { !$seen{$_}++ } @macros;
 
 	@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
 	return {
-		qw_start => $qw_start,
-		qw_end   => $qw_end,
-		macros   => \@macros
+		qw_start         => $qw_start,
+		qw_end           => $qw_end,
+		macros           => \@macros,
+		already_had_pgml => $already_had_pgml,
+		macro_comments   => \%macro_comments
 	};
 }
 
@@ -222,43 +388,42 @@ sub parseLoadMacros {
 # * converting $HR to ---
 # * convert center, bold and italics to PGML forms.
 # * converting other variables from $var to [$var]
-# * converting ans_rule to [_]{} format
-# * converting \{ \} to [@ @] without altering code within the \{ \}.
-
+# * converting \{ \} to [@ @] without altering code within the \{ \}, including any answer rule inside it, which is
+#   left as ordinary Perl code for manual conversion.
 sub convertPGMLBlock {
 	my ($block) = @_;
 	my @new_rows;
+
+	# The TEXT(EV2(<<TERM)); / SOLUTION(EV3(<<'TERM')); / HINT(EV2(<<"TERM")); forms end with a line that is just TERM,
+	# which could be any bareword the problem author chose, so unlike the mirroring BEGIN_TEXT/END_TEXT keyword
+	# substitutions below, both the opening and closing rows for this form are rewritten here by position (the
+	# first/last row of the block, which the main loop already identified using this same terminator) rather than by
+	# searching for TERM as text in every row, which risked corrupting an unrelated row that coincidentally contained
+	# TERM as a substring. A leading & (e.g. &SOLUTION(EV3(<<'EOT'));) is stripped along with the rest of the call.
+	if ($block->[0] =~ /^\s*&?(TEXT|HINT|SOLUTION)\s*\(\s*EV[23]\s*\(\s*<<\s*(['"]?)(\w+)\2\s*\)\s*\)\s*;?/) {
+		my ($kind, $term) = ($1, $3);
+		my $tag = $kind eq 'TEXT' ? 'PGML' : "PGML_$kind";
+		$block->[0]  = "BEGIN_$tag";
+		$block->[-1] = "END_$tag" if @$block > 1 && $block->[-1] =~ /^\Q$term\E$/;
+	}
+
 	while (@$block) {
 		my $row                   = shift @$block;
 		my $add_blank_line_before = ($row =~ /^\s*\$PAR/);
 		my $add_blank_line_after  = ($row =~ /\$PAR\s*$/);
 
-		# match all forms of ans_rule
-		$row = convertANSrule($row);
+		# A row can hold more than one \{ \} escape (they do not nest), so each is pulled out into its own entry
+		# and replaced with a placeholder, to be wrapped in [@ @] and put back after the other substitutions below,
+		# none of which should touch Perl code.
+		my ($extractedRow, $perlBlocks) = extractPerlBlocks($row, $block);
+		$row = $extractedRow;
 
-		# Capture any perl blocks inside \{ \}
-		my @perl_block;
+		# The whole row is consumed and replaced, not just the keyword, so that any horizontal whitespace and/or
+		# semicolons that would be stripped in translation do not linger in the output.
+		$row =~ s/^\h*(BEGIN|END)_TEXT[\h;]*$/$1_PGML/;
+		$row =~ s/^\h*(BEGIN|END)_(SOLUTION|HINT)[\h;]*$/$1_PGML_$2/;
 
-		if ($row =~ /^(.*)\\\{(.*)\\\}(.*)/) {
-			push(@perl_block, $2);
-			$row = "$1 PERL_BLOCK $3";
-		} elsif ($row =~ /^(.*)\\\{(.*)$/) {    # This is a multi-line perl block
-			my $tmp = $1;
-			push(@perl_block, $2);
-			do {
-				$row = shift @$block;
-				push(@perl_block, $row) unless $row =~ /^(.*)\\\}(.*)$/;
-			} until $row =~ /^(.*)\\\}(.*)$/;
-			push(@perl_block, $1);
-			$row = "$tmp PERL_BLOCK $2";
-		}
-
-		$row =~ s/(BEGIN|END)_TEXT/$1_PGML/;
-		$row =~ s/TEXT\(EV2\(<<EOT\)\)/BEGIN_PGML/;
-		$row =~ s/EOT/END_PGML/;
-		$row =~ s/(BEGIN|END)_(SOLUTION|HINT)/$1_PGML_$2/;
-		$row =~ s/SOLUTION\(EV3P?\(<<\'END_PGML_SOLUTION\'\)\);/BEGIN_PGML_SOLUTION/;
-		# remove $PAR, and $SPACE
+		# Remove $PAR, and $SPACE.
 		$row =~ s/\$PAR//g;
 		$row =~ s/\$SPACE//g;
 
@@ -278,40 +443,33 @@ sub convertPGMLBlock {
 		$row =~ s/\\\[/[```/g;
 		$row =~ s/\\\]/```]/g;
 
-		# if there is an $HR, add blank lines before and after the PGML "---"
-
+		# If there is an $HR, add blank lines before and after the PGML "---", and move on to the next row. $row itself
+		# is not touched, so falling through to the rest of this loop and the push at the bottom would push the row a
+		# second time, with its still-unconverted $HR wrapped into [$HR] by the variable interpolation below.
 		if ($row =~ /^(.*)\$HR(.*)$/) {
 			push @new_rows, $1 // '', '', '---', '', $2 // '';
+			next;
 		}
 
-		# After many other variables have been replaced, replace the variables in the PGML block.
-		# If a variable is inside [_]{}, like '[_]{$a}', then leave it alone.
-		if (my @matches = $row =~ /\$[\w\_]+/g) {
-			my %seen;
-			for my $m (grep { !$seen{$_}++ } @matches) {
-				# $row =~ s/(?<!\{)(\Q$m\E)(?!\})/[$1]/g;
-				$row =~ s/\[_+\]\{\Q$m\E\}(*SKIP)(*F)|(\Q$m\E)/[$1]/g;
-			}
-		}
+		# After many other variables have been replaced, replace the variables in the PGML block. An answer blank
+		# like '[_]{$a}' is Perl code, not PGML text, so its variable is protected from this and restored
+		# unchanged afterward.
+		my ($protectedRow, $protectedBlanks) = protectAnswerBlanks($row);
+		$protectedRow = wrapInterpolatedVariables($protectedRow);
+		$row          = restoreAnswerBlanks($protectedRow, $protectedBlanks);
 
-		# Do some converting inside a perl block:
-		for (0 .. $#perl_block) {
-			$perl_block[$_] =~ s/AnswerFormatHelp\(["']([\w\s]+)["']\)/helpLink('$1')/g;
+		# Wrap each extracted \{ \} block in [@ @] and put it back where its placeholder is. Adding a blank line
+		# before or after for a $PAR is independent of this, so it wraps around the whole row once this is done.
+		for my $lines (@$perlBlocks) {
+			my @lines = grep { $_ !~ /^\s*$/ } @$lines;
+			$lines[$_] =~ s/AnswerFormatHelp\(["']([\w\s]+)["']\)/helpLink('$1')/g for 0 .. $#lines;
+			$row =~ s/\x02\d+\x02/'[@ ' . join("\n", @lines) . ' @]*'/e;
 		}
 
 		if ($add_blank_line_before) {
 			push @new_rows, '', $row;
 		} elsif ($add_blank_line_after) {
 			push @new_rows, $row, '';
-		} elsif ($row =~ /^(.*)?\sPERL_BLOCK\s(.*)?$/) {
-			# remove any empty lines in the block
-			@perl_block = grep { $_ !~ /^\s*$/ } @perl_block;
-			# Wrap the perl block in [@ @]
-			if ($#perl_block == 0) {
-				push(@new_rows, ($1 // '') . ' [@ ' . $perl_block[0] . ' @]*' . ($2 // ''));
-			} else {
-				push(@new_rows, ($1 // '') . ' [@ ' . shift(@perl_block), @perl_block, ' @]*' . ($2 // ''));
-			}
 		} else {
 			push @new_rows, $row;
 		}
@@ -320,61 +478,254 @@ sub convertPGMLBlock {
 	return \@new_rows;
 }
 
-# Convert many ans_rule constructs to the PGML answer blank form [_]{$var}.
-# This is called recursively to handle multiple ans_rule on a single line.
+# Pulls every \{ ... \} escape out of $row, replacing each with a placeholder, and returns the modified row along
+# with an array reference of the removed blocks (each itself an array reference of the lines making up that block),
+# in the order the placeholders reference them. A \{ \} escape does not nest, so the first \} found after a \{
+# always closes it. If a \} is not found on the same row, rows are consumed from $block (further rows of the
+# surrounding BEGIN_TEXT/END_TEXT block being converted) until one is found, making a multi-line block. If $block
+# runs out first, the unterminated \{ and everything after it are left in the row as ordinary text.
+sub extractPerlBlocks {
+	my ($row, $block) = @_;
+	my @extracted;
+	my $out = '';
+	while ((my $open = index($row, '\{')) >= 0) {
+		$out .= substr($row, 0, $open);
+		$row = substr($row, $open + 2);
 
-sub convertANSrule {
-	my ($str) = @_;
-	if ($str =~ /(.*)\\\{\s*((\$\w+)->)?ans_rule(\((\d*)\))?\s*\\\}(.*)$/) {
-		my $ans  = shift(@ans_list);
-		my $var  = $3 // $ans->{arg} // '';
-		my $size = $5 ? "{$5}" : '';
-		return convertANSrule($1 // '') . '[_]' . "{$var}$size" . convertANSrule($6 // '');
-	} else {
-		return $str;
+		my @lines;
+		my $close = index($row, '\}');
+		while ($close < 0 && @$block) {
+			push(@lines, $row);
+			$row   = shift @$block;
+			$close = index($row, '\}');
+		}
+		if ($close < 0) {
+			$out .= '\{' . join("\n", @lines, $row);
+			$row = '';
+			last;
+		}
+		push(@lines, substr($row, 0, $close));
+		$row = substr($row, $close + 2);
+
+		$out .= "\x02" . scalar(@extracted) . "\x02";
+		push(@extracted, \@lines);
 	}
+	$out .= $row;
+	return ($out, \@extracted);
 }
 
-# remove some unnecessary code including:
-# * removing TEXT(beginproblem())
-# * removing Context()->texStrings;
-# * removing Context()->normalStrings;
-# * commenting out ANS, WEIGHTED_ANS, NAMED_ANS or LABELED_ANS
-# * removing any line that only comment symbols.
+# Returns the index of the first character after a quote-like construct.  Quote-like constructs include '...', "...",
+# q<delim>...<delim>, qq, qw, or qr, and delimited forms like q{...} that may nest.  Otherwise returns undef, and the
+# caller should treat the character at $pos as an ordinary one.  m, s, tr, and y are not handled for now. Treating a
+# bare "s" or "y" as the start of one risks misreading ordinary barewords or hash keys (e.g. "s => 5") as the start
+# of a quote-like construct instead.
+sub skipQuoteLike {
+	my ($str, $pos) = @_;
+	my $c = substr($str, $pos, 1);
 
+	return skipDelimitedRun($str, $pos + 1, $c, $c) if $c eq q(') || $c eq q(");
+
+	pos($str) = $pos;
+	return unless $str =~ /\G(qw|qq|qr|q)\b\s*([^a-zA-Z0-9_\s=])/gc;
+	my $delim = $2;
+	return skipDelimitedRun($str, pos($str), $delim, $QUOTE_LIKE_CLOSE{$delim} // $delim);
+}
+
+# Skips from $pos which should be the index of the first character after the opening delimiter in $str passed in
+# $openDelim to the first character in $str after the matching closing delimiter passed in $closeDelim. This honors
+# backslash escapes and, when $openDelim and $closeDelim differ (a bracket-style delimiter), nesting of the delimiter
+# pair (e.g.  q{a{b}c} balances its inner braces). Returns undef if the string ends before the close delimiter is found.
+sub skipDelimitedRun {
+	my ($str, $pos, $openDelim, $closeDelim) = @_;
+	my $depth = 1;
+	my $len   = length($str);
+	while ($pos < $len) {
+		my $c = substr($str, $pos, 1);
+		if ($c eq '\\') {
+			$pos += 2;
+			next;
+		} elsif ($openDelim ne $closeDelim && $c eq $openDelim) {
+			++$depth;
+		} elsif ($c eq $closeDelim) {
+			--$depth;
+			return $pos + 1 if $depth == 0;
+		}
+		++$pos;
+	}
+	return;
+}
+
+# Given a string and the index of an opening delimiter character in it, scans forward treating any of ( [ { as
+# equivalent openers and ) ] } as closers (skipping over quote-like constructs and comments) and returns the index of
+# the matching closing delimiter.  Returns undef if the string ends before the closing delimiter is found.
+sub matchingDelimiter {
+	my ($str, $pos) = @_;
+	my $depth = 0;
+	my $len   = length($str);
+	while ($pos < $len) {
+		my $next = skipQuoteLike($str, $pos);
+		if (defined $next) {
+			$pos = $next;
+			next;
+		}
+		my $c = substr($str, $pos, 1);
+		if ($c eq '#') {
+			my $nl = index($str, "\n", $pos);
+			return if $nl < 0;
+			$pos = $nl;
+		} elsif ($c =~ /[(\[{]/) {
+			++$depth;
+		} elsif ($c =~ /[)\]}]/) {
+			--$depth;
+			return $pos if $depth == 0;
+		}
+		++$pos;
+	}
+	return;
+}
+
+# Replaces each already-formed answer blank (a '[_]{...}', '[__]{...}', etc., with the brace content possibly spanning
+# nested delimiters) in $row with a placeholder, so that it can be passed through other substitutions unchanged and then
+# restored with restoreAnswerBlanks. Returns the modified row and an array reference of the blanks that were removed, in
+# the order the placeholders reference them.
+sub protectAnswerBlanks {
+	my ($row) = @_;
+	my @protected;
+	my $out = '';
+	my $pos = 0;
+	while ($row =~ /\[_+\]\{/g) {
+		my $matchStart = $-[0];
+		my $braceEnd   = matchingDelimiter($row, $+[0] - 1);
+		last unless defined $braceEnd;
+		$out .= substr($row, $pos, $matchStart - $pos) . "\x01" . scalar(@protected) . "\x01";
+		push(@protected, substr($row, $matchStart, $braceEnd - $matchStart + 1));
+		$pos = $braceEnd + 1;
+		pos($row) = $pos;
+	}
+	$out .= substr($row, $pos);
+	return ($out, \@protected);
+}
+
+sub restoreAnswerBlanks {
+	my ($row, $protected) = @_;
+	$row =~ s/\x01(\d+)\x01/$protected->[$1]/g;
+	return $row;
+}
+
+# Given a string and the index of a $ sigil in it, returns the index just past the full variable expression there:
+# the bare name, plus any immediately following chain of subscripts ($var[0], $var{key}) and arrow dereferences
+# ($var->[0], $var->{key}), matching what Perl itself interpolates for $var in a double-quoted string - a bare
+# ->method call, for example, is not part of that and is correctly left out. Returns undef if $pos is not the start
+# of a variable name.
+sub scalarVariableEnd {
+	my ($str, $pos) = @_;
+	return unless substr($str, $pos, 1) eq '$';
+	return unless substr($str, $pos + 1) =~ /^([A-Za-z_]\w*)/;
+	my $end = $pos + 1 + length($1);
+
+	while (1) {
+		my $subStart = $end;
+		$subStart += 2 if substr($str, $subStart, 2) eq '->' && substr($str, $subStart + 2, 1) =~ /[\[{]/;
+		last unless substr($str, $subStart, 1) =~ /[\[{]/;
+		my $close = matchingDelimiter($str, $subStart);
+		last unless defined $close;
+		$end = $close + 1;
+	}
+	return $end;
+}
+
+# Wraps every $var interpolation in $str in [ ], PGML style, including any subscript or dereference chain (see
+# scalarVariableEnd) so that e.g. $sa[0] becomes [$sa[0]], not [$sa][0].
+sub wrapInterpolatedVariables {
+	my ($str) = @_;
+	my $out   = '';
+	my $pos   = 0;
+	my $len   = length($str);
+	while ($pos < $len) {
+		my $end = scalarVariableEnd($str, $pos);
+		if (defined $end) {
+			$out .= '[' . substr($str, $pos, $end - $pos) . ']';
+			$pos = $end;
+		} else {
+			$out .= substr($str, $pos, 1);
+			++$pos;
+		}
+	}
+	return $out;
+}
+
+# Removes every unquoted # comment (from # to the next newline, if any) from $str. The content of any quote-like
+# construct (see skipQuoteLike), where a # is not a comment, is left untouched, and so are newlines themselves - only
+# the comment text between # and the end of its line is dropped.
+sub stripComments {
+	my ($str) = @_;
+	my $out   = '';
+	my $pos   = 0;
+	my $len   = length($str);
+	while ($pos < $len) {
+		my $next = skipQuoteLike($str, $pos);
+		if (defined $next) {
+			$out .= substr($str, $pos, $next - $pos);
+			$pos = $next;
+			next;
+		}
+		if (substr($str, $pos, 1) eq '#') {
+			my $nl = index($str, "\n", $pos);
+			$pos = $nl < 0 ? $len : $nl;
+			next;
+		}
+		$out .= substr($str, $pos, 1);
+		++$pos;
+	}
+	return $out;
+}
+
+# Splits a string (the inside of a balanced pair of brackets, not including the brackets themselves) on commas that
+# are at bracket depth 0 and outside of quote-like constructs (see skipQuoteLike), after first removing any #
+# comments (see stripComments) - not just skipping over them, since a comment between two commas would otherwise be
+# folded into whichever part follows it. This lets e.g. a loadMacros() list with macro names wrapped in q(...), or
+# with comments between entries, split into exactly the intended items.
+sub splitTopLevelArgs {
+	my ($str) = @_;
+	$str = stripComments($str);
+	my @parts;
+	my $depth = 0;
+	my $start = 0;
+	my $len   = length($str);
+	my $pos   = 0;
+	while ($pos < $len) {
+		my $next = skipQuoteLike($str, $pos);
+		if (defined $next) {
+			$pos = $next;
+			next;
+		}
+		my $c = substr($str, $pos, 1);
+		if ($c =~ /[(\[{]/) {
+			++$depth;
+		} elsif ($c =~ /[)\]}]/) {
+			--$depth;
+		} elsif ($c eq ',' && $depth == 0) {
+			push(@parts, substr($str, $start, $pos - $start));
+			$start = $pos + 1;
+		}
+		++$pos;
+	}
+	push(@parts, substr($str, $start));
+	return grep {/\S/} map {s/^\s+|\s+$//gr} @parts;
+}
+
+# Removes some unnecessary code, including:
+# * TEXT(beginproblem())
+# * Context()->texStrings;
+# * Context()->normalStrings;
+# * a line that is only comment symbols.
 sub cleanUpCode {
 	my ($row) = @_;
 	$row =~ s/^\s*#+\s*$//;
 	$row =~ s/Context\(\)->normalStrings;//;
 	$row =~ s/Context\(\)->texStrings;//;
 	$row =~ s/TEXT\(\s*&?beginproblem(\(\))?\s*\);//;
-	$row =~ s/^(LABELED_|NAMED_|WEIGHTED_|)ANS(.*)/# $1ANS$2/;
 	return $row;
-}
-
-# Loads the entire file searching for instances of ANS, WEIGHTED_ANS, NAMED_ANS or LABELED_ANS
-# and returns an arrayref with an ordered list of them.
-sub getANS {
-	my ($pg_source) = @_;
-	my @ans_list;
-	for my $row (split(/\n/, $pg_source)) {
-		if ($row !~ /^\s*#/ && $row =~ /(LABELED_|NAMED_|WEIGHTED_|)ANS/) {
-			# For style like ANS($ans->cmp());
-			if ($row =~ /((LABELED_|NAMED_|WEIGHTED_|)ANS)\(\s*([\$\w]+)->(\w+)(\(\))?\s*\)/) {
-				push(@ans_list, { type => $1, arg => $3 });
-				# for style like ANS(num_cmp($ans))
-			} elsif ($row =~ /((LABELED_|NAMED_|WEIGHTED_|)ANS)\(\s*(([\w\_]+)\((\$[\w\_]+)\))\)/) {
-				my $type = $1;
-				my $arg  = $3 =~ s/(std_)?num_cmp/Real/r;
-				$arg =~ s/str_cmp|std_num_cmp/String/;
-				$arg =~ s/interval_cmp/Interval/;
-				$arg =~ s/fun_cmp/Formula/;
-				$arg =~ s/radio_cmp|checkbox_cmp//;
-				push(@ans_list, { type => $type, arg => $arg });
-			}
-		}
-	}
-	return @ans_list;
 }
 
 1;

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -76,16 +76,6 @@ my @ans_list;
 sub convertToPGML {
 	my ($pg_source) = @_;
 
-	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement,
-	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
-
-	return { pgmlCode => $pg_source }
-		if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/m && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
-
-	# Return an error if the loadMacros isn't in the form loadMacros( ... );
-	return { errors => "The loadMacros command cannot be parsed.", pgmlCode => $pg_source }
-		unless $pg_source =~ /loadMacros\((.*?)\)\s*;/m;
-
 	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
 
@@ -126,58 +116,32 @@ sub convertToPGML {
 			}
 			$macros .= $row;
 
-			my @macros;
-			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
+			my $load_macros_block = parseLoadMacros($macros);
 
-			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
-			# loadMacros(qw{macro1.pl macro2.pl});
-			if ($macros =~ /loadMacros\((.*?)\);/ms) {
-				my @macro_str = split(/\s*,\s*/, $1);
+			# If PGML.pl is a macro and there are no BEGIN_TEXT/HINT/SOLUTION blocks
+			# return the original source.
+			return { pgmlCode => $pg_source }
+				if (!defined($load_macros_block->{errors})
+					&& grep { $_ eq 'PGML.pl' } @{ $load_macros_block->{macros} }
+					&& $pg_source !~ /^\s*BEGIN_(TEXT|HINT|SOLUTION)/m);
 
-				for my $str (@macro_str) {
-					if ($str =~ /^qw(.)/) {
-						my $qw_matches = { '{' => '}', '(' => ')', '[' => ']', '/' => '/', '|' => '|' };
-						$qw_start = $1;
-						$qw_end   = $qw_matches->{$qw_start};
+			return { errors => $load_macros_block->{errors}, pgmlCode => $pg_source } if ($load_macros_block->{errors});
 
-						if ($str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/) {
-							push(@macros, split(/\s+/, $1));
-						}
-					} else {
-						push(@macros, $str);
-					}
-				}
-
-				@macros =
-					grep {
-						$_
-						&& $_ !~
-						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
-					}
-					map {s/['"]//gr} @macros;
-
-				# Remove any duplicates:
-				my %seen;
-				@macros = grep { !$seen{$_}++ } @macros;
-			} else {
-				return {
-					errors   => 'The loadMacros command cannot be processed.',
-					pgmlCode => $pg_source
-				};
-			}
-
-			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
-
-			if ($qw_start) {
+			if ($load_macros_block->{qw_start}) {
 				if ($num_macro_lines > 1) {    # put each macro on a separate line
-					push(@all_lines, "loadMacros(qw$qw_start");
-					push(@all_lines, "\t$_") for (@macros);
-					push(@all_lines, "$qw_end);");
+					push(@all_lines, 'loadMacros(qw' . $load_macros_block->{qw_start});
+					push(@all_lines, "\t$_") for (@{ $load_macros_block->{macros} });
+					push(@all_lines, $load_macros_block->{qw_end} . ');');
 				} else {
-					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);", '');
+					push(@all_lines,
+						'loadMacros(qw'
+							. $load_macros_block->{qw_start}
+							. join(' ', @{ $load_macros_block->{macros} })
+							. $load_macros_block->{qw_end} . ');',
+						'');
 				}
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');', '');
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @{ $load_macros_block->{macros} }) . ');', '');
 			}
 		} else {
 			push(@all_lines, cleanUpCode($row));
@@ -209,7 +173,7 @@ sub parseLoadMacros {
 
 	# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
 	# loadMacros(qw{macro1.pl macro2.pl});
-	if ($macros =~ /loadMacros\(\s*(.*?)\s*\);/ms) {
+	if ($macros =~ /loadMacros\((.*?)\);/ms) {
 		my @macro_str = split(/\s*,\s*/, $1);
 
 		for my $str (@macro_str) {

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -76,12 +76,17 @@ my @ans_list;
 sub convertToPGML {
 	my ($pg_source) = @_;
 
-	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement.
+	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement,
 	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.
 
-	return $pg_source if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/ && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
+	return { pgmlCode => $pg_source }
+		if ($pg_source =~ /loadMacros\((.*)PGML\.pl(.*)\)/m && $pg_source !~ /BEGIN_(TEXT|HINT|SOLUTION)/);
 
-	# First get a list of all of the ANS, LABELED_ANS, etc. in the problem.
+	# Return an error if the loadMacros isn't in the form loadMacros( ... );
+	return { errors => "The loadMacros command cannot be parsed.", pgmlCode => $pg_source }
+		unless $pg_source =~ /loadMacros\((.*?)\)\s*;/m;
+
+	# Get a list of all of the ANS, LABELED_ANS, etc. in the problem.
 	@ans_list = getANS($pg_source);
 
 	my @pgml_block;
@@ -108,19 +113,20 @@ sub convertToPGML {
 		} elsif ($row =~ /loadMacros\(/) {
 			# Parse the macros, which may be on multiple rows and may be in a qw block.
 			my $macros          = '';
-			my $num_macro_lines = 0; # store the number of lines in the loadMacro so the output is similar to the input.
-			while (1) {
+			my $num_macro_lines = 1; # store the number of lines in the loadMacro so the output is similar to the input.
+			while ($row !~ /\)\s*;/) {
 				# Remove comments within loadMacros block (should we keep them?)
 				$row =~ s/#.*$//;
 				$macros .= $row;
-				last if ($row =~ /(.*)\);/);
 				++$num_macro_lines;
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
 				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
-			my @macros = ();
+			$macros .= $row;
+
+			my @macros;
 			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
 
 			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
@@ -146,7 +152,7 @@ sub convertToPGML {
 					grep {
 						$_
 						&& $_ !~
-						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
+						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
 					}
 					map {s/['"]//gr} @macros;
 
@@ -154,7 +160,10 @@ sub convertToPGML {
 				my %seen;
 				@macros = grep { !$seen{$_}++ } @macros;
 			} else {
-				warn 'The loadMacros statement in this file could not be processed.';
+				return {
+					errors   => 'The loadMacros command cannot be processed.',
+					pgmlCode => $pg_source
+				};
 			}
 
 			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
@@ -165,10 +174,10 @@ sub convertToPGML {
 					push(@all_lines, "\t$_") for (@macros);
 					push(@all_lines, "$qw_end);");
 				} else {
-					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);");
+					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);", '');
 				}
 			} else {
-				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');');
+				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');', '');
 			}
 		} else {
 			push(@all_lines, cleanUpCode($row));
@@ -183,7 +192,7 @@ sub convertToPGML {
 			splice(@all_lines, $empty_lines[$n], 1);
 		}
 	}
-	return join "\n", @all_lines;
+	return { pgmlCode => join "\n", @all_lines };
 }
 
 # This subroutine converts a block (passed in as an array ref of strings) to

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -107,32 +107,48 @@ sub convertToPGML {
 			push(@pgml_block, $row);
 		} elsif ($row =~ /loadMacros\(/) {
 			# Parse the macros, which may be on multiple rows and may be in a qw block.
-			my $macros = '';
+			my $macros          = '';
+			my $num_macro_lines = 0; # store the number of lines in the loadMacro so the output is similar to the input.
 			while (1) {
 				# Remove comments within loadMacros block (should we keep them?)
 				$row =~ s/#.*$//;
 				$macros .= $row;
 				last if ($row =~ /(.*)\);/);
+				++$num_macro_lines;
 				$row = shift @rows;
 				my @mrow = split(/#/, $row);
 				# This only adds the row if there is something relevant to the left of a #
 				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
-
 			my @macros = ();
 			my ($qw_start, $qw_end);    # the characters if the loadMacros has a qw block.
 
 			# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
 			# loadMacros(qw{macro1.pl macro2.pl});
-			if ($macros =~ /loadMacros\((qw(.))?(.*?)(.)?\)/ms) {
-				($qw_start, $qw_end) = ($2, $4);
+			if ($macros =~ /loadMacros\((.*?)\);/ms) {
+				my @macro_str = split(/\s*,\s*/, $1);
+
+				for my $str (@macro_str) {
+					if ($str =~ /^qw(.)/) {
+						my $qw_matches = { '{' => '}', '(' => ')', '[' => ']', '/' => '/', '|' => '|' };
+						$qw_start = $1;
+						$qw_end   = $qw_matches->{$qw_start};
+
+						if ($str =~ /^qw\Q${qw_start}\E(.*?)\Q${qw_end}\E/) {
+							push(@macros, split(/\s+/, $1));
+						}
+					} else {
+						push(@macros, $str);
+					}
+				}
+
 				@macros =
 					grep {
 						$_
 						&& $_ !~
 						/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/
 					}
-					map {s/['"]//gr} split(/\s+|\s*,\s*/, $3);
+					map {s/['"]//gr} @macros;
 
 				# Remove any duplicates:
 				my %seen;
@@ -144,7 +160,13 @@ sub convertToPGML {
 			@macros = ('PGstandard.pl', 'PGML.pl', @macros, 'PGcourse.pl');
 
 			if ($qw_start) {
-				push(@all_lines, "loadMacros(qw$qw_start\n\t" . join("\n\t", @macros) . "\n$qw_end);");
+				if ($num_macro_lines > 1) {    # put each macro on a separate line
+					push(@all_lines, "loadMacros(qw$qw_start");
+					push(@all_lines, "\t$_") for (@macros);
+					push(@all_lines, "$qw_end);");
+				} else {
+					push(@all_lines, "loadMacros(qw$qw_start" . join(' ', @macros) . "$qw_end);");
+				}
 			} else {
 				push(@all_lines, 'loadMacros(' . join(', ', map {"'$_'"} @macros) . ');');
 			}

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -106,13 +106,9 @@ sub convertToPGML {
 			my $num_macro_lines = 1; # store the number of lines in the loadMacro so the output is similar to the input.
 			while ($row !~ /\)\s*;/) {
 				# Remove comments within loadMacros block (should we keep them?)
-				$row =~ s/#.*$//;
-				$macros .= $row;
+				$macros .= $row =~ s/#.*$//r;
 				++$num_macro_lines;
 				$row = shift @rows;
-				my @mrow = split(/#/, $row);
-				# This only adds the row if there is something relevant to the left of a #
-				$macros .= $mrow[0] if $mrow[0] !~ /^\s*$/;
 			}
 			$macros .= $row;
 

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -70,15 +70,11 @@ This returns a string that is the converted input string.
 
 =cut
 
-use Mojo::Util qw(dumper);
-
 # This stores the answers inside of ANS and related functions.
 my @ans_list;
 
 sub convertToPGML {
 	my ($pg_source) = @_;
-
-	print dumper ($pg_source);
 
 	# Check that the file is not already in PGML format by looking for PGML.pl in the loadMacros statement.
 	# and there are no BEGIN_TEXT, BEGIN_SOLUTION, etc. blocks.

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -173,7 +173,7 @@ sub parseLoadMacros {
 
 	# The following can parse loadMacros in the form loadMacros('macro1.pl', 'macro2.pl'); or
 	# loadMacros(qw{macro1.pl macro2.pl});
-	if ($macros =~ /loadMacros\((.*?)\);/ms) {
+	if ($macros =~ /loadMacros\(\s*(.*?)\s*\);/ms) {
 		my @macro_str = split(/\s*,\s*/, $1);
 
 		for my $str (@macro_str) {

--- a/lib/WeBWorK/PG/ConvertToPGML.pm
+++ b/lib/WeBWorK/PG/ConvertToPGML.pm
@@ -185,8 +185,14 @@ sub parseLoadMacros {
 		@macros =
 			grep {
 				$_
-				&& $_ !~
-				/(PGstandard|PGML|PGauxiliaryFunctions|PGbasicmacros|PGanswermacros|MathObjects|PGcourse|AnswerFormatHelp).pl/x
+				&& $_ !~ /(PGstandard|
+					PGML|
+					PGauxiliaryFunctions|
+					PGbasicmacros|
+					PGanswermacros|
+					MathObjects|
+					PGcourse|
+					AnswerFormatHelp).pl/x
 			}
 			map {s/['"]//gr} @macros;
 


### PR DESCRIPTION
The loadMacros parsing is now much more versatile.  In addition to basic single and double quoting, and `qw` quotes, it can handle any quotelike quotes. There is a minimal attempt to keep comments inside of a `loadMacros` call. Basically, if a macro is removed from the list, then a comment after it is also removed.  If a macro is kept, then so is the comment that was after it. If there is a line that only has a comment on it, then if the preceding line had a comment it is assumed that the comment continues that one, and if that is kept so is the next line.  Otherwise the comment line is dropped.

Previously the `MathObjects.pl` macro was removed if loaded, since it is loaded by `PGML.pl`.  Now `niceTables.pl` is also removed, since `PGML.pl` also loads that.

The naive approach of replacing `ans_rule` calls with PGML has been removed.  Instead any `ans_rule` call is just wrapped in `[@ ... @]*`, and the corresponding `ANS` calls are left alone.  One advantage of this approach is that after the conversion is completed, the problem actually works.  In addition, the previous approach was clobbering the `ans_rule` calls in many cases that give information about what needs to be done to properly convert the answers into the PGML answer syntax. The con is that the conversion into PGML syntax must be done manually.  However, since that really was the case before other than basically just putting a non-functional PGML answer template into place, that is not really a tradeoff.

Instead of handling only two very specific forms of heredoc/nowdoc syntax `SOLUTION(EV3(<<'END_SOLUTION'));` and `TEXT(EV2(<<EOT))` where the heredoc/nowdoc terminator was fixed and must be exactly what is shown above, any such form is handled.  The heredoc/nowdoc terminator can be anything the author specified and an unquoted, singled quoted, or double quoted terminator can be used. In addition both `EV2` and `EV3` are covered, and the `HINT` form is also handled. In addition spaces can be in those constructs as allowed by Perl. Note that there are OPL problems that do all of those things, so it was really quite naive to only literally cover those two cases.

Variable interpolation now actually works much better, including for hash and array access, and hash reference and array reference access.

Note that a file that already uses PGML and does not have any of the old style PG constructs is actually completely left alone.  @pstaapb's #1425 still modifies those files in some cases.

The `bin/convert-to-pgml.pl` script no longer accepts `-s|--suffix` argument.  Instead it accepts a `-e|--extension-prefix` argument.  That is much the same except that its value is prepended to `.pg` instead of used as the extension itself. It defaults to `pgml` as the `suffix` option did before. So if `problem.pg` is converted, then the result will be written to `problem.pgml.pg`. Thus the resulting file has the correct pg problem file extension.

A new option for the `bin/convert-to-pgml.pl`, `-p|--output-path` was added. When given, the converted file is written into that directory with the same name as the original file. The `-b|--backup` and `-e|--extension-prefix` options are ignored, unless the output path resolves to the directory containing the original file, in which case those options will still apply.

TRhere were some other minor things fixed along the way as well that I did not list here, such as an issue with the conversion of the `$HR` variable into a PGML `---` in which the `---` was added, but the `$HR` variable left and changed into `[$HR]` resulting in

```
---

[$HR]
```

in the converted file.

Note that this is built on top of #1425, and is intended to replace that pull request.

This was done in collaboration with Claude.