### PR TITLE
Fix a random issue with the `parse-problem-doc.pl` script.

### DIFF
--- a/bin/parse-problem-doc.pl
+++ b/bin/parse-problem-doc.pl
@@ -31,8 +31,9 @@ use feature 'say';
 
 my $pg_root;
 
+use Mojo::File qw(curfile path);
+
 BEGIN {
-	use Mojo::File qw(curfile);
 	$pg_root = curfile->dirname->dirname;
 }
 
@@ -98,7 +99,7 @@ sub renderSampleProblem ($filename, %global) {
 	say "Processing file: $path" if $global{verbose};
 	my $parsed_file = parseSampleProblem($path, %global);
 
-	mkdir "$global{out_dir}/$relative_dir" unless -d "$global{out_dir}/$relative_dir";
+	path("$global{out_dir}/$relative_dir")->make_path unless -d "$global{out_dir}/$relative_dir";
 
 	say "Printing to '$global{out_dir}/$relative_dir/$filename.html'" if $global{verbose};
 	open(my $html_fh, '>:encoding(UTF-8)', "$global{out_dir}/$relative_dir/$filename.html")


### PR DESCRIPTION
The script works by generating the metadata for the files in the `tutorial/sample-problems` directory.  That is a hash whose keys are the filenames and whose values are hash references containing the metadata for the files. Then the keys of that hash are iterated over, and the sample problem documentation rendered.  In that process a subdirectory of the output location is created for the file if it does not already exist. Since hashes are not ordered, the order the files are iterated over will be different each time. So if the `tutorial/sample-problems/VectorCalc/VectorFieldGraph3D/VectorFieldGraph3D1.pg` problem happens to be processed before any of the other problems in the `tutorial/sample-problems/VectorCalc` directory, then the `mkdir` call attempts to create the output subdirectory `VectorCalc/VectorFieldGraph3D` which fails because the `VectorCalc` subdirectory does not yet exist and `mkdir` is not recursive.

To fix this use the `Mojo::File` `make_path` method instead, which is recursive.

It is not essential to hotfix this.  If the job fails when a hotfix goes in, then we just need to rerun the job, and hope that file, which is the only one with directory depth 2, is not processed before the other files in the directory the next time it is run.