### PR TITLE
Transfer aria labels of text inputs to MathQuill inputs.

### DIFF
--- a/htdocs/js/MathQuill/mqeditor.js
+++ b/htdocs/js/MathQuill/mqeditor.js
@@ -25,6 +25,8 @@
 
 		const answerQuill = document.createElement('span');
 		answerQuill.id = `mq-answer-${answerLabel}`;
+		answerQuill.setAttribute('aria-label', input.getAttribute('aria-label'));
+		answerQuill.role = 'textbox';
 		answerQuill.input = input;
 		input.classList.add('mq-edit');
 		answerQuill.latexInput = mq_input;


### PR DESCRIPTION
This is something that has been missed with MathQuill inputs for a while.  The original text input has an `aria-label`, but when it is hidden that becomes meaningless.  So transfer that label to the MathQuill input.  The input also needs the `role` to be set to `textbox` for this to work.