### PR TITLE
Drop POST_HEADER_TEXT support.

### DIFF
--- a/lib/PGcore.pm
+++ b/lib/PGcore.pm
@@ -52,10 +52,9 @@ sub new {
 	#warn "creating a new PGcore object";
 	my %options = @_;
 	my $self    = {
-		OUTPUT_ARRAY      => [],    # holds output body text
-		HEADER_ARRAY      => [],    # holds output for the header text
-		POST_HEADER_ARRAY => [],
-		PG_ANSWERS_HASH   => {},    # holds label=>answer pairs
+		OUTPUT_ARRAY    => [],    # holds output body text
+		HEADER_ARRAY    => [],    # holds output for the header text
+		PG_ANSWERS_HASH => {},    # holds label=>answer pairs
 
 		# Holds other data, besides answers, which persists during a session and beyond.
 		PERSISTENCE_HASH            => $envir->{PERSISTENCE_HASH} // {},    # Main data, received from DB
@@ -193,29 +192,6 @@ sub HEADER_TEXT {
 	my $self = shift;
 	push @{ $self->{HEADER_ARRAY} }, map { (defined($_)) ? $_ : '' } @_;
 	$self->{HEADER_ARRAY};
-}
-
-=head2 POST_HEADER_TEXT
-
- POST_HEADER_TEXT("string1", "string2", "string3");
-
-POST_HEADER_TEXT() concatenates its arguments and appends them to the stored post_header
-text string. It can be used more than once in a file.
-
-The macro is used for material which is destined to be placed iimmediately after the HEAD of
-the page as the first item in the body, before the main problem form
-when in HTML mode, such as JavaScript code.
-
-Spaces are placed between the arguments during concatenation, but no spaces are
-introduced between the existing content of the header text string and the new
-content being appended.
-
-=cut
-
-sub POST_HEADER_TEXT {
-	my $self = shift;
-	push @{ $self->{POST_HEADER_ARRAY} }, map { (defined($_)) ? $_ : '' } @_;
-	$self->{POST_HEADER_ARRAY};
 }
 
 =head2 TEXT

--- a/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/PG.pm
@@ -97,17 +97,16 @@ sub new_helper ($invocant, %options) {
 		if ($@) {
 			# The problem source file could not be read.
 			return bless {
-				translator       => $translator,
-				head_text        => '',
-				post_header_text => '',
-				body_text        => "Unable to read problem source file:\n$@\n",
-				answers          => {},
-				result           => {},
-				state            => {},
-				errors           => 'Failed to read the problem source file.',
-				warnings         => $warning_messages,
-				flags            => { error_flag => 1 },
-				pgcore           => $translator->{rh_pgcore},
+				translator => $translator,
+				head_text  => '',
+				body_text  => "Unable to read problem source file:\n$@\n",
+				answers    => {},
+				result     => {},
+				state      => {},
+				errors     => 'Failed to read the problem source file.',
+				warnings   => $warning_messages,
+				flags      => { error_flag => 1 },
+				pgcore     => $translator->{rh_pgcore},
 			}, $class;
 		}
 	}
@@ -155,17 +154,16 @@ sub new_helper ($invocant, %options) {
 		&& (!defined $result->{summary} || $result->{summary} !~ /\S/);
 
 	return bless {
-		translator       => $translator,
-		head_text        => ${ $translator->r_header },
-		post_header_text => ${ $translator->r_post_header },
-		body_text        => ${ $translator->r_text },
-		answers          => $translator->rh_evaluated_answers,
-		result           => $result,
-		state            => $state,
-		errors           => $translator->errors,
-		warnings         => $warning_messages,
-		flags            => $translator->rh_flags,
-		pgcore           => $translator->{rh_pgcore}
+		translator => $translator,
+		head_text  => ${ $translator->r_header },
+		body_text  => ${ $translator->r_text },
+		answers    => $translator->rh_evaluated_answers,
+		result     => $result,
+		state      => $state,
+		errors     => $translator->errors,
+		warnings   => $warning_messages,
+		flags      => $translator->rh_flags,
+		pgcore     => $translator->{rh_pgcore}
 	}, $class;
 }
 
@@ -317,7 +315,6 @@ __END__
     $translator       = $pg->{translator};          # WeBWorK::PG::Translator
     $body             = $pg->{body_text};           # text string
     $header           = $pg->{head_text};           # text string
-    $post_header_text = $pg->{post_header_text};    # text string
     $answerHash       = $pg->{answers};             # WeBWorK::PG::AnswerHash
     $result           = $pg->{result};              # hash reference
     $state            = $pg->{state};               # hash reference
@@ -611,11 +608,6 @@ The WeBWorK::PG::Translator object used to render the problem.
 =item head_text
 
 HTML code to be injected into the E<lt>headE<gt> tag of the web page containing
-the problem.
-
-=item post_header_text
-
-HTML code to be injected into the E<lt>bodyE<gt> tag before the form containing
 the problem.
 
 =item body_text

--- a/lib/WeBWorK/PG/Translator.pm
+++ b/lib/WeBWorK/PG/Translator.pm
@@ -25,7 +25,6 @@ WeBWorK::PG::Translator - Evaluate PG code and evaluate answers safely
 
     $PG_PROBLEM_TEXT_REF = $pt->r_text;               # reference to output text for the body of problem
     $PG_HEADER_TEXT_REF = $pt->r_header;              # reference to text for the header in HTML output
-    $PG_POST_HEADER_TEXT_REF = $pt->r_post_header;
     $PG_ANSWER_HASH_REF = $pt->rh_correct_answers;    # a hash of answer evaluators
     $PG_FLAGS_REF = $pt->rh_flags;                    # misc. status flags.
 
@@ -206,24 +205,23 @@ sub new {
 	my $safe_cmpt = exists($ENV{MOJO_MODE}) ? $WeBWorK::Translator::safeCache : WWSafe->new;
 
 	my $self = {
-		preprocess_code         => \&default_preprocess_code,
-		postprocess_code        => \&default_postprocess_code,
-		envir                   => undef,
-		PG_PROBLEM_TEXT_REF     => 0,
-		PG_HEADER_TEXT_REF      => 0,
-		PG_POST_HEADER_TEXT_REF => 0,
-		PG_ANSWER_HASH_REF      => {},
-		PG_FLAGS_REF            => {},
-		rh_pgcore               => undef,
-		safe                    => $safe_cmpt,
-		safe_compartment_name   => $safe_cmpt->root,
-		errors                  => '',
-		source                  => '',
-		rh_correct_answers      => {},
-		rh_student_answers      => {},
-		rh_evaluated_answers    => {},
-		rh_problem_result       => {},
-		rh_problem_state        => {
+		preprocess_code       => \&default_preprocess_code,
+		postprocess_code      => \&default_postprocess_code,
+		envir                 => undef,
+		PG_PROBLEM_TEXT_REF   => 0,
+		PG_HEADER_TEXT_REF    => 0,
+		PG_ANSWER_HASH_REF    => {},
+		PG_FLAGS_REF          => {},
+		rh_pgcore             => undef,
+		safe                  => $safe_cmpt,
+		safe_compartment_name => $safe_cmpt->root,
+		errors                => '',
+		source                => '',
+		rh_correct_answers    => {},
+		rh_student_answers    => {},
+		rh_evaluated_answers  => {},
+		rh_problem_result     => {},
+		rh_problem_state      => {
 			recorded_score       => 0,
 			num_of_correct_ans   => 0,
 			num_of_incorrect_ans => 0,
@@ -426,11 +424,6 @@ sub header {
 	return ${ $self->{PG_HEADER_TEXT_REF} };
 }
 
-sub post_header {
-	my $self = shift;
-	return ${ $self->{PG_POST_HEADER_TEXT_REF} };
-}
-
 sub h_flags {
 	my $self = shift;
 	return %{ $self->{PG_FLAGS_REF} };
@@ -454,11 +447,6 @@ sub r_text {
 sub r_header {
 	my $self = shift;
 	return $self->{PG_HEADER_TEXT_REF};
-}
-
-sub r_post_header {
-	my $self = shift;
-	return $self->{PG_POST_HEADER_TEXT_REF};
 }
 
 sub rh_correct_answers {
@@ -688,8 +676,6 @@ Sets the following hash keys of the translator object:
     PG_PROBLEM_TEXT_REF: Reference to a string containing the rendered text.
     PG_HEADER_TEXT_REF:  Reference to a string containing material to be placed
         in the header.
-    PG_POST_HEADER_TEXT_REF:  Reference to a string containing material to
-        be placed in body above form.
     rh_correct_answers:  Reference to an array containing the answer evaluators.
         Constructed from keys of $PGcore->{PG_ANSWERS_HASH}.
     PG_FLAGS_REF:  Reference to a hash containing flags and other references:
@@ -736,9 +722,8 @@ sub translate {
 		. $self->{envir}{probFileName} . '" };'
 		. &{ $self->{preprocess_code} }($evalString);
 
-	my ($PG_PROBLEM_TEXT_REF, $PG_HEADER_TEXT_REF, $PG_POST_HEADER_TEXT_REF, $PG_ANSWER_HASH_REF, $PG_FLAGS_REF,
-		$PGcore)
-		= $safe_cmpt->reval($evalString);
+	my ($PG_PROBLEM_TEXT_REF, $PG_HEADER_TEXT_REF, $PG_ANSWER_HASH_REF, $PG_FLAGS_REF, $PGcore) =
+		$safe_cmpt->reval($evalString);
 
 	# This section could use some more error messages.  In particular if a problem doesn't produce the right output,
 	# the user needs information about which problem was at fault.
@@ -808,10 +793,9 @@ sub translate {
 
 	# Make sure that these variables are defined.  If the eval failed with
 	# errors, one or more of these variables won't be defined.
-	$self->{PG_HEADER_TEXT_REF}      = $PG_HEADER_TEXT_REF      // \('');
-	$self->{PG_POST_HEADER_TEXT_REF} = $PG_POST_HEADER_TEXT_REF // \('');
-	$self->{rh_correct_answers}      = $PG_ANSWER_HASH_REF      // {};
-	$self->{PG_FLAGS_REF}            = $PG_FLAGS_REF            // {};
+	$self->{PG_HEADER_TEXT_REF} = $PG_HEADER_TEXT_REF // \('');
+	$self->{rh_correct_answers} = $PG_ANSWER_HASH_REF // {};
+	$self->{PG_FLAGS_REF}       = $PG_FLAGS_REF       // {};
 
 	$self->{rh_pgcore} = $PGcore;
 

--- a/macros/PG.pl
+++ b/macros/PG.pl
@@ -201,20 +201,6 @@ sub HEADER_TEXT {
 	$PG->HEADER_TEXT(@_);
 }
 
-=head2 POST_HEADER_TEXT
-
-DEPRECATED
-
-Content added by this method is appended just after the page head. This method
-should no longer be used. There is no valid reason to add content after the
-page head, and not in the problem itself.
-
-=cut
-
-sub POST_HEADER_TEXT {
-	$PG->POST_HEADER_TEXT(@_);
-}
-
 =head2 SET_PROBLEM_LANGUAGE
 
 Valid HTML language codes are expected, but a region code or other settings may
@@ -1547,11 +1533,10 @@ sub ENDDOCUMENT {
 	$PG->{flags}{KEPT_EXTRA_ANSWERS} = \@KEPT_EXTRA_ANSWERS;
 	$PG->{flags}{ANSWER_ENTRY_ORDER} = \@PG_ANSWER_ENTRY_ORDER;
 
-	my $STRINGforOUTPUT          = join('', @{ $PG->{OUTPUT_ARRAY} });
-	my $STRINGforHEADER_TEXT     = join('', @{ $PG->{HEADER_ARRAY} });
-	my $STRINGforPOSTHEADER_TEXT = join('', @{ $PG->{POST_HEADER_ARRAY} });
+	my $STRINGforOUTPUT      = join('', @{ $PG->{OUTPUT_ARRAY} });
+	my $STRINGforHEADER_TEXT = join('', @{ $PG->{HEADER_ARRAY} });
 
-	(\$STRINGforOUTPUT, \$STRINGforHEADER_TEXT, \$STRINGforPOSTHEADER_TEXT, \%PG_ANSWERS_HASH, $PG->{flags}, $PG);
+	(\$STRINGforOUTPUT, \$STRINGforHEADER_TEXT, \%PG_ANSWERS_HASH, $PG->{flags}, $PG);
 }
 
 sub alias {

--- a/macros/core/PGbasicmacros.pl
+++ b/macros/core/PGbasicmacros.pl
@@ -2179,11 +2179,10 @@ sub PTX_cleanup {
                     # with url specified in which case the revealed text is taken from the URL $url.
                     # The $display_text is always visible and is clicked to see the contents of the knowl.
     iframe($url, height=>'', width=>'', id=>'', name=>'' )
-                    # insert the web page referenced by $url in a space defined by height and width
-                    # if the webpage contains a form then this must be inserted between
-                    # BEGIN_POST_HEADER_TEXT/END_POST_HEADER_TEXT  to avoid having one
-                    # form(from the webpage) inside another (the defining form for the problem
-A wide variety of google widgets, youtube videos, and other online resources can be imbedded using this macro. In HTML mode it creates an iframe, in TeX mode it prints the url.
+                    Insert the web page referenced by $url in a space defined by height and width.
+                    A wide variety of google widgets, youtube videos, and other online resources
+                    can be embedded using this macro. In HTML mode it creates an iframe, in TeX
+                    mode it prints the url.
 
     helpLink($type)
                    Allows site specific help.

--- a/t/pg_problems/problem_file.t
+++ b/t/pg_problems/problem_file.t
@@ -16,8 +16,6 @@ ok my $pg = WeBWorK::PG->new(
 
 is($pg->{head_text}, '', 'head_text is empty');
 
-is($pg->{post_header_text}, '', 'post_header_text is empty');
-
 is(
 	$pg->{body_text},
 	qq{<div class="PGML">\n}


### PR DESCRIPTION
There is no valid reason for a problem to use `POST_HEADER_TEXT`. Anything that you want after the HTML `head` can be added to the problem text itself.  There was an invalid comment about iframes suggesting that this method be used if a page embedded in an iframe contains a form. However, it does not need to be outside of the problem form.  It is in an iframe which is a completely separate page, and will not conflict with the outer page's form.

Note that a problem author can still add to the `head` section of the HTML page with `HEADER_TEXT`.

This method is not used by any problem in the OPL or Contrib.

I have had this sitting here for 3 years.  I am pulling the trigger on it.