### PR TITLE
Remove the `README_maketext` file.

### DIFF
--- a/README_maketext
+++ b/README_maketext
@@ -1,9 +1,0 @@
-##### README
-
-
-Currently (version 1.25) Maketext has a "use strict" line as part of its string parser.  This "use strict" interacts badly with WWSafe and fails.  Unfortunately the use strict cannot be turned off in Maketext.  This means that you can use maketext in PG, but you cannot use any of its features, including simple ones like maketext('Hello [_1] World','Cruel');
-
-If it becomes necessary to use the more advance versions of maketext in PG we will need to fork Maketext. 
-
-
-  


### PR DESCRIPTION
It is entirely obsolete.  Everything it says is invalid.