### PR TITLE
Add unit tests for MathObjects (Value.pm, Parser.pm, and subclasses).

### DIFF
--- a/lib/Parser/Differentiation.pm
+++ b/lib/Parser/Differentiation.pm
@@ -757,22 +757,16 @@ sub Value::List::D {
 }
 
 sub Value::Interval::D {
-	shift;
-	shift;
 	my $self = shift;
 	$self->Error("Can't differentiate intervals");
 }
 
 sub Value::Set::D {
-	shift;
-	shift;
 	my $self = shift;
 	$self->Error("Can't differentiate sets");
 }
 
 sub Value::Union::D {
-	shift;
-	shift;
 	my $self = shift;
 	$self->Error("Can't differentiate unions");
 }

--- a/t/math_objects/absolute_value.t
+++ b/t/math_objects/absolute_value.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - absolute values
+
+Test absolute values.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+subtest 'check absolute value of number' => sub {
+	my $abs_minus_three = Compute('|-3|');
+
+	is $abs_minus_three->class, 'Real',   'absolute value of number is Real';
+	is $abs_minus_three->type,  'Number', 'absolute value of number is Number';
+
+	ok Value::isValue($abs_minus_three),    'absolute value of number is a value';
+	ok Value::isNumber($abs_minus_three),   'absolute value of number is a number';
+	ok Value::isReal($abs_minus_three),     'absolute value of number is a real number';
+	ok !Value::isComplex($abs_minus_three), 'absolute value of number is not complex';
+	ok !Value::isFormula($abs_minus_three), 'absolute value of number is not a formula';
+
+	is $abs_minus_three->value, 3, 'absolute value of number: value is correct';
+};
+
+subtest 'check absolute value of variable' => sub {
+	my $abs_x = Compute('|x|');
+
+	is $abs_x->class, 'Formula', 'absolute value of variable: check class of object';
+	is $abs_x->type,  'Number',  'absolute value of variable: check type of object';
+
+	ok Value::isValue($abs_x),    'absolute value of variable is a value';
+	ok Value::isNumber($abs_x),   'absolute value of variable is a number';
+	ok !Value::isReal($abs_x),    'absolute value of variable is not a real number';
+	ok !Value::isComplex($abs_x), 'absolute value of variable is not complex';
+	ok Value::isFormula($abs_x),  'absolute value of variable is a formula';
+
+	ok $abs_x == Compute('|-x|'), '|x| == |-x|';
+};
+
+done_testing();

