### PR TITLE
Explicitly set start/end arrow color in JSXGraph output.

### DIFF
--- a/lib/Plots/JSXGraph.pm
+++ b/lib/Plots/JSXGraph.pm
@@ -233,9 +233,21 @@ sub get_options {
 		$drawOptions{dash}        = $self->get_linestyle($data);
 		$drawOptions{strokeColor} = $self->get_color($data->style('color'));
 		$drawOptions{strokeWidth} = $data->style('width');
-		$drawOptions{firstArrow}  = { type => 2, size => $data->style('arrow_size') || 8 }
+
+		# Safari doesn't correctly inherit the stroke color, so explicitly set it for arrows.
+		$drawOptions{firstArrow} = {
+			type        => 2,
+			size        => $data->style('arrow_size') || 8,
+			strokeColor => $drawOptions{strokeColor},
+			fillColor   => $drawOptions{strokeColor}
+			}
 			if $data->style('start_mark') eq 'arrow';
-		$drawOptions{lastArrow} = { type => 2, size => $data->style('arrow_size') || 8 }
+		$drawOptions{lastArrow} = {
+			type        => 2,
+			size        => $data->style('arrow_size') || 8,
+			strokeColor => $drawOptions{strokeColor},
+			fillColor   => $drawOptions{strokeColor}
+			}
 			if $data->style('end_mark') eq 'arrow';
 	}
 


### PR DESCRIPTION
In `Plots::Plot`, explicitly set the start/end arrow color instead of relying on inheritance, since safari SVG doesn't correctly inherit the color of the curve for the marks. Fixes #1483.