### PR TITLE
Add a workflow for checking spelling.

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -1,0 +1,20 @@
+---
+name: Check Spelling
+
+on:
+  push:
+    branches-ignore: [main, develop]
+  pull_request:
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with crate-ci/typos
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Spell check code
+        uses: crate-ci/typos@v1.50.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,83 @@
+[files]
+extend-exclude = [
+  "lib/WeBWorK/PG/Localize/*",
+  "assets/stop-words-en.txt",
+  # This macro is deprecated and broken, and is not worth spell-checking.
+  "macros/deprecated/answerDiscussion.pl"
+]
+
+[default]
+extend-ignore-re = [
+  # Complex multiple of z in lib/Complex1.pm
+  '(log|exp)\(iz',
+  # Zero value variable in macros/math/SystemsOfLinearEquationsProblemPCC.pl
+  '\$[Zz]erod\>',
+  # "category|categories" regex alternation in lib/WeBWorK/PG/SampleProblemParser.pm
+  'categor\(y\|ies\)'
+]
+
+[default.extend-words]
+# This is a correct spelling
+colinear = "colinear"
+
+# Each entry below is scoped to one exact identifier/token (case-sensitive,
+# whole-match only) rather than a global word, so it won't suppress a
+# genuine future typo that merely happens to contain the same fragment.
+[default.extend-identifiers]
+# "Does Not Exist" notation in many places.
+DNE = "DNE"
+# "Does Not Exist" message in macros/deprecated/unionMessages.pl.
+DNE_MESSAGE = "DNE_MESSAGE"
+# Historical spelling preserved verbatim in the Artistic License text.
+MERCHANTIBILITY = "MERCHANTIBILITY"
+# X body closure expression type in lib/Rserve/QapEncoding.pm
+XT_CLOS = "XT_CLOS"
+# Numerator/denominator naming convention in lib/PowerPolynomial.pm.
+numer = "numer"
+numerAbs = "numerAbs"
+# Element abbreviations used in macros/math/PGnauGraphtheory.pl.
+shft = "shft"
+# PreTeXt's <fillin> tag name, used consistently for fill-in-the-blank answer rules.
+fillin = "fillin"
+# STRINGforOUTPUT/STRINGforHEADER_TEXT/STRINGforPOSTHEADER_TEXT variables in macros/PG.pl.
+STRINGforOUTPUT = "STRINGforOUTPUT"
+STRINGforHEADER_TEXT = "STRINGforHEADER_TEXT"
+STRINGforPOSTHEADER_TEXT = "STRINGforPOSTHEADER_TEXT"
+# $Aswitch/$Amult/$Aadd naming convention in macros/math/MatrixReduce.pl.
+Aadd = "Aadd"
+# "Format EQuations" mnemonic explaining the FEQ macro name in macros/core/PGbasicmacros.pl.
+EQuations = "EQuations"
+# Return-status term (not a typo of "encodes") in macros/math/LinearProgramming.pl.
+endcode = "endcode"
+endcodes = "endcodes"
+# Gilbert Strang, textbook author referenced in macros/deprecated/Alfredmacros.pl.
+Strang = "Strang"
+strang = "strang"
+strang_index = "strang_index"
+strang_TOC = "strang_TOC"
+# Periodic table element symbols in macros/contexts/contextReaction.pl.
+Ba = "Ba"
+Nd = "Nd"
+# Matrix product notation (matrix B times matrix A) in tutorial/sample-problems.
+BA = "BA"
+# LaTeX \oint (contour integral), \Oint, and \hom operators in macros/contexts/contextTypeset.pl.
+oint = "oint"
+Oint = "Oint"
+hom = "hom"
+# Ordinal fragments in POD-documented parameter names in macros/math/PGdiffeqmacros.pl.
+"1stAddend" = "1stAddend"
+"1stIndicator" = "1stIndicator"
+"2ndAddend" = "2ndAddend"
+"2ndIndicator" = "2ndIndicator"
+# Ordinal fragment in a variable name in lib/Hermite.pm.
+rf_function_2nd_derivative = "rf_function_2nd_derivative"
+# Rserve wire-protocol command names in lib/Rserve.pm; must match the external protocol spec exactly.
+CMD_serEval = "CMD_serEval"
+CMD_serAssign = "CMD_serAssign"
+CMD_serEEval = "CMD_serEEval"
+serEval = "serEval"
+# Sentinel placeholder string (not the ordinal fragment) in the statistics graphing macros.
+nd = "nd"
+# "they're" contraction as a sub name (no apostrophe allowed) in macros/misc/randomPerson.pl.
+theyre = "theyre"
+Theyre = "Theyre"

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-# Install required module dependancies listed here (runtime and test) with
+# Install required module dependencies listed here (runtime and test) with
 # cpanm --installdeps .
 
 on runtime => sub {
@@ -41,10 +41,10 @@ on test => sub {
 	recommends 'Test2::Tools::Explain'; # For debugging data structures
 };
 
-# Install development dependancies with
+# Install development dependencies with
 # cpanm --installdeps --with-develop --with-recommends .
 
 on develop => sub {
 	recommends 'Module::CPANfile';
-	recommends 'Test::CPANfile';   # Verifies this file has all the dependancies
+	recommends 'Test::CPANfile';   # Verifies this file has all the dependencies
 };

--- a/doc/MathObjectsAnswerCheckers.pod
+++ b/doc/MathObjectsAnswerCheckers.pod
@@ -790,7 +790,7 @@ Here is an example of a list checker:
 
 As you can see, list checkers are more complicated than checkers for
 the other types of data.  But for certain situations like the one
-above, they can be indispensible.
+above, they can be indispensable.
 
 =head3 Set and Union Answer Checkers
 

--- a/doc/UsingMathObjects.pod
+++ b/doc/UsingMathObjects.pod
@@ -29,7 +29,7 @@ than that, then you must provide additional values, as in
 
 =item C<< $f->reduce >>
 
-Tries to remove redundent items from your formula.  For example,
+Tries to remove redundant items from your formula.  For example,
 C<Formula("1x+0")> returns "C<x>".  Reduce tries to factor out
 negatives and do some other adjustments as well.  (There still needs
 to be more work done on this.  What it does is correct, but not always
@@ -421,7 +421,7 @@ To remove a variable, use
 
     $context->variables->remove('t');
 
-To get the names of the defind variables, use
+To get the names of the defined variables, use
 
     @names = $context->variables->names;
 

--- a/htdocs/helpFiles/Entering-Syntax.html
+++ b/htdocs/helpFiles/Entering-Syntax.html
@@ -31,7 +31,7 @@
 		<code style="color: black">[1+2]/[3*4]</code> click the "Preview Button".
 	</li>
 	<li>
-		Sometimes using the <code style="color: black">*</code> symbol to indicate mutiplication makes things easier to
+		Sometimes using the <code style="color: black">*</code> symbol to indicate multiplication makes things easier to
 		read. For example <code style="color: black">(1+2)*(3+4)</code> and
 		<code style="color: black">(1+2)(3+4)</code> are both valid. So are <code style="color: black">3*4</code> and
 		<code style="color: black">3 4</code> (<code style="color: black">3 space 4</code>, not

--- a/htdocs/helpFiles/Syntax.html
+++ b/htdocs/helpFiles/Syntax.html
@@ -31,7 +31,7 @@
 		<code style="color: black">[1+2]/[3*4]</code> click the "Preview Button".
 	</li>
 	<li>
-		Sometimes using the <code style="color: black">*</code> symbol to indicate mutiplication makes things easier to
+		Sometimes using the <code style="color: black">*</code> symbol to indicate multiplication makes things easier to
 		read. For example <code style="color: black">(1+2)*(3+4)</code> and
 		<code style="color: black">(1+2)(3+4)</code> are both valid. So are <code style="color: black">3*4</code> and
 		<code style="color: black">3 4</code> (<code style="color: black">3 space 4</code>, not

--- a/htdocs/js/GraphTool/graphtool.js
+++ b/htdocs/js/GraphTool/graphtool.js
@@ -155,7 +155,7 @@ window.graphTool = (containerId, options) => {
 		};
 
 		// Override the formatLabelText method for the axes ticks so that fractions can be either mixed numbers or
-		// improper fractions depending on our coorinateHintsType settings instead of using the JXG toFraction setting
+		// improper fractions depending on our coordinateHintsType settings instead of using the JXG toFraction setting
 		// that only allows mixed numbers.  This also honors the useMathJax setting even if the fraction setting is not
 		// used, and furthermore includes the scale symbol in the MathJax portion of the text. This looks better and
 		// allows the usage of '\\pi' instead of the unicode symbol for pi. Another change is that numbers with
@@ -1164,7 +1164,7 @@ window.graphTool = (containerId, options) => {
 			}
 		}
 
-		// If graphing is interupted by pressing escape or the graph tool losing focus,
+		// If graphing is interrupted by pressing escape or the graph tool losing focus,
 		// then clean up whatever has been done so far and deactivate the tool.
 		deactivate() {
 			if (this.useStandardDeactivation) {

--- a/htdocs/js/GraphTool/quadrilateral.js
+++ b/htdocs/js/GraphTool/quadrilateral.js
@@ -429,7 +429,7 @@
 
 					// Get new coordinates for a point that is on the board and not on any of the lines between the
 					// other vertices. This starts at a point one snap size to the right of the last vertex graphed,
-					// and then circles around the last vertex in a counter clockwise direction on the latice of
+					// and then circles around the last vertex in a counter clockwise direction on the lattice of
 					// points with coordinates that are multiples of the snap sizes until it finds one that works.
 					let count = 0;
 					let hDir = 0,

--- a/htdocs/js/LiveGraphics/liveGraphics.js
+++ b/htdocs/js/LiveGraphics/liveGraphics.js
@@ -15,12 +15,12 @@
 		screenReaderOnly.textContent = 'A manipulable 3d graph.';
 		container.append(screenReaderOnly);
 
-		// General options that can be overriden by settings in the input data.
+		// General options that can be overridden by settings in the input data.
 		let lighting = true;
 		let showAxes = false;
 		let axesLabels = ['x', 'y', 'z'];
 
-		// Inital view point and up vector.
+		// Initial view point and up vector.
 		const eye = { x: 1.25, y: 1.25, z: 1.25 };
 		const up = { x: 0, y: 0, z: 1 };
 
@@ -497,7 +497,7 @@
 		};
 
 		// This section of code is run whenever the object is created.  It obtains the data either from direct input, a
-		// zip file, or a data file.  Then it calls intialize with the data string.
+		// zip file, or a data file.  Then it calls initialize with the data string.
 
 		if (options.input) {
 			initialize(options.input);

--- a/htdocs/js/MathView/mathview.js
+++ b/htdocs/js/MathView/mathview.js
@@ -261,18 +261,18 @@
 		}
 
 		// Insert the appropriate string into the input box when a button in the viewer is pressed.
-		generateTex(strucValue) {
+		generateTex(structValue) {
 			let newpos = this.inputTextBox.selectionStart;
 
 			if (this.renderingMode === 'LATEX') {
-				this.insertAtCursor(this.inputTextBox, strucValue.latex);
-				const parmatch = strucValue.latex.match(/\(\)|\[,|\(,/);
+				this.insertAtCursor(this.inputTextBox, structValue.latex);
+				const parmatch = structValue.latex.match(/\(\)|\[,|\(,/);
 				if (parmatch) newpos += parmatch[0].index;
 				this.setCursorPosition(this.inputTextBox, newpos);
 				this.regenPreview();
 			} else {
-				this.insertAtCursor(this.inputTextBox, strucValue.PG);
-				const parmatch = strucValue.PG.match(/\(\)|\[,|\(,/);
+				this.insertAtCursor(this.inputTextBox, structValue.PG);
+				const parmatch = structValue.PG.match(/\(\)|\[,|\(,/);
 				if (parmatch) newpos += parmatch.index + 1;
 				this.setCursorPosition(this.inputTextBox, newpos);
 				this.regenPreview();

--- a/htdocs/js/MathView/mv_locale_us.js
+++ b/htdocs/js/MathView/mv_locale_us.js
@@ -1,4 +1,4 @@
-// This file has the list of functions to be shown on the viewer, seperated into categories.
+// This file has the list of functions to be shown on the viewer, separated into categories.
 // The structure of an element is
 //   text: latex string to render text on button
 //   autocomp: whether the string should be included in the autocompletion feature

--- a/lib/PGanswergroup.pm
+++ b/lib/PGanswergroup.pm
@@ -78,7 +78,7 @@ sub insert_responses {    # add a group of responses ( label/value pairs)
 sub insert_response_value {    # add a response value(with  label defined by answer group label)
 	my $self  = shift;
 	my $value = shift;
-	$self->{response}->append_reponse($self->{ans_label}, $value);
+	$self->{response}->append_response($self->{ans_label}, $value);
 }
 
 sub replace_response {    # add a response value(with  label defined by answer group label)

--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -189,8 +189,6 @@ content being appended.
 
 =cut
 
-# ^function HEADER_TEXT
-# ^uses $STRINGforHEADER_TEXT
 sub HEADER_TEXT {
 	my $self = shift;
 	push @{ $self->{HEADER_ARRAY} }, map { (defined($_)) ? $_ : '' } @_;
@@ -214,8 +212,6 @@ content being appended.
 
 =cut
 
-# ^function POST_HEADER_TEXT
-# ^uses $STRINGforHEADER_TEXT
 sub POST_HEADER_TEXT {
 	my $self = shift;
 	push @{ $self->{POST_HEADER_ARRAY} }, map { (defined($_)) ? $_ : '' } @_;
@@ -244,9 +240,6 @@ introduced between the existing content of the header text string and the new
 content being appended.
 
 =cut
-
-# ^function TEXT
-# ^uses $STRINGforOUTPUT
 
 sub TEXT {
 	my $self = shift;    #FIXME  filter for undefined entries replace by "";
@@ -369,7 +362,6 @@ and answer evaluators until RESUME_RENDERING() is called.
 
 =cut
 
-# ^function STOP_RENDERING
 sub STOP_RENDERING {
 	my $self = shift;
 	$self->{PG_ACTIVE} = 0;
@@ -385,7 +377,6 @@ evaluators. Reverses the effect of STOP_RENDERING().
 
 =cut
 
-# ^function RESUME_RENDERING
 sub RESUME_RENDERING {
 	my $self = shift;
 	$self->{PG_ACTIVE} = 1;
@@ -614,9 +605,6 @@ course temp directory.
 =cut
 
 # A very useful macro for making sure that all of the directories to a file have been constructed.
-
-# ^function surePathToTmpFile
-# ^uses getCourseTempDirectory
 
 sub surePathToTmpFile {
 	# constructs intermediate directories if needed beginning at ${Global::htmlDirectory}tmp/

--- a/lib/WWSafe.pm
+++ b/lib/WWSafe.pm
@@ -816,7 +816,7 @@ called from a compartment but not compiled within it.
 
 This evaluates the contents of file FILENAME inside the compartment.
 It uses the same rules as perl's built-in C<do> to locate the file,
-poossibly using C<@INC>.
+possibly using C<@INC>.
 
 See above documentation on the B<reval> method for further details.
 

--- a/macros/contexts/contextInequalities.pl
+++ b/macros/contexts/contextInequalities.pl
@@ -24,7 +24,7 @@ contextInequalities.pl - Provides contexts that allow intervals to be specified 
 =head1 DESCRIPTION
 
 Implements contexts that provides for inequalities that produce
-the cooresponding C<Interval>, C<Set> or C<Union> C<MathObjects>.  There are
+the corresponding C<Interval>, C<Set> or C<Union> C<MathObjects>.  There are
 two such contexts:  C<Context("Inequalities")>, in which both
 intervals and inequalities are defined, and C<Context("Inequalities-Only")>,
 which allows only inequalities as a means of producing intervals.

--- a/macros/contexts/contextSignificantFigures.pl
+++ b/macros/contexts/contextSignificantFigures.pl
@@ -1,13 +1,13 @@
 
 =head1 NAME
 
-contextSignificantFigures.pl - Implements a context to handle numbers where 
+contextSignificantFigures.pl - Implements a context to handle numbers where
 significant figures is important.
 
 =head1 DESCRIPTION
 
-This file implements a MathObject SignificantFigures class that provides the 
-ability to create numbers for given significant figures as well as the operations 
+This file implements a MathObject SignificantFigures class that provides the
+ability to create numbers for given significant figures as well as the operations
 +, -, *, /, **
 
 To load this context, use
@@ -32,7 +32,7 @@ track of significant figures. For example,
     $y = Real('37.1834');
 
 and these numbers will have 4 and 6 significant figures respectively.  To query
-the number of significant figures, use the C<sigfigs> method.  For example, 
+the number of significant figures, use the C<sigfigs> method.  For example,
 C<< $x->sigfigs >> will return 4.
 
 The standard arithmetic operations +, -, *, / are defined for these and the result
@@ -40,18 +40,18 @@ will have the correct number of significant figures. For example
 
     $x + $y;
 
-returns the value C<74.63>, where the first number is rounded to the hundredths 
+returns the value C<74.63>, where the first number is rounded to the hundredths
 place before adding.
 
    $x * $y;
 
-returns C<1392> or C<1.392E+02>. 
+returns C<1392> or C<1.392E+02>.
 
 Finally, we can also perform subtraction as in
 
    $x - $y;
 
-however, subtraction can lose significant figures.  The answer to this is C<0.27>, 
+however, subtraction can lose significant figures.  The answer to this is C<0.27>,
 resulting in only 2 significant figures.
 
 =head2 Significant Figure Rules
@@ -61,18 +61,18 @@ The rule about a zero's significance depends on where it is in a number.
 
 =over
 
-=item * Zeros between any significant digits are significant.  The zeros in 12.0034 
+=item * Zeros between any significant digits are significant.  The zeros in 12.0034
 are significant. There are 6 significant figures in this number.
 
-=item * Zeros to the left of a non-zero digit are not significant.  The zeros in 
+=item * Zeros to the left of a non-zero digit are not significant.  The zeros in
 0.00123 are not significant.  There are 3 significant figures in this number.
 
 =item * Zeros to right of the decimal point and to the right a non-zero digit are
-significant. The zeros in 12.3400 are significant. There are 6 significant figures 
+significant. The zeros in 12.3400 are significant. There are 6 significant figures
 in this number.
 
-=item * Zeros to the left of the decimal point and to the right of a non-zero 
-digit are not significant.  The zeros in 12300 are not significant. There are 3 
+=item * Zeros to the left of the decimal point and to the right of a non-zero
+digit are not significant.  The zeros in 12300 are not significant. There are 3
 significant figures in this number.  However, the presence of a significant zero
 changes the rule.  The zeros in 12300.0  are all significant because the rightmost
 0 is significant and therefore the other zeros are significant.
@@ -132,18 +132,18 @@ answers.  The default behavior is that a correct answer in this context is only
 given when a student has correct number of significant figures and the correct
 answer (to all digits).
 
-=over 
+=over
 
 =item Incorrect Significant Figures
 
 If an author wants show a message and possibly give partial credit for a correct
 answer (within tolerance) but the incorrect number of significant figures, then
-set the C<partial_incorrect_sf> flag to a value between 0 and 1. 
+set the C<partial_incorrect_sf> flag to a value between 0 and 1.
 
 If the flag C<partial_incorrect_sf> is set, and a student has the correct answer
 to within tolerance (using any of the tolerances set by C<Value::Real>) as well
 as the the incorrect number of significant figures, then a message will be
-shown to the student and the student will receive partial credit with this value. 
+shown to the student and the student will receive partial credit with this value.
 
 For example,
 
@@ -151,33 +151,33 @@ For example,
 
 will set the tolerance to 0.01 (this is the same C<tolerance> flag for reals)
 and the amount of partial credit to give for the correct answer with wrong number
-of significant figures. 
+of significant figures.
 
 Note that if the author would like to have the message shown, but no partial credit,
-use C<< partial_incorrect_sf => 0 >>. 
+use C<< partial_incorrect_sf => 0 >>.
 
 =item Correct Significant Figures and Close to the Correct Answer
 
 If an author would like to show a message and possibly give partial credit for a
 correct answer (within tolerance) and correct number of significant figures,
-then the flag C<partial_sf_within_tolerance> can be used.  
+then the flag C<partial_sf_within_tolerance> can be used.
 
 If this flag exists and a student has the correct number of significant figures
 and the answer is within tolerance (using those set by C<Value::Real>) then a
-message will be shown and the student will receive this value on the answer. 
+message will be shown and the student will receive this value on the answer.
 
 For example,
 
     Context('SignificantFigures')->flags->set(partial_sf_within_tolerance => 0.8);
 
 Note that if the author would like to have the message shown, but no partial credit, use
-C<< partial_sf_within_tolerance => 0 >>. 
+C<< partial_sf_within_tolerance => 0 >>.
 
-=back 
+=back
 
 =head2 SigFigNumber
 
-The function C<SigFigNumber> will also create a SigFigNumber with the second 
+The function C<SigFigNumber> will also create a SigFigNumber with the second
 argument the number of significant figures.  For example,
 
     $a = SigFigNumber(12.345);
@@ -577,7 +577,7 @@ sub checkExponentialForm {
 		$self->{expForm}     = 1;
 		$self->{def}         = { %{ $self->{def} }, string => 'x', TeX => '\times' };
 	} else {
-		Value::Error("The '%s' operator can ony appear between a simple constant and an integer power of ten",
+		Value::Error("The '%s' operator can only appear between a simple constant and an integer power of ten",
 			$self->{bop})
 			if $self->context->flag('limitedSigFigs') || $self->{bop} eq 'x';
 	}

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -1645,7 +1645,7 @@ sub quantity {
 #############################################################
 
 #
-#  Check if there should be a separtor before the units
+#  Check if there should be a separator before the units
 #
 sub noSep {
 	my $self = shift;

--- a/t/contexts/significant_figures.t
+++ b/t/contexts/significant_figures.t
@@ -2,7 +2,7 @@
 
 =head1 SignificantFigure context
 
-Test the SignifcantFigure context defined in contextSignificantFigure.pl.
+Test the SignificantFigure context defined in contextSignificantFigure.pl.
 
 =cut
 
@@ -165,7 +165,7 @@ subtest 'Create numbers with significant digits using Real' => sub {
 
 	my $a16 = Real('0.');
 	is $a16->format('E'), '0E+00', 'Check the format of 0.';
-	is $a16->sigfigs,     1,       '0. has 1 signficant figure';
+	is $a16->sigfigs,     1,       '0. has 1 significant figure';
 	is $a16->E,           0,       'The exponential of +00 is 0';
 	is $a16->string,      '0.',    'The string version is 0.';
 	is $a16->TeX,         '{0.}',  'The TeX version is {0.}';
@@ -258,7 +258,7 @@ subtest 'Set the number of significant digits' => sub {
 
 	my $a2 = Compute('-123.45');
 	is $a2->sigfigs,     5,               '-123.45 has 5 significant digits';
-	is $a2->sigfigs(7),  7,               'Change the number of signicant figures to 7';
+	is $a2->sigfigs(7),  7,               'Change the number of significant figures to 7';
 	is $a2->format('E'), '-1.234500E+02', "The internal format is '-1.2345E+02'";
 
 	my $a3 = Real(100, sigfigs => 3);
@@ -399,7 +399,7 @@ subtest 'Significant Figures for partial credit' => sub {
 	my $source = <<~'END_SOURCE';
 		DOCUMENT();
 		loadMacros("PGstandard.pl","PGML.pl",'contextSignificantFigures.pl');
-		Context('SignificantFigures')->flags->set(tolerance => 0.001, 
+		Context('SignificantFigures')->flags->set(tolerance => 0.001,
 			partial_incorrect_sf=>0.6,
 			partial_sf_within_tolerance => 0.8,
 		);
@@ -447,7 +447,7 @@ subtest 'Significant Figures for partial credit' => sub {
 		'The answer with incorrect number of sig. figs is given in sci. not. is scored with correct partial credit.';
 
 	like $pg4->{answers}{AnSwEr0001}{ans_message}, qr/Incorrect number of significant figures/,
-		'The answer in scientific notation and incorrect number of signficant figures is processed showing message.';
+		'The answer in scientific notation and incorrect number of significant figures is processed showing message.';
 
 	my $pg5 = WeBWorK::PG->new(
 		r_source       => \$source,
@@ -470,7 +470,7 @@ subtest 'Significant Figures for partial credit' => sub {
 	my $source = <<~'END_SOURCE';
 		DOCUMENT();
 		loadMacros("PGstandard.pl","PGML.pl",'contextSignificantFigures.pl');
-		Context('SignificantFigures')->flags->set(tolerance => 0.001, 
+		Context('SignificantFigures')->flags->set(tolerance => 0.001,
 			partial_incorrect_sf=>0.6,
 			partial_sf_within_tolerance => 0.8,
 		);

--- a/tutorial/sample-problems/ProblemTechniques/TikZImages.pg
+++ b/tutorial/sample-problems/ProblemTechniques/TikZImages.pg
@@ -54,7 +54,7 @@ $graph_image = createTikZImage();
 $graph_image->tikzLibraries("arrows.meta");
 
 # Randomization
-$a = non_zero_random(-6, 6);    # horizonatal translation
+$a = non_zero_random(-6, 6);    # horizontal translation
 $b = random(-4, 4);             # vertical translation
 
 $graph_image->BEGIN_TIKZ


### PR DESCRIPTION
A few more typos in the code were fixed.

crate-ci/typos is configured via the .typos.toml file with tightly scoped extend-identifiers/extend-ignore-re entries for the remaining legitimate non-dictionary terms so the checker stays useful for catching real future typos. macros/deprecated/answerDiscussion.pl is excluded entirely, since it is deprecated, broken, and not worth spell-checking.

This is basically the same as the similar webwork2 pull request.  There are several typos that should be fixed if we decide not to use the workflow.