### PR TITLE
Fix for an empty macro when running pg-critic

### DIFF
--- a/lib/Perl/Critic/Policy/PG/ProhibitDeprecatedMacros.pm
+++ b/lib/Perl/Critic/Policy/PG/ProhibitDeprecatedMacros.pm
@@ -25,7 +25,7 @@ sub violates ($self, $element, $) {
 			$_->[0]
 		)
 		}
-		grep { $deprecatedMacros->{ $_->[0]->string } } parse_arg_list($element);
+		grep { $deprecatedMacros->{ $_ ? $_->[0]->string : '' } } parse_arg_list($element);
 }
 
 1;


### PR DESCRIPTION
If there is an empty macro in a PG problem like

```
loadMacros('PGStandard.pl','PGML.pl',,'PGcourse.pl');
```
the `pg-critic.pl` script throws an error and stops.  This fix will replace an undefined macros with a ''. 