--- a/t/math_objects/complex.t
+++ b/t/math_objects/complex.t
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Complex numbers
+
+Test creation and manipulation of Complex number math objects.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Complex');
+
+subtest 'Creating a Complex number' => sub {
+	my $z1 = Complex(3, 4);
+	my $z2 = Complex([ 3, 4 ]);
+	my $z3 = Compute('3+4i');
+	my $z4 = Compute('3+4*i');
+
+	for my $z ($z1, $z2, $z3, $z4) {
+		is $z->class, 'Complex', 'a Complex number has class Complex';
+		is $z->type,  'Number',  'a Complex number has type Number';
+
+		ok Value::isValue($z),   'a Complex number is a value';
+		ok Value::isNumber($z),  'a Complex number is a number';
+		ok Value::isComplex($z), 'a Complex number is complex';
+		ok !Value::isReal($z),   'a Complex number is not real';
+
+		is $z->Re->value, 3, 'real part is correct';
+		is $z->Im->value, 4, 'imaginary part is correct';
+	}
+};
+
+subtest 'Real numbers promote to Complex' => sub {
+	my $z = Complex(5, 0) + Complex(0, 0);
+	is $z->class,     'Complex', 'result of Complex arithmetic is still Complex';
+	is $z->Re->value, 5,         'real part is correct';
+	is $z->Im->value, 0,         'imaginary part is correct';
+};
+
+subtest 'Arithmetic with Complex numbers' => sub {
+	my $z1 = Complex(1,  2);
+	my $z2 = Complex(3, -1);
+
+	is check_score($z1 + $z2, '4+i'),       1, 'addition of complex numbers';
+	is check_score($z1 - $z2, '-2+3i'),     1, 'subtraction of complex numbers';
+	is check_score($z1 * $z2, '5+5i'),      1, 'multiplication of complex numbers';
+	is check_score($z1 / $z2, '(1+7i)/10'), 1, 'division of complex numbers';
+
+	ok $z1 == Complex(1, 2), 'equality of complex numbers';
+	ok $z1 != $z2,           'inequality of complex numbers';
+
+	like(dies { $z1 / Complex(0, 0) }, qr/Division by zero/, 'division by zero is an error');
+};
+
+subtest 'Complex conjugate and modulus' => sub {
+	my $z = Complex(3, 4);
+
+	is check_score($z->conj, '3-4i'), 1, 'conjugate of a complex number';
+	is $z->abs->value,                5, 'absolute value (modulus) of a complex number';
+	is $z->norm->value,               5, 'norm of a complex number is the same as abs';
+
+	is Compute('i')->arg->value, Compute('pi/2')->value, 'argument of i is pi/2';
+};
+
+subtest 'Negation of Complex numbers' => sub {
+	my $z = Complex(3, -4);
+	is check_score(-$z, '-3+4i'), 1, 'negation of a complex number';
+};
+
+subtest 'Powers of Complex numbers' => sub {
+	my $z = Complex(0, 1);
+	is check_score($z**2, '-1'), 1, 'i^2 is -1';
+	is check_score($z**4, '1'),  1, 'i^4 is 1';
+};
+
+subtest 'sqrt and log of negative and complex numbers' => sub {
+	is check_score(Compute('sqrt(-4)'), '2i'), 1, 'square root of a negative number is imaginary';
+	is check_score(Compute('sqrt(-1)'), 'i'),  1, 'square root of -1 is i';
+	is check_score(Compute('e^(i pi)'), '-1'), 1, "Euler's identity: e^(i pi) = -1";
+
+	like(dies { Compute('log(0)') }, qr/Can't take log of 0/, 'log of zero is an error');
+};
+
+subtest 'Trigonometric and hyperbolic functions of Complex numbers' => sub {
+	my $f = Compute('sin(z)^2 + cos(z)^2');
+
+	is check_score($f->eval(z => Complex(1, 1)), '1'), 1, 'Pythagorean identity holds for complex arguments';
+
+	ok Value::isComplex(Compute('sinh(i)')), 'sinh of a complex number is complex';
+};
+
+subtest 'Comparing to a Real number' => sub {
+	my $z = Complex(5, 0);
+	ok $z == 5,            'a Complex number with zero imaginary part equals the corresponding Real number';
+	ok Complex(5, 1) != 5, 'a Complex number with nonzero imaginary part does not equal a Real number';
+};
+
+subtest 'Errors constructing invalid Complex numbers' => sub {
+	like(
+		dies { Complex(1, 2, 3) },
+		qr/Can't convert ARRAY of length 3 to a Complex Number/,
+		'a Complex number needs exactly two coordinates'
+	);
+};
+
+Context('Numeric');
+
+done_testing();

--- a/t/math_objects/differentiation.t
+++ b/t/math_objects/differentiation.t
@@ -1,0 +1,98 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - absolute values
+
+Test absolute values.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+use lib "$ENV{PG_ROOT}/lib";
+
+use Units;
+use Value;
+use Parser;
+use Parser::Legacy;
+
+loadMacros('PGstandard.pl', 'MathObjects.pl', 'contextUnits.pl');
+
+subtest 'basic differentiation' => sub {
+	my $f = Compute('(5x^2 + 3x - 4) / 7')->D;
+
+	is $f->class, 'Formula', 'derivative is formula';
+	is $f->type,  'Number',  'derivative is Number';
+
+	ok Value::isValue($f),    'derivative is a value';
+	ok Value::isNumber($f),   'derivative is a number';
+	ok !Value::isReal($f),    'derivative is not real';
+	ok !Value::isComplex($f), 'derivative is not complex';
+	ok Value::isFormula($f),  'derivative is a formula';
+
+	is check_score($f,              '(10x + 3) / 7'), 1, 'derivative of (5x^2 + 3x - 4) / 7 is (10x + 3) / 7';
+	is check_score(Compute('5')->D, '0'),             1, 'derivative of number is zero';
+
+	my $g = Compute('5x^2 + 3x - 4');
+	my $h = Compute('e^x + ln(x)');
+
+	is check_score(($g * $h)->D, '(10x + 3)(e^x + ln(x)) + (5x^2 + 3x - 4)(e^x + 1 / x)'), 1, 'product rule';
+	is check_score(($g / $h)->D, '((10x + 3)(e^x + ln(x)) - (5x^2 + 3x - 4)(e^x + 1 / x)) / (e^x + ln(x))^2'), 1,
+		'quotient rule';
+};
+
+subtest 'numeric function differentiation' => sub {
+	is check_score(Compute('sqrt(x)')->D, '1 / (2 sqrt(x))'), 1, 'derivative of sqrt(x) is 1 / (2 sqrt(x))';
+	is check_score(Compute('ln(x)')->D,   '1 / x'),           1, 'derivative of ln(x) is 1 / x';
+	is check_score(Compute('log(x)')->D,  '1 / x'),           1, 'derivative of log(x) is 1 / x';
+	is check_score(Compute('exp(x)')->D,  'exp(x)'),          1, 'derivative of exp(x) is exp(x)';
+	is check_score(Compute('abs(x)')->D,  'abs(x) / x'),      1, 'derivative of abs(x) is abs(x) / x';
+
+	Context()->flags->set(useBaseTenLog => 1);
+	is check_score(Compute('log(x)')->D, '1 / (ln(10)x)'), 1,
+		'derivative of log(x) with useBaseTenLog flag set is 1 / (ln(10) x)';
+	Context()->flags->set(useBaseTenLog => 0);
+
+};
+
+subtest 'trig differentiation' => sub {
+	is check_score(Compute('sin(x)')->D, 'cos(x)'),        1, 'derivative of sin(x) is cos(x)';
+	is check_score(Compute('cos(x)')->D, '-sin(x)'),       1, 'derivative of cos(x) is -sin(x)';
+	is check_score(Compute('tan(x)')->D, 'sec^2(x)'),      1, 'derivative of tan(x) is sec^2(x)';
+	is check_score(Compute('cot(x)')->D, '-csc^2(x)'),     1, 'derivative of cot(x) is -csc^2(x)';
+	is check_score(Compute('sec(x)')->D, 'sec(x)tan(x)'),  1, 'derivative of sec(x) is sec(x)tan(x)';
+	is check_score(Compute('csc(x)')->D, '-csc(x)cot(x)'), 1, 'derivative of csc(x) is -csc(x)cot(x)';
+};
+
+subtest 'list differentiation' => sub {
+	is check_score(Compute('|x|')->D,      '|x| / x'),  1, 'derivative of |x| is |x| / x';
+	is check_score(Compute('x^2, x^3')->D, '2x, 3x^2'), 1, 'derivative of the list "x^2, x^3" is "2x, 3x^2"';
+};
+
+subtest 'differentiation with units' => sub {
+	Context('Units')->withUnitsFor('length', 'time')->assignUnits(t => 's');
+	is check_score(Compute('(3t^2 - 2t) m')->D, '(6t - 2) m/s'), 1, 'derivative of (3t^2 - 2t) m';
+	Context('Numeric');
+};
+
+subtest 'invalid differentiation' => sub {
+	like(
+		dies { Compute('x!')->D },
+		qr/Differentiation for 'factorial' is not implemented/,
+		'derivative of factorial is not implemented'
+	);
+
+	like(dies { Compute('{5, 8}')->D }, qr/Can't differentiate sets/, 'Sets can not be differentiated');
+
+	Context('Interval');
+	like(dies { Compute('[5, 8)')->D }, qr/Can't differentiate intervals/, 'Intervals can not be differentiated');
+	like(
+		dies { Compute('(-5, 0) U (0, 5)')->D },
+		qr/Can't differentiate unions/,
+		'Unions can not be differentiated'
+	);
+};
+
+done_testing();

--- a/t/math_objects/matrix_linear_algebra.t
+++ b/t/math_objects/matrix_linear_algebra.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Matrix linear algebra
+
+Test the linear algebra methods of Matrix math objects that are passed through to
+C<MatrixReal1.pm> (C<det>, C<inverse>, C<trace>, C<norm_one>, C<norm_max>, C<solve>, C<order>) and
+the C<power> operator, which are not covered by C<t/math_objects/matrix.t>.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Matrix');
+
+subtest 'Determinant' => sub {
+	is check_score(Matrix([ 2, 1 ], [ 1, 1 ])->det, '1'), 1, 'determinant of a 2x2 matrix';
+	is check_score(Matrix([ 1, 2, 3 ], [ 0, 1, 4 ], [ 5, 6, 0 ])->det, '1'), 1, 'determinant of a 3x3 matrix';
+
+	like(
+		dies { Matrix([ 1, 2, 3 ], [ 4, 5, 6 ])->det },
+		qr/Can't take determinant of non-square matrix/,
+		'determinant requires a square matrix'
+	);
+	like(
+		dies { Matrix([ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ])->det },
+		qr/Matrix must be two-dimensional/,
+		'determinant is not defined for a degree 3 tensor'
+	);
+};
+
+subtest 'Inverse' => sub {
+	my $A = Matrix([ 2, 1 ], [ 1, 1 ]);
+	is check_score($A->inverse, '[[1,-1],[-1,2]]'), 1, 'inverse of an invertible 2x2 matrix';
+	ok $A * $A->inverse == Value::Matrix->I(2), 'a matrix times its inverse is the identity';
+
+	my $singular = Matrix([ 1, 2 ], [ 2, 4 ]);
+	ok !defined($singular->inverse), 'inverse of a singular matrix is undefined';
+};
+
+subtest 'Trace' => sub {
+	is Matrix([ 2, 1 ], [ 1, 1 ])->trace, 3, 'trace of a 2x2 matrix';
+	is Matrix([ 1, 0, 0 ], [ 0, 2, 0 ], [ 0, 0, 3 ])->trace, 6, 'trace of a 3x3 diagonal matrix';
+};
+
+subtest 'Norms' => sub {
+	my $A = Matrix([ 2, 1 ], [ 1, 1 ]);
+	is $A->norm_one->value, 3, 'norm_one is the maximum absolute column sum';
+	is $A->norm_max->value, 3, 'norm_max is the maximum absolute row sum';
+};
+
+subtest 'Solving a linear system' => sub {
+	my $A = Matrix([ 2, 1 ], [ 1, 1 ]);
+	my $b = Matrix([5],      [6]);
+
+	my ($d, $x) = $A->solve($b);
+	ok $A * $x == $b, 'the solution satisfies A x = b';
+};
+
+subtest 'Order of the LR decomposition' => sub {
+	is Matrix([ 2, 1 ], [ 1, 1 ])->order, 2, 'order of a full-rank 2x2 matrix';
+};
+
+subtest 'Matrix powers' => sub {
+	my $A = Matrix([ 2, 1 ], [ 1, 1 ]);
+
+	is check_score($A**2, '[[5,3],[3,2]]'), 1, 'squaring a matrix';
+	ok $A**0 == Value::Matrix->I(2), 'a matrix to the 0 power is the identity';
+	ok $A**-1 == $A->inverse,        'a matrix to the -1 power is its inverse';
+
+	like(
+		dies { Matrix([ 1, 2, 3 ], [ 4, 5, 6 ])**2 },
+		qr/Only square matrices can be raised to a power/,
+		'only square matrices can be raised to a power'
+	);
+	like(dies { $A**1.5 }, qr/Matrix powers must be non-negative integers/, 'a matrix power must be an integer');
+};
+
+Context('Numeric');
+
+done_testing();

--- a/t/math_objects/parser_errors.t
+++ b/t/math_objects/parser_errors.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+
+=head1 Parser - malformed expression errors
+
+Test that C<Parser.pm> reports sensible, specific errors for malformed input, such as
+mismatched parentheses, missing operands, unknown functions/variables, and incorrect
+numbers of function arguments.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Numeric');
+
+subtest 'Mismatched parentheses' => sub {
+	like(
+		dies { Compute('(1+2') },
+		qr/Missing close parenthesis for '\('/,
+		'a missing close parenthesis is an error'
+	);
+	like(dies { Compute('1+2)') }, qr/Extra close parenthesis '\)'/, 'an extra close parenthesis is an error');
+};
+
+subtest 'Missing operands' => sub {
+	like(dies { Compute('1 +') }, qr/Missing operand after '\+'/,
+		'a missing operand after an operator is an error');
+	like(
+		dies { Compute('*2') },
+		qr/Missing operand before '\*'/,
+		'a missing operand before an operator is an error'
+	);
+	like(
+		dies { Compute('2^') },
+		qr/Missing operand after '\^'/,
+		'a missing operand after the power operator is an error'
+	);
+};
+
+subtest 'Unexpected characters' => sub {
+	like(dies { Compute('@') },     qr/Unexpected character '\@'/, 'an unrecognized character is an error');
+	like(dies { Compute('1 & 2') }, qr/Unexpected character '&'/,  'an unrecognized operator character is an error');
+};
+
+subtest 'Function argument count' => sub {
+	like(
+		dies { Compute('sin()') },
+		qr/Function 'sin' has too few inputs/,
+		'calling a function with too few arguments is an error'
+	);
+	like(
+		dies { Compute('sin(1,2)') },
+		qr/Function 'sin' has too many inputs/,
+		'calling a function with too many arguments is an error'
+	);
+	like(
+		dies { Compute('atan2(1)') },
+		qr/Function 'atan2' has too few inputs/,
+		'a two-argument function called with one argument is an error'
+	);
+};
+
+subtest 'Undeclared variables and unknown functions' => sub {
+	like(
+		dies { Compute('q') },
+		qr/Variable 'q' is not defined in this context/,
+		'an undeclared variable is an error'
+	);
+	like(
+		dies { Compute('foo(1)') },
+		qr/'foo' is not defined in this context/,
+		'an unknown function name is an error'
+	);
+};
+
+subtest 'Division by zero is caught at parse/evaluation time for constants' => sub {
+	like(dies { Compute('1/0') }, qr/Division by zero/, 'dividing a constant by zero is an error');
+};
+
+done_testing();

--- a/t/math_objects/point.t
+++ b/t/math_objects/point.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Point
+
+Test creation and manipulation of Point math objects.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Point');
+
+subtest 'Creating a Point' => sub {
+	my $p1 = Point(1, 2, 3);
+	my $p2 = Point([ 1, 2, 3 ]);
+	my $p3 = Compute('(1,2,3)');
+
+	for my $p ($p1, $p2, $p3) {
+		is $p->class, 'Point', 'a Point has class Point';
+		is $p->type,  'Point', 'a Point has type Point';
+
+		ok Value::isValue($p),   'a Point is a value';
+		ok !Value::isNumber($p), 'a Point is not a number';
+
+		is [ $p->value ], [ 1, 2, 3 ], 'the coordinates are correct';
+	}
+};
+
+subtest 'Adding and subtracting Points' => sub {
+	my $p1 = Point(1, 2, 3);
+	my $p2 = Point(4, 5, 6);
+
+	is check_score($p1 + $p2, '(5,7,9)'),    1, 'sum of two Points is a Point';
+	is check_score($p1 - $p2, '(-3,-3,-3)'), 1, 'difference of two Points is a Point';
+	is(($p1 + $p2)->class, 'Point', 'sum of two Points has class Point');
+
+	like(
+		dies { $p1 + Point(1, 2) },
+		qr/Can't add Points with different numbers of coordinates/,
+		'addition requires matching dimensions'
+	);
+	like(
+		dies { $p1 - Point(1, 2) },
+		qr/Can't subtract Points with different numbers of coordinates/,
+		'subtraction requires matching dimensions'
+	);
+};
+
+subtest 'A Point combined with a Vector produces a Vector' => sub {
+	my $p = Point(1, 2, 3);
+	my $v = Vector(1, 1, 1);
+
+	ok $p + $v == Vector(2, 3, 4), 'Point plus Vector is a Vector';
+	is(($p + $v)->class, 'Vector', 'Point plus Vector has class Vector');
+};
+
+subtest 'Scalar multiplication and division' => sub {
+	my $p = Point(1, 2, 3);
+
+	is check_score(2 * $p, '(2,4,6)'),    1, 'scalar multiplication of a Point';
+	is check_score(-$p,    '(-1,-2,-3)'), 1, 'negation of a Point';
+
+	like(
+		dies { $p * Point(1, 2, 3) },
+		qr/Points can only be multiplied by Numbers/,
+		'a Point cannot be multiplied by another Point'
+	);
+	like(dies { $p / 0 }, qr/Division by zero/,             'division by zero is an error');
+	like(dies { $p**2 },  qr/Can't raise Points to powers/, 'a Point cannot be raised to a power');
+};
+
+subtest 'Comparing Points' => sub {
+	ok Point(1, 2, 3) == Point(1, 2, 3), 'equal Points compare as equal';
+	ok Point(1, 2, 3) != Point(1, 2, 4), 'different Points compare as not equal';
+};
+
+Context('Numeric');
+
+done_testing();

--- a/t/math_objects/set.t
+++ b/t/math_objects/set.t
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Set
+
+Test creation and manipulation of Set math objects.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Interval');
+
+subtest 'Creating a Set' => sub {
+	my $s1 = Set(1, 2, 3);
+	my $s2 = Compute('{1,2,3}');
+
+	for my $s ($s1, $s2) {
+		is $s->class, 'Set', 'a Set has class Set';
+
+		ok Value::isValue($s),   'a Set is a value';
+		ok $s->isSetOfReals,     'a Set is a set of reals';
+		ok !Value::isNumber($s), 'a Set is not a number';
+
+		is [ $s->value ], [ 1, 2, 3 ], 'the elements are correct';
+	}
+};
+
+subtest 'Sets sort and deduplicate their elements' => sub {
+	is check_score(Set(3, 1, 2, 1), '{1,2,3}'), 1, 'a Set is sorted and deduplicated';
+};
+
+subtest 'isEmpty' => sub {
+	ok Set()->isEmpty,   'a Set with no elements is empty';
+	ok !Set(1)->isEmpty, 'a Set with an element is not empty';
+};
+
+subtest 'contains and isSubsetOf' => sub {
+	my $s = Set(1, 2, 3);
+
+	ok $s->contains(Compute('2')),  'a Set contains one of its elements';
+	ok !$s->contains(Compute('4')), 'a Set does not contain a value that is not an element';
+
+	ok Set(1,  2)->isSubsetOf($s), 'a Set of matching elements is a subset';
+	ok !Set(1, 4)->isSubsetOf($s), 'a Set with an extra element is not a subset';
+	ok Set()->isSubsetOf($s), 'the empty Set is a subset of every Set';
+};
+
+subtest 'Union of Sets (the + operator)' => sub {
+	my $s1 = Set(1, 2, 3);
+	my $s2 = Set(3, 4, 5);
+
+	is check_score($s1 + $s2, '{1,2,3,4,5}'), 1, 'union of two Sets removes duplicate elements';
+	is(($s1 + $s2)->class, 'Set', 'union of two Sets is a Set');
+};
+
+subtest 'Intersection of Sets' => sub {
+	my $s1 = Set(1, 2, 3);
+	my $s2 = Set(2, 3, 4);
+
+	is check_score($s1->intersect($s2),             '{2,3}'), 1, 'intersection of two Sets';
+	is check_score(Set(1, 2)->intersect(Set(3, 4)), '{}'),    1, 'intersection of disjoint Sets is empty';
+};
+
+subtest 'Sets combined with Intervals produce a Union or a Set' => sub {
+	my $s = Set(1, 2, 3);
+
+	is check_score($s->intersect(Compute('[2,5)')), '{2,3}'), 1,
+		'intersection of a Set and an Interval can be a Set';
+	is(($s + Compute('[4,5)'))->class, 'Union', 'union of a Set and a disjoint Interval is a Union');
+};
+
+subtest 'Errors constructing invalid Sets' => sub {
+	like(
+		dies { Set([ 1, 2 ], [ 3, 4 ]) },
+		qr/An element of a set can't be a List of Numbers/,
+		'a Set element must be a real number'
+	);
+};
+
+Context('Numeric');
+
+done_testing();

--- a/t/math_objects/string.t
+++ b/t/math_objects/string.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - String
+
+Test creation and manipulation of String math objects (used for special values like C<DNE> and C<none>).
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Numeric');
+
+subtest 'Creating a String' => sub {
+	my $s1 = String('DNE');
+	my $s2 = Compute('DNE');
+
+	for my $s ($s1, $s2) {
+		is $s->class, 'String', 'a String has class String';
+
+		ok Value::isValue($s),   'a String is a value';
+		ok !Value::isNumber($s), 'a String is not a number';
+
+		ok !$s->isZero, 'a String is never zero';
+		ok !$s->isOne,  'a String is never one';
+	}
+};
+
+subtest 'Comparing Strings' => sub {
+	ok String('DNE') == String('DNE'),  'equal Strings compare as equal';
+	ok String('DNE') != String('none'), 'different Strings compare as not equal';
+	ok String('DNE') != Compute('5'),   'a String never equals a Number';
+};
+
+subtest 'quoteHTML escapes HTML special characters' => sub {
+	is Value::String->quoteHTML(q{<a>&"}), '&lt;a&gt;&amp;&quot;', 'HTML special characters are escaped';
+};
+
+subtest 'quoteXML escapes XML special characters' => sub {
+	is Value::String->quoteXML('<tag>&amp;'), '&lt;tag&gt;&amp;amp;', 'XML special characters are escaped';
+};
+
+subtest 'quoteTeX wraps plain text and verbatim-quotes special text' => sub {
+	is Value::String->quoteTeX('hello, world'), '\text{hello, world}', 'plain text is wrapped in \text{}';
+	like Value::String->quoteTeX('50%'), qr/^\{\\verb.*\}$/, 'text with special characters is verbatim-quoted';
+};
+
+subtest 'Errors constructing an undefined String constant' => sub {
+	like(
+		dies { String('banana') },
+		qr/String constant 'banana' is not defined in this context/,
+		'a String must be one of the constants defined in the context'
+	);
+};
+
+done_testing();

--- a/t/math_objects/union.t
+++ b/t/math_objects/union.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Union
+
+Test creation and manipulation of Union math objects (unions of Intervals and Sets).
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Interval');
+
+subtest 'Creating a Union of disjoint Intervals' => sub {
+	my $u = Compute('(-inf,0) U (0,inf)');
+
+	is $u->class, 'Union', 'a Union of disjoint intervals has class Union';
+	ok Value::isValue($u), 'a Union is a value';
+	ok $u->isSetOfReals,   'a Union is a set of reals';
+
+	is check_score($u, '(0,inf) U (-inf,0)'), 1, 'order of the members of a Union does not matter';
+};
+
+subtest 'Overlapping and adjacent Intervals are merged when reduced' => sub {
+	my $overlap  = Compute('[0,2) U [1,3)');
+	my $adjacent = Compute('[0,1) U [1,2)');
+
+	ok $overlap->isReduced,  'overlapping intervals are automatically reduced';
+	ok $adjacent->isReduced, 'adjacent intervals are automatically reduced';
+
+	is scalar(@{ $overlap->data }),  1, 'the reduced Union has a single member';
+	is scalar(@{ $adjacent->data }), 1, 'the reduced Union has a single member';
+
+	is check_score($overlap,  '[0,3)'), 1, 'overlapping intervals merge into their span';
+	is check_score($adjacent, '[0,2)'), 1, 'adjacent intervals merge into their span';
+};
+
+subtest 'contains and isSubsetOf' => sub {
+	my $u = Compute('[0,1) U [2,3)');
+
+	ok $u->contains(Compute('0.5')),  'a Union contains a value in one of its members';
+	ok !$u->contains(Compute('1.5')), 'a Union does not contain a value in the gap';
+
+	ok Compute('[0,0.5)')->isSubsetOf($u),  'an Interval inside one member is a subset';
+	ok !Compute('[0,1.5)')->isSubsetOf($u), 'an Interval spanning the gap is not a subset';
+};
+
+subtest 'Intersection of a Union' => sub {
+	my $u = Compute('[0,1) U [2,3)');
+
+	is check_score($u->intersect(Compute('[0.5,2.5)')), '[0.5,1) U [2,2.5)'), 1,
+		'intersecting a Union with an Interval intersects each member';
+};
+
+subtest 'A Union of a Set and an Interval' => sub {
+	my $u = Set(1, 2) + Compute('[3,4)');
+
+	is $u->class,                        'Union', 'a Set unioned with a disjoint Interval is a Union';
+	is check_score($u, '[3,4) U {1,2}'), 1,       'the Union contains both members';
+};
+
+subtest 'Errors constructing invalid Unions' => sub {
+	like(
+		dies { Compute('5 U [0,1)') },
+		qr/Operands of 'U' must be intervals or sets/,
+		'a Union operand must be an Interval or a Set'
+	);
+	like(dies { Union() }, qr/Empty unions are not allowed/, 'a Union must have at least one member');
+};
+
+Context('Numeric');
+
+done_testing();

--- a/t/math_objects/vector.t
+++ b/t/math_objects/vector.t
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+
+=head1 MathObjects - Vector
+
+Test creation and manipulation of Vector math objects.
+
+=cut
+
+use Test2::V0 '!E', { E => 'EXISTS' };
+
+die "PG_ROOT not found in environment.\n" unless $ENV{PG_ROOT};
+do "$ENV{PG_ROOT}/t/build_PG_envir.pl";
+
+loadMacros('MathObjects.pl');
+
+Context('Vector');
+
+subtest 'Creating a Vector' => sub {
+	my $v1 = Vector(1, 2, 3);
+	my $v2 = Vector([ 1, 2, 3 ]);
+	my $v3 = Compute('<1,2,3>');
+	my $v4 = Compute('i + 2j + 3k');
+
+	for my $v ($v1, $v2, $v3, $v4) {
+		is $v->class, 'Vector', 'a Vector has class Vector';
+		is $v->type,  'Vector', 'a Vector has type Vector';
+
+		ok Value::isValue($v),   'a Vector is a value';
+		ok !Value::isNumber($v), 'a Vector is not a number';
+
+		is [ $v->value ], [ 1, 2, 3 ], 'the coordinates are correct';
+	}
+};
+
+subtest 'ijk notation' => sub {
+	is Vector(1, 2, 3)->ijk, 'i+2j+3k', 'ijk string form of a 3-space vector';
+
+	like(
+		dies { Vector(1, 2, 3, 4)->ijk },
+		qr/Method 'ijk' can only be used on Vectors in 3-space/,
+		'ijk is not defined for vectors with more than 3 coordinates'
+	);
+};
+
+subtest 'Dot product' => sub {
+	my $v1 = Vector(1, 2, 3);
+	my $v2 = Vector(4, 5, 6);
+
+	is $v1->dot($v2)->value, 32, 'dot product of two vectors';
+
+	like(
+		dies { $v1->dot(Vector(1, 2)) },
+		qr/Can't dot Vectors with different numbers of coordinates/,
+		'dot product requires matching dimensions'
+	);
+};
+
+subtest 'Cross product' => sub {
+	my $v1 = Vector(1, 2, 3);
+	my $v2 = Vector(4, 5, 6);
+
+	is check_score($v1->cross($v2), '<-3,6,-3>'), 1, 'cross product of two 3-space vectors';
+
+	like(
+		dies { $v1->cross(Vector(1, 2)) },
+		qr/Vectors for cross product must be in 3-space/,
+		'cross product requires 3-space vectors'
+	);
+};
+
+subtest 'Norm and unit vector' => sub {
+	my $v = Vector(3, 4);
+
+	is $v->norm->value, 5, 'norm (length) of a vector';
+	is $v->abs->value,  5, 'abs is the same as norm';
+
+	is check_score($v->unit, '<3/5, 4/5>'), 1, 'unit vector has length 1 and same direction';
+};
+
+subtest 'Parallel vectors' => sub {
+	my $v1 = Vector(1, 2, 3);
+
+	ok $v1->isParallel(Vector(2,   4, 6)),  'parallel vectors (same direction) are detected';
+	ok $v1->isParallel(Vector(-1, -2, -3)), 'parallel vectors (opposite direction) are detected';
+	ok !$v1->isParallel(Vector(1,  2, 4)),  'nonparallel vectors are not parallel';
+};
+
+subtest 'Arithmetic with Vectors' => sub {
+	my $v1 = Vector(1, 2, 3);
+	my $v2 = Vector(4, 5, 6);
+
+	is check_score($v1 + $v2, '<5,7,9>'),    1, 'addition of vectors';
+	is check_score($v1 - $v2, '<-3,-3,-3>'), 1, 'subtraction of vectors';
+	is check_score(2 * $v1,   '<2,4,6>'),    1, 'scalar multiplication of a vector';
+	is check_score(-$v1,      '<-1,-2,-3>'), 1, 'negation of a vector';
+
+	ok $v1 == Vector(1, 2, 3), 'equality of vectors';
+	ok $v1 != $v2,             'inequality of vectors';
+
+	like(
+		dies { $v1 + Vector(1, 2) },
+		qr/Can't add Vectors with different numbers of coordinates/,
+		'addition requires matching dimensions'
+	);
+	like(
+		dies { $v1 - Vector(1, 2) },
+		qr/Can't subtract Vectors with different numbers of coordinates/,
+		'subtraction requires matching dimensions'
+	);
+	like(
+		dies { $v1 * $v2 },
+		qr/Vectors can only be multiplied by Numbers/,
+		'a vector cannot be multiplied by another vector with *'
+	);
+	like(dies { $v1 / 0 }, qr/Division by zero/,              'division by zero is an error');
+	like(dies { $v1**2 },  qr/Can't raise Vectors to powers/, 'a vector cannot be raised to a power');
+};
+
+Context('Numeric');
+
+done_testing();


### PR DESCRIPTION
Covers previously untested or thinly-tested classes: Complex, Vector, Point, Set, Union, String, AbsoluteValue, and Matrix linear algebra methods (det, inverse, trace, norms, solve, order, power), plus Parser.pm error paths for malformed expressions and differentiation of formulas with units.

Also fixes Value::Interval::D, Value::Set::D, and Value::Union::D in Differentiation.pm, which each had two extra leftover `shift` calls before `my $self = shift`, so $self was bound to the wrong argument (or undef) instead of the invocant, breaking the "can't differentiate" error methods. This is covered by the new differentiation.t tests.

I wrote the `absolute_value.t` and `differentiation.t` tests and fixed the issue in `lib/Parser/Differentiation.pm` a long time ago. I asked Claude to add some more unit tests for better MathObject test coverage.  This is one of the things that AI is quite good at.