### PR TITLE
Stop wrapping math in `<script type="math/tex">...</script>`.

### DIFF
--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -1204,8 +1204,7 @@ sub ENDDOCUMENT {
 					if ($main::displayMode eq 'HTML' || !$wrapPreviewInTex) {
 						return $preview;
 					} elsif ($main::displayMode eq 'HTML_MathJax') {
-						return Mojo::DOM->new_tag('script', type => 'math/tex; mode=display', sub {$preview})
-							->to_string;
+						return "\\[$preview\\]";
 					}
 				};
 

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -1886,35 +1886,28 @@ sub general_math_ev3 {
 	my $in   = shift;
 	my $mode = shift || "inline";
 
-	$in = FEQ($in);                          # Format EQuations
-	$in =~ s/((^|[^\\])(\\\\)*)%/$1\\%/g;    # avoid % becoming TeX comments (unless already escaped)
+	$in = FEQ($in);                          # Format equations
+	$in =~ s/((^|[^\\])(\\\\)*)%/$1\\%/g;    # Avoid % becoming TeX comments (unless already escaped).
 
-	## remove leading and trailing spaces so that HTML mode will
-	## not include unwanted spaces as per Davide Cervone.
-	$in =~ s/^\s+//;
-	$in =~ s/\s+$//;
-	## If it ends with a backslash, there should be another space
-	## at the end
-	if ($in =~ /(^|[^\\])(\\\\)*\\$/) { $in .= ' ' }
+	# Remove leading and trailing spaces so that HTML mode will not include unwanted spaces.
+	$in =~ s/^\s+|\s+$//g;
+	# If it ends with a backslash, there should be another space at the end.
+	$in .= ' ' if $in =~ /(^|[^\\])(\\\\)*\\$/;
 
-	# some modes want the delimiters, some don't
+	# Some modes want the delimiters, some don't.
 	my $in_delim = $mode eq "inline" ? "\\($in\\)" : "\\[$in\\]";
 
-	my $out;
 	if ($displayMode eq "HTML_MathJax") {
-		$out = '<script type="math/tex' . ($mode eq 'display' ? '; mode=display' : '') . '">' . $in . '</script>';
+		return HTML::Entities::encode_entities($in_delim, '<>&');
 	} elsif ($displayMode eq "HTML_tth") {
-		$out = tth($in_delim);
-		## remove leading and trailing spaces as per Davide Cervone.
-		$out =~ s/^\s+//;
-		$out =~ s/\s+$//;
+		return tth($in_delim) =~ s/^\s+|\s+$//gr;
 	} elsif ($displayMode eq "PTX") {
-		# protect XML control characters
+		# Protect XML control characters.
 		$in =~ s/\&(?!([\w#]+;))/\\amp /g;
 		$in =~ s/</\\lt /g;
-		# attempt to parse align|alignat|gather into complete md/mrow structure, otherwise use me
+		# Attempt to parse align|alignat|gather into complete md/mrow structure, otherwise use me.
 		if ($mode eq 'inline') {
-			$out = "<m>$in</m>";
+			return "<m>$in</m>";
 		} elsif ($mode eq 'display' && $in =~ /^\s*\\begin\{(align|alignat|gather)}((?!\\end\{\1}).)*\\end\{\1}\s*$/s) {
 			my $alignment = $1;
 			my $lines =
@@ -1925,17 +1918,16 @@ sub general_math_ev3 {
 			my @rows = map {"<mrow>$_</mrow>"} @lines;
 			my $rows = join("\n", @rows);
 			$alignment = ($alignment eq 'align') ? '' : " alignment=\"$alignment\"";
-			$out       = "<md${alignment}>\n$rows\n</md>";
+			return "<md${alignment}>\n$rows\n</md>";
 		} elsif ($mode eq 'display') {
-			$out = "<md>$in</md>";
+			return "<md>$in</md>";
 		}
 	} elsif ($displayMode eq "HTML") {
 		$in_delim = HTML::Entities::encode_entities($in_delim);
-		$out      = "<span class='tex2jax_ignore'>$in_delim</span>";
+		return "<span class='tex2jax_ignore'>$in_delim</span>";
 	} else {
-		$out = $in_delim;
+		return $in_delim;
 	}
-	return $out;
 }
 
 sub EV2 {

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -21,7 +21,7 @@ is($pg->{post_header_text}, '', 'post_header_text is empty');
 is(
 	$pg->{body_text},
 	qq{<div class="PGML">\n}
-		. qq{Enter a value for <script type="math/tex">\\pi</script>.}
+		. qq{Enter a value for \\(\\pi\\).}
 		. qq{<div style="margin-top:1em"></div>}
 		. qq{<div class="text-nowrap d-inline" dir="ltr">}
 		. qq{<input aria-label="answer 1 " autocapitalize="off" autocomplete="off" class="codeshard" }


### PR DESCRIPTION
This used to be handled directly by MathJax long ago, but it no longer does so.  Using `\(...\)` or `\[...\]` now works.  So just do that. Also make sure that `&`, `<`, and `>` are properly HTML escaped. This actually gets done when the `post_process_content` method is called, but just in case the `general_math_ev3` method also does this. Note the `Mojo::DOM` parser is smart enough not to doubly escape these things.

The script tag handling in the webwork2 `mathjax-config.js` file seems to be causing issues in some cases, and switching to using `\(...\)` or `\[...\]` fixes those issues.  See #1498 for details.

It is also time to start doing some code clean up. I just did some minimal clean up of the `general_math_ev3` method.