### PR TITLE
Fix bug in problemRandomize hardcopy.

### DIFF
--- a/macros/deprecated/problemRandomize.pl
+++ b/macros/deprecated/problemRandomize.pl
@@ -166,8 +166,10 @@ sub new {
 		when         => "correct",
 		onlyAfterDue => 1,
 		style        => "Button",
-		styleName    =>
-			($main::inputs_ref->{effectiveUser} ne $main::inputs_ref->{user} ? "checkAnswers" : "submitAnswers"),
+		styleName    => (
+			!$main::inputs_ref->{effectiveUser}
+				|| ($main::inputs_ref->{effectiveUser} ne $main::inputs_ref->{user}) ? "checkAnswers" : "submitAnswers"
+		),
 		label         => undef,
 		buttonLabel   => $main::PG->maketext("Get a new version of this problem"),
 		checkboxLabel => $main::PG->maketext("Get a new version of this problem"),


### PR DESCRIPTION
When generating hardcopy with a problem using problemRandomize, `$input_ref` doesn't contain the `user` or  `effectiveUser` keys, which causes an error when trying to compare them. Only compare if `user`  and `efficitveUser` are equal in the case `effectiveUser` is a defined key in `$input_ref`.

Fixes #1515.

Note this is just a quick fix, as the macro is deprecated and there could probably be other issues with its approach.