### PR TITLE
2 small changes to improve behavior in RTL problems/courses

### DIFF
--- a/htdocs/js/Problem/problem.scss
+++ b/htdocs/js/Problem/problem.scss
@@ -412,6 +412,7 @@
 				}
 
 				&.feedback-message {
+					direction: ltr;
 					background-color: #ede275;
 					&:not(:last-child) {
 						border-bottom: 1px solid black;

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -301,6 +301,7 @@ sub NAMED_ANS_RULE {
 		HTML => tag(
 			'div',
 			class => 'text-nowrap d-inline',
+			dir   => 'ltr',
 			tag(
 				'input',
 				type           => 'text',

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -23,7 +23,7 @@ is(
 	qq{<div class="PGML">\n}
 		. qq{Enter a value for <script type="math/tex">\\pi</script>.}
 		. qq{<div style="margin-top:1em"></div>}
-		. qq{<div class="text-nowrap d-inline">}
+		. qq{<div class="text-nowrap d-inline" dir="ltr">}
 		. qq{<input aria-label="answer 1 " autocapitalize="off" autocomplete="off" class="codeshard" }
 		. qq{dir="auto" id="AnSwEr0001" name="AnSwEr0001" size="5" spellcheck="false" type="text" value="3.14159">}
 		. qq{<input id="MaThQuIlL_AnSwEr0001" name="MaThQuIlL_AnSwEr0001" type="hidden" value="">}


### PR DESCRIPTION
Changes for problems in courses in RTL languages:

1. The DIV containing the standard answer boxes are set to use `dir='ltr'` so that then result/feedback icon appears to their right even when a answer box is used directly in the text in a problem which is being rendered in an RTL setting. This will match the behavior which occurs when answers are inside an LTR span in order to handle interleaved math and answers in RTL language problems. The change makes things consistent for problems in RTL languages. This change was suggested to me by @drgrice1 (and has been in use with WW 2.19 on my servers as a local change).
    - A unit test needed to be updated as a result of this change.
3. Set the CSS for the feedback message box to have a default setting of `dir='ltr'`. This will be changed automatically to `dir='rtl'` when the course language is either set to Hebrew or Arabic (as those languages are set by `get_lang_and_dir` of `webwork2/lib/WeBWorK/Utils/LanguageAndDirection.pm` to put `dir='rtl'` on the main `HTML` tag, so will use the RTL version of the CSS.) That will make feedback messages in such courses (which are expected to mostly be in the RTL language) render in the appropriate RTL manner.

Neither change should have **any** visible effect on problems in English or other LTR languages.

I think the most critical thing to confirm that no changes will occur in courses in English and other LTR languages.

A PG problem for testing is provided below. Testing requires suitable setting made in `simple.conf` or via the config menu.

---

Testing of the fix to the location of the feedback message requires temporarily setting either 
`$language = 'ar';` (Arabic) or `$language = 'he-IL';` (Hebrew).

Testing with the course language in Arabic is probably easier, as there is not much actual translation of the UI to Arabic, so essentially everything will be in english but places in a right-to-left manner.

The goal of the first change is that the "math" in the feedback message when the first answer is incorrect will appear on the left side, while without the change it appears on the right side. (Images below.)

---

Testing of the fix to the location of the result/feedback button require setting 
`$perProblemLangAndDirSettingMode` to a value which will allow RTL rendering of a problem. The suggested setting is `$perProblemLangAndDirSettingMode = 'auto:en:ltr';` as that will default to leaving problems in English and LTR, but accept overrides made by in the PG code of any given problem as is done in every Hebrew problem.

Before the change, the button should appear on the left of the answer box on the bottom line, and after the change, it should appear on the right side. (Images below.)

---

PG problem for testing:

```
DOCUMENT();

loadMacros('PGstandard.pl', 'PGML.pl');

SET_PROBLEM_LANGUAGE('he-IL');
SET_PROBLEM_TEXTDIRECTION('rtl');

Context("Numeric");
$ans = Compute('pi/3')->cmp(
    checker => sub {
        my ($correct, $student, $ansHash) = @_;
	$ansHash->{ans_message} = 'נסה שנית. לא מתקיים \( \cos(x) = \frac{\sqrt{3}}{2} \).'
            if cos($student) != sqrt(3) / 2 && !$ansHash->{isPreview};
        return cos($correct) == cos($student);
    }
);


$ans2 = Real(0)->cmp(
    checker => sub {
        my ($correct, $student, $ansHash) = @_;
        $ansHash->{ans_message} = 'נסה שנית. יש להזין \( 0 \).'
            if $student != 0 && !$ansHash->{isPreview};
        return $correct == $student;
    }
);

BEGIN_PGML

הזן ערך של
[`x`]
עבורו
[`\cos(x) = [@ Compute('cos(pi/3)') @]`].

[@ openSpan( { 'dir' => 'ltr' } )  @]*
Enter a value of [`x`] for which [`\cos(x) = \frac{\sqrt{3}}{2} `].
[@ closeSpan() @]*

[@ openSpan( { 'dir' => 'ltr' } )  @]*
[`x =`] [___]{$ans}
[@ closeSpan() @]*

רשום 0 כאן:
[___]{$ans2}

END_PGML

ENDDOCUMENT();
```

---

Image of the confusing placement of the result/feedback button before these changes. It is the second button which is placed in a confusing manner. After the changes - it should be on the right side.

<img width="386" height="223" alt="rtl-issue-1" src="https://github.com/user-attachments/assets/e1337892-9c5b-4a51-9215-712f19dd8a31" />

---

Image of the flawed (LTR) layout of a Hebrew feedback message before the change. The `cos` term appears on the far right, but needs to be on the left.

<img width="284" height="325" alt="rtl-issue-2" src="https://github.com/user-attachments/assets/c3b343e5-0763-4cfa-877e-39ab405ee0a9" />

---

Image of the correct (RTL) layout of a Hebrew feedback message after the change. (Will only appear this way for a course with the main language set to Hebrew or Arabic, as otherwise the RTL version of the CSS files will not be used.)

<img width="268" height="264" alt="rtl-issue-2-after-fix" src="https://github.com/user-attachments/assets/8736dba9-548c-4a2b-a0c9-8733fdadb8af" />
