### PR TITLE
Wait for the `MathJax.startup.promise` to update the feedback popover. (hotfix of #1528)

### DIFF
--- a/htdocs/js/Feedback/feedback.js
+++ b/htdocs/js/Feedback/feedback.js
@@ -13,7 +13,10 @@
 
 		feedbackBtn.addEventListener('inserted.bs.popover', () => {
 			// Render MathJax previews.
-			if (window.MathJax) MathJax.typesetPromise?.([feedbackPopover.tip]).then(() => feedbackPopover.update());
+			if (window.MathJax)
+				MathJax.startup.promise
+					.then(() => MathJax.typesetPromise([feedbackPopover.tip]))
+					.then(() => feedbackPopover.update());
 
 			// Execute javascript in the answer preview.
 			feedbackPopover.tip?.querySelectorAll('script').forEach((origScript) => {


### PR DESCRIPTION
The `inserted.bs.popover` event still does not occur late enough for the MathJax `typesetPromise` to be defined on the page sometimes. I am not seeing this once the update is deferred a bit more with a `setTimeout` call.  So wait on the `MathJax.startup.promise` to be fulfilled before updating.

One way to see the issue is to set the "Assist with the student answer entry process" option to "MathView".  Then click the "Show Correct Answers" button in a problem with multiple answers (it can occur with one answer, but more reliably occurs with multiple answers).  The popovers are not positioned correctly.

Another way to see the issue is to add `console.log(MathJax.typesetPromise)` on the line before the change in this pull request (even with MathQuill enabled).  You will see that most of the time, that is undefined.