### PR TITLE
Fix bug in copying a context.

### DIFF
--- a/lib/Value/Context.pm
+++ b/lib/Value/Context.pm
@@ -69,29 +69,28 @@ sub copy {
 	my $self    = shift;
 	my $context = $self->new();
 	$context->{_initialized} = 0;
-	foreach my $data (@{ $context->{data}{objects} }) {
+	for my $data (@{ $self->{data}{objects} }) {
 		$context->{$data}->copy($self->{$data});
 	}
-	foreach my $data (@{ $context->{data}{hashes} }) {
+	for my $data (@{ $self->{data}{hashes} }) {
 		$context->{$data} = {};
-		foreach my $x (keys %{ $self->{$data} }) {
+		for my $x (keys %{ $self->{$data} }) {
 			$context->{$data}{$x} = { %{ $self->{$data}{$x} } };
 		}
 	}
-	foreach my $data (@{ $context->{data}{arrays} }) {
+	for my $data (@{ $self->{data}{arrays} }) {
 		$context->{$data} = {};
-		foreach my $x (keys %{ $self->{$data} }) {
+		for my $x (keys %{ $self->{$data} }) {
 			$context->{$data}{$x} = [ @{ $self->{$data}{$x} } ];
 		}
 	}
-	foreach my $data (@{ $context->{data}{values} }) {
+	for my $data (@{ $self->{data}{values} }) {
 		$context->{$data} = { %{ $self->{$data} } };
 	}
 	$context->{error}{msg}     = { %{ $self->{error}{msg} } };
-	$context->{error}{convert} = $self->{error}{convert}
-		if defined $self->{error}{convert};
-	$context->{name}         = $self->{name};
-	$context->{_initialized} = 1;
+	$context->{error}{convert} = $self->{error}{convert} if defined $self->{error}{convert};
+	$context->{name}           = $self->{name};
+	$context->{_initialized}   = 1;
 	return $context;
 }
 


### PR DESCRIPTION
When creating a copy of a context, only keys on the new context were copied, instead all keys from the old context should be copied. This is fixed by looping over `$self` instead of `$context`. This fix was suggested by @dpvc.